### PR TITLE
Remove standard fields from updind template interface [WIP]

### DIFF
--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -716,7 +716,7 @@ function changeCalendar(e,v,m,c) {
             %end;
             <option value="NotDead" %if;not_dead; selected%end;>[*alive]</option>
             <option value="DontKnowIfDead" %if;(dont_know_if_dead and has_birth_date)%sp;selected%end;>[*don't know]0%nl;</option>
-            <option value="Death" %if;(death.year != "" or death.text != "" or dead_dont_know_when) selected%end;>[*died]2...</option>
+            <option value="Death" %if;(has_pevent_death or dead_dont_know_when) selected%end;>[*died]2...</option>
             <option value="DeadYoung" %if;died_young; selected%end;>[*died young]2</option>
             <option value="OfCourseDead" %if;of_course_dead; selected%end;>[*of course dead]</option>
           </select>
@@ -797,7 +797,7 @@ function changeCalendar(e,v,m,c) {
           %end;
           <option value="NotDead" %if;not_dead;selected%end;>[*alive]2</option>
           <option value="DontKnowIfDead" %if;(dont_know_if_dead and has_birth_date)%sp;selected%end;>[*don't know]0%nl;</option>
-          <option value="Death" %if;(death.year != "" or death.text != "" or dead_dont_know_when) selected%end;>[*died]2</option>
+          <option value="Death" %if;(has_pevent_death or dead_dont_know_when) selected%end;>[*died]2</option>
           <option value="DeadYoung" %if;died_young; selected%end;>[*died young]2</option>
           <option value="OfCourseDead" %if;of_course_dead; selected%end;>[*of course dead]</option>
         </select>
@@ -1084,20 +1084,6 @@ function changeCalendar(e,v,m,c) {
   <div class="card">
     %apply;card_header("birth")
     <div class="card-block">
-      <div style="display:none;">
-        <table style="border-width:1;width:700">
-          <tr>
-            <td>[*born]2...</td>
-            <td><label for="birth_place">[*place]</label></td>
-            <td>
-              <input type="text" name="birth_place" size="90" maxlength="200" value="%birth_place;" id="birth_place"%/>
-            </td>
-          </tr>
-        </table>
-        %apply;date([*date/dates]0, "birth", "birth", "")
-        %apply;note("birth")
-        %apply;source("birth")
-      </div>
       %if;has_pevent_birth;
         %foreach;pevent;
           %apply;one_specific_pevent(cnt, "#birt")
@@ -1112,20 +1098,6 @@ function changeCalendar(e,v,m,c) {
   <div class="card">
     %apply;card_header("baptism")
     <div class="card-block">
-      <div style="display:none;">
-        <table style="border-width:1;width:700">
-          <tr>
-            <td>[*baptized]2...</td>
-            <td><label for="bapt_place">[*place]</label></td>
-            <td>
-              <input type="text" name="bapt_place" size="90" maxlength="200" value="%bapt_place;" id="bapt_place"%/>
-            </td>
-          </tr>
-        </table>
-        %apply;date([*date/dates]0, "bapt", "bapt", "")
-        %apply;note("bapt")
-        %apply;source("bapt")
-      </div>
       %if;has_pevent_baptism;
         %foreach;pevent;
           %apply;one_specific_pevent(cnt, "#bapt")
@@ -1140,48 +1112,6 @@ function changeCalendar(e,v,m,c) {
   <div class="card">
     %apply;card_header("death")
     <div class="card-block">
-      <div style="display:none;">
-        <table style="border-width:1;width:700">
-          <tr>
-            <td>
-              <select name="old_death" id="death_selectxcnt" onchange="change_death('xcnt')">
-                %if;(not has_birth_date and dont_know_if_dead)
-                  <option value="Auto" selected> -</option>
-                %end;
-                <option value="NotDead" %if;not_dead; selected%end;>[*alive]2</option>
-                <option value="DontKnowIfDead" %if;(dont_know_if_dead and has_birth_date)%sp;selected%end;>[*don't know]0%nl;</option>
-                <option value="Death" %if;(death.year != "" or death.text != "" or dead_dont_know_when) selected%end;>[*died]2</option>
-                <option value="DeadYoung" %if;died_young; selected%end;>[*died young]2</option>
-                <option value="OfCourseDead" %if;of_course_dead; selected%end;>[*of course dead]</option>
-              </select>
-            </td>
-            <td>
-              <label>[*place]0
-                <input type="text" name="death_place" size="90" maxlength="200" value="%death_place;" onfocus='setDead()'%/></label>
-            </td>
-          </tr>
-        </table>
-        %apply;date([*date/dates]0, "death", "death", "onfocus='setDead()'")
-        <table style="border-width:1;width:700">
-          <tr>
-            <td>
-              <label>
-                <input type="radio" name="death_reason" value="Killed"%if;dr_killed; checked%end; onclick='set_death_focus(xcnt)'%/>[*killed (in action)]2
-              </label><label>
-                <input type="radio" name="death_reason" value="Murdered"%if;dr_murdered; checked%end; onclick='set_death_focus(xcnt)'%/>[*murdered]2
-              </label><label>
-                <input type="radio" name="death_reason" value="Executed"%if;dr_executed; checked%end; onclick='set_death_focus(xcnt)'%/>[*executed (legally killed)]2
-              </label><label>
-                <input type="radio" name="death_reason" value="Disappeared"%if;dr_disappeared; checked%end; onclick='set_death_focus(xcnt)'%/>[*disappeared]2
-              </label><label>
-                <input type="radio" name="death_reason" value="Unspecified"%if;dr_unspecified; checked%end; onclick='set_death_focus(xcnt)'%/>[*unspecified]2
-              </label>
-            </td>
-          </tr>
-        </table>
-        %apply;note("death")
-        %apply;source("death")
-      </div>
       %if;has_pevent_death;
         %foreach;pevent;
           %apply;one_specific_pevent(cnt, "#deat")
@@ -1196,27 +1126,6 @@ function changeCalendar(e,v,m,c) {
   <div class="card">
     %apply;card_header("burial")
     <div class="card-block">
-      <div style="display:none;">
-        <table style="border-width:1;width:700">
-          <tr>
-            <td>
-              <select name="burial">
-                <option value="UnknownBurial"%if;bt_unknown_burial; selected%end;>-</option>
-                <option value="Buried"%if;bt_buried; selected%end;>[*buried]2</option>
-                <option value="Cremated"%if;bt_cremated; selected%end;>[*cremated]2</option>
-              </select>
-            </td>
-            <td>
-              <label>[*place]0
-                <input type="text" name="burial_place" size="90" maxlength="200" value="%burial_place;"%/>
-              </label>
-            </td>
-          </tr>
-        </table>
-        %apply;date([*date/dates]0, "burial", "burial", "")
-        %apply;note("burial")
-        %apply;source("burial")
-      </div>
       %if;has_pevent_burial;
         %foreach;pevent;
           %apply;one_specific_pevent(cnt, "#buri")

--- a/src/updateInd.ml
+++ b/src/updateInd.ml
@@ -69,42 +69,13 @@ and eval_simple_var conf base env p loc =
   | ["acc_if_titles"] -> bool_val (p.access = IfTitles)
   | ["acc_private"] -> bool_val (p.access = Private)
   | ["acc_public"] -> bool_val (p.access = Public)
-  | ["bapt_place"] -> str_val (quote_escaped p.baptism_place)
-  | ["bapt_note"] -> str_val (quote_escaped p.baptism_note)
-  | ["bapt_src"] -> str_val (quote_escaped p.baptism_src)
-  | ["birth"; s] -> eval_date_var (Adef.od_of_codate p.birth) s
-  | ["birth_place"] -> str_val (quote_escaped p.birth_place)
-  | ["birth_note"] -> str_val (quote_escaped p.birth_note)
-  | ["birth_src"] -> str_val (quote_escaped p.birth_src)
-  | ["bapt"; s] -> eval_date_var (Adef.od_of_codate p.baptism) s
   | ["bt_buried"] ->
         bool_val (match p.burial with [ Buried _ -> True | _ -> False ])
   | ["bt_cremated"] ->
         bool_val (match p.burial with [ Cremated _ -> True | _ -> False ])
   | ["bt_unknown_burial"] -> bool_val (p.burial = UnknownBurial)
-  | ["burial"; s] ->
-      let od =
-        match p.burial with
-        [ Buried cod -> Adef.od_of_codate cod
-        | Cremated cod -> Adef.od_of_codate cod
-        | _ -> None ]
-      in
-      eval_date_var od s
-  | ["burial_place"] -> str_val (quote_escaped p.burial_place)
-  | ["burial_note"] -> str_val (quote_escaped p.burial_note)
-  | ["burial_src"] -> str_val (quote_escaped p.burial_src)
   | ["cnt"] -> eval_int_env "cnt" env
   | ["dead_dont_know_when"] -> bool_val (p.death = DeadDontKnowWhen)
-  | ["death"; s] ->
-      let od =
-        match p.death with
-        [ Death _ cd -> Some (Adef.date_of_cdate cd)
-        | _ -> None ]
-      in
-      eval_date_var od s
-  | ["death_place"] -> str_val (quote_escaped p.death_place)
-  | ["death_note"] -> str_val (quote_escaped p.death_note)
-  | ["death_src"] -> str_val (quote_escaped p.death_src)
   | ["died_young"] -> bool_val (p.death = DeadYoung)
   | ["digest"] -> eval_string_env "digest" env
   | ["dont_know_if_dead"] -> bool_val (p.death = DontKnowIfDead)

--- a/src/updateIndOk.mli
+++ b/src/updateIndOk.mli
@@ -36,8 +36,6 @@ value check_person :
   config -> base -> Def.gen_person (string * string * 'b * 'c * 'd) string -> option string;
 value error_person : config -> base -> 'a -> string -> unit;
 value update_relations_of_related : base -> iper -> list iper -> unit;
-value reconstitute_death :
-  config -> option Def.date -> option Def.date -> string -> Def.burial -> string -> Def.death;
 value reconstitute_from_pevents :
   list (Def.gen_pers_event 'a string) -> bool ->
   (Def.codate * string * string * string) ->


### PR DESCRIPTION
Work in progress.

To fix https://github.com/geneweb/geneweb/issues/551.

Furthermore, it allows to get rid of standard fields in `updind` template (currently hidden with `<div style="display:none;">`).

These fields are anyway overwritten by `reconstitute_from_pevents` in `updateIndOk.ml`.

For the deleted lines in `updateIndOk.mli`, I have checked with `grep -rn reconstitute_death` that this function is not used elsewhere.

Any comments?

N.B. : Seems to work with  `templm`, but I need to do further tests.