### PR TITLE
Compile and commit date shown on mouseover

### DIFF
--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -15,6 +15,10 @@
 %define;template_link(xx,yy)
   <a class="dropdown-item" href="%prefix_no_templ;templ=xx;%suffix;">yy</a>
 %end;
+%define;compil(xx,yy)
+  [compiled on %s from commit %s:::xx:yy]
+%end;
+
 %if;(not cancel_links and evar.m != "MOD_DATA_OK" and evar.m != "DEL_IND_OK" and evar.m != "DEL_FAM_OK")
   <div class="row" id="copyr">
     <div class="col-10 offset-1 mt-3 mb-1">
@@ -72,12 +76,13 @@
         </div>
         <div class="col-9">
           <div class="btn-group float-right">
-            <span class="align-self-center">%version; - %commit; (%commit_date;)
-              %if;(bvar.display_compilation_time="on")([compiled on] %compilation_time;)%end;%sp;
-            &copy; <a href="https://www.inria.fr/">INRIA</a> 1998-2017 %connections; %sq;</span>
-            <a href="https://github.com/geneweb/geneweb" class="ml-1" target="_blank" title="GeneWeb sources on GitHub">
+            <a href="https://github.com/geneweb/geneweb" target="_blank" title="GeneWeb sources on GitHub">
             <img src="%image_prefix;/logo_bas.png" alt="Logo GeneWeb"/></a>
-            <a href="https://geneweb.tuxfamily.org/wiki/GeneWeb%if;(bvar.default_lang = "fr" or evar.lang = "fr")/fr%end;" class="ml-1" target="_blank" title="GeneWeb documentation MediaWiki">
+            <span class="align-self-center mx-1">
+            <a href="https://github.com/geneweb/geneweb/commit/%commit;"
+              title="GeneWeb %version %apply;compil%with;%compilation_time;%and;%commit;%end; %if;(compilation_time!=commit_date)(%commit_date;)%end;">v.&nbsp;%version;</a>
+            &copy; <a href="https://www.inria.fr/">INRIA</a> 1998-2017%if;(connections!="") %connections;%end;%nn;</span>
+            <a href="https://geneweb.tuxfamily.org/wiki/GeneWeb%if;(bvar.default_lang = "fr" or evar.lang = "fr")/fr%end;" target="_blank" title="GeneWeb documentation MediaWiki">
             <img src="%image_prefix;/logo_bas_mw.png" alt="Logo GeneWeb Mediawiki"/></a>
           </div>
         </div>

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -24,9 +24,9 @@ ru: около
 en: book of %s
 fr: dictionnaire des %s
 
-    compiled on
-en: compiled on
-fr: compilé le
+    compiled on %s from commit %s
+en: compiled on %s from commit %s
+fr: compilé le %s à partir du commit %s
 
     presentation
 de: Präsentation

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,9 +12,9 @@ LINKFLAGS = -I $(CAMLP5D)
 include $(ROOT)/tools/Makefile.common
 
 compilation.ml: always
-	echo "Util.set_compilation_time \"$$(date "+%Y-%m-%d %T %z")\";" > $@
+	echo "Util.set_compilation_time \"$$(date "+%d %B %Y")\";" > $@
 	echo "Util.set_commit \"$$(git show -s --pretty=format:%h)\";" >> $@
-	echo "Util.set_commit_date \"$$(git show -s --pretty=format:%ci)\";" >> $@
+	echo "Util.set_commit_date \"$$(git show -s --pretty=format:%cd --date=format:'%d %B %Y')\";" >> $@
 
 gwlib.ml:
 	echo "value prefix =" > $@

--- a/src/version.ml
+++ b/src/version.ml
@@ -1,7 +1,7 @@
 (* $Id: version.ml,v 5.8 2011-01-06 09:59:58 ddr Exp $ *)
 (* Copyright (c) 1998-2007 INRIA *)
 
-value txt = "7.00 - exp";
+value txt = "7.00-exp";
 
 value available_languages =
   ["af"; "bg"; "br"; "ca"; "cs"; "da"; "de"; "en"; "es"; "eo"; "et"; "fi";


### PR DESCRIPTION
Moving the mouse over version number or commit number reveals the compile and commit date.