### PR TITLE
Include OfCourseDead in is_dead

### DIFF
--- a/src/mergeInd.ml
+++ b/src/mergeInd.ml
@@ -173,6 +173,8 @@ value compatible_deaths d1 d2 =
     [ (Death dr1 cd1, Death dr2 cd2) ->
         compatible_death_reasons dr1 dr2 && compatible_cdates cd1 cd2
     | (Death _ _, NotDead) -> False
+    | (Death _ _, OfCourseDead) -> False
+    | (OfCourseDead, Death _ _) -> False
     | (Death _ _, _) -> True
     | (_, DontKnowIfDead) -> True
     | (DontKnowIfDead, _) -> True

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -3482,7 +3482,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
       | _ -> False ]
   | "is_dead" ->
       match get_death p with
-      [ Death _ _ | DeadYoung | DeadDontKnowWhen -> p_auth
+      [ Death _ _ | DeadYoung | DeadDontKnowWhen | OfCourseDead -> p_auth
       | _ -> False ]
   | "is_descendant" ->
       match get_env "desc_mark" env with
@@ -4036,6 +4036,7 @@ and string_of_died conf base env p p_auth =
         | Disappeared -> transl_nth conf "disappeared" is ]
     | DeadYoung -> transl_nth conf "died young" is
     | DeadDontKnowWhen -> transl_nth conf "died" is
+    | OfCourseDead -> transl_nth conf "died" is
     | _ -> "" ]
   else ""
 and string_of_image_url conf base env (p, p_auth) html =


### PR DESCRIPTION
Additionnaly, detect OfCourseDead discrepancy when merging two individuals.
(Merging OfCourseDead with Death (date) lost the date value).
A better correction would choose the obviously right option without asking to the user. 

There are possibly other places where OfCourseDead is not correctly handled:
possible example:
date.ml (888):     | DontKnowIfDead | NotDead | OfCourseDead -> () ];
when DeadYoung and  DeadDontKnowWhen produce some text.