### PR TITLE
Fix Secure.decompose for absolute paths with drive letters in windows

### DIFF
--- a/src/secure.ml
+++ b/src/secure.ml
@@ -12,7 +12,7 @@ value base_dir_r = ref Filename.current_dir_name;
 value decompose =
   loop [] where rec loop r s =
     let b = Filename.basename s in
-    if b = "" || b = Filename.current_dir_name then
+    if b = "" || b = Filename.current_dir_name || b = Filename.dir_sep then
       let d = Filename.dirname s in
       if d = "" || d = Filename.current_dir_name then r
       else if d = s then [d :: r]


### PR DESCRIPTION
See : https://github.com/geneweb/geneweb/issues/423

For discussion purpose, I'm not sure 100% about the approach (is there some side effects?) and with the coding style