### PR TITLE
Circumvent input_value bug in OCaml 4.03 (V7)

### DIFF
--- a/contrib/history/convert_hist.ml
+++ b/contrib/history/convert_hist.ml
@@ -82,7 +82,9 @@ value load_old_person_history fname = do {
             let v : old_gen_record = input_value ic in
             history.val := [v :: history.val]
           }
-        with [ End_of_file -> () ];
+        with
+          [ End_of_file -> ()
+          | Failure "input_value: truncated object" -> () ];
         close_in ic
       }
   | None -> () ];

--- a/contrib/history/fix_hist.ml
+++ b/contrib/history/fix_hist.ml
@@ -107,6 +107,7 @@ value load_old_person_history_both2 fname = do {
               }
             with 
             [ End_of_file -> raise End_of_file
+            | Failure "input_value: truncated object" -> raise End_of_file
             | x -> 
                 do {
                   seek_in ic last_pos;
@@ -117,7 +118,9 @@ value load_old_person_history_both2 fname = do {
                 }]
           in
           loop (pos_in ic)
-        with [ End_of_file -> () ];
+        with
+          [ End_of_file -> ()
+          | Failure "input_value: truncated object" -> () ];
         close_in ic
       }
   | None -> () ];

--- a/contrib/history/is_gw_plus.ml
+++ b/contrib/history/is_gw_plus.ml
@@ -21,7 +21,9 @@ value test_history fname pos =
             let _ = List.length v.gen_p.pevents in
             ()
           }
-        with [ End_of_file -> () ];
+        with
+          [ End_of_file -> ()
+          | Failure "input_value: truncated object" -> () ];
         close_in ic
       }
   | None -> () ]

--- a/src/gwc1.ml
+++ b/src/gwc1.ml
@@ -43,8 +43,10 @@ value next_family_fun_templ gwo_list fi = do {
         match ic_opt.val with
         [ Some ic ->
             match
-              try Some (input_value ic : gw_syntax) with
-              [ End_of_file -> None ]
+              try Some (input_value ic : gw_syntax)
+              with
+                [ End_of_file -> None
+                | Failure "input_value: truncated object" -> None ]
             with
             [ Some fam -> Some fam
             | None -> do {

--- a/src/gwc2.ml
+++ b/src/gwc2.ml
@@ -55,8 +55,10 @@ value next_family_fun_templ gwo_list fi = do {
         match ic_opt.val with
         [ Some ic ->
             match
-              try Some (input_value ic : gw_syntax) with
-              [ End_of_file -> None ]
+              try Some (input_value ic : gw_syntax)
+              with
+                [ End_of_file -> None
+                | Failure "input_value: truncated object" -> None ]
             with
             [ Some fam -> Some fam
             | None -> do {

--- a/src/history_diff.ml
+++ b/src/history_diff.ml
@@ -298,7 +298,9 @@ value load_person_history conf fname = do {
             let v : gen_record = input_value ic in
             history.val := [v :: history.val]
           }
-        with [ End_of_file -> () ];
+        with
+          [ End_of_file -> ()
+          | Failure "input_value: truncated object" -> () ];
         close_in ic
       }
   | None -> () ];


### PR DESCRIPTION
First attempt of "fix" to be ready for OCaml 4.03 and its bug with input_value, for the master branch (V7).

For discussion purpose.

To find all the problematic patterns, I used : ```grep -rn -A 6 -B 6 "input_value" ```

See : 
https://github.com/geneweb/geneweb/issues/455#issuecomment-254344857
https://caml.inria.fr/mantis/view.php?id=7142