### PR TITLE
m=DOC;s=file.ext for images, pdf, html and text. m=DOC;s=file.txt is …

### DIFF
--- a/src/image.ml
+++ b/src/image.ml
@@ -6,19 +6,20 @@ open Config;
 
 (* ************************************************************************** *)
 (*  [Fonc] content : string -> int -> string -> unit                          *)
-(** [Description] : Envoie les en-têtes de contenu et de cache pour une image
-                    sur le flux HTTP sortant de Wserver.
+(** [Description] : Envoie les en-têtes de contenu et de cache pour un fichier
+                    image, pdf ou html sur le flux HTTP sortant de Wserver.
     [Args] :
-      - t : le type MIME de l'image, par exemple "png", "jpeg" ou "gif"
-      - len : la taille en octet de l'image
-      - fname : le nom du fichier image
+      - ct : le content_type MIME du fichier, par exemple "image/png", 
+             "image/jpeg" ou "application/pdf"
+      - len : la taille en octet du fichier
+      - fname : le nom du fichier 
     [Retour] : aucun
     [Rem] : Ne pas utiliser en dehors de ce module.                           *)
 (* ************************************************************************** *)
-value content c_t len fname =
+value content ct len fname =
   do {
     Wserver.http HttpStatus.OK;
-    Wserver.header "Content-type: %s" c_t;
+    Wserver.header "Content-type: %s" ct;
     Wserver.header "Content-length: %d" len;
     Wserver.header "Content-disposition: inline; filename=%s"
       (Filename.basename fname);
@@ -34,18 +35,19 @@ value content c_t len fname =
                     utilisant Wserver.
     [Args] :
       - fname : le chemin vers le fichier image
-      - itype : le type MIME de l'image, par exemple "png", "jpeg" ou "gif"
+      - ctype : le content_type MIME du fichier, par exemple "image/png", 
+                "image/jpeg" ou "application/pdf"
     [Retour] : True si le fichier image existe et qu'il a été servi en réponse
                HTTP.
     [Rem] : Ne pas utiliser en dehors de ce module.                           *)
 (* ************************************************************************** *)
-value print_image_type fname c_type  =
+value print_image_type fname ctype  =
   match try Some (Secure.open_in_bin fname) with [ Sys_error _ -> None ] with
   [ Some ic ->
       let buf = Bytes.create 1024 in
       let len = in_channel_length ic in
       do {
-        content c_type len fname;
+        content ctype len fname;
         let rec loop len =
           if len = 0 then ()
           else do {
@@ -67,10 +69,10 @@ value print_image_type fname c_type  =
 (* ************************************************************************** *)
 value print_image_file fname =
   List.exists
-    (fun (suff, itype, c_type) ->
+    (fun (suff, itype, ctype) ->
        if Filename.check_suffix fname suff ||
           Filename.check_suffix fname (String.uppercase suff) then
-         print_image_type fname c_type
+         print_image_type fname ctype
        else False)
     [(".png", "png", "image/png"); 
      (".jpg", "jpeg", "image/jpeg");
@@ -113,8 +115,10 @@ value print_source_image conf f =
   let fname =
     if f.[0] = '/' then String.sub f 1 (String.length f - 1) else f
   in
-  let fname = Util.source_image_file_name conf.bname fname in
-  if print_image_file fname then ()
+  (* TODO remove Filename.basename to handle sub_dirs *)
+  if fname = Filename.basename fname then
+    let fname = Util.source_image_file_name conf.bname fname in
+    if print_image_file fname then () else Hutil.incorrect_request conf
   else Hutil.incorrect_request conf
 ;
 

--- a/src/request.ml
+++ b/src/request.ml
@@ -627,15 +627,6 @@ value family_m conf base =
       match p_getenv conf.env "v" with
       [ Some f -> Srcfile.print_source conf base f
       | _ -> Hutil.incorrect_request conf ]
-  | Some "TXT" ->
-      match p_getenv conf.env "s" with
-      [ Some f ->
-          let f =
-            if String.sub f (String.length f - 4) 4 = ".txt" then
-              String.sub f 0 (String.length f - 4)
-            else f
-          in
-          Srcfile.print_source conf base f ]
   | Some "STAT" -> BirthDeath.print_statistics conf base
   | Some "CHANGE_WIZ_VIS" when conf.wizard ->
       Wiznotes.change_wizard_visibility conf base
@@ -904,7 +895,14 @@ value treat_request conf base = do {
   [ (Some s, _, _) -> print_moved conf base s
   | (_, Some "no_index", _) -> print_no_index conf base
   | (_, _, Some "IM") -> Image.print conf base
-  | (_, _, Some "DOC") -> Image.print conf base
+  | (_, _, Some "DOC") -> 
+    match p_getenv conf.env "s" with
+    [ Some f ->
+      if String.sub f (String.length f - 4) 4 = ".txt" then
+        (* remove the .txt ext as needed by Srcfile.print_source *)
+        let f = String.sub f 0 (String.length f - 4) in
+          Srcfile.print_source conf base f
+      else Image.print conf base ]  
   | _ ->
       do {
         set_owner conf;

--- a/src/srcfile.ml
+++ b/src/srcfile.ml
@@ -176,14 +176,15 @@ value any_lang_file_name fname =
 value source_file_name conf fname =
   let bname = conf.bname in
   let lang = conf.lang in
+  (* TODO deal with Filename.basename to handle sub_dirs *)
   let fname1 =
     List.fold_right Filename.concat [Util.base_path ["src"] bname; lang]
-      (fname ^ ".txt")
+      (Filename.basename fname ^ ".txt")
   in
   if Sys.file_exists fname1 then fname1
   else
     Filename.concat (Util.base_path ["src"] bname)
-      (fname ^ ".txt")
+      (Filename.basename fname ^ ".txt")
 ;
 
 value digit =


### PR DESCRIPTION
…= m=SRC;v=file

I suppressed the code that allowed sub_dirs and left a TODO note.
I also suppressed m=TXT and replaced it by m=DOC;s=file.txt