### PR TITLE
Add UTF-8 as default option for exporting GED file

### DIFF
--- a/setup/lang/gwb2ged.htm
+++ b/setup/lang/gwb2ged.htm
@@ -120,7 +120,7 @@ sv: Välj de optioner du vill ha:
 <dl><dt><dd><table style="border:1px solid">
 
 <tr align="left"><td>
-<input type="radio" name="charset" value="ASCII" checked="checked" />&nbsp;&nbsp;&nbsp;</td>
+<input type="radio" name="charset" value="ASCII" />&nbsp;&nbsp;&nbsp;</td>
 <td>[
 de: Kodiere die Zeichen in ASCII.
 en: Encode the characters in ASCII.
@@ -130,6 +130,20 @@ fr: Coder les caract&egrave;res en ASCII.
 it: Codificare i caratteri in ASCII.
 lv: Burti ASCII kodçjumâ.
 sv: Koda tecknen i ASCII.
+]</td>
+</tr>
+
+<tr align="left"><td>
+<input type="radio" name="charset" value="UTF-8" checked="checked" />&nbsp;&nbsp;&nbsp;</td>
+<td>[
+de: Kodiere die Zeichen in UTF-8.
+en: Encode the characters in UTF-8.
+es: Codificar los car&aacute;cteres en UTF-8.
+fi: Koodaa merkit UTF-8 muodossa.
+fr: Coder les caract&egrave;res en UTF-8.
+it: Codificare i caratteri in UTF-8.
+lv: Burti UTF-8 kodçjumâ.
+sv: Koda tecknen i UTF-8.
 ]</td>
 </tr>
 


### PR DESCRIPTION
Add UTF-8 as default option for exporting GED file