### PR TITLE
Fix urls in V6

### DIFF
--- a/etc/START.htm
+++ b/etc/START.htm
@@ -83,11 +83,10 @@
         <li><a href="http://localhost:2316/de" target="_blank">Verwaltung und Erstellung</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">Bedienungsanleitung</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">Bedienungsanleitung</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">Lizenz</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Impressum</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Lizenz</a> /
       </div>
     </div>
 
@@ -98,11 +97,10 @@
         <li><a href="http://localhost:2316/en" target="_blank">Management and creation</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">License</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Credits</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
       </div>
     </div>
 
@@ -113,11 +111,10 @@
         <li><a href="http://localhost:2316/es" target="_blank">Ggestión y Creación</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">Modo de empleo</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">Modo de empleo</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">Licencia</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Créditos</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Licencia</a> /
       </div>
     </div>
 
@@ -128,11 +125,10 @@
         <li><a href="http://localhost:2316/fr" target="_blank">Gestion et création</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/Fr_home" target="_blank">Mode d'emploi</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/Fr_home" target="_blank">Mode d'emploi</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">Licence</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Crédits</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Licence</a> /
       </div>
     </div>
 
@@ -143,11 +139,10 @@
         <li><a href="http://localhost:2316/it" target="_blank">Gestione e la creazione</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">Istruzioni per l'uso</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">Istruzioni per l'uso</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">Licenza</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Crediti</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Licenza</a> /
       </div>
     </div>
 
@@ -158,11 +153,10 @@
         <li><a href="http://localhost:2316/en" target="_blank">Gwsetup</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">License</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Credits</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
       </div>
     </div>
 
@@ -173,11 +167,10 @@
         <li><a href="http://localhost:2316/en" target="_blank">Gwsetup</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">License</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Credits</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
       </div>
     </div>
 
@@ -188,11 +181,10 @@
         <li><a href="http://localhost:2316/en" target="_blank">Gwsetup</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">License</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Credits</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
       </div>
     </div>
 
@@ -203,11 +195,10 @@
         <li><a href="http://localhost:2316/sv" target="_blank">ledning och skapande</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Licence" target="_blank">License</a> /
-        <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Credits" target="_blank">Credits</a>
+        <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
       </div>
     </div>
 

--- a/etc/START.htm
+++ b/etc/START.htm
@@ -97,7 +97,7 @@
         <li><a href="http://localhost:2316/en" target="_blank">Management and creation</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
@@ -111,7 +111,7 @@
         <li><a href="http://localhost:2316/es" target="_blank">Ggestión y Creación</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">Modo de empleo</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">Modo de empleo</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Licencia</a> /
@@ -125,7 +125,7 @@
         <li><a href="http://localhost:2316/fr" target="_blank">Gestion et création</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/Fr_home" target="_blank">Mode d'emploi</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">Mode d'emploi</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Licence</a> /
@@ -139,7 +139,7 @@
         <li><a href="http://localhost:2316/it" target="_blank">Gestione e la creazione</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">Istruzioni per l'uso</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">Istruzioni per l'uso</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">Licenza</a> /
@@ -153,7 +153,7 @@
         <li><a href="http://localhost:2316/en" target="_blank">Gwsetup</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
@@ -167,7 +167,7 @@
         <li><a href="http://localhost:2316/en" target="_blank">Gwsetup</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
@@ -181,7 +181,7 @@
         <li><a href="http://localhost:2316/en" target="_blank">Gwsetup</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /
@@ -195,7 +195,7 @@
         <li><a href="http://localhost:2316/sv" target="_blank">ledning och skapande</a></li>   
       </ul>
       <ul class="doc">
-        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb/en_home" target="_blank">User Guide</a></li>
+        <li><a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">User Guide</a></li>
       </ul>
       <div class="bottom">
         <a href="https://github.com/geneweb/geneweb/blob/master/LICENSE" target="_blank">License</a> /

--- a/etc/a.gwf
+++ b/etc/a.gwf
@@ -34,7 +34,7 @@
 # Customize the default.css stylesheet or create your own one and
 # specify it to geneweb by adding this line in your gwf.
 # More about how to customize here :
-# http://opensource.geneanet.org/projects/geneweb/wiki/en_css
+# http://geneweb.tuxfamily.org/wiki/CSS
 css_prop=stylesheet
 
 
@@ -372,7 +372,7 @@ expand_env=no
 #authorized_wizards_notes=yes/no
 
 # Custom the individual page.
-# Full documentation here http://opensource.geneanet.org/projects/geneweb/wiki/Fr_Template#Personnalisation-de-toutes-les-pages
+# Full documentation here http://geneweb.tuxfamily.org/wiki/Templates
 #
 # Basic explanation :
 # Add the element you want like this :

--- a/gui/gui.ml
+++ b/gui/gui.ml
@@ -780,7 +780,7 @@ value rec show_main conf = do {
     (inser_toolbar
        (capitale (transl "doc")) (capitale (transl "view doc")) "gui_doc.png"
        (fun () ->
-         let url = "http://opensource.geneanet.org/projects/geneweb/wiki" in
+         let url = "http://geneweb.tuxfamily.org/wiki/GeneWeb" in
          ignore (browse conf url)) );
   toolbar#insert_space ();
 (* TOTO : gérer le restart

--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -9,7 +9,7 @@
       style="vertical-align: middle; border: 0"
       alt="GeneWeb" title="GeneWeb"%/></a>%sp;
       Version %version; %compilation_time;%sp;
-      Copyright &copy; 1998-2013 %connections;%sq;
+      Copyright &copy; 1998-2016 %connections;%sq;
     </em><br%/>
   </div>
 </div>

--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -4,9 +4,9 @@
   <hr />
   <div>
     <em>
-      <a href="http://opensource.geneanet.org/projects/geneweb/" target="_blank">
-      <img src="%image_prefix;/logo_bas.png" 
-      style="vertical-align: middle; border: 0" 
+      <a href="https://github.com/geneweb/geneweb" target="_blank">
+      <img src="%image_prefix;/logo_bas.png"
+      style="vertical-align: middle; border: 0"
       alt="GeneWeb" title="GeneWeb"%/></a>%sp;
       Version %version; %compilation_time;%sp;
       Copyright &copy; 1998-2013 %connections;%sq;

--- a/hd/etc/templ502/copyr.txt
+++ b/hd/etc/templ502/copyr.txt
@@ -13,6 +13,6 @@ it: Pagina visualizzata da
 sl: Strani ustvarjene z:
     <a href="http://www.geneweb.org/">GeneWeb %version;</a>
 ])%compilation_time;%sp;
-Copyright &copy; 1998-2007 INRIA%connections;%sq;
+Copyright &copy; 1998-2016 INRIA%connections;%sq;
 %if;(not cancel_links) - <a href="%prefix;m=DOC">DOC</a>%end;%sq;
 %setup_link;</em><br%/><br%/></div>

--- a/hd/etc/templm/trl.txt
+++ b/hd/etc/templm/trl.txt
@@ -39,7 +39,7 @@
       <a href="%prefix_no_templ;templ=templ502;%suffix;">templ502</a>
     </div>
     <div class="button" style="margin-top:-1.3em;margin-left:2px;">
-      <a href="http://opensource.geneanet.org/projects/geneweb/wiki/Fr_templm">Doc templm</a>
+      <a href="http://geneweb.tuxfamily.org/wiki/templm">Doc templm</a>
     </div>
    %end;
   %if;(wizard)

--- a/hd/lang/start.txt
+++ b/hd/lang/start.txt
@@ -51,7 +51,7 @@ sv: Genealogi
 <table border="0" width="100%%">
 <tr align="%L">
 <td rowspan="2" style="width: 20%%">
-<a href="http://opensource.geneanet.org/projects/geneweb/"><img width="96" height="108"
+<a href="https://github.com/geneweb/geneweb"><img width="96" height="108"
  src="%o/gwlogo.png" style="align: %L; border: 0" alt="GeneWeb"%/></a>
 </td>
 %I&wNf<td align="%R"

--- a/hd/lang/start_utf8.txt
+++ b/hd/lang/start_utf8.txt
@@ -57,7 +57,7 @@ sv: Genealogi
   <table border="0" width="100%%">
     <tr align="%L">
       <td rowspan="2" style="width: 20%%">
-        <a href="http://opensource.geneanet.org/projects/geneweb/"><img width="96" height="108"
+        <a href="https://github.com/geneweb/geneweb"><img width="96" height="108"
          src="%o/gwlogo.png" style="border: 0" alt="GeneWeb"%/></a>
       </td>
       %I&wNf<td align="%R"

--- a/setup/lang/main.htm
+++ b/setup/lang/main.htm
@@ -382,23 +382,23 @@ sv: ... eller gå tillbaka till <a href="%l">välkomstsidan</a> för "gwsetup"
 [
 de: ... oder schaue in die vollst&auml;ndige <b><font
     color=#2f6400>GeneWeb</font></b>-<a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">Dokumentation</a>
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">Dokumentation</a>
 en: ... or consult the complete <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">documentation</a> of <font
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentation</a> of <font
     color=#2f6400><b>GeneWeb</b></font>
 es: ... o consultar la <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">documentaci&oacute;n</a> completa de
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentaci&oacute;n</a> completa de
     <font color=#2f6400><b>GeneWeb</b></font>
 fi: ... tai konsultoi <b>GeneWeb</b> <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">dokumentaatiota</a>
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">dokumentaatiota</a>
 fr: ... ou consulter la <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki/fr_home" target="_blank">documentation</a> compl&egrave;te de
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentation</a> compl&egrave;te de
     <font color=#2f6400><b>GeneWeb</b></font>.
 it: ... o consultare la <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">documentazione</a> completa di
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentazione</a> completa di
     <font color=#2f6400><b>GeneWeb</b></font>.
 lv: ... vai skatît <font color=#2f6400><b>GeneWeb</b></font> <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">aprakstu</a>
-sv: ... eller läs <a href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">dokumentationen</a> för
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">aprakstu</a>
+sv: ... eller läs <a href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">dokumentationen</a> för
     <font color=#2f6400><b>GeneWeb</b></font>
 ]

--- a/setup/lang/welcome.htm
+++ b/setup/lang/welcome.htm
@@ -363,24 +363,24 @@ sv: parametrarna för <a href="gwd?lang=%l;v=gwd.htm">gwd servicen</a>
 [
 de: Du kannst auch auf die komplette <font
     color=#2f6400><b>GeneWeb</b></font>-<a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">Dokumentation</a> zugreifen.
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">Dokumentation</a> zugreifen.
 en: You can also consult the complete <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki/en_home" target="_blank">documentation</a> of <font
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentation</a> of <font
     color=#2f6400><b>GeneWeb</b></font>.
 es: Ud puede igualmente consultar la <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">documentaci&oacute;n</a> completa de
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentaci&oacute;n</a> completa de
     <font color=#2f6400><b>GeneWeb</b></font>.
 fr: Vous pouvez &eacute;galement consulter la <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki/fr_home" target="_blank">documentation</a> compl&egrave;te de
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentation</a> compl&egrave;te de
     <b><font color=#2f6400>GeneWeb</font></b>.
 it: Potete anche consultare la <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">documentazione</a> completa di
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">documentazione</a> completa di
     <b><font color=#2f6400>GeneWeb</font></b>.
 lv: Kâ arî Jûs variet skatît pilnîgu <font
     color=#2f6400><b>GeneWeb</b></font> <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">aprakstu</a> .
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">aprakstu</a> .
 sv: Du kan också konsultera den kompletta <a
-    href="http://opensource.geneanet.org/projects/geneweb/wiki" target="_blank">dokumentationen</a> för <font
+    href="http://geneweb.tuxfamily.org/wiki/GeneWeb" target="_blank">dokumentationen</a> för <font
     color=#2f6400><b>GeneWeb</b></font>.
 ]
 

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -126,7 +126,7 @@ value trailer conf =
     Wserver.wprint "<hr />\n";
     Wserver.wprint "<div>\n";
     Wserver.wprint "<em>\n";
-    Wserver.wprint "<a href=\"http://opensource.geneanet.org/projects/geneweb/\"><img src=\"images/logo_bas.png\" align=\"absmiddle\" style = \"border: 0\" /></a> Version %s Copyright &copy 1998-2012\n</em>\n" Version.txt;
+    Wserver.wprint "<a href=\"https://github.com/geneweb/geneweb/\"><img src=\"images/logo_bas.png\" align=\"absmiddle\" style = \"border: 0\" /></a> Version %s Copyright &copy 1998-2012\n</em>\n" Version.txt;
     Wserver.wprint "</div>\n" ;
     Wserver.wprint "</div>\n" ;
     (* finish the html page *)

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -126,7 +126,7 @@ value trailer conf =
     Wserver.wprint "<hr />\n";
     Wserver.wprint "<div>\n";
     Wserver.wprint "<em>\n";
-    Wserver.wprint "<a href=\"https://github.com/geneweb/geneweb/\"><img src=\"images/logo_bas.png\" align=\"absmiddle\" style = \"border: 0\" /></a> Version %s Copyright &copy 1998-2012\n</em>\n" Version.txt;
+    Wserver.wprint "<a href=\"https://github.com/geneweb/geneweb/\"><img src=\"images/logo_bas.png\" align=\"absmiddle\" style = \"border: 0\" /></a> Version %s Copyright &copy 1998-2016\n</em>\n" Version.txt;
     Wserver.wprint "</div>\n" ;
     Wserver.wprint "</div>\n" ;
     (* finish the html page *)

--- a/src/place.ml
+++ b/src/place.ml
@@ -10,8 +10,8 @@ open Util;
 
 
 value fold_place inverted s =
-  (* petit hack (pour GeneaNet) en attendant une vraie gestion des lieux *)
-  (* transforme "[foo-bar] - boobar (baz)" en "foo-bar, boobar (baz)"    *)
+  (* petit hack en attendant une vraie gestion des lieux transforme
+     "[foo-bar] - boobar (baz)" en "foo-bar, boobar (baz)" *)
   let s =
    Str.global_replace (Str.regexp "^\[\([^]]+\)\] *- *\(.*\)") "\1, \2" s
   in


### PR DESCRIPTION
As I am preparing to push the updated V6 to the Debian repo, I thought it would be worthwhile to update broken links to bring geneweb users to the right website when they click on the links
