### PR TITLE
update appveyor: full x64 + install lablgtk

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,20 @@
 platform:
-  - x86
+  - x64
 
 environment:
-  CYG_ROOT: C:/cygwin
+  CYG_ROOT: C:/cygwin64
   CYG_BASH: '%CYG_ROOT%/bin/bash -lc'
 
 install:
-  - '%CYG_ROOT%\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P ocaml -P ocaml-camlp4 -P ocaml-compiler-libs -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core'
+  - '%CYG_ROOT%\setup-x86_64.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core -P mingw64-x86_64-gtk2.0'
   - '%CYG_BASH% "curl -fsSL -o opam64.tar.xz https://dl.dropboxusercontent.com/s/b2q2vjau7if1c1b/opam64.tar.xz"'
   - '%CYG_BASH% "tar -xf opam64.tar.xz"'
   - '%CYG_BASH% "opam64/install.sh"'
-  - '%CYG_BASH% "opam init -a mingw https://github.com/fdopen/opam-repository-mingw.git" --comp 4.02.3+mingw64c --switch 4.02.3+mingw64c"'
+  - '%CYG_BASH% "opam init -a mingw https://github.com/fdopen/opam-repository-mingw.git --comp 4.02.3+mingw64c --switch 4.02.3+mingw64c"'
   - '%CYG_BASH% "eval `opam config env`"'
-  - '%CYG_BASH% "opam install -y ocamlfind camlp5 lablgtk"'
+  - '%CYG_BASH% "opam install -y camlp5 depext depext-cygwinports"'
+  - 'set PATH=%PATH%;/usr/x86_64-w64-mingw32/sys-root/mingw/bin'
+  - '%CYG_BASH% "opam depext -i lablgtk"'
 
 build_script:
-  - '%CYG_BASH% "cd ${APPVEYOR_BUILD_FOLDER} && ./configure && make everything && make distrib"'
+  - '%CYG_BASH% "export CYGWIN=winsymlinks:native && cd ${APPVEYOR_BUILD_FOLDER} && ./configure && make everything && make distrib && ./distribution/gw/gwd -cgi"'


### PR DESCRIPTION
* use x64 cygwin setup
* remove not needed cygwin packets: ocaml/ocaml-camlp4/ocaml-compiler-libs
* lablgtk itself needs: 
* – mingw64-x86_64-gtk2.0 (cygwin packet + its dependencies) 
* – changing environment variable PATH
* – opam depext/depext-cygwinports (ocamlfind is installed with this)
* add `CYGWIN=winsymlinks:native` before configure/make gw