### PR TITLE
Revert "mybase.gwb/params.gwf" in setup.ml + Copyright year

### DIFF
--- a/etc/LISEZMOI.txt
+++ b/etc/LISEZMOI.txt
@@ -17,7 +17,7 @@ changements par rapport aux versions precedentes.
 
      -----------------
 
-GeneWeb est Copyright (c) 1998-2016 INRIA.
+GeneWeb est Copyright (c) 1998-2017 INRIA.
 Créateur d'origine Daniel de Rauglaudre
 
 Remarques, suggestions, questions, rapports d'erreur sur:

--- a/etc/README.txt
+++ b/etc/README.txt
@@ -17,7 +17,7 @@ the previous versions.
 
      -----------------
 
-GeneWeb is Copyright (c) 1998-2016 INRIA.
+GeneWeb is Copyright (c) 1998-2017 INRIA.
 Original creator Daniel de Rauglaudre
 
 Remarks, suggestions, questions, bug reports to:

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -118,7 +118,7 @@ value trailer conf =
     Wserver.printf "<hr />\n";
     Wserver.printf "<div>\n";
     Wserver.printf "<em>\n";
-    Wserver.printf "<a href=\"https://github.com/geneweb/geneweb/\"><img src=\"images/logo_bas.png\" align=\"absmiddle\" style = \"border: 0\" /></a> Version %s Copyright &copy 1998-2016\n</em>\n" Version.txt;
+    Wserver.printf "<a href=\"https://github.com/geneweb/geneweb/\"><img src=\"images/logo_bas.png\" align=\"absmiddle\" style = \"border: 0\" /></a> Version %s Copyright &copy 1998-2017\n</em>\n" Version.txt;
     Wserver.printf "</div>\n" ;
     Wserver.printf "</div>\n" ;
     (* finish the html page *)

--- a/setup/setup.ml
+++ b/setup/setup.ml
@@ -783,9 +783,8 @@ value print_default_gwf_file conf =
   in
   let bname = try List.assoc "o" conf.env with [ Not_found -> "" ] in
   let dir = Sys.getcwd () in
-  let fname =
-    List.fold_left Filename.concat dir [(bname ^ ".gwb"); "params.gwf"]
-  in  if Sys.file_exists fname then ()
+  let fname = Filename.concat dir (bname ^ ".gwf") in
+  if Sys.file_exists fname then ()
   else do {
     let oc = open_out fname in
     List.iter (fun s -> fprintf oc "%s\n" s) gwf;
@@ -1425,7 +1424,7 @@ value rec cut_at_equal s =
 ;
 
 value read_base_env bname =
-  let fname = Filename.concat (bname ^ ".gwb") "params.gwf" in
+  let fname = bname ^ ".gwf" in
   match try Some (open_in fname) with [ Sys_error _ -> None ] with
   [ Some ic ->
       let env =
@@ -1511,7 +1510,7 @@ value gwf_1 conf =
   let benv = read_base_env in_base in
   let (vars, files) = variables "gwf_1.htm" in
   do {
-    let oc = open_out (Filename.concat (in_base ^ ".gwb") "params.gwf") in
+    let oc = open_out (in_base ^ ".gwf") in
     let body_prop =
       match p_getenv conf.env "proposed_body_prop" with
       [ Some "" | None -> s_getenv conf.env "body_prop"


### PR DESCRIPTION
- Revert "mybase.gwb/params.gwf" in setup.ml (see https://github.com/geneweb/geneweb/issues/530)
- Change copyright year to 2017 for setup.ml, README.txt and LISEZMOI.txt

Compiled (with Linux) and tested.