### PR TITLE
Fix display of notes and sources from standard fields, for Cremated vs Buried [WIP]

### DIFF
--- a/hd/etc/perso_module/notes.txt
+++ b/hd/etc/perso_module/notes.txt
@@ -98,8 +98,11 @@
       <h3>[*death]</h3>
       <blockquote>%death_note;</blockquote>
     %end;
-    %if;has_burial_note;
+    %if;(has_burial_note and is_buried)
       <h3>[*burial]</h3>
+      <blockquote>%burial_note;</blockquote>
+    %elseif;(has_burial_note and is_cremated)
+      <h3>[*cremation]</h3>
       <blockquote>%burial_note;</blockquote>
     %end;
     %foreach;event;
@@ -108,7 +111,8 @@
              event.name!=[baptism] and
              event.name!=[marriage event] and
              event.name!=[death] and
-             event.name!=[burial])
+             event.name!=[burial] and
+             event.name!=[cremation])
           <h3>%apply;capitalize(event.name)</h3>
           <blockquote>%event.note;</blockquote>
         %end;

--- a/hd/etc/perso_module/sources.txt
+++ b/hd/etc/perso_module/sources.txt
@@ -28,6 +28,7 @@
           event.name!=[marriage event] and
           event.name!=[death] and
           event.name!=[burial] and
+          event.name!=[cremation] and
           event.name!="special" and
           event.name!="special1" and
           event.name!="special2")

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -5105,7 +5105,12 @@ value print_foreach conf base print_ast eval_expr =
           insert (transl_nth conf "death" 0) (sou base (get_death_src p)) srcl
         in
         let srcl =
-          insert (transl_nth conf "burial" 0) (sou base (get_burial_src p)) srcl
+          let burial_or_cremation =
+            match get_burial p with
+            [ Cremated _ -> "cremation"
+            | _ -> "burial" ]
+          in
+          insert (transl_nth conf burial_or_cremation 0) (sou base (get_burial_src p)) srcl
         in
         srcl
       else []


### PR DESCRIPTION
This PR is only for the display of notes and sources coming from "standard fields". Display of notes and sources coming from events remains unchanged.

I noticed this display "problem" when working on my other PR about `updind`. Among other things, the same source and notes can be displayed twice for a person that is `Cremated`.

Using only notes and sources from events would be another interesting option to consider. For example, in `templm`, it's possible to have both events (`Buried` vs `Cremated`) while it is not currently the case for the default template.
