### PR TITLE
m=DOC;s=file.ext for images, pdf, html and text. m=DOC;s=file.txt is …

### DIFF
--- a/src/request.ml
+++ b/src/request.ml
@@ -895,6 +895,14 @@ value treat_request conf base = do {
   [ (Some s, _, _) -> print_moved conf base s
   | (_, Some "no_index", _) -> print_no_index conf base
   | (_, _, Some "IM") -> Image.print conf base
+  | (_, _, Some "DOC") -> 
+    match p_getenv conf.env "s" with
+      [ Some f ->
+        if Filename.check_suffix f ".txt" then
+          (* remove the .txt ext as needed by Srcfile.print_source *)
+          let f = Filename.chop_suffix f ".txt" in
+          Srcfile.print_source conf base f
+        else Image.print conf base ]  
   | _ ->
       do {
         set_owner conf;

--- a/src/srcfile.ml
+++ b/src/srcfile.ml
@@ -176,6 +176,7 @@ value any_lang_file_name fname =
 value source_file_name conf fname =
   let bname = conf.bname in
   let lang = conf.lang in
+  (* TODO deal with Filename.basename to handle sub_dirs *)
   let fname1 =
     List.fold_right Filename.concat [Util.base_path ["src"] bname; lang]
       (Filename.basename fname ^ ".txt")


### PR DESCRIPTION
…equivalent to  m=SRC;v=file

I have removed the part about sub-dirs.
I suppressed m=TXT and folded it into m=DOC;s=file.txt