### PR TITLE
Templates : déplacement de l'appel au sous programme Image_MF + petits correctifs

### DIFF
--- a/hd/etc/perso_module/arbre_horizontal.txt
+++ b/hd/etc/perso_module/arbre_horizontal.txt
@@ -10,6 +10,7 @@
 %end;
 
 %define;access(num,nnn)
+  %apply;image_MF("nnn")
   %if;(evars=1)num%end; %apply;display_sosa("nnn")%nn;
   %if;("num" = 1)
     %nnn;%nnn.title;%nnn.dates;<br>

--- a/hd/etc/perso_module/chronologie.txt
+++ b/hd/etc/perso_module/chronologie.txt
@@ -117,7 +117,6 @@
     %if;(event_witness_kind = [kindx]0)
       %incr_count;
       <span class="text-nowrap">%nn;
-      %apply;image_MF("event_witness")%nn;
       %apply;short_display_person("event_witness")%nn;
       </span>%nn;
       %if;(count=k_cnt).
@@ -176,7 +175,7 @@
     %and;%apply;dprec("ccc.birth_date")%nn;
     %and;%count2;
     %and;%if;(ccc.birth_date!="")%ccc.birth_date;%else;([missing date]0)%end;%nn;
-    %and;%apply;a_of_b%with;[birth]%and;%if;ccc.is_male;[labl]0%elseif;ccc.is_female;[labl]1%else;[labl]2%end;%end;%sp;%apply;image_MF("ccc")%apply;short_display_person("ccc")%nn;
+    %and;%apply;a_of_b%with;[birth]%and;%if;ccc.is_male;[labl]0%elseif;ccc.is_female;[labl]1%else;[labl]2%end;%end;%sp;%apply;short_display_person("ccc")%nn;
     %and;%nn;
     %and;%nn;
     %and;%(debug sort: %ccc.birth_date.year;%apply;month("ccc.birth_date")%apply;day("ccc.birth_date")%apply;dprec("ccc.birth_date"),%)%nn;
@@ -197,7 +196,7 @@
       %and;%apply;dprec("ccc.death_date")%nn;
       %and;%count2;
       %and;%if;(ccc.death_date!="")%ccc.death_date;%else;([missing date]0)%end;%nn;
-      %and;%apply;a_of_b%with;[death]%and;%if;ccc.is_male;[labl]0%elseif;ccc.is_female;[labl]1%else;[labl]2%end;%end;%sp;%apply;image_MF("ccc")%apply;short_display_person("ccc")%if;(ccc.computable_death_age)%sp;(%ccc.death_age;)%end;%nn;
+      %and;%apply;a_of_b%with;[death]%and;%if;ccc.is_male;[labl]0%elseif;ccc.is_female;[labl]1%else;[labl]2%end;%end;%sp;%apply;short_display_person("ccc")%if;(ccc.computable_death_age)%sp;(%ccc.death_age;)%end;%nn;
       %and;%nn;
       %and;%nn;
       %and;%(debug sort: %ccc.birth_date.year;%apply;month("ccc.birth_date")%apply;day("ccc.birth_date")%apply;dprec("ccc.birth_date"),%)%nn;
@@ -318,7 +317,7 @@
       %and;%apply;dprec("related.baptism_date")%nn;
       %and;%count2;
       %and;%if;(related.baptism_date!="")%related.baptism_date;%else;([missing date]0)%end;%nn;
-      %and;%related_type;[:]%sp;%apply;image_MF("related")%apply;short_display_person("related")%nn;
+      %and;%related_type;[:]%sp;%apply;short_display_person("related")%nn;
       %and;%related.baptism_place;%nn;
       %and;%nn;
       %and;%related.baptism_note;%nn;
@@ -338,7 +337,7 @@
         %and;2%nn;
         %and;%count2;
         %and;([missing date]0)%nn;
-        %and;%relation_type;[:]%sp;%apply;image_MF("relation_him")%apply;short_display_person("relation_him")%sp;%apply;image_MF("relation_her")%apply;short_display_person("relation_her")%nn;
+        %and;%relation_type;[:]%sp;%apply;short_display_person("relation_him")%sp;%apply;short_display_person("relation_her")%nn;
         %and;%nn;
         %and;%nn;
         %and;%nn;
@@ -354,7 +353,7 @@
         %and;2%nn;
         %and;%count2;
         %and;([missing date]0)%nn;
-        %and;%relation_type;[:]%sp;%apply;image_MF("relation_him")%apply;short_display_person("relation_him")%nn;
+        %and;%relation_type;[:]%sp;%apply;short_display_person("relation_him")%nn;
         %and;%nn;
         %and;%nn;
         %and;%nn;
@@ -370,7 +369,7 @@
         %and;2%nn;
         %and;%count2;
         %and;([missing date]0)%nn;
-        %and;%relation_type;[:]%sp;%apply;image_MF("relation_her")%apply;short_display_person("relation_her")%nn;
+        %and;%relation_type;[:]%sp;%apply;short_display_person("relation_her")%nn;
         %and;%nn;
         %and;%nn;
         %and;%nn;
@@ -392,9 +391,9 @@
       %and;%if;(event_witness_relation.event.date!="")%event_witness_relation.event.date;%else;([missing date]0)%end;%nn;
       %and;%apply;a_of_b%with;%apply;a_of_b%with;%event_witness_relation_kind;%and;
         %sp;%event_witness_relation.event.name;%end;%and;
-          %apply;image_MF("event_witness_relation.person")%apply;short_display_person("event_witness_relation.person")%sp;
+          %apply;short_display_person("event_witness_relation.person")%sp;
           %if;(event_witness_relation.event.spouse != "")
-            %sp;[and]%sp;%apply;image_MF("event_witness_relation.event.spouse")%apply;short_display_person("event_witness_relation.event.spouse")%nn;
+            %sp;[and]%sp;%apply;short_display_person("event_witness_relation.event.spouse")%nn;
           %end;%end;%nn;
       %and;%nn;
       %and;%nn;
@@ -414,7 +413,7 @@
         %and;%apply;dprec("father.death_date")%nn;
         %and;%count2;
         %and;%if;(father.death_date!="")%father.death_date;%else;([missing date]0)%end;%nn;
-        %and;%apply;a_of_b%with;[death]%and;[father/mother]0%end;%apply;image_MF("father")%apply;short_display_person("father")%if;(father.computable_death_age)%sp;(%father.death_age;)%end;%nn;%nn;
+        %and;%apply;a_of_b%with;[death]%and;[father/mother]0%end;%apply;short_display_person("father")%if;(father.computable_death_age)%sp;(%father.death_age;)%end;%nn;%nn;
         %and;%nn;
         %and;%nn;
         %and;%nn;
@@ -431,7 +430,7 @@
         %and;%apply;dprec("mother.death_date")%nn;
         %and;%count2;
         %and;%if;(mother.death_date!="")%mother.death_date;%else;([missing date]0)%end;%nn;
-        %and;%apply;a_of_b%with;[death]%and;[father/mother]1%end;%apply;image_MF("mother")%apply;short_display_person("mother")%if;(mother.computable_death_age)%sp;(%mother.death_age;)%end;%nn;%nn;
+        %and;%apply;a_of_b%with;[death]%and;[father/mother]1%end;%if;(mother.computable_death_age)%sp;(%mother.death_age;)%end;%nn;%nn;
         %and;%nn;
         %and;%nn;
         %and;%nn;
@@ -462,7 +461,7 @@
           %and;%apply;dprec("spouse.death_date")%nn;
           %and;%count2;
           %and;%if;(spouse.death_date!="")%spouse.death_date;%else;([missing date]0)%end;%nn;
-          %and;%apply;a_of_b%with;[death]%and;%if;spouse.is_male;[the spouse]0%else;[the spouse]1%end;%end;%apply;image_MF("spouse")%apply;short_display_person("spouse")%if;(spouse.computable_death_age)%sp;(%spouse.death_age;)%end;%nn;
+          %and;%apply;a_of_b%with;[death]%and;%if;spouse.is_male;[the spouse]0%else;[the spouse]1%end;%end;%apply;short_display_person("spouse")%if;(spouse.computable_death_age)%sp;(%spouse.death_age;)%end;%nn;
           %and;%nn;
           %and;%nn;
           %and;%nn;
@@ -529,19 +528,19 @@
                         %foreach;relation;
                           %if;(has_relation_him and has_relation_her)
                             %if;(relation_type=[godfather/godmother/godparents]2)
-                              <span class="text-nowrap">[*godfather/godmother/godparents]0[:]%apply;image_MF("relation_him")%nn;
+                              <span class="text-nowrap">[*godfather/godmother/godparents]0[:]%nn;
                               %apply;short_display_person("relation_him").</span><br>
-                              <span class="text-nowrap">[*godfather/godmother/godparents]1[:]%apply;image_MF("relation_her")%nn;
+                              <span class="text-nowrap">[*godfather/godmother/godparents]1[:]%nn;
                               %apply;short_display_person("relation_her").</span>
                             %end;
                           %elseif;has_relation_him;
                             %if;(relation_type=[godfather/godmother/godparents]0)
-                              <span class="text-nowrap">%apply;capitalize(relation_type)[:]%apply;image_MF("relation_him")%nn;
+                              <span class="text-nowrap">%apply;capitalize(relation_type)[:]%nn;
                               %apply;short_display_person("relation_him").</span>
                             %end;
                           %elseif;has_relation_her;
                             %if;(relation_type=[godfather/godmother/godparents]1)
-                              <span class="text-nowrap">%apply;capitalize(relation_type)[:]%apply;image_MF("relation_her")%nn;
+                              <span class="text-nowrap">%apply;capitalize(relation_type)[:]%nn;
                               %apply;short_display_person("relation_her").</span>
                             %end;
                           %end;

--- a/hd/etc/perso_module/chronologie.txt
+++ b/hd/etc/perso_module/chronologie.txt
@@ -430,7 +430,7 @@
         %and;%apply;dprec("mother.death_date")%nn;
         %and;%count2;
         %and;%if;(mother.death_date!="")%mother.death_date;%else;([missing date]0)%end;%nn;
-        %and;%apply;a_of_b%with;[death]%and;[father/mother]1%end;%if;(mother.computable_death_age)%sp;(%mother.death_age;)%end;%nn;%nn;
+        %and;%apply;a_of_b%with;[death]%and;[father/mother]1%end;%apply;short_display_person("mother")%if;(mother.computable_death_age)%sp;(%mother.death_age;)%end;%nn;%nn;
         %and;%nn;
         %and;%nn;
         %and;%nn;

--- a/hd/etc/perso_module/fratrie.txt
+++ b/hd/etc/perso_module/fratrie.txt
@@ -247,7 +247,6 @@
         %if;(parent.nb_families>1)
           <td style="width:47%%">
             %apply;display_shared_parent%with;
-            %apply;image_MF("parent")
             %apply;short_display_person("parent")%end;
           </td>
         %end;

--- a/hd/etc/perso_module/individu.txt
+++ b/hd/etc/perso_module/individu.txt
@@ -150,6 +150,7 @@
 
 %if;(evar.m!="MOD_IND")
   <h1 class="%if;(p_mod="" or p_mod="zz")col-12%end; %if;(op_m=2)text-center%end;">
+    %apply;image_MF("self")
     %if;has_public_name;
       %if;has_qualifiers;%public_name; <em>%qualifier;</em>
       %else;%public_name; %surname;%end;

--- a/hd/etc/perso_module/parents.txt
+++ b/hd/etc/perso_module/parents.txt
@@ -44,7 +44,6 @@
     %if;(op_m=4)
       %apply;long_display_person("mother")%sp;
     %elseif;(op_m=5)
-      %apply;image_MF("mother")
       %apply;display_horizontal("mother")
     %end;
     %foreach;father.family;

--- a/hd/etc/perso_module/relations.txt
+++ b/hd/etc/perso_module/relations.txt
@@ -87,30 +87,25 @@
       <li>%apply;capitalize(relation_type)[:]%nl;
         <ul>
           %apply;li_SDC("relation_him")
-            %apply;image_MF("relation_him")
             %apply;short_display_person("relation_him")
           </li>
           %apply;li_SDC("relation_her")
-            %apply;image_MF("relation_her")
             %apply;short_display_person("relation_her")
           </li>
         </ul>
       </li>
     %elseif;has_relation_him;
       %apply;li_SDC("relation_him")%apply;capitalize(relation_type)[:]%sp;
-        %apply;image_MF("relation_him")
         %apply;short_display_person("relation_him")
       </li>
     %elseif;has_relation_her;
       %apply;li_SDC("relation_her")%apply;capitalize(relation_type)[:]%sp;
-        %apply;image_MF("relation_her")
         %apply;short_display_person("relation_her")
       </li>
     %end;
   %end;
   %foreach;related;
     %apply;li_SDC("related")%apply;capitalize(related_type)[:]%sp;
-      %apply;image_MF("related")
       %apply;short_display_person("related")
     </li>
   %end;

--- a/hd/etc/perso_module/unions.txt
+++ b/hd/etc/perso_module/unions.txt
@@ -197,7 +197,6 @@
           <ul>
             %foreach;child;
               %apply;li_SDC("child")
-                %apply;image_MF("child")
                 %if;(bvar.always_surname="yes")
                   %apply;short_display_person("child")
                 %else;
@@ -429,7 +428,6 @@
           <ul>
             %foreach;child;
               %apply;li_SDC("child")
-                %apply;image_MF("child")
                 %if;(bvar.always_surname="yes")
                   %apply;short_display_person("child")
                 %else;
@@ -472,9 +470,7 @@
         %apply;long_display_person("spouse")
         %if;spouse.has_parents;
           <span style="font-size: 90%%"><em> ([parents][:]
-            %apply;image_MF("spouse.father")
-            %apply;short_display_person("spouse.father")%sp;
-            & %apply;image_MF("spouse.mother")
+            %apply;short_display_person("spouse.father") &%sp;
             %apply;short_display_person("spouse.mother"))</em>%nn;
           </span>%nn;
         %end;
@@ -482,7 +478,6 @@
           &nbsp;([witness/witnesses]w[:]
           %foreach;witness;
             %if;not is_first;, %end;
-            %apply;image_MF("witness")
             %apply;short_display_person("witness")
           %end;)
         %end;
@@ -501,7 +496,6 @@
           <ul>
             %foreach;child;
               %apply;li_SDC("child")
-                %apply;image_MF("child")
                 %apply;short_display_person("child")
                 %if;child.has_families;
                   %foreach;child.family;
@@ -517,7 +511,6 @@
                         <ul>
                           %foreach;child;
                             %apply;li_SDC("child")
-                              %apply;image_MF("child")
                               %apply;short_display_person("child")
                               %if;child.has_families;
                                 %foreach;child.family;
@@ -533,7 +526,6 @@
                                       <ul>
                                         %foreach;child;
                                           %apply;li_SDC("child")
-                                            %apply;image_MF("child")
                                             %apply;short_display_person("child")
                                           </li>
                                         %end;
@@ -577,13 +569,10 @@
               <td style="vertical-align: middle">
         %end;
         %apply;long_married_f("self", "UPPER")%sp;
-        %apply;image_MF("spouse")
         %apply;display_horizontal("spouse")
         <span style="font-size: 90%%">
           %if;spouse.has_parents;<em> ([parents][:]
-            %apply;image_MF("spouse.father")
-            %apply;short_display_person_f("spouse.father")%sp;
-            & %apply;image_MF("spouse.mother")
+            %apply;short_display_person_f("spouse.father") &%sp;
             %apply;short_display_person_f("spouse.mother"))</em>%nn;
           %end;
         </span>%nn;
@@ -610,7 +599,6 @@
                       </td>
                       <td style="vertical-align: middle">
                 %end;
-                %apply;image_MF("child")
                 %apply;short_display_person_f("child")
                 %if;child.has_families;
                   %foreach;child.family;
@@ -619,7 +607,6 @@
                         src="%image_prefix;/1pixel.png" alt="1px" title=""%/>%sp;
                       <em>%child;%child.title;%child.dates;</em>%end;
                     <em>&nbsp;%apply;long_married_f("child", "lower")</em>
-                    %apply;image_MF("spouse")
                     %apply;short_display_person_f("spouse")%nn;
                     %if;are_divorced; [divorced]0%divorce_date;%end;
                     %if;are_separated; [separated]0%end;
@@ -630,7 +617,6 @@
                         <ul>
                           %foreach;child;
                             %apply;li_SDC("child")
-                              %apply;image_MF("child")
                               %apply;short_display_person_f("child")
                               %if;child.has_families;
                                 %foreach;child.family;
@@ -639,7 +625,6 @@
                                             src="%image_prefix;/1pixel.png" alt="1px" title=""%/>
                                     <em>%child;%child.title;%child.dates;</em>%nl;%end;
                                   <em>&nbsp;%apply;long_married_f("child", "lower")</em>
-                                  %apply;image_MF("spouse")
                                   %apply;short_display_person_f("spouse")
                                   %if;are_divorced; [divorced]0%divorce_date;%end;
                                   %if;are_separated; [separated]0%end;
@@ -648,7 +633,6 @@
                                     <div style="font-size: 90%%">%nn;
                                       %foreach;child;
                                         %if;(child_cnt!=1) , %end;
-                                          %apply;image_MF("child")
                                           %apply;short_display_person_f("child")
                                       %end;
                                     </div>

--- a/hd/etc/perso_utils.txt
+++ b/hd/etc/perso_utils.txt
@@ -51,7 +51,7 @@
 
 %define;image_MF(xx)
   %if;(wizard and not cancel_links)
-    <a href="%prefix;m=MOD_IND;i=%xx.index;" title="[*modify::] %xx.first_name;%if;(xx.occ!="0").%xx.occ;%end; %xx.surname;">
+    <a href="%prefix;m=MOD_IND;i=%xx.index;" title="[*modify::] %xx.first_name;%if;(xx.occ!="0").%xx.occ;%end; %xx.surname;">%nn;
   %end;
   %if;xx.is_male;
     <i class="fa fa-mars male mr-1"></i>%nn;
@@ -196,6 +196,7 @@
 %end;
 
 %define;short_display_person(xx)
+  %apply;image_MF("xx")
   %apply;display_sosa("xx")
   %if;(xx.index=central_index)<b>%xx;</b>%else;
     %if;(cancel_links or xx.is_restricted)%xx;
@@ -206,7 +207,8 @@
 %end;
 
 %define;short_display_person_tree(xx)
-  %if;(xx.has_sosa)%apply;display_sosa("xx")<br>%end;
+  %apply;image_MF("xx")
+  %apply;display_sosa("xx")
   %if;(cancel_links or xx.is_restricted)<span class="text-nowrap">%if;(xx.public_name!="")%xx.public_name;</span>%else;%xx.first_name;</span>%end;<br><span class="text-nowrap">%xx.surname;</span>
   %else;<a %apply;ext_link("xx") href="%xx.bname_prefix;%xx.access;;%if;(evar.t!="")t=%evar.t;;%end;%if;(evar.v!="")v=%evar.v;;%end;%if;(evar.image="on")image=on;%end;%if;(evar.marriage="on")marriage=on;%end;"><span class="text-nowrap">%if;(xx.public_name!="")%xx.public_name;</span>%else;%xx.first_name;</span>%end;<br><span class="text-nowrap">%xx.surname;</span></a>%nn;
   %end;
@@ -224,6 +226,7 @@
 %end;
 
 %define;short_display_person_noname(xx,yy,zz,uu)
+  %apply;image_MF("xx")
   %apply;display_sosa("xx")
   %if;(xx.index=central_index)<b>%if;(xx.surname=father.surname)%if;(xx.public_name!="")%xx.public_name;%else;%xx.first_name;%end;%else;%xx;%end;</b>%else;
     %if;(cancel_links or xx.is_restricted)%if;(bvar.always_surname!="yes" and xx.surname=father.surname)%if;(xx.public_name!="")%xx.public_name;%else;%xx.first_name;%end;%else;%xx;%end;%nn;
@@ -252,6 +255,7 @@
 %end;
 
 %define;very_short_display_person(xx)
+  %apply;image_MF("xx")
   %apply;display_sosa("xx")
   %if;(xx.index=central_index)<b>%xx;</b>%else;
     %if;(cancel_links or xx.is_restricted)%xx;
@@ -260,6 +264,7 @@
 %end;
 
 %define;very_short_display_person_name(xx)
+  %apply;image_MF("xx")
   %apply;display_sosa("xx")
   %if;(xx.index=central_index)<b>%xx_name;</b>%else;
     %if;(cancel_links or xx.is_restricted)%xx_name;
@@ -268,6 +273,7 @@
 %end;
 
 %define;long_display_person(xx)
+  %apply;image_MF("xx")
   %apply;display_sosa("xx")
   %if;(xx.index=central_index)<b>%xx;</b>%else;
     %if;(cancel_links or xx.is_restricted)%xx;
@@ -395,6 +401,7 @@
 
 %define;display_horizontal(xx)
   %if;(xx.index!=central_index)
+    %apply;image_MF("xx")
     %apply;display_sosa("xx")
     %if;(cancel_links or xx.is_restricted)%xx;%nn;
     %else;<a href="%prefix;%xx.access;">%xx;</a>%end;%nn;
@@ -461,10 +468,11 @@
 %define;married_to_f(UP_lo, m_f, date_place)
   %if;(wizard and not cancel_links)
     <a href="%prefix;;m=MOD_FAM;i=%family.index;;ip=%index;">%nn;
-      <img class="mb-1" src="%image_prefix;/picto_molette.png"%sp;
-           title="[*modify::family/families]0 [with]%sp;
-           %spouse.first_name;%if;(spouse.occ!=0).%spouse.occ;%end; %spouse.surname;"%sp;
-           height="13" width="13" alt="[*modify::family/families]0"%/>%nn;
+      <i class="fa fa-wrench%sp;
+        %if;(m_f=0)male%elseif;(m_f=1)female%else;neuter%end;"%sp;
+        title="[*modify::family/families]0 [with]%sp;
+        %spouse.first_name;%if;(spouse.occ!=0).%spouse.occ;%end;%sp;
+        %spouse.surname;"></i>%nn;
     </a>%sp;
   %end;
   %let;marr_text;
@@ -536,21 +544,18 @@
 
 %define;short_display_siblings()
   %apply;li_SDC("child")
-    %apply;image_MF("child")
     %apply;short_display_person("child")%nn;
   </li>
 %end;
 
 %define;short_display_siblings_noname()
   %apply;li_SDC("child")
-    %apply;image_MF("child")
     %apply;short_display_person_noname("child","","","")%nn;
   </li>
 %end;
 
 %define;long_display_siblings()
   %apply;li_SDC("child")
-    %apply;image_MF("child")
     %apply;short_display_person("child")%nn;
     %if;child.has_families;
       %foreach;child.family;
@@ -577,7 +582,6 @@
           </td>
           <td style="vertical-align: middle">
     %end;
-    %apply;image_MF("child")
     %apply;short_display_person_f("child")
     %if;child.has_families;
       %foreach;child.family;
@@ -586,7 +590,6 @@
           <em>%child;%child.title;%child.dates;</em>
         %end;
         <em>%apply;long_married_f("child", "lower")</em>
-        %apply;image_MF("spouse")
         %apply;short_display_person_f("spouse")
       %end;
     %end;
@@ -607,7 +610,6 @@
           <tr>
             <td style="vertical-align: middle">
               [with]
-              %apply;image_MF("spouse")
               %apply;short_display_person("spouse")
             </td>
             <td style="vertical-align: middle">
@@ -618,7 +620,6 @@
         </table>
       %else;
         [with]
-        %apply;image_MF("spouse")
         %apply;short_display_person("spouse")
       %end;
       %if;has_children;

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -189,7 +189,7 @@ function changeCalendar(e,v,m,c) {
 
 %define;date(xlab,xvar,xdt,xcond)
   %let;day_input;pattern="(?:0?[1-9]|1[0-9]|2[0-9]|3[0-1])" size="1" maxlength="2" xcond%in;
-  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VR|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC)" size="1" maxlength="2" xcond%in;
+  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VD|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC)" size="1" maxlength="2" xcond%in;
   %let;year_input;pattern="[?><~/]?-?\d*/?" size="4" maxlength="8" xcond%in;
   <div class="row justify-content-sm-between justify-content-md-start">
     <div class="col-sm-1 col-md-2 col-form-label">
@@ -352,7 +352,7 @@ function changeCalendar(e,v,m,c) {
 
 %define;small_date(kind,xvar,xx,verbose)
   %let;day_input;pattern="(?:0?[1-9]|1[0-9]|2[0-9]|3[0-1])" size="1" maxlength="2"%in;
-  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VR|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC)" size="1" maxlength="2"%in;
+  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VD|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC)" size="1" maxlength="2"%in;
   %let;year_input;pattern="[?><~/]?-?\d*/?" size="4" maxlength="8"%in;
   <div class="row">
     <span class="col-sm-2 col-form-label">[*kind]</span>

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -249,7 +249,7 @@ function changeCalendar(e,v,m,c) {
 
 %define;date(xlab,xvar,xdt,xcond)
   %let;day_input;pattern="(?:0?[1-9]|1[0-9]|2[0-9]|3[0-1])" size="1" maxlength="2" xcond%in;
-  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VR|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC)" size="1" maxlength="2" xcond%in;
+  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VD|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC)" size="1" maxlength="2" xcond%in;
   %let;year_input;pattern="[?><~/]?-?\d*/?" size="4" maxlength="8" xcond%in;
   <div class="row justify-content-sm-between justify-content-md-start">
     <div class="col-sm-1 col-md-2 col-form-label">


### PR DESCRIPTION
- Depuis la disparition du second paramètre du sous programme template
image_MF, il est souhaitable que tous les appels à ce sous-programme
soient faits le plus haut possible dans les divers composants des
templates.
- Remplacement de l'image picto-molette.png par une class
defont-awesome.min.css
- Rectification VR en VD pour Vendémiaire dans les formulaires de MAJ
updind.txt et updfam.txt

Voir #553 et #517