### PR TITLE
camlp5_depend.sh: new approach to remove backslashes and CR

### DIFF
--- a/tools/camlp5_depend.sh
+++ b/tools/camlp5_depend.sh
@@ -60,6 +60,9 @@ for FILE in $FILES; do
       COMMAND="camlp5r $CAMLP5_LOAD_OPTIONS -- $CAMLP5_OTHER_OPTIONS $FILE";;
     esac
     echo $COMMAND $FILE >&2
-    # camlp5 on Windows generates backslashes -> replace them with slashes
-    $COMMAND $FILE | sed "s/[\\\\]\(.\)/\/\\1/g"
+    # camlp5 on Windows generates backslashes and carriage returns
+    # the first sed command removes all carriage returns (\x0D)
+    # the second sed command replaces all single backslashes by slashes,
+    # except those located at the end of a line. $ is required for macOS
+    $COMMAND $FILE | sed -e $'s/\x0D//' -e 's/\\\(.\)/\/\1/g'
 done


### PR DESCRIPTION
=> To fix compilation with windows + cygwin

See: https://github.com/geneweb/geneweb/issues/531