### PR TITLE
Propose to visualize comm.log after base creation

### DIFF
--- a/setup/lang/bso_comm.htm
+++ b/setup/lang/bso_comm.htm
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
+            "http://www.w3.org/TR/REC-html40/loose.dtd">
+<head>
+  <!-- Copyright (c) 1998-2006 INRIA - GeneWeb -->
+  <!-- $Id: bso_ok.htm,v 5.1 2006-01-01 05:35:06 ddr Exp $ -->
+  <meta http-equiv="Content-Type" content="text/html; charset=[ !charset]"%/>
+  <meta http-equiv="Content-Style-Type" content="text/css"%/>
+  <meta name="robots" content="none"%/>
+  <link rel="shortcut icon" href="images/favicon_gwsetup.png"%/>
+
+  <title>[
+de: Inhalt der Datei "comm.log"
+en: Content of comm.log
+es: Contenido del fichero "comm.log"
+fi: Tiedoston "comm.log" sisältö
+fr: Contenu du fichier comm.log
+it: Contenuto del file "comm.log"
+sv: Innehållet i filen "comm.log"
+]</title>
+</head>
+
+<body background="images/gwback.jpg">
+
+<div style="background:url('images/gwlogo.png') no-repeat left top; text-align:center; height:95px; line-height:95px; color:#2f6400;">
+<h1 style="margin:0;">
+[
+de: Inhalt der Datei "comm.log"
+en: Content of comm.log
+es: Contenido del fichero "comm.log"
+fi: Tiedoston "comm.log" sisältö
+fr: Contenu du fichier comm.log
+it: Contenuto del file "comm.log"
+sv: Innehållet i filen "comm.log"
+]
+</h1>
+</div>
+
+<p />
+
+<dl><dt><dd>
+<pre>
+%g{- [
+de: empty file
+en: empty file
+es: fichero vacio
+fi: tyhjä tiedosto
+fr: fichier vide
+it: file vuoto
+lv: datne ir tukða
+sv: tom fil
+lv: datne ir tukða
+] -}
+</pre>
+</dl>
+

--- a/setup/lang/bso_ok.htm
+++ b/setup/lang/bso_ok.htm
@@ -133,3 +133,12 @@ lv: Jûs variet arî atgriezties <a
 sv: Du kan också återvända till <a
     href="gwsetup?lang=%l;v=welcome.htm">huvudmenyn</a>.
 ]
+
+<br /><p />
+
+[
+en: Click <a href="gwsetup?lang=%l;v=bso_comm.htm">here</a> for the alert messages in the file "comm.log":
+fr: Cliquer <a href="gwsetup?lang=%l;v=bso_comm.htm">ici</a> pour les messages d'alerte dans le fichier "comm.log".
+]
+
+<p />


### PR DESCRIPTION
In the current situation, comm.log is visible only if the base creation fails.
If the base is successfully created, one should nonetheless be able to see the alert messages!