### PR TITLE
 Improvements to gui [UPDATED]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ distrib:
 	cp setup/lang/*.htm $(DESTDIR)/gw/setup/lang/.
 	cp setup/lang/lexicon.txt $(DESTDIR)/gw/setup/lang/.
 	cp -R hd/* $(DESTDIR)/gw/.
+	if [ -a gui/gui ]; then \
+	  cp gui/gw/gui_lex.txt $(DESTDIR)/gw/.; \
+	  cp gui/gui $(DESTDIR)/gw/gui$(EXE); \
+	fi
 
 .merlin:
 	echo "PKG $(PACKAGES)" > $@

--- a/gui/gui.ml
+++ b/gui/gui.ml
@@ -1238,7 +1238,7 @@ value launch_config () =
          page_3#as_widget);
     ignore
       (assistant#append_page
-         ~{ title = transl "Finnish";
+         ~{ title = transl "Completed!";
             page_type = `CONFIRM;
             complete = True }
          page_4#as_widget);

--- a/gui/gui.ml
+++ b/gui/gui.ml
@@ -21,6 +21,8 @@ value bin_dir =
   else path
 ;
 
+value share_dir = bin_dir;
+
 value trace = ref False;
 
 value default_lang =
@@ -35,9 +37,6 @@ value lexicon_mtime = ref 0.0;
 value lexicon_file = Filename.concat bin_dir "gui_lex.txt";
 
 value config_gui_file = Filename.concat bin_dir "config.txt";
-value config_gwd_file = Filename.concat bin_dir "gwd.arg";
-value config_only_file = Filename.concat bin_dir "only.txt";
-
 
 (**/**) (* Gestion du dictionnaire des langues pour GUI. *)
 
@@ -213,8 +212,7 @@ value write_base_env conf bname env =
 ;
 
 value write_config_file conf = do {
-  let fname = Filename.concat bin_dir "config.txt" in
-  match try Some (open_out fname) with [ Sys_error _ -> None] with
+  match try Some (open_out config_gui_file) with [ Sys_error _ -> None] with
   [ Some oc ->
       do {
         List.iter (fun (k, v) -> fprintf oc "%s=%s\n" k v) conf.gui_arg;
@@ -703,7 +701,7 @@ value rec show_main conf = do {
        packing = vbox#pack } () in
   let icon name =
     let file =
-      List.fold_left Filename.concat bin_dir ["images"; name]
+      List.fold_left Filename.concat share_dir ["images"; name]
     in
     let info = GDraw.pixmap_from_xpm ~{ file } () in
     (GMisc.pixmap info ())#coerce
@@ -1110,7 +1108,7 @@ and launch_server conf = do {
   try Sys.remove stop_server with [ Sys_error _ -> () ];
   let prog = Filename.concat bin_dir "gwd" in
   let args =
-    ["-hd"; bin_dir; "-bd"; conf.bases_dir; "-p"; sprintf "%d" conf.port]
+    ["-hd"; share_dir; "-bd"; conf.bases_dir; "-lang"; lang.val; "-p"; sprintf "%d" conf.port]
   in
   let server_pid = exec prog args gwd_log gwd_log in
   let (pid, ps) = Unix.waitpid [Unix.WNOHANG] server_pid in
@@ -1213,7 +1211,7 @@ value launch_config () =
                let page = assistant#nth_page num in
                assistant#set_page_complete page btn#active } })
     | None -> () ];
-    let page_4 = GMisc.label ~{ text = transl "save preferences" } () in
+    let page_4 = GMisc.label ~{ text = transl ("Your configuration file is:") ^ "\n" ^ config_gui_file; line_wrap = True } () in
     ignore
       (assistant#append_page
          ~{ title = transl "Introduction";

--- a/gui/gw/gui_lex.txt
+++ b/gui/gw/gui_lex.txt
@@ -123,7 +123,7 @@ fr: Configurez éventuellement le numéro de port
 
     select browser
 en: Select the browser you want to use
-fr: Selectionnez le navigateur que vous voulez utiliser
+fr: Selectionnez le navigateur à utiliser
 
     save preferences
 en: Save preference
@@ -200,3 +200,7 @@ fr: Consang
     Update_nldb
 en: Update_nldb
 fr: Update_nldb
+
+    Your configuration file is:
+en: Your configuration file is:
+fr: Votre fichier de configuration est:

--- a/gui/gw/gui_lex.txt
+++ b/gui/gw/gui_lex.txt
@@ -145,9 +145,9 @@ fr: Configuration du port
 en: Setup browser
 fr: Configuration du navigateur
 
-    Finnish
-en: Finnish
-fr: Terminer
+    Completed!
+en: Completed!
+fr: Terminé!
 
     Home
 en: Home


### PR DESCRIPTION
- correct English error in gui ("Finnish" vs ~~"Finished"~~ "Completed!")
- add gui and gui_lex.txt to distrib: in Makefile
- remove dead code (config_gwd_file, config_only_file)
- remove duplicated definition of "config.txt"
- add share_dir for -hd argument of gwd (needed for packaging in Debian)
- start gwd using the -lang argument
- <s>close_server now more robust to multiple gwd instances</s> (REMOVED, addressed separately in https://github.com/geneweb/geneweb/issues/547)
- indicate the location of the configuration file in the assistant
- shorten a line in the French translation of the assistant