### PR TITLE
Add images, notes and sources in tables

### DIFF
--- a/hd/etc/ancmenu.txt
+++ b/hd/etc/ancmenu.txt
@@ -245,6 +245,8 @@ function no_options () {
           [*display smallest sosa number relative to ancestor]
         </label>
       </p>
+      <input type="hidden" name="ns" value="on"%/>
+      <input type="hidden" name="image" value="on"%/>
       </div>
    </div>
    <div class="p-2">

--- a/hd/etc/ancmenu.txt
+++ b/hd/etc/ancmenu.txt
@@ -225,7 +225,7 @@ function no_options () {
           [*where dead]
         </label>
         <label>
-          <input type="checkbox" id="t_death_age" name="death_age" value="on"%/>
+          <input type="checkbox" id="t_death_age" name="age" value="on"%/>
           [*age at death]
         </label>
       </p>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -19,6 +19,10 @@
         %if;(qualifier != "") %qualifier;%end;
         %sp;%surname;
       %end;
+      %if;(evar.cgl="on")
+        %let;nb_gen;%apply;min(evar.v, max_anc_level)%in;
+        %apply;togen(nb_gen).
+      %end;
     %end;
   </title>
   <meta name="robots" content="none">
@@ -31,20 +35,6 @@
 <body%body_prop;>
 %message_to_wizard;
 <div class="container-fluid">
-<h1>%nn;
-  %apply;a_of_b%with;
-    %if;(evar.t = "M")
-      %if;(evar.evt = "on")[*missing events]%else;[*missing ancestors]%end;
-    %else;[*ancestors]
-    %end;
-  %and;
-    %if;(public_name != "")%public_name;%else;%first_name;%end;
-    %if;(qualifier != "") <em>%qualifier;</em>%end;
-    %sp;%surname;
-    %if;(alias != "") <em>(%alias;)</em>%end;
-  %end;
-  %if;(evar.t = "D") [up to] %pvar.1;%end;
-</h1>
 
 %if;not cancel_links;
   <div class="btn-group float-%right; mb-1">
@@ -58,7 +48,7 @@
 %let;central_index;%index;%in;
 
 %define;tothegen(xx)
-  [*to the %s generation:::xx]%nn;
+  [to the %s generation:::xx]%nn;
 %end;
 
 %define;thegen(xx)
@@ -66,10 +56,10 @@
 %end;
 
 %define;togena(xx)
-  %if;(xx = 1)[*specify::generation/generations]0%nn;
-  %elseif;(xx = 2)[*to the parents]%nn;
-  %elseif;(xx = 3)[*to the grandparents]%nn;
-  %elseif;(xx = 4)[*to the great-grandparents]%nn;
+  %if;(xx = 1)[specify::generation/generations]0%nn;
+  %elseif;(xx = 2)[to the parents]%nn;
+  %elseif;(xx = 3)[to the grandparents]%nn;
+  %elseif;(xx = 4)[to the great-grandparents]%nn;
   %else;
     %apply;tothegen%with;
       %apply;nth([nth (generation)], xx)
@@ -77,19 +67,11 @@
   %end;
 %end;
 
-%define;tothegen(xx)
-  [*to the %s generation:::xx]%nn;
-%end;
-
-%define;thegen(xx)
-  [*the %s generation:::xx]%nn;
-%end;
-
 %define;togen(xx)
-  %if;(xx = 1)[*specify::generation/generations]0%nn;
-  %elseif;(xx = 2)[*to the parents]%nn;
-  %elseif;(xx = 3)[*to the grandparents]%nn;
-  %elseif;(xx = 4)[*to the great-grandparents]%nn;
+  %if;(xx = 1)[specify::generation/generations]0%nn;
+  %elseif;(xx = 2)[to the parents]%nn;
+  %elseif;(xx = 3)[to the grandparents]%nn;
+  %elseif;(xx = 4)[to the great-grandparents]%nn;
   %else;
     %apply;tothegen%with;
       %apply;nth([nth (generation)], xx)
@@ -1285,11 +1267,31 @@
    Main
 %)
 
+<h1>%nn;
+  %apply;a_of_b%with;
+    %if;(evar.t = "M")
+      %if;(evar.evt = "on")[*missing events]%else;[*missing ancestors]%end;
+    %else;[*ancestors]
+    %end;
+  %and;
+    %if;(public_name != "")%public_name;%else;%first_name;%end;
+    %if;(qualifier != "") <em>%qualifier;</em>%end;
+    %sp;%surname;
+    %if;(alias != "") <em>(%alias;)</em>%end;
+  %end;
+  %if;(evar.t = "D") [up to] %pvar.1;
+  %else;
+     %if;(cancel_links) %apply;togena(evar.v)%end;
+  %end;
+</h1>
+
 %if;(evar.t = "Z" and not cancel_links)
   <div class="form-inline">
-    <a role="button" class="btn btn-link my-0 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;p=%first_name;;n=%surname;;m=A">
-        <i class="fa fa-cog fa-lg fa-fw mr-1"></i>[*options] [ancestors] </a>
+        <i class="fa fa-cog fa-lg fa-fw mr-1">
+        </i>[*options] [ancestors] 
+    </a>
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
       href="%apply;rebuild_url%with;D
             %and;I
@@ -1302,7 +1304,6 @@
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
       href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
         <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
-    
     <div class="input-group ml-3 mb-1">
       <span class="input-group-btn">
         %if;(evar.v>=3)<a 
@@ -1839,7 +1840,6 @@
 
   %elseif;(evar.t = "Z")
     %let;nb_gen;%apply;min(evar.v, max_anc_level)%in;
-    <p>%apply;togen(nb_gen).</p>
     %reset_count;
     <table class="table table-hover ascends_table">
       <tr class="ascends_table_header align-middle">%apply;table_header()</tr>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -953,7 +953,8 @@
                         %end;
                         %foreach;ancestor.source;
                           %let;birthbaptism;[birth], [baptism]%in;
-                          %if;(not ancestor.has_baptism_note and ((not ancestor.has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
+                          %let;birthdeath;[birth], [death]%in;
+                          %if;(not ancestor.has_baptism_note and ((not ancestor.has_baptism_source and source_type=[birth]) or source_type=birthbaptism or source_type=birthdeath))
                             %apply;capitalize(ancestor.source).
                           %elseif;((ancestor.has_baptism_note or ancestor.has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
                             <li>%apply;capitalize(source_type)[:] %ancestor.source;.</li>
@@ -1096,7 +1097,8 @@
                         %end;
                         %foreach;ancestor.source;
                           %let;deathburial;[death], [burial]%in;
-                          %if;(not ancestor.has_burial_note and ((not ancestor.has_burial_source and source_type=[death]) or source_type=deathburial))
+                          %let;birthdeath;[birth], [death]%in;
+                          %if;(not ancestor.has_burial_note and ((not ancestor.has_burial_source and source_type=[death]) or source_type=deathburial or source_type=birthdeath))
                             %apply;capitalize(ancestor.source).
                           %elseif;((ancestor.has_burial_note or ancestor.has_burial_source) and (source_type=[death] or source_type=[burial]))
                             %if;(source_type=[burial] and ancestor.is_cremated)

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1341,7 +1341,7 @@
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
         <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
-    <div class="ml-auto mr-5">
+    <div class="mr-5">
       %if;(evar.v>=3)
         <a role="button" class="btn" href="%apply;rebuild_url%with;A
             %and;%evar.t;

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1306,14 +1306,22 @@
     <div class="input-group ml-3 mb-1">
       <span class="input-group-btn">
         %if;(evar.v>=3)<a 
-          href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v-1)%end;%if;(evar.ns="on")ns=on;%end;" 
+          href="%apply;rebuild_url%with;A
+            %and;%evar.t;
+            %and;%expr(evar.v-1)
+            %end;
+            %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;" 
             class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
       <input class="form-control text-center" size="12" 
         value="%evar.v; [generation/generations]1" 
         title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
       <span class="input-group-btn">
-        <a href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v+1)%end;%if;(evar.ns="on")ns=on;%end;" 
+        <a href="%apply;rebuild_url%with;A
+          %and;%evar.t;
+          %and;%expr(evar.v+1)
+          %end;
+          %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;" 
           class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
       </span>
     </div>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1094,7 +1094,7 @@
 %if;(evar.t = "Z" and not cancel_links)
   <div class="form-inline">
     <a role="button" class="btn btn-link my-0 px-0 mb-1" href="%prefix;p=%first_name;;n=%surname;;m=A"><i class="fa fa-cog fa-lg fa-fw mr-1"></i>[*options] [ancestors] </a>
-    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" href="%apply;rebuild_url%with;D%and;I;%and;%max_desc_level;%end" class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" href="%apply;rebuild_url%with;D%and;I;%and;%max_desc_level;%end;%if;(evar.notes="on")notes=on;%end;%if;(evar.image="on")image=on;%end;" class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on"><span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
     <div class="input-group ml-3 mb-1">
       <span class="input-group-btn">

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -51,7 +51,6 @@
     %if;(referer != "")
       <a role="button" class="btn btn-link px-0" href="%referer;"><span class="fa fa-arrow-left fa-lg" title="<<"></span></a>
     %end;
-    <a role="button" class="btn btn-link ml-1 px-0" href="%url;cgl=on" target="_blank"><span class="fa fa-chain-broken fa-lg" title="[*cancel GeneWeb links]"></span></a>%nn;
     <a role="button" class="btn btn-link ml-1 px-0" href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span></a>
   </div>
 %end;
@@ -865,13 +864,13 @@
 %( Ancêtre %)
   <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
       class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
-    %if;(evar.show_ns="on")
+    %if;(evar.ns="on")
         %if;(ancestor.has_notes and not ancestor.has_psources) note%nn;
         %elseif;(not ancestor.has_notes and ancestor.has_psources) source%nn;
         %elseif;(ancestor.has_notes and ancestor.has_psources) notesource%nn;
         %end;
     %end;'
-    %if;(evar.show_ns="on" and (ancestor.has_notes or ancestor.has_psources))
+    %if;(evar.ns="on" and (ancestor.has_notes or ancestor.has_psources))
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
       data-content='%if;(ancestor.has_notes)%ancestor.notes;%end;
                     %if;(ancestor.has_notes and ancestor.has_psources)<hr>%end;
@@ -882,17 +881,25 @@
             %end;'
     %end;
     >
-    %apply;image_MF("ancestor")
-    %apply;link%with;%ancestor.access;%and;
-      %ancestor;
-    %end
-    %if;(evar.title="on")%ancestor.title;%end;
-    %if;(ancestor.same != "" and evar.repeat = "on")
-      %sp;→
-      %if(evar.sosab = 16)%ancestor.same.hexa;
-      %elseif(evar.sosab = 8)%ancestor.same.octal;
-      %else;%ancestor.same;%end;
-    %end;
+    <div class="d-flex justify-content-between">
+      <div class="align-self-center mr-2">
+        %apply;image_MF("ancestor")
+        %apply;link%with;%ancestor.access;%and;
+          %ancestor;
+        %end;
+        %if;(evar.title="on")%ancestor.title;%end;
+        %if;(ancestor.same != "" and evar.repeat = "on")
+          %sp;→
+          %if(evar.sosab = 16)%ancestor.same.hexa;
+          %elseif(evar.sosab = 8)%ancestor.same.octal;
+          %else;%ancestor.same;
+          %end;
+        %end;
+      </div>
+      %if;(evar.image="on" and ancestor.has_image)
+        <img src="%ancestor.image_url;" class="rounded align-self-center" height="%if;(evar.px!="")%evar.px;%else;60%end;px">
+      %end;
+    </div>
 %( Date de naissance %)
   </td>
   %if;(evar.birth = "on")
@@ -910,7 +917,7 @@
   %if;(evar.birth_place = "on")
     <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
       class='align-middle%nn;
-        %if;(evar.show_ns="on")
+        %if;(evar.ns="on")
           %if;((ancestor.has_birth_note or ancestor.has_baptism_note) and not
                (ancestor.has_birth_source or ancestor.has_baptism_source)) note%nn;
           %elseif;(not (ancestor.has_birth_note or ancestor.has_baptism_note) and
@@ -919,7 +926,7 @@
                (ancestor.has_birth_source or ancestor.has_baptism_source)) notesource%nn;
           %end;
         %end;'
-        %if;(evar.show_ns="on")
+        %if;(evar.ns="on")
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(ancestor.has_birth_note or ancestor.has_baptism_note)
                           %if;(ancestor.has_birth_note)%if;(ancestor.has_baptism_note)[*birth][:] %end;%ancestor.birth_note;%end;
@@ -958,7 +965,7 @@
           <td %if;(ancestor.nb_families > 1) %end;>
             %apply;image_MF("spouse")
             %apply;link%with;%spouse.access;%and;
-              %family_cnt; %spouse;
+              %spouse;
             %end;
           </td>
         %end;
@@ -992,14 +999,14 @@
         %if;(family_cnt = 1)
           <td %if;(ancestor.nb_families>1) %end; 
             class='align-middle%nn;
-            %if;(evar.show_ns="on")
+            %if;(evar.ns="on")
               %if;(has_marriage_note and not has_marriage_source) note%nn;
               %elseif;(not has_marriage_note and has_marriage_source) source%nn;
               %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
               %end;
             %end;'
             %rowspan;
-            %if;(evar.show_ns="on")
+            %if;(evar.ns="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
               data-content='%if;(has_marriage_note)%marriage_note;%end;
                             %if;(has_marriage_note and has_marriage_source)<hr>%end;
@@ -1056,7 +1063,7 @@
   %if;(evar.death_place = "on")
     <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
       class='align-middle%nn;
-        %if;(evar.show_ns="on")
+        %if;(evar.ns="on")
           %if;((ancestor.has_death_note or ancestor.has_burial_note) and not
                (ancestor.has_death_source or ancestor.has_burial_source)) note%nn;
           %elseif;(not (ancestor.has_death_note or ancestor.has_burial_note) and
@@ -1065,7 +1072,7 @@
                (ancestor.has_death_source or ancestor.has_burial_source)) notesource%nn;
           %end;
         %end;'
-        %if;(evar.show_ns="on")
+        %if;(evar.ns="on")
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(ancestor.has_death_note or ancestor.has_burial_note)
                           %if;(ancestor.has_death_note)%if;(ancestor.has_burial_note)[*death][:] %end;%ancestor.death_note;%end;
@@ -1122,25 +1129,25 @@
           %if;(evar.marr = "on")
             <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
               class='align-middle%nn;
-                %if;(evar.show_ns="on")
+                %if;(evar.ns="on")
                   %if;(spouse.has_pnotes and not spouse.has_psources) note%nn;
                   %elseif;(not spouse.has_pnotes and spouse.has_psources) source%nn;
                   %elseif;(spouse.has_pnotes and spouse.has_psources) notesource%nn;
                   %end;
                 %end;'
-              %if;(evar.show_ns="on")
+              %if;(evar.ns="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-                data-content='%if;(spouse.has_pnotes)%spouse.pnotes;%end;
-                              %if;(spouse.has_psources)
-                                %if;(spouse.has_pnotes)<hr>%end;
-                                %spouse.psources;
-                              %end;'
-                  title='%if;(spouse.has_psources or spouse.has_pnotes)
-                           %if;(spouse.has_pnotes and not spouse.has_psources)[*note/notes]1%nn;
-                           %elseif;(not spouse.has_pnotes and spouse.has_psources)[source/sources]1%nn;
-                           %elseif;(spouse.has_pnotes and spouse.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
-                           %end;
-                         %end;'
+              data-content='%if;(spouse.has_pnotes)%spouse.pnotes;%end;
+                            %if;(spouse.has_psources)
+                              %if;(spouse.has_pnotes)<hr>%end;
+                              %spouse.psources;
+                            %end;'
+                title='%if;(spouse.has_psources or spouse.has_pnotes)
+                         %if;(spouse.has_pnotes and not spouse.has_psources)[*note/notes]1%nn;
+                         %elseif;(not spouse.has_pnotes and spouse.has_psources)[source/sources]1%nn;
+                         %elseif;(spouse.has_pnotes and spouse.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
+                         %end;
+                       %end;'
               %end;
               >
               %apply;image_MF("spouse")
@@ -1161,19 +1168,20 @@
           %if;(evar.marr_place = "on")
             <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
               class='align-middle%nn;
-              %if;(evar.show_ns="on")
+              %if;(evar.ns="on")
                 %if;(has_marriage_note and not has_marriage_source) note%nn;
                 %elseif;(not has_marriage_note and has_marriage_source) source%nn;
                 %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
                 %end;
               %end;'
-              %rowspan;
-              %if;(evar.show_ns="on")
+              %if;(evar.ns="on")
                 tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
                 data-content='%if;(has_marriage_note)%marriage_note;%end;
-                              %if;(has_marriage_note and has_marriage_source)<hr>%end;
-                              %if;(has_marriage_source)%apply;capitalize(marriage_source)%end;'
-                title='%if;(has_marriage_source or has_marriage_note)
+                              %if;(has_marriage_source)
+                                %if;(has_marriage_note)<hr>%end;
+                                %apply;capitalize(marriage_source)
+                              %end;'
+                title='%if;(has_marriage_note or has_marriage_source)
                          %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
                          %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1
                          %elseif;(has_marriage_note and has_marriage_source)[*note/notes]1 [and] [source/sources]1
@@ -1191,19 +1199,20 @@
           %if;(evar.child = "on")
             <td align="center" style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
               class='align-middle%nn;
-              %if;(evar.show_ns="on")
+              %if;(evar.ns="on")
                 %if;(has_fnotes and not has_fsources) note%nn;
                 %elseif;(not has_fnotes and has_fsources) source%nn;
                 %elseif;(has_fnotes and has_fsources) notesource%nn;
                 %end;
               %end;'
-              %rowspan;
-              %if;(evar.show_ns="on")
+              %if;(evar.ns="on")
                 tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
                 data-content='%if;(has_fnotes)%fnotes;%end;
-                              %if;(has_fnotes and has_fsources)<hr>%end;
-                              %if;(has_fsourcess)%apply;capitalize(fsources)%end;'
-                title='%if;(has_fsourcess or has_fnotes)
+                              %if;(has_fsources)
+                                %if;(has_fnotes)<hr>%end;
+                                %apply;capitalize(fsources)
+                              %end;'
+                title='%if;(has_fsources or has_fnotes)
                          %if;(has_fnotes and not has_fsources)[*note/notes]1
                          %elseif;(not has_fnotes and has_fsources)[*source/sources]1
                          %elseif;(has_fnotes and has_fsources)[*note/notes]1 [and] [source/sources]1
@@ -1287,7 +1296,7 @@
             %and;%max_desc_level;
             %end;
             %if;(evar.notes="on")notes=on;%end;
-            %if;(evar.show_ns="on")show_ns=on;%end;
+            %if;(evar.ns="on")ns=on;%end;
             %if;(evar.image="on")image=on;%end;" 
             class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
@@ -1297,30 +1306,53 @@
     <div class="input-group ml-3 mb-1">
       <span class="input-group-btn">
         %if;(evar.v>=3)<a 
-          href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v-1)%end;%if;(evar.show_ns="on")show_ns=on;%end;" 
+          href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v-1)%end;%if;(evar.ns="on")ns=on;%end;" 
             class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
       <input class="form-control text-center" size="12" 
         value="%evar.v; [generation/generations]1" 
         title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
       <span class="input-group-btn">
-        <a href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v+1)%end;%if;(evar.show_ns="on")show_ns=on;%end;" 
+        <a href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v+1)%end;%if;(evar.ns="on")ns=on;%end;" 
           class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
       </span>
     </div>
   </div>
   <div class="form-inline">
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+     href="%apply;rebuild_url%with;A
+           %and;Z
+           %and;%evar.v;
+           %end;
+           %if;(evar.image="" or evar.image!="on")image=on;%else;image=off;%end;
+           px=%evar.px;;">
+            <i class="fa fa-picture-o fa-lg fa-fw
+             %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
+     %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
+    </a>
+    %if;(evar.image="on")
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+       href="%apply;rebuild_url%with;A
+             %and;Z
+             %and;%evar.v;
+             %end;
+             %if;(evar.ns="on")ns=on;%end;
+             %if;(evar.cgl="on")cgl=on;%end;
+             %if;(evar.image="on")image=on;%end;
+             %if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;"
+       title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
+    %end;
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;A
             %and;Z
             %and;%evar.v;
             %end;
-            %if;(evar.show_ns="on")show_ns=off;%else;show_ns=on;%end;
+            %if;(evar.ns="on")ns=off;%else;ns=on;%end;
             %if;(evar.image="on")image=on;%end;"
             title="small arrow in corner shows existence of note or source">
               <i class="fa fa-file-text-o fa-lg fa-fw
-               %if;(evar.show_ns="on")text-danger%end; mr-1"></i>%nn;
-      %if;(evar.show_ns="" or evar.show_ns!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
+               %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
+      %if;(evar.ns="" or evar.ns!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
         <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
     </a>
     %if;(evar.cgl="" or evar.cgl!="on")
@@ -1330,7 +1362,7 @@
               %and;%evar.v;
               %end;
               %if;(evar.image="on")image=on;%end;
-              show_ns=off;cgl=on;"
+              ns=off;cgl=on;"
               title="Cancel url links in whole page">
         <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
       </a>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1248,55 +1248,26 @@
   %end;
 %end;
 
-%define;rebuild_url(mmm,xxx,vvv)
+%define;rebuild_url(mmm,xxx,vvv,nnn,ccc,iii,ppp)
   %let;new_url;%prefix;m=mmm;%nn;
   %access;;t=xxx;%nn;
-  %if;(evar.num = "on")
-    num=on;%nn;
-  %end;
-  %if;(evar.nowrap = "on")
-    nowrap=on;%nn;
-  %end;
-  %if;(evar.birth = "on")
-    birth=on;%nn;
-  %end;
-  %if;(evar.title = "on")
-    title=on;%nn;
-  %end;
-  %if;(evar.birth_place = "on")
-    birth_place=on;%nn;
-  %end;
-  %if;(evar.marr= "on")
-    marr=on;%nn;
-  %end;
-  %if;(evar.marr_date = "on")
-    marr_date=on;%nn;
-  %end;
-  %if;(evar.marr_place = "on")
-    marr_place=on;%nn;
-  %end;
-  %if;(evar.child = "on")
-    child=on;%nn;
-  %end;
-  %if;(evar.death = "on")
-    death=on;%nn;
-  %end;
-  %if;(evar.death_place = "on")
-    death_place=on;%nn;
-  %end;
-  %if;(evar.age = "on")
-    age=on;%nn;
-  %end;
-  %if;(evar.occu = "on")
-    occu=on;%nn;
-  %end;
-  %if;(evar.gen = "on")
-    gen=on;%nn;
-  %end;
-  %if;(evar.cgl = "on")
-    cgl=on;%nn;
-  %end;
-  v=vvv;%in;
+  %if;(evar.num="on")num=on;%nn;%end;
+  %if;(evar.nowrap="on")nowrap=on;%nn;%end;
+  %if;(evar.title="on")title=on;%nn;%end;
+  %if;(evar.birth="on")birth=on;%nn;%end;
+  %if;(evar.birth_place="on")birth_place=on;%nn;%end;
+  %if;(evar.marr= "on")marr=on;%nn;%end;
+  %if;(evar.marr_date="on")marr_date=on;%nn;%end;
+  %if;(evar.marr_place="on")marr_place=on;%nn;%end;
+  %if;(evar.child="on")child=on;%nn;%end;
+  %if;(evar.death="on")death=on;%nn;%end;
+  %if;(evar.death_place="on")death_place=on;%nn;%end;
+  %if;(evar.age="on")age=on;%nn;%end;
+  %if;(evar.occu="on")occu=on;%nn;%end;
+  %if;(evar.gen="on")gen=on;%nn;%end;
+  %if;(evar.notes="on")notes=on;%nn;%end;
+  %if;(evar.src="on")src=on;%nn;%end;
+  vvv;nnn;ccc;iii;ppp;%in;
   %new_url;
 %end;
 
@@ -1332,11 +1303,12 @@
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;I
-            %and;%max_desc_level;
-            %end;
-            %if;(evar.notes="on")notes=on;%end;
-            %if;(evar.ns="on")ns=on;%end;
-            %if;(evar.image="on")image=on;%end;"
+            %and;v=%max_desc_level;
+            %and;%if;(evar.ns="on")ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
+            %end;"
             class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
@@ -1345,55 +1317,68 @@
       %if;(evar.v>=3)
         <a role="button" class="btn" href="%apply;rebuild_url%with;A
             %and;%evar.t;
-            %and;%expr(evar.v-1)
-            %end;
-            %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;"
+            %and;v=%expr(evar.v-1)
+            %and;%if;(evar.ns="on")ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
+            %end;"
             class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">
           <i class="fa fa-minus fa-lg "></i>
         </a>
+      %else;
+           <i class="fa fa-lg ">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</i>
       %end;
       <span class="text-primary mt-2">%apply;togena%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
-      <a role="button" class="btn" href="%apply;rebuild_url%with;A
-          %and;%evar.t;
-          %and;%expr(evar.v+1)
-          %end;
-          %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;"
-          class="btn btn-secondary" title="[*add] 1 [generation/generations]0">
-          <i class="fa fa-plus fa-lg"></i>
-      </a>
+      <a role="button" class="btn"
+        href="%apply;rebuild_url%with;A
+              %and;%evar.t;
+              %and;v=%expr(evar.v+1)
+              %and;%if;(evar.ns="on")ns=on;%end;
+              %and;%if;(evar.cgl="on")cgl=on;%end;
+              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.px!="")px=%evar.px;;%end;
+              %end;"
+              class="btn btn-secondary" title="[*add] 1 [generation/generations]0">
+              <i class="fa fa-plus fa-lg"></i>
+        </a>
     </div>
   </div>
   <div class="d-flex">
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-     href="%apply;rebuild_url%with;A
-           %and;Z
-           %and;%evar.v;
-           %end;
-           %if;(evar.image="" or evar.image!="on")image=on;%else;image=off;%end;
-           px=%evar.px;;">
+      href="%apply;rebuild_url%with;A
+            %and;Z
+            %and;v=%evar.v;
+            %and;%if;(evar.ns="on")ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="" or evar.image!="on")image=on;%else;image=off;%end;
+            %and;px=%evar.px;;
+            %end;">
             <i class="fa fa-picture-o fa-lg fa-fw
              %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
      %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
     </a>
     %if;(evar.image="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-       href="%apply;rebuild_url%with;A
-             %and;Z
-             %and;%evar.v;
-             %end;
-             %if;(evar.ns="on")ns=on;%end;
-             %if;(evar.cgl="on")cgl=on;%end;
-             %if;(evar.image="on")image=on;%end;
-             %if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;"
+        href="%apply;rebuild_url%with;A
+              %and;Z
+              %and;v=%evar.v;
+              %and;%if;(evar.ns="on")ns=on;%end;
+              %and;%if;(evar.cgl="on")cgl=on;%end;
+              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
+              %end;"
        title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
     %end;
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;A
             %and;Z
-            %and;%evar.v;
-            %end;
-            %if;(evar.ns="on")ns=off;%else;ns=on;%end;
-            %if;(evar.image="on")image=on;%end;"
+            %and;v=%evar.v;
+            %and;%if;(evar.ns="on")ns=off;%else;ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")%evar.px;%end;
+            %end;"
             title="small arrow in corner shows existence of note or source">
               <i class="fa fa-file-text-o fa-lg fa-fw
                %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
@@ -1404,10 +1389,12 @@
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
         href="%apply;rebuild_url%with;A
               %and;Z
-              %and;%evar.v;
-              %end;
-              %if;(evar.image="on")image=on;%end;
-              ns=off;cgl=on;"
+              %and;v=%evar.v;
+              %and;ns=off;
+              %and;cgl=on;
+              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.px="")px=%evar.px;%end;
+              %end;"
               title="Cancel url links in whole page">
         <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
       </a>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1324,12 +1324,13 @@
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;"
             class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">
-          <i class="fa fa-minus fa-lg "></i>
+          <i class="fa fa-minus fa-lg"></i>
         </a>
       %else;
-           <i class="fa fa-lg ">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</i>
+        <span class="btn btn-secondary disabled" aria-disabled="true" title="[*delete] 1 [generation/generations]0">
+          <i class="fa fa-minus fa-lg" ></i>
+        </span>
       %end;
-      <span class="text-primary mt-2">%apply;togena%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
       <a role="button" class="btn"
         href="%apply;rebuild_url%with;A
               %and;%evar.t;
@@ -1342,6 +1343,7 @@
               class="btn btn-secondary" title="[*add] 1 [generation/generations]0">
               <i class="fa fa-plus fa-lg"></i>
         </a>
+      <span class="text-primary mt-2">%apply;togena%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
     </div>
   </div>
   <div class="d-flex">

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -786,59 +786,104 @@
    Display ascend in table
 %)
 
+
 %define;table_header()
-  %reset_count;
-  <th>[*Sosa]</th>
-  %incr_count;
-  <th>[*person/persons]0</th>
-  %incr_count;
-  %if;(evar.birth = "on")
-    <th>[*date of birth]</th>
+  <tr class="ascends_table_header align-middle">
+    %reset_count;
+    %if;(evar.num="on")
+      <th class="text-center align-middle" rowspan="2" title="[*Sosa]">№</th>
+      %incr_count;
+    %end;
+    <th class="pl-2 align-middle" rowspan="2">[*person/persons]0</th>
     %incr_count;
-  %end;
-  %if;(evar.birth_place = "on")
-    <th>[*where born]</th>
-    %incr_count;
-  %end;
-  %if;(evar.marr = "on")
-    <th>[*spouse/spouses]1</th>
-    %incr_count;
-  %end;
-  %if;(evar.marr_date = "on")
-    <th>[*date of marriage]</th>
-    %incr_count;
-  %end;
-  %if;(evar.marr_place = "on")
-    <th>[*where married]</th>
-    %incr_count;
-  %end;
-  %if;(evar.child = "on")
-    <th>[*nb children]</th>
-    %incr_count;
-  %end;
-  %if;(evar.death = "on")
-    <th>[*date of death]</th>
-    %incr_count;
-  %end;
-  %if;(evar.death_place = "on")
-    <th>[*where dead]</th>
-    %incr_count;
-  %end;
-  %if;(evar.death_age = "on")
-    <th>[*age at death]</th>
-    %incr_count;
-  %end;
-  %if;(evar.occu = "on")
-    <th>[*occupation/occupations]1</th>
-    %incr_count;
-  %end;
+    %if;(evar.birth="on" and evar.birth_place="on")
+      <th class="text-center" colspan="2">[*birth]</th>
+      %incr_count;%incr_count;
+    %elseif;(evar.birth="on" and evar.birth_place!="on")
+      <th class="text-center" rowspan="2">[*date of birth]</th>
+      %incr_count;
+    %elseif;(evar.birth!="on" and evar.birth_place="on")
+      <th class="text-center" rowspan="2">[*birth place]</th>
+      %incr_count;
+    %end;
+    %if;(evar.marr="on")
+      <th class="pl-2 align-middle" rowspan="2">[*spouse/spouses]1</th>
+      %incr_count;
+    %end;
+    %if;((evar.marr_date="on" and evar.marr_place="on") or
+         (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
+      <th class="text-center"
+        colspan="%if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")3%else;2%end;">
+        [*marriage/marriages]0
+      </th>
+      %if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")
+        %incr_count;%incr_count;%incr_count;%else;%incr_count;%incr_count;%end;
+    %elseif;(evar.marr_date="on" and evar.marr_place!="on" and evar.child!="on")
+      <th class="text-center" rowspan="2">[*date of marriage]</th>
+      %incr_count;
+    %elseif;(evar.marr_date!="on" and evar.marr_place="on" and evar.child!="on")
+      <th class="text-center text-middle" rowspan="2">[*marriage place]</th>
+      %incr_count;
+    %elseif;(evar.marr_date!="on" and evar.marr_place!="on" and evar.child="on")
+      <th class="text-center" rowspan="2" title="[*nb children]/[nb children] [total]">
+        <span class="fa fa-child"></span>
+      </th>
+      %incr_count;
+    %end;
+    %if;(evar.death="on" and evar.death_place="on")
+      <th class="text-center" colspan="2">[*death]</th>
+      %incr_count;%incr_count;
+    %elseif;(evar.death="on" and evar.death_place!="on")
+      <th class="text-center" rowspan="2">[*date of death]</th>
+      %incr_count;
+    %elseif;(evar.death!="on" and evar.death_place="on")
+      <th class="text-center" rowspan="2">[*death place]</th>
+      %incr_count;
+    %end;
+    %if;(evar.age="on")
+      <th class="pl-2 align-middle" rowspan="2">[*age]</th>
+      %incr_count;
+    %end;
+    %if;(evar.occu="on")
+      <th class="pl-2 align-middle" rowspan="2">[*occupation/occupations]1</th>
+      %incr_count;
+    %end;
+    </tr>
+    <tr class="ascends_table_header">
+    %if;(evar.birth="on" and evar.birth_place="on")
+      <th class="text-right pr-2" title="[*date of birth]">[*date/dates]0</th>
+      <th class="pl-2" title="[*birth place]">[*place]</th>
+    %end;
+    %if;((evar.marr_date="on" and evar.marr_place="on") or
+         (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
+      %if;(evar.marr_date="on")
+        <th class="%if;(evar.marr_place!="on")text-center%else;text-right pr-2%end;"
+          title="[*date of marriage]">[*date/dates]0
+        </th>
+      %end;
+      %if;(evar.marr_place="on")
+        <th class="%if;(evar.marr_date!="on")text-center%else;pl-2%end;"
+          title="[*marriage place]">[*place]
+        </th>
+      %end;
+      %if;(evar.child="on")
+        <th class="text-center px-2" title="[*nb children]/[nb children] [total]">
+          <span class="fa fa-child"></span>
+        </th>
+      %end;
+    %end;
+    %if;(evar.death="on" and evar.death_place="on")
+      <th class="text-right pr-2" title="[*date of death]">[*date/dates]0</th>
+      <th class="pl-2" title="[*death place]">[*place]</th>
+    %end;
+  </tr>
 %end;
 
 %define;table_row()
   %lazy_force;
   %if;(ancestor.same = "")%incr_count;%end;
 %( Sosa %)
-  <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+  <td class="align-middle text-center" %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
     %if;(evar.sosab = 16)%ancestor.anc_sosa.hexa;
     %elseif;(evar.sosab = 8)%ancestor.anc_sosa.octal;
     %else;%ancestor.anc_sosa;%end;
@@ -853,7 +898,7 @@
         %end;
     %end;'
     %if;(evar.ns="on" and (ancestor.has_notes or ancestor.has_psources))
-      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
       data-content='%if;(ancestor.has_notes)%ancestor.notes;%end;
                     %if;(ancestor.has_notes and ancestor.has_psources)<hr>%end;
                     %if;(ancestor.has_psources)%apply;capitalize(ancestor.psources)%end;'
@@ -885,9 +930,7 @@
 %( Date de naissance %)
   </td>
   %if;(evar.birth = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
-      class='align-middle%nn;'
-      >
+    <td class="align-middle text-right" %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
       %if;ancestor.has_approx_birth_date;
         %ancestor.slash_approx_birth_date;
       %else;
@@ -916,15 +959,15 @@
                         %end;
                         %foreach;ancestor.source;
                           %let;birthbaptism;[birth], [baptism]%in;
-                          %if;((not ancestor.has_baptism_note and not ancestor.has_baptism_source) and (ancestor.source_type=[birth] or ancestor.source_type=birthbaptism))
+                          %if;(not ancestor.has_baptism_note and ((not ancestor.has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
                             %apply;capitalize(ancestor.source).
-                          %elseif;((ancestor.has_baptism_note or ancestor.has_baptism_source) and (ancestor.source_type=[birth] or ancestor.source_type=[baptism]))
-                            <li>%apply;capitalize(ancestor.source_type)[:] %ancestor.source;.</li>
+                          %elseif;((ancestor.has_baptism_note or ancestor.has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
+                            <li>%apply;capitalize(source_type)[:] %ancestor.source;.</li>
                           %end;
                         %end;'
             title='%if;(ancestor.has_birth_source or ancestor.has_baptism_source or ancestor.has_birth_note or ancestor.has_baptism_note)
                      %if;((ancestor.has_birth_note or ancestor.has_baptism_note) and not (ancestor.has_birth_source or ancestor.has_baptism_source))[*note/notes]1%nn;
-                     %elseif;(not (ancestor.has_birth_note or ancestor.has_baptism_note) and (ancestor.has_birth_source or ancestor.has_baptism_source))[source/sources]1%nn;
+                     %elseif;(not (ancestor.has_birth_note or ancestor.has_baptism_note) and (ancestor.has_birth_source or ancestor.has_baptism_source))[*source/sources]1%nn;
                      %elseif;((ancestor.has_birth_note or ancestor.has_baptism_note) and (ancestor.has_birth_source or ancestor.has_baptism_source))[*note/notes]1 [and] [source/sources]1%nn;
                      %end;
                    %end;'
@@ -944,7 +987,7 @@
     %else;
       %foreach;ancestor.family;
         %if;(family_cnt = 1)
-          <td %if;(ancestor.nb_families > 1) %end;>
+          <td class="align-middle" %if;(ancestor.nb_families > 1) %end;>
             %apply;image_MF("spouse")
             %apply;link%with;%spouse.access;%and;
               %spouse;
@@ -961,7 +1004,7 @@
     %else;
       %foreach;ancestor.family;
         %if;(family_cnt = 1)
-          <td %if;(ancestor.nb_families > 1) %end;>
+          <td class="align-middle text-right" %if;(ancestor.nb_families > 1) %end;>
             %if;(slash_marriage_date != "")
               %slash_marriage_date;
             %else;
@@ -987,7 +1030,6 @@
               %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
               %end;
             %end;'
-            %rowspan;
             %if;(evar.ns="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
               data-content='%if;(has_marriage_note)%marriage_note;%end;
@@ -1019,7 +1061,7 @@
       %if;(evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on")
         %foreach;ancestor.family;
           %if;(family_cnt = 1)
-            <td align="center" %if;(ancestor.nb_families > 1) %end;>
+            <td class="align-middle text-center">
               %nb_children;
             </td>
           %end;
@@ -1031,9 +1073,7 @@
   %end;
 %( Date du décès %)
   %if;(evar.death = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
-      class='align-middle%nn;'
-      >
+    <td class="align-middle text-right" %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
       %if;ancestor.has_approx_death_date;
         %ancestor.slash_approx_death_date;
       %else;
@@ -1062,15 +1102,15 @@
                         %end;
                         %foreach;ancestor.source;
                           %let;deathburial;[death], [burial]%in;
-                          %if;((not ancestor.has_burial_note and not ancestor.has_burial_source) and (ancestor.source_type=[death] or ancestor.source_type=deathburial))
+                          %if;(not ancestor.has_burial_note and ((not ancestor.has_burial_source and source_type=[death]) or source_type=deathburial))
                             %apply;capitalize(ancestor.source).
-                          %elseif;((ancestor.has_burial_note or ancestor.has_burial_source) and (ancestor.source_type=[death] or ancestor.source_type=[burial]))
-                            <li>%apply;capitalize(ancestor.source_type)[:] %ancestor.source;.</li>
+                          %elseif;((ancestor.has_burial_note or ancestor.has_burial_source) and (source_type=[death] or source_type=[burial]))
+                            <li>%apply;capitalize(source_type)[:] %ancestor.source;.</li>
                           %end;
                         %end;'
             title='%if;(ancestor.has_death_source or ancestor.has_burial_source or ancestor.has_death_note or ancestor.has_burial_note)
                      %if;((ancestor.has_death_note or ancestor.has_burial_note) and not (ancestor.has_death_source or ancestor.has_burial_source))[*note/notes]1%nn;
-                     %elseif;(not (ancestor.has_death_note or ancestor.has_burial_note) and (ancestor.has_death_source or ancestor.has_burial_source))[source/sources]1%nn;
+                     %elseif;(not (ancestor.has_death_note or ancestor.has_burial_note) and (ancestor.has_death_source or ancestor.has_burial_source))[*source/sources]1%nn;
                      %elseif;((ancestor.has_death_note or ancestor.has_burial_note) and (ancestor.has_death_source or ancestor.has_burial_source))[*note/notes]1 [and] [source/sources]1%nn;
                      %end;
                    %end;'
@@ -1083,17 +1123,16 @@
       %end;
     </td>
   %end
-%( Age %)
-  %if;(evar.death_age = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
-      %ancestor.death_age;
+%( Âge %)
+  %if;(evar.age = "on")
+    <td class="align-middle" %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+      %if;ancestor.computable_death_age;%ancestor.death_age;%end;
+      %if;ancestor.computable_age;%ancestor.age;%end;
     </td>
   %end;
 %( Profession %)
   %if;(evar.occu = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
-      class='align-middle%nn;'
-      >
+    <td class="align-middle" %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
       %if;(ancestor.has_occupation)
         %ancestor.occupation
       %else;
@@ -1109,8 +1148,7 @@
       %if;(family_cnt != 1)
         <tr>
           %if;(evar.marr = "on")
-            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
-              class='align-middle%nn;
+            <td class='border-top-0 align-middle%nn;
                 %if;(evar.ns="on")
                   %if;(spouse.has_pnotes and not spouse.has_psources) note%nn;
                   %elseif;(not spouse.has_pnotes and spouse.has_psources) source%nn;
@@ -1126,7 +1164,7 @@
                             %end;'
                 title='%if;(spouse.has_psources or spouse.has_pnotes)
                          %if;(spouse.has_pnotes and not spouse.has_psources)[*note/notes]1%nn;
-                         %elseif;(not spouse.has_pnotes and spouse.has_psources)[source/sources]1%nn;
+                         %elseif;(not spouse.has_pnotes and spouse.has_psources)[*source/sources]1%nn;
                          %elseif;(spouse.has_pnotes and spouse.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
                          %end;
                        %end;'
@@ -1139,7 +1177,7 @@
             </td>
           %end;
           %if;(evar.marr_date = "on")
-            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;">
+            <td class="border-top-0">
               %if;(slash_marriage_date != "")
                 %slash_marriage_date;
               %else;
@@ -1148,8 +1186,7 @@
             </td>
           %end;
           %if;(evar.marr_place = "on")
-            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
-              class='align-middle%nn;
+            <td class='border-top-0 align-middle%nn;
               %if;(evar.ns="on")
                 %if;(has_marriage_note and not has_marriage_source) note%nn;
                 %elseif;(not has_marriage_note and has_marriage_source) source%nn;
@@ -1161,7 +1198,7 @@
                 data-content='%if;(has_marriage_note)%marriage_note;%end;
                               %if;(has_marriage_source)
                                 %if;(has_marriage_note)<hr>%end;
-                                %apply;capitalize(marriage_source)
+                                %apply;capitalize(marriage_source).
                               %end;'
                 title='%if;(has_marriage_note or has_marriage_source)
                          %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
@@ -1286,8 +1323,8 @@
 </h1>
 
 %if;(evar.t = "Z" and not cancel_links)
-  <div class="form-inline">
-    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
+  <div class="d-flex">
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;p=%first_name;;n=%surname;;m=A">
         <i class="fa fa-cog fa-lg fa-fw mr-1">
         </i>[*options] [ancestors] 
@@ -1304,30 +1341,29 @@
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
         <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
-        <div class="input-group ml-3 mb-1">
-      <span class="input-group-btn">
-        %if;(evar.v>=3)<a
-          href="%apply;rebuild_url%with;A
+    <div class="ml-auto mr-5">
+      %if;(evar.v>=3)
+        <a role="button" class="btn" href="%apply;rebuild_url%with;A
             %and;%evar.t;
             %and;%expr(evar.v-1)
             %end;
             %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;"
-            class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
-      </span>
-      <input class="form-control text-center" size="12"
-        value="%evar.v; [generation/generations]1"
-        title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
-      <span class="input-group-btn">
-        <a href="%apply;rebuild_url%with;A
+            class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">
+          <i class="fa fa-minus fa-lg "></i>
+        </a>
+      %end;
+      <span class="text-primary mt-2">%apply;togena%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
+      <a role="button" class="btn" href="%apply;rebuild_url%with;A
           %and;%evar.t;
           %and;%expr(evar.v+1)
           %end;
           %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;"
-          class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
-      </span>
+          class="btn btn-secondary" title="[*add] 1 [generation/generations]0">
+          <i class="fa fa-plus fa-lg"></i>
+      </a>
     </div>
   </div>
-  <div class="form-inline">
+  <div class="d-flex">
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
      href="%apply;rebuild_url%with;A
            %and;Z
@@ -1378,9 +1414,6 @@
     %end;
   </div>
 %end;
-
-
-
 
 %if;(evar.t = "P")
   %include.perso_short;
@@ -1814,7 +1847,7 @@
   %elseif;(evar.t = "Z" and evar.only = "on")
     <p>%apply;gen("v").</p>
     %reset_count;
-    <table class="table table-hover ascends_table">
+    <table class="table table-hover ascends_table mt-1">
       <tr class="ascends_table_header align-middle">%apply;table_header()</tr>
       %let;nb_col;%count;%in;
       %reset_count;
@@ -1841,14 +1874,14 @@
   %elseif;(evar.t = "Z")
     %let;nb_gen;%apply;min(evar.v, max_anc_level)%in;
     %reset_count;
-    <table class="table table-hover ascends_table">
+    <table class="table table-hover ascends_table mt-1">
       <tr class="ascends_table_header align-middle">%apply;table_header()</tr>
       %let;nb_col;%count;%in;
       %reset_count;
       %foreach;ancestor_level(nb_gen)
-        %if;(evar.gen = "on")
+        %if;(evar.gen = "on" and level!=1)
           <tr>
-            <th align="left" colspan="%nb_col;">[*generation/generations]0 %level;</th>
+            <td class="pl-2 font-weight-bold color-gray" colspan="%nb_col;">[*generation/generations]0 %level;</td>
           </tr>
         %end;
         %foreach;ancestor;

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -37,12 +37,7 @@
 <div class="container-fluid">
 
 %if;not cancel_links;
-  <div class="btn-group float-%right; mb-1">
-    %if;(referer != "")
-      <a role="button" class="btn btn-link px-0" href="%referer;"><span class="fa fa-arrow-left fa-lg" title="<<"></span></a>
-    %end;
-    <a role="button" class="btn btn-link ml-1 px-0" href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span></a>
-  </div>
+  %import;menubar;
 %end;
 
 %let;central_index;%index;%in;
@@ -1104,7 +1099,11 @@
                           %if;(not ancestor.has_burial_note and ((not ancestor.has_burial_source and source_type=[death]) or source_type=deathburial))
                             %apply;capitalize(ancestor.source).
                           %elseif;((ancestor.has_burial_note or ancestor.has_burial_source) and (source_type=[death] or source_type=[burial]))
-                            <li>%apply;capitalize(source_type)[:] %ancestor.source;.</li>
+                            %if;(source_type=[burial] and ancestor.is_cremated)
+                               <li>%apply;capitalize([cremation])[:] %ancestor.source;.</li>
+                            %else;
+                              <li>%apply;capitalize(source_type)[:] %ancestor.source;.</li>
+                            %end;
                           %end;
                         %end;'
             title='%if;(ancestor.has_death_source or ancestor.has_burial_source or ancestor.has_death_note or ancestor.has_burial_note)

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -890,7 +890,7 @@
   </td>
 %( Ancêtre %)
   <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
-      class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
+      class='%if;(ancestor.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
     %if;(evar.ns="on")
         %if;(ancestor.has_notes and not ancestor.has_psources) note%nn;
         %elseif;(not ancestor.has_notes and ancestor.has_psources) source%nn;

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -786,7 +786,6 @@
    Display ascend in table
 %)
 
-
 %define;table_header()
   <tr class="ascends_table_header align-middle">
     %reset_count;
@@ -1267,7 +1266,12 @@
   %if;(evar.gen="on")gen=on;%nn;%end;
   %if;(evar.notes="on")notes=on;%nn;%end;
   %if;(evar.src="on")src=on;%nn;%end;
-  vvv;nnn;ccc;iii;ppp;%in;
+  %if;("vvv"!="")vvv;%end;
+  %if;("nnn"!="")nnn;%end;
+  %if;("ccc"!="")ccc;%end;
+  %if;("iii"!="")iii;%end;
+  %if;("ppp"!="")ppp;%end;
+  %in;
   %new_url;
 %end;
 
@@ -1304,44 +1308,43 @@
       href="%apply;rebuild_url%with;D
             %and;I
             %and;v=%max_desc_level;
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;"
-            class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
+      class="btn btn-secondary">
+      <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]
+    </a>
     <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
-        <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
+      <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]
+    </a>
     <div class="mr-5">
-      %if;(evar.v>=3)
-        <a role="button" class="btn" href="%apply;rebuild_url%with;A
+      <a role="button" class="btn pl-3
+      %if;(evar.v<"3")disabled" aria-disabled="true"%else;"%end;
+        href="%apply;rebuild_url%with;A
             %and;%evar.t;
             %and;v=%expr(evar.v-1)
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;"
-            class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">
-          <i class="fa fa-minus fa-lg"></i>
-        </a>
-      %else;
-        <span class="btn btn-secondary disabled" aria-disabled="true" title="[*delete] 1 [generation/generations]0">
-          <i class="fa fa-minus fa-lg" ></i>
-        </span>
-      %end;
+        class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">
+        <i class="fa fa-minus fa-lg"></i>
+      </a>
       <a role="button" class="btn"
         href="%apply;rebuild_url%with;A
               %and;%evar.t;
               %and;v=%expr(evar.v+1)
-              %and;%if;(evar.ns="on")ns=on;%end;
-              %and;%if;(evar.cgl="on")cgl=on;%end;
-              %and;%if;(evar.image="on")image=on;%end;
-              %and;%if;(evar.px!="")px=%evar.px;;%end;
+              %and;%if;(evar.ns="on")ns=on%end;
+              %and;%if;(evar.cgl="on")cgl=on%end;
+              %and;%if;(evar.image="on")image=on%end;
+              %and;%if;(evar.px!="")px=%evar.px;%end;
               %end;"
-              class="btn btn-secondary" title="[*add] 1 [generation/generations]0">
-              <i class="fa fa-plus fa-lg"></i>
+          class="btn btn-secondary" title="[*add] 1 [generation/generations]0">
+          <i class="fa fa-plus fa-lg"></i>
         </a>
       <span class="text-primary mt-2">%apply;togena%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
     </div>
@@ -1351,53 +1354,54 @@
       href="%apply;rebuild_url%with;A
             %and;Z
             %and;v=%evar.v;
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="" or evar.image!="on")image=on;%else;image=off;%end;
-            %and;px=%evar.px;;
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="" or evar.image!="on")image=on%else;image=off%end;
+            %and;px=%evar.px;
             %end;">
-            <i class="fa fa-picture-o fa-lg fa-fw
-             %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
-     %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
+      <i class="fa fa-picture-o fa-lg fa-fw %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
+      %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
     </a>
     %if;(evar.image="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
         href="%apply;rebuild_url%with;A
               %and;Z
               %and;v=%evar.v;
-              %and;%if;(evar.ns="on")ns=on;%end;
-              %and;%if;(evar.cgl="on")cgl=on;%end;
-              %and;%if;(evar.image="on")image=on;%end;
-              %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
+              %and;%if;(evar.ns="on")ns=on%end;
+              %and;%if;(evar.cgl="on")cgl=on%end;
+              %and;%if;(evar.image="on")image=on%end;
+              %and;%if;(evar.px="")px=90%elseif;(evar.px="90")px=120%end;
               %end;"
-       title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
+        title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px">
+        <i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1
+      </a>
     %end;
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;A
             %and;Z
             %and;v=%evar.v;
-            %and;%if;(evar.ns="on")ns=off;%else;ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.ns="on")ns=off%else;ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")%evar.px;%end;
             %end;"
-            title="small arrow in corner shows existence of note or source">
-              <i class="fa fa-file-text-o fa-lg fa-fw
-               %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
+      title="small arrow in corner shows existence of note or source">
+      <i class="fa fa-file-text-o fa-lg fa-fw %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
       %if;(evar.ns="" or evar.ns!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
-        <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
+      <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1
+      </span>
     </a>
     %if;(evar.cgl="" or evar.cgl!="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
         href="%apply;rebuild_url%with;A
               %and;Z
               %and;v=%evar.v;
-              %and;ns=off;
-              %and;cgl=on;
-              %and;%if;(evar.image="on")image=on;%end;
+              %and;ns=off
+              %and;cgl=on
+              %and;%if;(evar.image="on")image=on%end;
               %and;%if;(evar.px="")px=%evar.px;%end;
               %end;"
-              title="Cancel url links in whole page">
+        title="Cancel url links in whole page">
         <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
       </a>
     %end;

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -979,7 +979,7 @@
     %else;
       %foreach;ancestor.family;
         %if;(family_cnt = 1)
-          <td %if;(ancestor.nb_families>1) %end; 
+          <td %if;(ancestor.nb_families>1) %end;
             class='align-middle%nn;
             %if;(evar.ns="on")
               %if;(has_marriage_note and not has_marriage_source) note%nn;
@@ -1134,7 +1134,7 @@
               >
               %apply;image_MF("spouse")
               %apply;link%with;%spouse.access;%and;
-                %spouse; 
+                %spouse;
               %end;
             </td>
           %end;
@@ -1292,37 +1292,37 @@
         <i class="fa fa-cog fa-lg fa-fw mr-1">
         </i>[*options] [ancestors] 
     </a>
-    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;I
             %and;%max_desc_level;
             %end;
             %if;(evar.notes="on")notes=on;%end;
             %if;(evar.ns="on")ns=on;%end;
-            %if;(evar.image="on")image=on;%end;" 
+            %if;(evar.image="on")image=on;%end;"
             class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
-    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
         <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
-    <div class="input-group ml-3 mb-1">
+        <div class="input-group ml-3 mb-1">
       <span class="input-group-btn">
-        %if;(evar.v>=3)<a 
+        %if;(evar.v>=3)<a
           href="%apply;rebuild_url%with;A
             %and;%evar.t;
             %and;%expr(evar.v-1)
             %end;
-            %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;" 
+            %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;"
             class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
-      <input class="form-control text-center" size="12" 
-        value="%evar.v; [generation/generations]1" 
+      <input class="form-control text-center" size="12"
+        value="%evar.v; [generation/generations]1"
         title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
       <span class="input-group-btn">
         <a href="%apply;rebuild_url%with;A
           %and;%evar.t;
           %and;%expr(evar.v+1)
           %end;
-          %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;" 
+          %if;(evar.ns="on")ns=on;%end;%if;(evar.image="on")image=on;%end;"
           class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
       </span>
     </div>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -856,12 +856,32 @@
 %define;table_row()
   %lazy_force;
   %if;(ancestor.same = "")%incr_count;%end;
+%( Sosa %)
   <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
     %if;(evar.sosab = 16)%ancestor.anc_sosa.hexa;
     %elseif;(evar.sosab = 8)%ancestor.anc_sosa.octal;
     %else;%ancestor.anc_sosa;%end;
   </td>
-  <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+%( Ancêtre %)
+  <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
+      class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
+    %if;(evar.show_ns="on")
+        %if;(ancestor.has_notes and not ancestor.has_psources) note%nn;
+        %elseif;(not ancestor.has_notes and ancestor.has_psources) source%nn;
+        %elseif;(ancestor.has_notes and ancestor.has_psources) notesource%nn;
+        %end;
+    %end;'
+    %if;(evar.show_ns="on" and (ancestor.has_notes or ancestor.has_psources))
+      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+      data-content='%if;(ancestor.has_notes)%ancestor.notes;%end;
+                    %if;(ancestor.has_notes and ancestor.has_psources)<hr>%end;
+                    %if;(ancestor.has_psources)%apply;capitalize(ancestor.psources)%end;'
+      title='%if;(ancestor.has_notes and not ancestor.has_psources)[*note/notes]1%nn;
+            %elseif;(not ancestor.has_notes and ancestor.has_psources)[*source/sources]1%nn;
+            %elseif;(ancestor.has_notes and ancestor.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
+            %end;'
+    %end;
+    >
     %apply;image_MF("ancestor")
     %apply;link%with;%ancestor.access;%and;
       %ancestor;
@@ -873,9 +893,12 @@
       %elseif(evar.sosab = 8)%ancestor.same.octal;
       %else;%ancestor.same;%end;
     %end;
+%( Date de naissance %)
   </td>
   %if;(evar.birth = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
+      class='align-middle%nn;'
+      >
       %if;ancestor.has_approx_birth_date;
         %ancestor.slash_approx_birth_date;
       %else;
@@ -883,8 +906,41 @@
       %end;
     </td>
   %end;
+%( Lieu de naissance %)
   %if;(evar.birth_place = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
+      class='align-middle%nn;
+        %if;(evar.show_ns="on")
+          %if;((ancestor.has_birth_note or ancestor.has_baptism_note) and not
+               (ancestor.has_birth_source or ancestor.has_baptism_source)) note%nn;
+          %elseif;(not (ancestor.has_birth_note or ancestor.has_baptism_note) and
+               (ancestor.has_birth_source or ancestor.has_baptism_source)) source%nn;
+          %elseif;((ancestor.has_birth_note or ancestor.has_baptism_note) and
+               (ancestor.has_birth_source or ancestor.has_baptism_source)) notesource%nn;
+          %end;
+        %end;'
+        %if;(evar.show_ns="on")
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;(ancestor.has_birth_note or ancestor.has_baptism_note)
+                          %if;(ancestor.has_birth_note)%if;(ancestor.has_baptism_note)[*birth][:] %end;%ancestor.birth_note;%end;
+                          %if;(ancestor.has_baptism_note)[*baptism][:] %ancestor.baptism_note;%end;
+                        %end;
+                        %foreach;ancestor.source;
+                          %let;birthbaptism;[birth], [baptism]%in;
+                          %if;((not ancestor.has_baptism_note and not ancestor.has_baptism_source) and (ancestor.source_type=[birth] or ancestor.source_type=birthbaptism))
+                            %apply;capitalize(ancestor.source).
+                          %elseif;((ancestor.has_baptism_note or ancestor.has_baptism_source) and (ancestor.source_type=[birth] or ancestor.source_type=[baptism]))
+                            <li>%apply;capitalize(ancestor.source_type)[:] %ancestor.source;.</li>
+                          %end;
+                        %end;'
+            title='%if;(ancestor.has_birth_source or ancestor.has_baptism_source or ancestor.has_birth_note or ancestor.has_baptism_note)
+                     %if;((ancestor.has_birth_note or ancestor.has_baptism_note) and not (ancestor.has_birth_source or ancestor.has_baptism_source))[*note/notes]1%nn;
+                     %elseif;(not (ancestor.has_birth_note or ancestor.has_baptism_note) and (ancestor.has_birth_source or ancestor.has_baptism_source))[source/sources]1%nn;
+                     %elseif;((ancestor.has_birth_note or ancestor.has_baptism_note) and (ancestor.has_birth_source or ancestor.has_baptism_source))[*note/notes]1 [and] [source/sources]1%nn;
+                     %end;
+                   %end;'
+        %end;
+      >
       %if;ancestor.has_approx_birth_place;
         %ancestor.approx_birth_place;
       %else;
@@ -892,56 +948,81 @@
       %end;
     </td>
   %end;
+%( Conjoints %)
   %if;(evar.marr = "on")
     %if;(ancestor.nb_families = 0)
       <td>&nbsp;</td>
     %else;
       %foreach;ancestor.family;
         %if;(family_cnt = 1)
-          <td %if;(ancestor.nb_families > 1) style="border-bottom:none" %end;>
+          <td %if;(ancestor.nb_families > 1) %end;>
             %apply;image_MF("spouse")
             %apply;link%with;%spouse.access;%and;
-              %spouse;
+              %family_cnt; %spouse;
             %end;
           </td>
         %end;
       %end;
     %end;
   %end;
+%( Date du mariage %)
   %if;(evar.marr_date = "on")
     %if;(ancestor.nb_families = 0)
       <td>&nbsp;</td>
     %else;
-    %foreach;ancestor.family;
-      %if;(family_cnt = 1)
-        <td %if;(ancestor.nb_families > 1) style="border-bottom:none" %end;>
-          %if;(slash_marriage_date != "")
-            %slash_marriage_date;
-          %else;
-            &nbsp;
-          %end;
-        </td>
-      %end;
+      %foreach;ancestor.family;
+        %if;(family_cnt = 1)
+          <td %if;(ancestor.nb_families > 1) %end;>
+            %if;(slash_marriage_date != "")
+              %slash_marriage_date;
+            %else;
+              &nbsp;
+            %end;
+          </td>
+        %end;
       %end;
     %end;
   %end;
+%( Lieu du mariage %)
   %if;(evar.marr_place = "on")
     %if;(ancestor.nb_families = 0)
       <td>&nbsp;</td>
     %else;
-    %foreach;ancestor.family;
-      %if;(family_cnt = 1)
-        <td %if;(ancestor.nb_families>1) style="border-bottom:none" %end;>
-          %if;(marriage_place != "")
-            %marriage_place;
-          %else;
-            &nbsp;
-          %end;
-        </td>
-      %end;
+      %foreach;ancestor.family;
+        %if;(family_cnt = 1)
+          <td %if;(ancestor.nb_families>1) %end; 
+            class='align-middle%nn;
+            %if;(evar.show_ns="on")
+              %if;(has_marriage_note and not has_marriage_source) note%nn;
+              %elseif;(not has_marriage_note and has_marriage_source) source%nn;
+              %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
+              %end;
+            %end;'
+            %rowspan;
+            %if;(evar.show_ns="on")
+              tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+              data-content='%if;(has_marriage_note)%marriage_note;%end;
+                            %if;(has_marriage_note and has_marriage_source)<hr>%end;
+                            %if;(has_marriage_source)%apply;capitalize(marriage_source)%end;'
+              title='%if;(has_marriage_source or has_marriage_note)
+                       %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
+                       %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1
+                       %elseif;(has_marriage_note and has_marriage_source)[*note/notes]1 [and] [source/sources]1
+                       %end;
+                     %end;'
+            %end;
+            >
+            %if;(marriage_place != "")
+              %marriage_place;
+            %else;
+              &nbsp;
+            %end;
+          </td>
+        %end;
       %end;
     %end;
   %end;
+%( Nombre d'enfants %)
   %if;(evar.child = "on")
     %if;(ancestor.nb_families = 0)
       <td>&nbsp;</td>
@@ -949,7 +1030,7 @@
       %if;(evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on")
         %foreach;ancestor.family;
           %if;(family_cnt = 1)
-            <td align="center" %if;(ancestor.nb_families > 1) style="border-bottom:none" %end;>
+            <td align="center" %if;(ancestor.nb_families > 1) %end;>
               %nb_children;
             </td>
           %end;
@@ -959,8 +1040,11 @@
       %end;
     %end;
   %end;
+%( Date du décès %)
   %if;(evar.death = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
+      class='align-middle%nn;'
+      >
       %if;ancestor.has_approx_death_date;
         %ancestor.slash_approx_death_date;
       %else;
@@ -968,8 +1052,41 @@
       %end;
     </td>
   %end;
+%( Lieu du décès %)
   %if;(evar.death_place = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
+      class='align-middle%nn;
+        %if;(evar.show_ns="on")
+          %if;((ancestor.has_death_note or ancestor.has_burial_note) and not
+               (ancestor.has_death_source or ancestor.has_burial_source)) note%nn;
+          %elseif;(not (ancestor.has_death_note or ancestor.has_burial_note) and
+               (ancestor.has_death_source or ancestor.has_burial_source)) source%nn;
+          %elseif;((ancestor.has_death_note or ancestor.has_burial_note) and
+               (ancestor.has_death_source or ancestor.has_burial_source)) notesource%nn;
+          %end;
+        %end;'
+        %if;(evar.show_ns="on")
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;(ancestor.has_death_note or ancestor.has_burial_note)
+                          %if;(ancestor.has_death_note)%if;(ancestor.has_burial_note)[*death][:] %end;%ancestor.death_note;%end;
+                          %if;(ancestor.has_burial_note)[*burial][:] %ancestor.burial_note;%end;
+                        %end;
+                        %foreach;ancestor.source;
+                          %let;deathburial;[death], [burial]%in;
+                          %if;((not ancestor.has_burial_note and not ancestor.has_burial_source) and (ancestor.source_type=[death] or ancestor.source_type=deathburial))
+                            %apply;capitalize(ancestor.source).
+                          %elseif;((ancestor.has_burial_note or ancestor.has_burial_source) and (ancestor.source_type=[death] or ancestor.source_type=[burial]))
+                            <li>%apply;capitalize(ancestor.source_type)[:] %ancestor.source;.</li>
+                          %end;
+                        %end;'
+            title='%if;(ancestor.has_death_source or ancestor.has_burial_source or ancestor.has_death_note or ancestor.has_burial_note)
+                     %if;((ancestor.has_death_note or ancestor.has_burial_note) and not (ancestor.has_death_source or ancestor.has_burial_source))[*note/notes]1%nn;
+                     %elseif;(not (ancestor.has_death_note or ancestor.has_burial_note) and (ancestor.has_death_source or ancestor.has_burial_source))[source/sources]1%nn;
+                     %elseif;((ancestor.has_death_note or ancestor.has_burial_note) and (ancestor.has_death_source or ancestor.has_burial_source))[*note/notes]1 [and] [source/sources]1%nn;
+                     %end;
+                   %end;'
+        %end;
+      >
       %if;ancestor.has_approx_death_date;
         %ancestor.approx_death_place;
       %else;
@@ -977,13 +1094,17 @@
       %end;
     </td>
   %end
+%( Age %)
   %if;(evar.death_age = "on")
     <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
       %ancestor.death_age;
     </td>
   %end;
+%( Profession %)
   %if;(evar.occu = "on")
-    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;>
+    <td %if;(ancestor.nb_families>1 and (evar.marr = "on" or evar.marr_date = "on" or evar.marr_place = "on"))rowspan="%ancestor.nb_families;"%end;
+      class='align-middle%nn;'
+      >
       %if;(ancestor.has_occupation)
         %ancestor.occupation
       %else;
@@ -999,15 +1120,37 @@
       %if;(family_cnt != 1)
         <tr>
           %if;(evar.marr = "on")
-            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) border-bottom:none %end;">
+            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
+              class='align-middle%nn;
+                %if;(evar.show_ns="on")
+                  %if;(spouse.has_pnotes and not spouse.has_psources) note%nn;
+                  %elseif;(not spouse.has_pnotes and spouse.has_psources) source%nn;
+                  %elseif;(spouse.has_pnotes and spouse.has_psources) notesource%nn;
+                  %end;
+                %end;'
+              %if;(evar.show_ns="on")
+              tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+                data-content='%if;(spouse.has_pnotes)%spouse.pnotes;%end;
+                              %if;(spouse.has_psources)
+                                %if;(spouse.has_pnotes)<hr>%end;
+                                %spouse.psources;
+                              %end;'
+                  title='%if;(spouse.has_psources or spouse.has_pnotes)
+                           %if;(spouse.has_pnotes and not spouse.has_psources)[*note/notes]1%nn;
+                           %elseif;(not spouse.has_pnotes and spouse.has_psources)[source/sources]1%nn;
+                           %elseif;(spouse.has_pnotes and spouse.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
+                           %end;
+                         %end;'
+              %end;
+              >
               %apply;image_MF("spouse")
               %apply;link%with;%spouse.access;%and;
-                %spouse;
+                %spouse; 
               %end;
             </td>
           %end;
           %if;(evar.marr_date = "on")
-            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) border-bottom:none %end;">
+            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;">
               %if;(slash_marriage_date != "")
                 %slash_marriage_date;
               %else;
@@ -1016,7 +1159,28 @@
             </td>
           %end;
           %if;(evar.marr_place = "on")
-            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) border-bottom:none %end;">
+            <td style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
+              class='align-middle%nn;
+              %if;(evar.show_ns="on")
+                %if;(has_marriage_note and not has_marriage_source) note%nn;
+                %elseif;(not has_marriage_note and has_marriage_source) source%nn;
+                %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
+                %end;
+              %end;'
+              %rowspan;
+              %if;(evar.show_ns="on")
+                tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+                data-content='%if;(has_marriage_note)%marriage_note;%end;
+                              %if;(has_marriage_note and has_marriage_source)<hr>%end;
+                              %if;(has_marriage_source)%apply;capitalize(marriage_source)%end;'
+                title='%if;(has_marriage_source or has_marriage_note)
+                         %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
+                         %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1
+                         %elseif;(has_marriage_note and has_marriage_source)[*note/notes]1 [and] [source/sources]1
+                         %end;
+                       %end;'
+              %end;
+              >
               %if;(marriage_place != "")
                 %marriage_place;
               %else;
@@ -1025,7 +1189,28 @@
             </td>
           %end;
           %if;(evar.child = "on")
-            <td align="center" style="border-top:none; %if;(ancestor.nb_families != family_cnt) border-bottom:none %end;">
+            <td align="center" style="border-top:none; %if;(ancestor.nb_families != family_cnt) %end;"
+              class='align-middle%nn;
+              %if;(evar.show_ns="on")
+                %if;(has_fnotes and not has_fsources) note%nn;
+                %elseif;(not has_fnotes and has_fsources) source%nn;
+                %elseif;(has_fnotes and has_fsources) notesource%nn;
+                %end;
+              %end;'
+              %rowspan;
+              %if;(evar.show_ns="on")
+                tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+                data-content='%if;(has_fnotes)%fnotes;%end;
+                              %if;(has_fnotes and has_fsources)<hr>%end;
+                              %if;(has_fsourcess)%apply;capitalize(fsources)%end;'
+                title='%if;(has_fsourcess or has_fnotes)
+                         %if;(has_fnotes and not has_fsources)[*note/notes]1
+                         %elseif;(not has_fnotes and has_fsources)[*source/sources]1
+                         %elseif;(has_fnotes and has_fsources)[*note/notes]1 [and] [source/sources]1
+                         %end;
+                       %end;'
+              %end;
+              >
               %nb_children;
             </td>
           %end;
@@ -1093,20 +1278,68 @@
 
 %if;(evar.t = "Z" and not cancel_links)
   <div class="form-inline">
-    <a role="button" class="btn btn-link my-0 px-0 mb-1" href="%prefix;p=%first_name;;n=%surname;;m=A"><i class="fa fa-cog fa-lg fa-fw mr-1"></i>[*options] [ancestors] </a>
-    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" href="%apply;rebuild_url%with;D%and;I;%and;%max_desc_level;%end;%if;(evar.notes="on")notes=on;%end;%if;(evar.image="on")image=on;%end;" class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
-    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on"><span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
+    <a role="button" class="btn btn-link my-0 px-0 mb-1" 
+      href="%prefix;p=%first_name;;n=%surname;;m=A">
+        <i class="fa fa-cog fa-lg fa-fw mr-1"></i>[*options] [ancestors] </a>
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
+      href="%apply;rebuild_url%with;D
+            %and;I
+            %and;%max_desc_level;
+            %end;
+            %if;(evar.notes="on")notes=on;%end;
+            %if;(evar.show_ns="on")show_ns=on;%end;
+            %if;(evar.image="on")image=on;%end;" 
+            class="btn btn-secondary"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*table] [descendants]</a>
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1" 
+      href="%prefix;m=A;t=T;%access;;v=%evar.v;;image=on;marriage=on">
+        <span class="fa fa-sitemap fa-rotate-180 fa-lg fa-fw mr-1"></span>[*ascendants tree]</a>
+    
     <div class="input-group ml-3 mb-1">
       <span class="input-group-btn">
-        %if;(evar.v>=3)<a href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v-1)%end" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
+        %if;(evar.v>=3)<a 
+          href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v-1)%end;%if;(evar.show_ns="on")show_ns=on;%end;" 
+            class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
-      <input class="form-control text-center" size="12" value="%evar.v; [generation/generations]1" title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
+      <input class="form-control text-center" size="12" 
+        value="%evar.v; [generation/generations]1" 
+        title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
       <span class="input-group-btn">
-        <a href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v+1)%end" class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
+        <a href="%apply;rebuild_url%with;A%and;%evar.t;%and;%expr(evar.v+1)%end;%if;(evar.show_ns="on")show_ns=on;%end;" 
+          class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
       </span>
     </div>
   </div>
+  <div class="form-inline">
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+      href="%apply;rebuild_url%with;A
+            %and;Z
+            %and;%evar.v;
+            %end;
+            %if;(evar.show_ns="on")show_ns=off;%else;show_ns=on;%end;
+            %if;(evar.image="on")image=on;%end;"
+            title="small arrow in corner shows existence of note or source">
+              <i class="fa fa-file-text-o fa-lg fa-fw
+               %if;(evar.show_ns="on")text-danger%end; mr-1"></i>%nn;
+      %if;(evar.show_ns="" or evar.show_ns!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
+        <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
+    </a>
+    %if;(evar.cgl="" or evar.cgl!="on")
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+        href="%apply;rebuild_url%with;A
+              %and;Z
+              %and;%evar.v;
+              %end;
+              %if;(evar.image="on")image=on;%end;
+              show_ns=off;cgl=on;"
+              title="Cancel url links in whole page">
+        <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
+      </a>
+    %end;
+  </div>
 %end;
+
+
+
 
 %if;(evar.t = "P")
   %include.perso_short;
@@ -1596,5 +1829,18 @@
 %include.copyr;
 </div>
 %include.js;
+<script>
+// Initialize Bootstrap tooltip and popover component, dismiss on next click function
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+$(function () {
+  $('[data-toggle="popover"]').popover()
+})
+$('.popover-dismiss').popover({
+  trigger: 'focus'
+})
+</script>
+
 </body>
 </html>

--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -90,3 +90,7 @@
     </div>
   </div>
 %end;
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+.

--- a/hd/etc/css.css
+++ b/hd/etc/css.css
@@ -1,7 +1,19 @@
-div.anchor_updind {
-  position:absolute;
-  top:-25px;
+.fixed_top_btn {
+  position: fixed;
+  top: 0px;
+  transform: translateX(8px);
 }
+
+div.anchor_upd {
+  position:absolute;
+  top:-34px;
+}
+
+/* hide placeholder on input focus */
+input:focus::-webkit-input-placeholder { color:transparent; }
+input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
+input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
+input:focus:-ms-input-placeholder { color:transparent; }
 
 /* Capitalization unavailable in note from Ocaml */
 p::first-letter {
@@ -29,9 +41,9 @@ img.image-popover {
 .p_mod-dropdown-menu-wizard {
   padding: 0px;
   border: 0px;
-  left: 20%;
+  left: 25%;
   right: auto;
-  transform: translateX(-20%);
+  transform: translateX(-25%);
 }
 
 div.p_mod_builder {
@@ -1082,10 +1094,10 @@ hr.full
 .ascends_table th, .ascends_table td,
 .descends_table th, .descends_table td
 {
- border:1px solid black;
- vertical-align:top;
- padding:4px;
- empty-cells: show;
+  border: 1px solid black;
+  vertical-align: top;
+  padding: 4px;
+  empty-cells: show;
 }
 
 .ascends_table_header th,
@@ -1197,29 +1209,55 @@ ul.missing_ancestors_sort > li
   padding-left: 10px;
 }
 
-.note, .source, .notesource {
+/* adjust also colors in destable.txt */
+.note, .source, .notesource, .notespouse, .sourcespouse, .notesourcespouse {
     position: relative;
 }
-.note:after, .source:after, .notesource:after {
+.note:after, .source:after, .notesource:after, .notespouse:after, .sourcespouse:after, .notesourcespouse:after {
     content: "";
     position: absolute;
     top: 0;
-    right: 0;
-    width: 0; 
-    height: 0; 
+    width: 0;
+    height: 0;
     display: block;
-    border-left: 12px solid transparent;
     border-bottom: 12px solid transparent;
 }
-
-/* adjust also colors in destable.txt */
 .note:after {
-    border-top: 12px solid #FFA07A;
-}
-.source:after {
-    border-top: 12px solid #90EE90;
-}
-.notesource:after {
+    right: 0;
+    border-left: 12px solid transparent;
     border-top: 12px solid #87CEFA;
 }
-
+.source:after {
+    right: 0;
+    border-left: 12px solid transparent;
+    border-top: 12px solid #FFD700;
+}
+.notesource:after {
+    right: 0;
+    border-left: 12px solid transparent;
+    border-top: 12px solid #90EE90;
+}
+.notespouse:after {
+    left: 0;
+    border-right: 12px solid transparent;
+    border-top: 12px solid #87CEFA; 
+}
+.sourcespouse:after {
+    left: 0;
+    border-right: 12px solid transparent;
+    border-top: 12px solid #FFD700;
+}
+.notesourcespouse:after {
+    left: 0;
+    border-right: 12px solid transparent;
+    border-top: 12px solid #90EE90;
+}
+span.notecolor {
+    color: #87CEFA;
+}
+span.sourcecolor {
+    color: #FFD700;
+}
+span.notesourcecolor {
+    color: #90EE90;
+}

--- a/hd/etc/css.css
+++ b/hd/etc/css.css
@@ -15,10 +15,12 @@ input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
 input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
 input:focus:-ms-input-placeholder { color:transparent; }
 
-/* Capitalization unavailable in note from Ocaml */
+/* Capitalization unavailable in note from Ocaml 
+> temporary disactivated: too intrusive for notes in popovers, but needed for note in timeline...
 p::first-letter {
   text-transform: capitalize;
 }
+*/
 
 .pmod::first-letter {
   font-weight: bold
@@ -1260,4 +1262,8 @@ span.sourcecolor {
 }
 span.notesourcecolor {
     color: #90EE90;
+}
+.popover{
+    word-wrap: break-word;
+    max-width: 40%;
 }

--- a/hd/etc/css.css
+++ b/hd/etc/css.css
@@ -1,19 +1,7 @@
-.fixed_top_btn {
-  position: fixed;
-  top: 0px;
-  transform: translateX(8px);
-}
-
-div.anchor_upd {
+div.anchor_updind {
   position:absolute;
-  top:-34px;
+  top:-25px;
 }
-
-/* hide placeholder on input focus */
-input:focus::-webkit-input-placeholder { color:transparent; }
-input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
-input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
-input:focus:-ms-input-placeholder { color:transparent; }
 
 /* Capitalization unavailable in note from Ocaml 
 > temporary disactivated: too intrusive for notes in popovers, but needed for note in timeline...
@@ -43,9 +31,9 @@ img.image-popover {
 .p_mod-dropdown-menu-wizard {
   padding: 0px;
   border: 0px;
-  left: 25%;
+  left: 20%;
   right: auto;
-  transform: translateX(-25%);
+  transform: translateX(-20%);
 }
 
 div.p_mod_builder {

--- a/hd/etc/css.css
+++ b/hd/etc/css.css
@@ -1196,3 +1196,30 @@ ul.missing_ancestors_sort > li
   border-left: 1px solid;
   padding-left: 10px;
 }
+
+.note, .source, .notesource {
+    position: relative;
+}
+.note:after, .source:after, .notesource:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0; 
+    height: 0; 
+    display: block;
+    border-left: 12px solid transparent;
+    border-bottom: 12px solid transparent;
+}
+
+/* adjust also colors in destable.txt */
+.note:after {
+    border-top: 12px solid #FFA07A;
+}
+.source:after {
+    border-top: 12px solid #90EE90;
+}
+.notesource:after {
+    border-top: 12px solid #87CEFA;
+}
+

--- a/hd/etc/desmenu.txt
+++ b/hd/etc/desmenu.txt
@@ -232,7 +232,7 @@ function table_spouse_disabled () {
             <input type="checkbox" id="t_gen" name="gen" value="on"%/>
             [*display generation]
           </label>
-          <input type="hidden" name="notes" value="on"%/>
+          <input type="hidden" name="ns" value="on"%/>
           <input type="hidden" name="image" value="on"%/>
         </p>
       </div>

--- a/hd/etc/desmenu.txt
+++ b/hd/etc/desmenu.txt
@@ -232,6 +232,8 @@ function table_spouse_disabled () {
             <input type="checkbox" id="t_gen" name="gen" value="on"%/>
             [*display generation]
           </label>
+          <input type="hidden" name="notes" value="on"%/>
+          <input type="hidden" name="image" value="on"%/>
         </p>
       </div>
     </div>

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -859,7 +859,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %and;%if;(evar.image="on")image=on;%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;">
-            <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>%end;
+            <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>
+    %end;
     <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
       <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]
@@ -878,9 +879,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">%nn;
           <i class="fa fa-minus fa-lg"></i>%nn;
         </a>
+      %else;
+        <span class="btn btn-secondary disabled" aria-disabled="true" title="[*delete] 1 [generation/generations]0">
+          <i class="fa fa-minus fa-lg" ></i>
+        </span>
       %end;
-      <span class="text-primary mt-2">%apply;togend%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
-      %if;((evar.v="" or evar.v="0") and evar.v<desc_level)
+      %(if;((evar.v="" or evar.v="0") and evar.v<desc_level%)
         <a role="button" class="btn"
           href="%apply;rebuild_url%with;D
                 %and;%evar.t;
@@ -893,7 +897,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 class="btn btn-secondary" title="[*add] 1 [generation/generations]0">%nn;
          <i class="fa fa-plus fa-lg"></i>%nn;
        </a>
-      %end;
+      %(end;%)
+      <span class="text-primary mt-2">%apply;togend%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
     </div>
   </div>
   <div class="d-flex">

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -210,23 +210,21 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;("yyy"="desc")
       <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2%nn;
         %if;(evar.notes="on")
-          %if;(has_notes and not has_sources) note%nn;
-          %elseif;(not has_notes and has_sources) source%nn;
-          %elseif;(has_notes and has_sources) notesource%nn;
+          %if;(has_notes and not has_psources) note%nn;
+          %elseif;(not has_notes and has_psources) source%nn;
+          %elseif;(has_notes and has_psources) notesource%nn;
           %end;
         %end;'
         %rowspan;
-        %if;(evar.notes="on" and (has_notes or has_sources))
+        %if;(evar.notes="on" and (has_notes or has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
-                        %foreach;source;
-                          %if;(source_type=[person/persons]0)
-                            %if;(has_notes)<hr>%end;
-                              %apply;capitalize(source).
-                          %end;
-                        %end;'
-          title="%if;(has_notes)[*note/notes]1%if;(has_sources) [and] [source/sources]1%end;
-                 %elseif;(not has_notes and has_sources)[*source/sources]1%end;"
+                        %if;(has_notes and has_psources)<hr>%end;
+                        %if;(has_psources)%apply;capitalize(psources)%end;'
+          title="%if;(has_notes and not has_psources)[*note/notes]1%nn;
+                %elseif;(not has_notes and has_psources)[source/sources]1%nn;
+                %elseif;(has_notes and has_psources)[*note/notes]1 [and] [*source/sources]1%nn;
+                %end;"
         %end;
         >
         %incr_count1;
@@ -240,44 +238,35 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       <td class='align-middle text-right%if;(evar.nowrap="on") text-nowrap%end;%nn;
         %if;(evar.notes="on")
           %if;("yyy"="desc")
-            %if;(xxx.has_notes and not xxx.has_sources) note%nn;
-            %elseif;(not xxx.has_notes and xxx.has_sources) source%nn;
-            %elseif;(xxx.has_notes and xxx.has_sources) notesource%nn;
+            %if;(xxx.has_notes and not xxx.has_psources) note%nn;
+            %elseif;(not xxx.has_notes and xxx.has_psources) source%nn;
+            %elseif;(xxx.has_notes and xxx.has_psources) notesource%nn;
             %end;
           %elseif;("yyy"="spous")
-            %if;(xxx.has_notes and not xxx.has_sources) notespouse%nn;
-            %elseif;(not xxx.has_notes and xxx.has_sources) sourcespouse%nn;
-            %elseif;(xxx.has_notes and xxx.has_sources) notesourcespouse%nn;
+            %if;(xxx.has_notes and not xxx.has_psources) notes%nn;
+            %elseif;(not xxx.has_notes and xxx.has_psources) sources%nn;
+            %elseif;(xxx.has_notes and xxx.has_psources) notesources%nn;
             %end;
           %end;
         %end;'
-        %if;(evar.notes="on" and "yyy"="desc" and (has_notes or has_sources))
+        %if;(evar.notes="on" and "yyy"="desc" and (has_notes or has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-          data-content='%if;("yyy"="desc" and has_notes)%notes;%end;
-                        %foreach;source;
-                          %if;(source_type="[person/persons]0")
-                            %if;("yyy"="desc" and has_notes)<hr>%end;
-                              %apply;capitalize(source).
-                          %end;
-                        %end;'
-          title="%if;(has_notes and not has_sources)[*note/notes]1 %has_person_source;
-                %elseif;(not has_notes and has_sources)[*source/sources]1
-                %elseif;(has_notes and has_sources)[*note/notes]1 [and] [source/sources]1
+          data-content='%if;(has_notes)%notes;%end;
+                        %if;(has_notes and has_psources)<hr>%end;
+                        %if;(has_psources)%apply;capitalize(source)%end;'
+          title="%if;(has_notes and not has_psources)[*note/notes]1%nn;
+                %elseif;(not has_notes and has_psources)[*source/sources]1%nn;
+                %elseif;(has_notes and has_psources)[*note/notes]1 [and] [source/sources]1%nn;
                 %end;"
         %end;
-        %if;(evar.notes="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_sources))
+        %if;(evar.notes="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
-                        %foreach;xxx.source;
-                          %if;(source_type="[person/persons]0")
-                            %if;(xxx.has_notes)<hr>%end;
-                              %apply;capitalize(xxx.source).
-                          %else;
-                          %end;
-                        %end;'
-          title="%if;(xxx.has_notes and not xxx.has_sources)[*note/notes]1
-                %elseif;(not xxx.has_notes and xxx.has_sources)[*source/sources]1
-                %elseif;(xxx.has_notes and xxx.has_sources)[*note/notes]1 [and] [source/sources]1
+                        %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
+                        %if;(xxx.has_psources)%apply;capitalize(xxx.psource)%end;'
+          title="%if;(xxx.has_notes and not xxx.has_psources)[*note/notes]11%nn;
+                %elseif;(not xxx.has_notes and xxx.has_psources)[*source/sources]11%nn;
+                %elseif;(xxx.has_notes and xxx.has_psources)[*note/notes]1 [and] [source/sources]11%nn;
                 %end;"
         %end;
         >
@@ -447,13 +436,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %rowspan;
             %if;(evar.notes="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-              data-content='%if;(has_marriage_note)
-                              %marriage_note;
-                            %end;
-                            %if;(has_marriage_source)
-                              %if;(has_marriage_note)<hr>%end;
-                              %apply;capitalize(marriage_source).
-                            %end;'
+              data-content='%if;(has_marriage_note)%marriage_note;%end;
+                            %if;(has_marriage_note and has_marriage_source)<hr>%end;
+                            %if;(has_marriage_source)%apply;capitalize(marriage_source)%end;'
               title='%if;(has_marriage_source or has_marriage_note)
                        %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
                        %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -47,7 +47,7 @@
     <a role="button" class="btn btn-link ml-1 px-0"
       href="%url;cgl=on" target="_blank">
       <span class="fa fa-chain-broken fa-lg" title="[*cancel GeneWeb links]"></span>
-    </a>%nn;
+    </a>
     <a role="button" class="btn btn-link ml-1 px-0"
       href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span>
     </a>
@@ -88,7 +88,7 @@
       <th class="pl-2" rowspan="2" title="[*n° d'Aboville]">№</th>
       %incr_count;
     %end;
-    <th class="pl-2" rowspan="2" colspan="2">[*person/persons]0</th>
+    <th class="pl-2" rowspan="2">[*person/persons]0</th>
     %incr_count;
     %if;(evar.birth="on" and evar.birth_place="on")
       <th class="text-center" colspan="2">[*birth]</th>
@@ -205,26 +205,24 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
-
+%( attention has_sources vérifie toutes les sources, manque un simple has_person_source %)
   %if;(famx=1)
     %if;("yyy"="desc")
-      <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
+      <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2%nn;
         %if;(evar.notes="on")
-          %if;(has_notes and not has_sources)note
-          %elseif;(not has_notes and has_sources)source
-          %elseif;(has_notes and has_sources)notesource
+          %if;(has_notes and not has_sources) note%nn;
+          %elseif;(not has_notes and has_sources) source%nn;
+          %elseif;(has_notes and has_sources) notesource%nn;
           %end;
         %end;'
-        %rowspan; colspan="2"
+        %rowspan;
         %if;(evar.notes="on" and (has_notes or has_sources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
-                        %if;(has_sources)
-                          %if;(has_notes)<hr>%end;
-                          %foreach;source;
-                            %if;(source_type=[person/persons]0)
-                              <li>%apply;capitalize(source_type)[:] %source;.</li>
-                            %end;
+                        %foreach;source;
+                          %if;(source_type=[person/persons]0)
+                            %if;(has_notes)<hr>%end;
+                              %apply;capitalize(source).
                           %end;
                         %end;'
           title="%if;(has_notes)[*note/notes]1%if;(has_sources) [and] [source/sources]1%end;
@@ -239,42 +237,46 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %if;(evar.title="on")%xxx.title;%end
       </td>
    %elseif;(evar.t="I")
-      <td class="align-middle border-right-0 pl-1"></td>
-      <td class='align-middle text-right border-left-0 pr-2 %if;(evar.nowrap="on")text-nowrap%end;
+      <td class='align-middle text-right%if;(evar.nowrap="on") text-nowrap%end;%nn;
         %if;(evar.notes="on")
-          %if;(xxx.has_notes and not xxx.has_sources)note%elseif;(not xxx.has_notes and
-               xxx.has_sources)source%elseif;(xxx.has_notes and xxx.has_sources)notesource
+          %if;("yyy"="desc")
+            %if;(xxx.has_notes and not xxx.has_sources) note%nn;
+            %elseif;(not xxx.has_notes and xxx.has_sources) source%nn;
+            %elseif;(xxx.has_notes and xxx.has_sources) notesource%nn;
+            %end;
+          %elseif;("yyy"="spous")
+            %if;(xxx.has_notes and not xxx.has_sources) notespouse%nn;
+            %elseif;(not xxx.has_notes and xxx.has_sources) sourcespouse%nn;
+            %elseif;(xxx.has_notes and xxx.has_sources) notesourcespouse%nn;
+            %end;
           %end;
         %end;'
         %if;(evar.notes="on" and "yyy"="desc" and (has_notes or has_sources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;("yyy"="desc" and has_notes)%notes;%end;
-                        %if;("yyy"="desc" and has_sources)
-                          %if;("yyy"="desc" and has_notes)<hr>%end;
-                          %foreach;source;
-                            %if;(source_type=[person/persons]0)
-                              <li>%apply;capitalize(source_type)[:] %source;.</li>
-                            %end;
+                        %foreach;source;
+                          %if;(source_type="[person/persons]0")
+                            %if;("yyy"="desc" and has_notes)<hr>%end;
+                              %apply;capitalize(source).
                           %end;
                         %end;'
-          title="%if;(has_notes and not has_sources)[*note/notes]1
-                %elseif;(not has_notes and has_sources)[source/sources]1
+          title="%if;(has_notes and not has_sources)[*note/notes]1 %has_person_source;
+                %elseif;(not has_notes and has_sources)[*source/sources]1
                 %elseif;(has_notes and has_sources)[*note/notes]1 [and] [source/sources]1
                 %end;"
         %end;
         %if;(evar.notes="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_sources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
-                        %if;(xxx.has_sources)
-                          %if;(xxx.has_notes)<hr>%end;
-                          %foreach;xxx.source;
-                            %if;(source_type=[person/persons]0)
-                              <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
-                            %end;
+                        %foreach;xxx.source;
+                          %if;(source_type="[person/persons]0")
+                            %if;(xxx.has_notes)<hr>%end;
+                              %apply;capitalize(xxx.source).
+                          %else;
                           %end;
                         %end;'
           title="%if;(xxx.has_notes and not xxx.has_sources)[*note/notes]1
-                %elseif;(not xxx.has_notes and xxx.has_sources)[source/sources]1
+                %elseif;(not xxx.has_notes and xxx.has_sources)[*source/sources]1
                 %elseif;(xxx.has_notes and xxx.has_sources)[*note/notes]1 [and] [source/sources]1
                 %end;"
         %end;
@@ -283,8 +285,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %apply;image_MF("xxx")
         %apply;link%with;%xxx.access;%and;
           %xxx;
-        %end
-        %if;(evar.title="on")%xxx.title;%end
+        %end;
+        %if;(evar.title="on")%xxx.title;%end;
       </td>
     %end;
   %end;
@@ -305,26 +307,26 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 
   %if;(evar.birth_place="on" and famx=1)
     %if;("yyy"="desc")
-      <td class='align-middle
+      <td class='align-middle%nn;
         %if;(evar.notes="on")
           %if;((has_birth_note or has_baptism_note) and not
-               (has_birth_source or has_baptism_source)) note
+               (has_birth_source or has_baptism_source)) note%nn;
           %elseif;(not (has_birth_note or has_baptism_note) and
-               (has_birth_source or has_baptism_source)) source
+               (has_birth_source or has_baptism_source)) source%nn;
           %elseif;((has_birth_note or has_baptism_note) and
-               (has_birth_source or has_baptism_source)) notesource
+               (has_birth_source or has_baptism_source)) notesource%nn;
           %end;
         %end;'
         %rowspan;
     %else;
-      <td class='align-middle
+      <td class='align-middle%nn;
         %if;(evar.notes="on")
           %if;((xxx.has_birth_note or xxx.has_baptism_note) and not
-               (xxx.has_birth_source or xxx.has_baptism_source)) note
+               (xxx.has_birth_source or xxx.has_baptism_source)) note%nn;
           %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and
-               (xxx.has_birth_source or xxx.has_baptism_source)) source
+               (xxx.has_birth_source or xxx.has_baptism_source)) source%nn;
           %elseif;((xxx.has_birth_note or xxx.has_baptism_note) and
-               (xxx.has_birth_source or xxx.has_baptism_source)) notesource
+               (xxx.has_birth_source or xxx.has_baptism_source)) notesource%nn;
           %end;
         %end;'
         %rowspan;
@@ -345,7 +347,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                           %end;
                           %foreach;source;
                             %let;birthbaptism;[birth], [baptism]%in;
-                            %if;(source_type=[birth] or source_type=[baptism] or source_type=birthbaptism)
+                            %if;(not has_baptism_note and not has_baptism_source) and (source_type=[birth] or source_type=birthbaptism))
+                              %apply;capitalize(source).
+                            %elseif;((has_baptism_note or has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
                               <li>%apply;capitalize(source_type)[:] %source;.</li>
                             %end;
                           %end;
@@ -435,9 +439,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class='align-middle%nn;
             %if;(evar.notes="on")
-              %if;(has_marriage_note and not has_marriage_source) note
-              %elseif;(not has_marriage_note and has_marriage_source) source
-              %elseif;(has_marriage_note and has_marriage_source) notesource
+              %if;(has_marriage_note and not has_marriage_source) note%nn;
+              %elseif;(not has_marriage_note and has_marriage_source) source%nn;
+              %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
               %end;
             %end;'
             %rowspan;
@@ -448,17 +452,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                             %end;
                             %if;(has_marriage_source)
                               %if;(has_marriage_note)<hr>%end;
-                              %foreach;source;
-                                %let;mevt;[marriage event] %fam_cnt;%in;
-                                %if;(fam_cnt="1" and (source_type=mevt or source_type=[marriage event]) 
-                                     or (fam_cnt>1 and source_type=mevt))
-                                  %if;(not has_marriage_note)
-                                    %apply;capitalize(source).
-                                  %else;
-                                    <li>%apply;capitalize(source).</li>
-                                  %end;
-                                %end;
-                              %end;
+                              %apply;capitalize(marriage_source).
                             %end;'
               title='%if;(has_marriage_source or has_marriage_note)
                        %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
@@ -558,13 +552,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;("yyy"="desc")
       <td class='align-middle
         %if;(evar.notes="on")
-          %if;((has_death_note or has_burial_note) and not
-              (has_death_source or has_burial_source))note
-          %elseif;(not (has_death_note or has_burial_note) and
-              (has_death_source or has_burial_source))source
-          %elseif;((has_death_note or has_burial_note) and
-              (has_death_source or has_burial_source))notesource
-          %end;
+        %if;((has_death_note or has_burial_note) and not
+            (has_death_source or has_burial_source))note%elseif;
+            (not (has_death_note or has_burial_note) and
+            (has_death_source or has_burial_source))source%elseif;
+            ((has_death_note or has_burial_note) and
+            (has_death_source or has_burial_source))notesource%end;
         %end;'
         %rowspan;
         %if;(evar.notes="on")
@@ -840,18 +833,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 
 %if;(not cancel_links)
   <div class="form-inline">
-    %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
-      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-         href="%apply;rebuild_url%with;D
-                %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
-                %and;%evar.v;
-                %and;%if;(evar.notes="on")on%else;off%end;
-                %and;%if;(evar.cgl="on")on%else;off%end;
-                %end;">
-                <i class="fa fa-table fa-lg fa-fw mr-1"></i>%nn;
-        %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
-      </a>
-    %end;
     <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;m=D;%access;"><i class="fa fa-cog fa-lg fa-fw mr-1">
       </i>[*options] [descendants]
@@ -876,7 +857,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %and;%expr(evar.v-1)
                 %and;%if;(evar.notes="on")on%else;off%end;
                 %and;%if;(evar.cgl="on")on%else;off%end;
-                %end" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
+                %end" class="btn" title="-1 [generation/generations]0">-</a>%end;
       </span>
       <input class="form-control text-center" size="12"
         value="%if;(evar.v="")0%else;%evar.v;%end;%sp;
@@ -888,13 +869,24 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                  %and;%expr(evar.v+1)
                  %and;%if;(evar.notes="on")on%else;off%end;
                  %and;%if;(evar.cgl="on")on%else;off%end;
-                 %end" class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
+                 %end" class="btn" title="+1 [generation/generations]0">+</a>
       </span>
     </div>
   </div>
 
-%( Check colors with note, source, notesource in css.css %)
   <div class="form-inline">
+    %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+         href="%apply;rebuild_url%with;D
+                %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
+                %and;%evar.v;
+                %and;%if;(evar.notes="on")on%else;off%end;
+                %and;%if;(evar.cgl="on")on%else;off%end;
+                %end;">
+                <i class="fa fa-table fa-lg fa-fw mr-1"></i>%nn;
+        %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
+      </a>
+    %end;
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
@@ -905,20 +897,19 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             title="small arrow in corner shows existence of note or source">
              <i class="fa fa-cog fa-lg fa-fw mr-1"></i>%nn;
       %if;(evar.notes="off" or evar.notes="")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
-        [indicators] <span style="color:#FFA07A">[note/notes]1</span>, <span style="color:#90EE90">[source/sources]1</span>,
-        <span style="color:#87CEFA">[note/notes]1 [and] [source/sources]1</span>
+        <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
     </a>
     %if;(evar.cgl="" or evar.cgl="off")
-    <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-      href="%apply;rebuild_url%with;D
-            %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-            %and;%evar.v;
-            %and;off
-            %and;%if;(evar.cgl="on")off%else;on%end;
-            %end;"
-            title="Cancel url links in whole page">
-      <i class="fa fa-cog fa-lg fa-fw mr-1"></i> [*cancel GeneWeb links]
-    </a>
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+        href="%apply;rebuild_url%with;D
+              %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+              %and;%evar.v;
+              %and;off
+              %and;%if;(evar.cgl="on")off%else;on%end;
+              %end;"
+              title="Cancel url links in whole page">
+        <i class="fa fa-cog fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
+      </a>
     %end;
   </div>
 %end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -892,7 +892,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
       <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]
     </a>
-    <div class="ml-auto mr-5">
+    <div class="mr-5">
       %if;(evar.v>=1)
         <a role="button" class="btn"
           href="%apply;rebuild_url%with;D

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -504,7 +504,27 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %if;((nb_families=1 and "yyy"="desc") or (nb_families>1 and
             ((xxx.spouse=zzz and (ddd=family.index)) or
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
-          <td class="align-middle text-center %if;(evar.nowrap="on")text-nowrap%end; px-1" %rowspan;>
+          <td class='align-middle text-center %if;(evar.nowrap="on")text-nowrap%end; px-1
+            %if;(evar.notes="on")
+              %if;(has_comment and fsources="") note%nn;
+              %elseif;(not has_comment and fsources!="") source%nn;
+              %elseif;(has_comment and fsources!="") notesource%nn;
+              %end;
+            %end;'
+            %rowspan;
+            %if;(evar.notes="on")
+              tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+              data-content='%if;(has_comment)%comment;%end;
+                            %if;(has_comment and fsources!="")<hr>%end;
+                            %if;(fsources!="")%apply;capitalize(fsources)%end;'
+              title='%if;(has_fsources!="")
+                      %if;(has_comment and fsources="")[*note/notes]1%nn;
+                      %elseif;(not has_comment and fsources!="")[*source/sources]1%nn;
+                      %elseif;(has_comment and fsources!="")[*note/notes]1 [and] [*source/sources]1%nn;
+                      %end;
+                     %end;'
+            %end;
+            >            
             %if;(nb_children>0 and not cancel_links)<a href="#%labl0;%if;(nb_families>1)%apply;letter(fam_cnt)%end;.1" title="[*link to children]">%end;
             %if;("yyy"="desc" and evar.t="I")
               %nb_ch_tot_desc;%if;(nb_ch_tot_desc!=nb_ch_tot_spous)/%nb_ch_tot_spous;%(!! nb_ch_tot_spous is wrong: gives father total of children?! %)%end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -44,11 +44,11 @@
     %if;(referer != "")
       <a role="button" class="btn btn-link px-0" href="%referer;"><span class="fa fa-arrow-left fa-lg" title="<<"></span></a>
     %end;
-    <a role="button" class="btn btn-link ml-1 px-0" 
+    <a role="button" class="btn btn-link ml-1 px-0"
       href="%url;cgl=on" target="_blank">
       <span class="fa fa-chain-broken fa-lg" title="[*cancel GeneWeb links]"></span>
     </a>%nn;
-    <a role="button" class="btn btn-link ml-1 px-0" 
+    <a role="button" class="btn btn-link ml-1 px-0"
       href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span>
     </a>
   </div>
@@ -58,7 +58,7 @@
 
 %define;image_MF(xxx)
   %if;(wizard and not cancel_links)
-    <a href="%prefix;m=MOD_IND;i=%xxx.index;" 
+    <a href="%prefix;m=MOD_IND;i=%xxx.index;"
       title="[*modify::] %xxx.first_name;%if;(xxx.occ!="0").%xxx.occ;%end; %xxx.surname;">
   %end;
   %if;xxx.is_male;
@@ -106,7 +106,7 @@
     %end;
     %if;((evar.marr_date="on" and evar.marr_place="on") or
          (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
-      <th class="text-center" 
+      <th class="text-center"
         colspan="%if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")3%else;2%end;">
         [*marriage/marriages]0
       </th>
@@ -148,15 +148,15 @@
       <th class="text-right pr-2" title="[*date of birth]">[*date/dates]0</th>
       <th class="pl-2" title="[*where born]/[birth place]">[*place]</th>
     %end;
-    %if;((evar.marr_date="on" and evar.marr_place="on") or 
+    %if;((evar.marr_date="on" and evar.marr_place="on") or
          (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
       %if;(evar.marr_date="on")
-        <th class="%if;(evar.marr_place!="on")text-center%else;text-right pr-2%end;" 
+        <th class="%if;(evar.marr_place!="on")text-center%else;text-right pr-2%end;"
           title="[*date of marriage]">[*date/dates]0
         </th>
       %end;
       %if;(evar.marr_place="on")
-        <th class="%if;(evar.marr_date!="on")text-center%else;pl-2%end;" 
+        <th class="%if;(evar.marr_date!="on")text-center%else;pl-2%end;"
           title="[*where married]/[marriage place]">[*place]
         </th>
       %end;
@@ -184,7 +184,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %let;zro;%if;("prefx"="-1")0%else;1%end;%in;
   %let;labl;%if;(zro=1)%if;("prefx"!="")prefxfff.%end;ch_count%else;1%end;%in;
   %let;labl0;%if;(zro=1)%if;("prefx"!="")prefxfff.%end;ch_cnt%else;1%end;%in;
-  %let;rowspan;%if;(nb_families>1 and evar.t="H" and 
+  %let;rowspan;%if;(nb_families>1 and evar.t="H" and
                    (evar.marr="on" or evar.marr_date="on" or evar.marr_place="on"
                     or evar.child="on"))rowspan="%xxx.nb_families;"%end;%in;
 
@@ -214,16 +214,19 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               has_sources)source%elseif;(has_notes and has_sources)notesource%end;
         %end;'
         %rowspan; colspan="2"
-        %if;(has_notes or has_sources)
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+        %if;(evar.notes="on" and (has_notes or has_sources))
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
                         %if;(has_sources)
-                          <hr>
-                           %foreach;source;
-                             <li>%apply;capitalize(source_type)[:] %source;.</li>
+                          %if;(has_notes)<hr>%end;
+                          %foreach;source;
+                            %if;(source_type=[person/persons]0)
+                              <li>%apply;capitalize(source_type)[:] %source;.</li>
                             %end;
+                          %end;
                         %end;'
-          title="[*note/notes]1 [and] [source/sources]1"
+          title="%if;(has_notes)[*note/notes]1%if;(has_sources) [and] [source/sources]1%end;
+                 %elseif;(not has_notes and has_sources)[*source/sources]1%end;"
         %end;
         >
         %incr_count1;
@@ -237,37 +240,40 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       <td class="align-middle border-right-0 pl-1"></td>
       <td class='align-middle text-right border-left-0 pr-2 %if;(evar.nowrap="on")text-nowrap%end;
         %if;(evar.notes="on")
-          %if;(xxx.has_notes and not xxx.has_sources)note
-          %elseif;(not xxx.has_notes and xxx.has_sources)source
-          %elseif;(xxx.has_notes and xxx.has_sources)notesource
+          %if;(xxx.has_notes and not xxx.has_sources)note%elseif;(not xxx.has_notes and
+               xxx.has_sources)source%elseif;(xxx.has_notes and xxx.has_sources)notesource
           %end;
         %end;'
         %if;("yyy"="desc" and (has_notes or has_sources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;("yyy"="desc" and has_notes)%notes;%end;
                         %if;("yyy"="desc" and has_sources)
-                          <hr>
-                           %foreach;source;
-                             <li>%apply;capitalize(source_type)[:] %source;.</li>
+                          %if;("yyy"="desc" and has_notes)<hr>%end;
+                          %foreach;source;
+                            %if;(source_type=[person/persons]0)
+                              <li>%apply;capitalize(source_type)[:] %source;.</li>
                             %end;
+                          %end;
                         %end;'
           title="%if;(has_notes and not has_sources)[*note/notes]1
-                %elseif;(not has_notes and  has_sources)[source/sources]1
-                %elseif;(has_notes and  has_sources)[*note/notes]1 [and] [source/sources]1
+                %elseif;(not has_notes and has_sources)[source/sources]1
+                %elseif;(has_notes and has_sources)[*note/notes]1 [and] [source/sources]1
                 %end;"
         %end;
         %if;("yyy"="spous" and (xxx.has_notes or xxx.has_sources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_sources)
-                          <hr>
-                           %foreach;xxx.source;
-                             <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                          %if;(xxx.has_notes)<hr>%end;
+                          %foreach;xxx.source;
+                            %if;(source_type=[person/persons]0)
+                              <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
                             %end;
+                          %end;
                         %end;'
           title="%if;(xxx.has_notes and not xxx.has_sources)[*note/notes]1
                 %elseif;(not xxx.has_notes and xxx.has_sources)[source/sources]1
-                %elseif;(xxx.has_notes and  xxx.has_sources)[*note/notes]1 [and] [source/sources]1
+                %elseif;(xxx.has_notes and xxx.has_sources)[*note/notes]1 [and] [source/sources]1
                 %end;"
         %end;
         >
@@ -299,12 +305,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;("yyy"="desc")
       <td class='align-middle
         %if;(evar.notes="on")
-        %if;((has_birth_note or has_baptism_note) and not
-             (has_birth_source or has_baptism_source)) note
-        %elseif;(not (has_birth_note or has_baptism_note) and
-             (has_birth_source or has_baptism_source)) source
-        %elseif;((has_birth_note or has_baptism_note) and
-             (has_birth_source or has_baptism_source)) notesource%end;
+          %if;((has_birth_note or has_baptism_note) and not
+               (has_birth_source or has_baptism_source)) note
+          %elseif;(not (has_birth_note or has_baptism_note) and
+               (has_birth_source or has_baptism_source)) source
+          %elseif;((has_birth_note or has_baptism_note) and
+               (has_birth_source or has_baptism_source)) notesource
+          %end;
         %end;'
         %rowspan;
     %else;
@@ -320,42 +327,45 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
         %rowspan;
     %end;
-        tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-        data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
-                        %if;(has_birth_note)<li>[*birth][:] %birth_note;</li>%end;
-                        %if;(has_baptism_note)<li>[*baptism][:] %baptism_note;</li>%end;
-                      %elseif;(xxx.has_birth_note or xxx.has_baptism_note)
-                        %if;(xxx.has_birth_note)<li>[*birth][:] %xxx.birth_note;</li>%end;
-                        %if;(xxx.has_baptism_note)<li>[*baptism][:] %xxx.baptism_note;</li>%end;
-                      %end;
-                      %if;(("yyy"="desc" and (has_birth_source or has_baptism_source))
-                             or xxx.has_birth_source or xxx.has_baptism_source)
-                        %if;(("yyy"="desc" and has_birth_note or has_baptism_note)
-                            or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
+        %if;(evar.notes="on")
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
+                          %if;(has_birth_note)%if;(has_baptism_note)[*birth][:] %end;%birth_note;%end;
+                          %if;(has_baptism_note)[*baptism][:] %baptism_note;%end;
+                        %elseif;(xxx.has_birth_note or xxx.has_baptism_note)
+                          %if;(xxx.has_birth_note)%if;(xxx.has_baptism_note)[*birth][:] %end;%xxx.birth_note;%end;
+                          %if;(xxx.has_baptism_note)[*baptism][:] %xxx.baptism_note;%end;
                         %end;
-                        %foreach;source;
-                          %if;(source_type=[birth] or source_type=[baptism])
-                            <li>%apply;capitalize(source_type)[:] %source;.</li>
+                        %if;(("yyy"="desc" and (has_birth_source or has_baptism_source))
+                               or (xxx.has_birth_source or xxx.has_baptism_source))
+                          %if;(("yyy"="desc" and (has_birth_note or has_baptism_note))
+                              or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
                           %end;
+                          %foreach;source;
+                            %let;birthbaptism;[birth], [baptism]%in;
+                            %if;(source_type=[birth] or source_type=[baptism] or source_type=birthbaptism)
+                              <li>%apply;capitalize(source_type)[:] %source;.</li>
+                            %end;
+                          %end;
+                        %end;'
+            title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
+                     %if;(has_birth_note or has_baptism_note)[*note/notes]1%end;
+                     %if;(has_birth_source or has_baptism_source)
+                        %if;(not has_birth_note and not has_baptism_note)[*source/sources]1%else; [and] [source/sources]1%end;
+                     %end;
+                   %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
+                     %if;(xxx.has_birth_note or xxx.has_baptism_note)[*note/notes]1%end;
+                     %if;(xxx.has_birth_source or xxx.has_baptism_source)
+                        %if;(not xxx.has_birth_note and not xxx.has_baptism_note)
+                          [*source/sources]1%else; [and] [source/sources]1
                         %end;
-                      %end;'
-          title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
-                   %if;(has_birth_note or has_baptism_note)[*note/notes]1%end;
-                   %if;(has_birth_source or has_baptism_source)
-                      %if;(not has_birth_note and not has_baptism_note)[*source/sources]1%else; [and] [source/sources]1%end;
-                   %end;
-                 %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
-                   %if;(xxx.has_birth_note or xxx.has_baptism_note)[*note/notes]1%end;
-                   %if;(xxx.has_birth_source or xxx.has_baptism_source)
-                      %if;(not xxx.has_birth_note and not xxx.has_baptism_note)
-                        [*source/sources]1%else; [and] [source/sources]1
-                      %end;
-                   %end;
-                 %end;'
+                     %end;
+                   %end;'
+        %end;
       >
-          %if;xxx.has_approx_birth_place;
-            %xxx.approx_birth_place;
-          %end;
+        %if;xxx.has_approx_birth_place;
+          %xxx.approx_birth_place;
+        %end;
     </td>
   %end;
 
@@ -365,33 +375,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %else;
       %foreach;xxx.family;
         %if;(family_cnt=fam_cnt)
-          <td class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
-            %if;(evar.notes="on")
-              %if;(spouse.has_notes and not spouse.has_sources)note
-              %elseif;(not spouse.has_notes and spouse.has_sources)source
-              %elseif;(spouse.has_notes and spouse.has_sources)notesource
-              %end;
-            %end;'
-            %if;(spouse.has_notes or spouse.has_sources))
-              tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-              data-content='%if;(spouse.has_notes)%spouse.notes;%end;
-                            %if;(spouse.has_sources)
-                              <hr>
-                              %foreach;spouse.source;
-                                <li>%apply;capitalize(source_type)[:] %spouse.source;.</li>
-                              %end;
-                            %end;'
-              title='%if;(spouse.has_notes and not spouse.has_sources)[*note/notes]1
-                    %elseif;(not spouse.has_notes and spouse.has_sources)[source/sources]1
-                    %elseif;(spouse.has_notes and  spouse.has_sources)[*note/notes]1 [and] [source/sources]1
-                    %end;'
-            %end;
-            >
+          <td class="%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2">
             %incr_count1;
             %if;(zzz.nb_families>1)%apply;letter(family_cnt).%end;
             %apply;image_MF("spouse")
-            %apply;link%with;%spouse.access;
-              %and;%spouse;
+            %apply;link%with;%spouse.access;%and;
+              %spouse;
             %end;
           </td>
         %end;
@@ -410,7 +399,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class="align-middle text-right" %rowspan;>
           %if;(wizard and not cancel_links)
-            <a class="d-block" href="%prefix;m=MOD_FAM;i=%family.index;;ip=%index;" 
+            <a class="d-block" href="%prefix;m=MOD_FAM;i=%family.index;;ip=%index;"
               title="%if;(slash_marriage_date="")[*add::marriage/marriages]0%else;
               [*update::family/families]0%end; %xxx; [and] %xxx.spouse;">
               %if;(slash_marriage_date != "")%slash_marriage_date;%else;<span class="fa fa-%nn;
@@ -437,39 +426,45 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       <td></td>
     %else;
       %let;rowspan;rowspan="%if;(evar.t="I" and zzz.nb_families=1)2%else;1%end;"%in;
-      %foreach;family;
-        %let;find;%family.index;%in;
-        %if;((nb_families=1 and "yyy"="desc") or 
-             (nb_families>1 and 
-              ((xxx.spouse=zzz and ddd=family.index) or %(ddd=f.index to sort out remarriage between same pers %)
+      %foreach;xxx.family;
+        %if;((nb_families=1 and "yyy"="desc") or
+             (nb_families>1 and
+              ((xxx.spouse=zzz and ddd=family.index) or
                 (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
-          <td class='align-middle
+          <td class='align-middle%nn;
             %if;(evar.notes="on")
-              %if;(has_marriage_note and not has_marriage_source)note
-              %elseif;(not has_marriage_note and has_marriage_source)source
-              %elseif;(has_marriage_note and has_marriage_source)notesource
+              %if;(has_marriage_note and not has_marriage_source) note
+              %elseif;(not has_marriage_note and has_marriage_source) source
+              %elseif;(has_marriage_note and has_marriage_source) notesource
               %end;
             %end;'
             %rowspan;
-            tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-            data-content='%if;(has_marriage_note)
-                            <li>[*note/notes]1[:] %marriage_note;</li>
-                          %end;
-                          %if;(has_marriage_source)
-                            <hr>
-                            %foreach;xxx.family;
-                              %let;mevt;[marriage event] %family_cnt;%in;
-                              %if;(find=family.index)
-                                <li>[*source/sources]1[:] %marriage_source;.</li>
-                              %end;
+            %if;(evar.notes="on")
+              tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+              data-content='%if;(has_marriage_note)
+                              %marriage_note;
                             %end;
-                          %end;'
-            title='%if;(has_marriage_source or has_marriage_note)
-                     %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
-                     %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1
-                     %elseif;(has_marriage_note and has_marriage_source)[*note/notes]1 [and] [source/sources]1
-                     %end;
-                   %end;'
+                            %if;(has_marriage_source)
+                              %if;(has_marriage_note)<hr>%end;
+                              %foreach;source;
+                                %let;mevt;[marriage event] %fam_cnt;%in;
+                                %if;(fam_cnt="1" and (source_type=mevt or source_type=[marriage event]) 
+                                     or (fam_cnt>1 and source_type=mevt))
+                                  %if;(not has_marriage_note)
+                                    %apply;capitalize(source).
+                                  %else;
+                                    <li>%apply;capitalize(source).</li>
+                                  %end;
+                                %end;
+                              %end;
+                            %end;'
+              title='%if;(has_marriage_source or has_marriage_note)
+                       %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
+                       %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1
+                       %elseif;(has_marriage_note and has_marriage_source)[*note/notes]1 [and] [source/sources]1
+                       %end;
+                     %end;'
+            %end;
           >
           %if;(marriage_place != "")
             %marriage_place;
@@ -565,33 +560,36 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             (has_death_source or has_burial_source))note%elseif;
             (not (has_death_note or has_burial_note) and
             (has_death_source or has_burial_source))source%elseif;
-            ((has_death_note or has_burial_note) and 
+            ((has_death_note or has_burial_note) and
             (has_death_source or has_burial_source))notesource%end;
         %end;'
         %rowspan;
-        tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-        data-content='%if;(has_death_note or has_burial_note)
-                        %if;(has_death_note)[*death][:] %death_note;%end;
-                        %if;(has_burial_note)[*burial][:] %burial_note;%end;
-                      %end;
-                      %if;(has_death_source or has_burial_source)
-                        <hr>
-                        %foreach;source;
-                          %if;(source_type=[death] and not has_burial_source)
-                            %apply;capitalize(source).
-                          %elseif;((source_type=[burial] and not has_death_source and has_burial_source)
-                                   or ((source_type=[death] or source_type=[burial])
-                                        and has_burial_source and has_death_source))
-                            <li>%apply;capitalize(source_type)[:] %source;.</li>
-                          %end;
+        %if;(evar.notes="on")
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;(has_death_note or has_burial_note)
+                          %if;(has_death_note)%if;(has_burial_note)[*death][:] %end;%death_note;%end;
+                          %if;(has_burial_note)[*burial][:] %burial_note;%end;
                         %end;
-                      %end;'
-          title='%if;(has_death_source or has_burial_source or has_death_note or has_burial_note)
-                   %if;((has_death_note or has_burial_note) and not (has_death_source or has_burial_source))[*note/notes]1
-                   %elseif;(not (has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*source/sources]1
-                   %elseif;((has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*note/notes]1 [and] [source/sources]1
-                   %end;
-                 %end;'
+                        %if;(has_death_source or has_burial_source)
+                          %if;(has_death_note or has_burial_note)<hr>%end;
+                          %foreach;source;
+                            %let;deathburial;[death], [burial]%in;
+                            %if;(source_type=[death] and not has_burial_source)
+                              %apply;capitalize(source).
+                            %elseif;((source_type=[burial] and not has_death_source and has_burial_source)
+                                     or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
+                                          and has_burial_source and has_death_source))
+                              <li>%apply;capitalize(source_type)[:] %source;.</li>
+                            %end;
+                          %end;
+                        %end;'
+            title='%if;(has_death_source or has_burial_source or has_death_note or has_burial_note)
+                     %if;((has_death_note or has_burial_note) and not (has_death_source or has_burial_source))[*note/notes]1
+                     %elseif;(not (has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*source/sources]1
+                     %elseif;((has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*note/notes]1 [and] [source/sources]1
+                     %end;
+                   %end;'
+        %end;
       >
     %elseif;("yyy"="spous")
       <td class='align-middle
@@ -600,34 +598,37 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               (xxx.has_death_source or xxx.has_burial_source))note
           %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and
               (xxx.has_death_source or xxx.has_burial_source))source
-          %elseif;((xxx.has_death_note or xxx.has_burial_note) and 
+          %elseif;((xxx.has_death_note or xxx.has_burial_note) and
               (xxx.has_death_source or xxx.has_burial_source))notesource
           %end;
         %end;'
         %rowspan;
-        tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-        data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
-                        %if;(xxx.has_death_note)[*death][:] %xxx.death_note;%end;
-                        %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
-                      %end;
-                      %if;(has_death_source or has_burial_source)
-                        <hr>
-                        %foreach;xxx.source;
-                          %if;(source_type=[death] and not has_burial_source)
-                            %apply;capitalize(xxx.source).
-                          %elseif;((source_type=[burial] and not xxx.has_death_source and xxx.has_burial_source)
-                                   or ((source_type=[death] or source_type=[burial])
-                                        and xxx.has_burial_source and xxx.has_death_source))
-                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
-                          %end;
+        %if;(evar.notes="on")
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
+                          %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
+                          %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
                         %end;
-                      %end;'
-          title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
-                   %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
-                   %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
-                   %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
-                   %end;
-                 %end;'
+                        %if;(xxx.has_death_source or xxx.has_burial_source)
+                          %if;(xxx.has_death_note or xxx.has_burial_note)<hr>%end;
+                          %foreach;xxx.source;
+                            %let;deathburial;[death], [burial]%in;
+                            %if;(source_type=[death] and not xxx.has_burial_source)
+                              %apply;capitalize(xxx.source).
+                            %elseif;((source_type=[burial] and not xxx.has_death_source and xxx.has_burial_source)
+                                     or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
+                                          and xxx.has_burial_source and xxx.has_death_source))
+                              <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                            %end;
+                          %end;
+                        %end;'
+            title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
+                     %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
+                     %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
+                     %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
+                     %end;
+                   %end;'
+        %end;
       >
     %end;
     %if;xxx.has_approx_death_place;
@@ -837,7 +838,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %if;(not cancel_links)
   <div class="form-inline">
     %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
-      <a role="button" class="btn btn-link ml-2 px-0 mb-1" 
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
          href="%apply;rebuild_url%with;D
                 %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
                 %and;%evar.v;
@@ -848,11 +849,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
       </a>
     %end;
-    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;m=D;%access;"><i class="fa fa-cog fa-lg fa-fw mr-1">
       </i>[*options] [descendants]
     </a>
-    %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" 
+    %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%apply;rebuild_url%with;A
             %and;Z;
             %and;%if;(evar.v="" or evar.v<=2)2%else;%evar.v;%end;
@@ -860,13 +861,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %and;%if;(evar.cgl="on")on%else;off%end;
             %end">
             <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>%end;
-    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
       <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]
     </a>
     <div class="input-group mx-2 mb-1">
       <span class="input-group-btn">
-        %if;(evar.v>=1)<a 
+        %if;(evar.v>=1)<a
           href="%apply;rebuild_url%with;D
                 %and;%evar.t;
                 %and;%expr(evar.v-1)
@@ -874,9 +875,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %and;%if;(evar.cgl="on")on%else;off%end;
                 %end" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
-      <input class="form-control text-center" size="12" 
+      <input class="form-control text-center" size="12"
         value="%if;(evar.v="")0%else;%evar.v;%end;%sp;
-          %if;(evar.v>1)[generation/generations]1%else;[generation/generations]0%end;" 
+          %if;(evar.v>1)[generation/generations]1%else;[generation/generations]0%end;"
         title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
       <span class="input-group-btn">
         <a href="%apply;rebuild_url%with;D
@@ -891,7 +892,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 
 %( Check colors with note, source, notesource in css.css %)
   <div class="form-inline">
-    <a role="button" class="btn btn-link ml-2 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
             %and;%evar.v;
@@ -901,11 +902,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             title="small arrow in corner shows existence of note or source">
              <i class="fa fa-cog fa-lg fa-fw mr-1"></i>%nn;
       %if;(evar.notes="off" or evar.notes="")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
-        [indicators] <span style="color:#FFA07A">[note/notes]1</span>, <span style="color:#90EE90">[source/sources]1</span>, 
+        [indicators] <span style="color:#FFA07A">[note/notes]1</span>, <span style="color:#90EE90">[source/sources]1</span>,
         <span style="color:#87CEFA">[note/notes]1 [and] [source/sources]1</span>
     </a>
     %if;(evar.cgl="" or evar.cgl="off")
-    <a role="button" class="btn btn-link ml-2 px-0 mb-1" 
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
             %and;%evar.v;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -195,7 +195,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       </td>
     %elseif;(evar.t="I")
       %if;(has_families and nb_families>1)
-        <td class="border-left-0 text-center align-middle">%labl0;%if;(nb_families>1)%apply;letter(family_cnt).%end;</td>
+        <td class="border-left-0 text-center align-middle">%apply;letter(family_cnt)</td>
       %else;
         <td></td>
       %end;
@@ -410,7 +410,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           %end;
           >
             %incr_count1;
-            %if;(zzz.nb_families>1)%apply;letter(family_cnt).%end;
+            %if;(zzz.nb_families>1)%apply;letter(family_cnt)%end;
             %apply;image_MF("spouse")
             %apply;link%with;%spouse.access;%and;
               %spouse;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -304,8 +304,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                     %if;(xxx.has_birth_source or xxx.has_baptism_source)
                       %if;(xxx.has_birth_note or xxx.has_baptism_note)<hr>%end;
                       %let;birthbaptism;[birth], [baptism]%in;
+                      %let;birthdeath;[birth], [death]%in;
                       %foreach;xxx.source;
-                        %if;(not xxx.has_baptism_note and ((not xxx.has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
+                        %if;(not xxx.has_baptism_note and ((not xxx.has_baptism_source and source_type=[birth]) or source_type=birthbaptism or source_type=birthdeath))
                           %apply;capitalize(xxx.source).
                         %elseif;((xxx.has_baptism_note or xxx.has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
                           <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
@@ -553,8 +554,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                     %if;(xxx.has_death_source or xxx.has_burial_source)
                       %if;(xxx.has_death_note or xxx.has_burial_note)<hr>%end;
                       %let;deathburial;[death], [burial]%in;
+                      %let;birthdeath;[birth], [death]%in;
                       %foreach;xxx.source;
-                        %if;(not xxx.has_burial_note and ((not xxx.has_burial_source and source_type=[death]) or source_type=deathburial))
+                        %if;(not xxx.has_burial_note and ((not xxx.has_burial_source and source_type=[death]) or source_type=deathburial or source_type=birthdeath))
                           %apply;capitalize(xxx.source).
                         %elseif;((xxx.has_burial_note or xxx.has_burial_source) and (source_type=[death] or source_type=[burial]))
                           %if;(source_type=[burial] and xxx.is_cremated)

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -81,10 +81,10 @@
   <tr class="descends_table_header align-middle">
     %reset_count;
     %if;(evar.num="on")
-      <th class="pl-2 text-center align-middle" rowspan="2" title="[*n° d'Aboville]">№</th>
+      <th class="text-center align-middle" rowspan="2" title="[*n° d'Aboville]">№</th>
       %incr_count;
     %end;
-    <th class="pl-2 text-center align-middle" rowspan="2">[*person/persons]0</th>
+    <th class="pl-2 align-middle" rowspan="2">[*person/persons]0</th>
     %incr_count;
     %if;(evar.birth="on" and evar.birth_place="on")
       <th class="text-center" colspan="2">[*birth]</th>
@@ -93,11 +93,11 @@
       <th class="text-center" rowspan="2">[*date of birth]</th>
       %incr_count;
     %elseif;(evar.birth!="on" and evar.birth_place="on")
-      <th class="text-center" rowspan="2">[*birth place]</th>
+      <th class="text-center" rowspan="2">[*birth place]0</th>
       %incr_count;
     %end;
     %if;(evar.marr="on" and evar.t="H")
-      <th class="pl-2" rowspan="2">[*spouse/spouses]1</th>
+      <th class="pl-2 align-middle" rowspan="2">[*spouse/spouses]1</th>
       %incr_count;
     %end;
     %if;((evar.marr_date="on" and evar.marr_place="on") or
@@ -142,7 +142,7 @@
     <tr class="ascends_table_header">
     %if;(evar.birth="on" and evar.birth_place="on")
       <th class="text-right pr-2" title="[*date of birth]">[*date/dates]0</th>
-      <th class="pl-2" title="[*where born]/[birth place]">[*place]</th>
+      <th class="pl-2" title="[*birth place]">[*place]</th>
     %end;
     %if;((evar.marr_date="on" and evar.marr_place="on") or
          (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
@@ -153,18 +153,18 @@
       %end;
       %if;(evar.marr_place="on")
         <th class="%if;(evar.marr_date!="on")text-center%else;pl-2%end;"
-          title="[*where married]/[marriage place]">[*place]
+          title="[*marriage place]">[*place]
         </th>
       %end;
       %if;(evar.child="on")
-        <th class="text-center px-2" title="[*nb children]/[*nb children] [total]">
+        <th class="text-center px-2" title="[*nb children]/[nb children] [total]">
           <span class="fa fa-child"></span>
         </th>
       %end;
     %end;
     %if;(evar.death="on" and evar.death_place="on")
       <th class="text-right pr-2" title="[*date of death]">[*date/dates]0</th>
-      <th class="pl-2" title="[*where dead]/[death place]">[*place]</th>
+      <th class="pl-2" title="[*death place]">[*place]</th>
     %end;
   </tr>
 %end;
@@ -201,7 +201,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
-%( Descendant et son conjoint en mode I %)  
+%( Descendant et son conjoint en mode I %)
   %if;(famx=1)
     %if;("yyy"="desc")
       <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2%nn;
@@ -213,7 +213,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
         %rowspan;
         %if;(evar.ns="on" and (has_notes or has_psources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
                         %if;(has_notes and has_psources)<hr>%end;
                         %if;(has_psources)%apply;capitalize(psources)%end;'
@@ -225,9 +225,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         >
         %incr_count1;
         <div class="d-flex justify-content-between">
-          %if;(evar.image="on" and xxx.has_image)
-            <div></div>
-          %end;
           <div class="align-self-center mr-2">
             %apply;image_MF("xxx")
             %apply;link%with;%xxx.access;%and;
@@ -236,7 +233,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %if;(evar.title="on")%xxx.title;%end;
           </div>
           %if;(evar.image="on" and xxx.has_image)
-            <img src="%xxx.image_url;" class="rounded align-self-center" height="%if;(evar.px!="")%evar.px;%else;60%end;px">
+            <img src="%xxx.image_url;" class="rounded align-self-center"
+             height="%if;(evar.px!="")%evar.px;%else;60%end;px">
           %end;
         </div>
       </td>
@@ -256,7 +254,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           %end;
         %end;'
         %if;(evar.ns="on" and "yyy"="desc" and (has_notes or has_psources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
                         %if;(has_notes and has_psources)<hr>%end;
                         %if;(has_psources)%apply;capitalize(source)%end;'
@@ -266,7 +264,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %end;"
         %end;
         %if;(evar.ns="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_psources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
                         %if;(xxx.has_psources)%apply;capitalize(xxx.psources)%end;'
@@ -279,8 +277,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %incr_count1;
         <div class="d-flex justify-content-between">
           %if;(evar.image="on" and xxx.has_image)
-            <img src="%xxx.image_url;" class="rounded align-self-center" 
+            <img src="%xxx.image_url;" class="rounded align-self-center"
              height="%if;(evar.px!="")%evar.px;%else;60%end;px">
+          %else;<div></div>
           %end;
           <div class="align-self-center px-1">
             %apply;image_MF("xxx")
@@ -289,9 +288,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %end;
             %if;(evar.title="on")%xxx.title;%end;
           </div>
-          %if;(evar.image="on" and xxx.has_image)
-            <div></div>
-          %end;
+
         </div>
       </td>
     %end;
@@ -350,12 +347,22 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                       %if;(("yyy"="desc" and (has_birth_note or has_baptism_note))
                           or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
                       %end;
-                      %foreach;source;
-                        %let;birthbaptism;[birth], [baptism]%in;
-                        %if;((not has_baptism_note and not has_baptism_source) and (source_type=[birth] or source_type=birthbaptism))
-                          %apply;capitalize(source).
-                        %elseif;((has_baptism_note or has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
-                          <li>%apply;capitalize(source_type)[:] %source;.</li>
+                      %let;birthbaptism;[birth], [baptism]%in;
+                      %if;("yyy"="desc")
+                        %foreach;source;
+                          %if;(not has_baptism_note and ((not has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
+                            %apply;capitalize(source).
+                          %elseif;((has_baptism_note or has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
+                            <li>%apply;capitalize(source_type)[:] %source;.</li>
+                          %end;
+                        %end;
+                      %else;
+                        %foreach;xxx.source;
+                          %if;(not xxx.has_baptism_note and ((not xxx.has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
+                            %apply;capitalize(xxx.source).
+                          %elseif;((xxx.has_baptism_note or xxx.has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
+                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                          %end;
                         %end;
                       %end;
                     %end;'
@@ -386,9 +393,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %if;(family_cnt=fam_cnt)
           <td class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
           %if;(evar.ns="on")
-              %if;(spouse.has_notes and not spouse.has_psources) notespouse%nn;
-              %elseif;(not spouse.has_notes and spouse.has_psources) sourcespouse%nn;
-              %elseif;(spouse.has_notes and spouse.has_psources) notesourcespouse%nn;
+              %if;(spouse.has_notes and not spouse.has_psources) note%nn;
+              %elseif;(not spouse.has_notes and spouse.has_psources) source%nn;
+              %elseif;(spouse.has_notes and spouse.has_psources) notesource%nn;
               %end;
           %end;'
           %if;(evar.ns="on" and (spouse.has_notes or spouse.has_psources))
@@ -555,7 +562,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                       %end;
                      %end;'
             %end;
-            >            
+            >
             %if;(nb_children>0 and not cancel_links)<a href="#%labl0;%if;(nb_families>1)%apply;letter(fam_cnt)%end;.1" title="[*link to children]">%end;
             %if;("yyy"="desc" and evar.t="I")
               %nb_ch_tot_desc;%if;(nb_ch_tot_desc!=nb_ch_tot_spous)/%nb_ch_tot_spous;%(!! nb_ch_tot_spous is wrong: gives father total of children?! %)%end;
@@ -623,14 +630,22 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                       %if;(("yyy"="desc" and (has_death_note or has_burial_note))
                           or (xxx.has_death_note or xxx.has_burial_note))<hr>
                       %end;
-                      %foreach;source;
-                        %let;deathburial;[death], [burial]%in;
-                        %if;(source_type=[death] and not has_burial_source)
-                          %apply;capitalize(source).
-                        %elseif;((source_type=[burial] and not has_death_source and has_burial_source)
-                                 or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
-                                      and has_burial_source and has_death_source))
-                          <li>%apply;capitalize(source_type)[:] %source;.</li>
+                      %let;deathburial;[death], [burial]%in;
+                      %if;("yyy"="desc")
+                        %foreach;source;
+                          %if;(not has_burial_note and ((not has_burial_source and source_type=[death]) or source_type=deathburial))
+                            %apply;capitalize(source).
+                          %elseif;((has_burial_note or has_burial_source) and (source_type=[death] or source_type=[burial]))
+                            <li>%apply;capitalize(source_type)[:] %source;.</li>
+                          %end;
+                        %end;
+                      %else;
+                        %foreach;xxx.source;
+                          %if;(not xxx.has_burial_note and ((not xxx.has_burial_source and source_type=[death]) or source_type=deathburial))
+                            %apply;capitalize(xxx.source).
+                          %elseif;((xxx.has_burial_note or xxx.has_burial_source) and (source_type=[death] or source_type=[burial]))
+                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                          %end;
                         %end;
                       %end;
                     %end;'
@@ -644,32 +659,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                   %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
                   %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
                   %end;
-               %end;'
-    %end;
-    %if;(evar.ns="on")
-      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-      data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
-                      %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
-                      %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
-                    %end;
-                    %if;(xxx.has_death_source or xxx.has_burial_source)
-                      %if;(xxx.has_death_note or xxx.has_burial_note)<hr>%end;
-                      %foreach;xxx.source;
-                        %let;deathburial;[death], [burial]%in;
-                        %if;(source_type=[death] and not xxx.has_burial_source)
-                          %apply;capitalize(xxx.source).
-                        %elseif;((source_type=[burial] and not xxx.has_death_source and xxx.has_burial_source)
-                                 or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
-                                      and xxx.has_burial_source and xxx.has_death_source))
-                          <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
-                        %end;
-                      %end;
-                    %end;'
-        title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
-                 %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
-                 %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
-                 %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
-                 %end;
                %end;'
     %end;
       >
@@ -697,7 +686,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %end;
 
 %define;one_child(xxx, prefx, fff, ch_cnt)
-  %incr_count; 
+  %incr_count;
   %( Les enfants d'une personne sont numérotés de 1 à n indépendamment du nombre de mariages %)
   %let;prfx;%if;("prefx"="-1")%else;prefx%end;%in;
   %if;(evar.t="A")
@@ -766,7 +755,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %if;(wizard and not cancel_links)
         <a href="%prefix;m=MOD_FAM;i=%family.index;;ip=%index;" title="[*modify::family/families]0 %xxx; [and] %xxx.spouse;">
         %if;(slash_marriage_date != "")<span class="nowrap">%slash_marriage_date;</span>%else;<span class="fa fa-venus-mars
-          %if;((xxx.is_male and spouse.xxx.is_female) or 
+          %if;((xxx.is_male and spouse.xxx.is_female) or
               (xxx.is_female and xxx.spouse.is_female))venus-mars%nn;
           %elseif;(xxx.is_male and spouse.xxx.is_male)mars-double%nn;
           %else;(xxx.is_female and spouse.xxx.is_female)venus-double%nn;
@@ -884,8 +873,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %end;
 %( Boutons de configurations et d'options %)
 %if;(not cancel_links)
-  <div class="form-inline">
-    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
+  <div class="d-flex">
+    <a role="button" class="btn btn-link ml-2 my-0 px-0 mb-1"
       href="%prefix;m=D;%access;"><i class="fa fa-cog fa-lg fa-fw mr-1">
       </i>[*options] [descendants]
     </a>
@@ -903,9 +892,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
       <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]
     </a>
-    <div class="input-group mx-2 mb-1">
-      <span class="input-group-btn">
-        %if;(evar.v>=1)<a
+    <div class="ml-auto mr-5">
+      %if;(evar.v>=1)
+        <a role="button" class="btn"
           href="%apply;rebuild_url%with;D
                 %and;%evar.t;
                 %and;v=%expr(evar.v-1);
@@ -913,40 +902,27 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %and;%if;(evar.cgl="on")cgl=on;%end;
                 %and;%if;(evar.image="on")image=on;%end;
                 %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
-      </span>
-      <input class="form-control text-center" size="12"
-        value="%if;(evar.v="")0%else;%evar.v;%end;%sp;
-          %if;(evar.v>1)[generation/generations]1%else;[generation/generations]0%end;"
-        title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
-      <span class="input-group-btn">
-        <a href="%apply;rebuild_url%with;D
-                 %and;%evar.t;
-                 %and;v=%expr(evar.v+1);
-                 %and;%if;(evar.ns="on")ns=on;%end;
-                 %and;%if;(evar.cgl="on")cgl=on;%end;
-                 %and;%if;(evar.image="on")image=on;%end;
-                 %and;%if;(evar.px!="")px=%evar.px;%end;
-                 %end;" class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
-      </span>
-    </div>
-  </div>
-  
-  <div class="form-inline">
-    %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
-      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-         href="%apply;rebuild_url%with;D
-                %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
-                %and;v=%evar.v;;
+                %end;" class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">%nn;
+          <i class="fa fa-minus fa-lg"></i>%nn;
+        </a>
+      %end;
+      <span class="text-primary mt-2">%apply;togend%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
+      %if;((evar.v="" or evar.v="0") and evar.v<desc_level)
+        <a role="button" class="btn"
+          href="%apply;rebuild_url%with;D
+                %and;%evar.t;
+                %and;v=%expr(evar.v+1);
                 %and;%if;(evar.ns="on")ns=on;%end;
                 %and;%if;(evar.cgl="on")cgl=on;%end;
                 %and;%if;(evar.image="on")image=on;%end;
                 %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;">
-                <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
-        %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
-      </a>
-    %end;
+                %end;" class="btn btn-secondary" title="[*add] 1 [generation/generations]0">%nn;
+         <i class="fa fa-plus fa-lg"></i>%nn;
+       </a>
+      %end;
+    </div>
+  </div>
+  <div class="d-flex">
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
      href="%apply;rebuild_url%with;D
            %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
@@ -999,6 +975,20 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               %end;"
               title="Cancel url links in whole page">
         <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
+      </a>
+    %end;
+    %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+         href="%apply;rebuild_url%with;D
+                %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
+                %and;v=%evar.v;;
+                %and;%if;(evar.ns="on")ns=on;%end;
+                %and;%if;(evar.cgl="on")cgl=on;%end;
+                %and;%if;(evar.image="on")image=on;%end;
+                %and;%if;(evar.px!="")px=%evar.px;%end;
+                %end;">
+                <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
+        %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
       </a>
     %end;
   </div>

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -34,21 +34,14 @@
   %end;
 %end;
 
+%if;not cancel_links;
+  %import;menubar;
+%end;
+
 <h1 class="d-inline-block">%nn;
   %if;(evar.v!=0)%apply;a_of_b%with;[*descendants]%and;%self;%end;%else;%self; ([no descendants])%end;
    %if;(cancel_links and evar.v!=0) %apply;togend(evar.v)%end;
 </h1>
-
-%if;not cancel_links;
-  <div class="btn-group float-%right; mt-2 mr-2">
-    %if;(referer != "")
-      <a role="button" class="btn btn-link px-0" href="%referer;"><span class="fa fa-arrow-left fa-lg" title="<<"></span></a>
-    %end;
-    <a role="button" class="btn btn-link ml-1 px-0"
-      href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span>
-    </a>
-  </div>
-%end;
 
 %let;central_index;%index;%in;
 
@@ -619,7 +612,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;(evar.ns="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
       data-content='%if;("yyy"="desc" and (has_death_note or has_burial_note))
-                      %if;(has_death_note)%if;(has_burial_note)[*death][:] %end;%death_note;%end;
+                      %if;(has_death_note)[*death][:] %death_note;%end;
                       %if;(has_burial_note)[*burial][:] %burial_note;%end;
                     %elseif;(xxx.has_death_note or xxx.has_burial_note)
                       %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
@@ -636,7 +629,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                           %if;(not has_burial_note and ((not has_burial_source and source_type=[death]) or source_type=deathburial))
                             %apply;capitalize(source).
                           %elseif;((has_burial_note or has_burial_source) and (source_type=[death] or source_type=[burial]))
-                            <li>%apply;capitalize(source_type)[:] %source;.</li>
+                            %if;(source_type=[burial] and is_cremated)
+                               <li>%apply;capitalize([cremation])[:] %source;.</li>
+                            %else;
+                              <li>%apply;capitalize(source_type)[:] %source;.</li>
+                            %end;
                           %end;
                         %end;
                       %else;
@@ -644,7 +641,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                           %if;(not xxx.has_burial_note and ((not xxx.has_burial_source and source_type=[death]) or source_type=deathburial))
                             %apply;capitalize(xxx.source).
                           %elseif;((xxx.has_burial_note or xxx.has_burial_source) and (source_type=[death] or source_type=[burial]))
-                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                            %if;(source_type=[burial] and xxx.is_cremated)
+                               <li>%apply;capitalize([cremation])[:] %xxx.source;.</li>
+                            %else;
+                              <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                            %end;
                           %end;
                         %end;
                       %end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -45,10 +45,6 @@
       <a role="button" class="btn btn-link px-0" href="%referer;"><span class="fa fa-arrow-left fa-lg" title="<<"></span></a>
     %end;
     <a role="button" class="btn btn-link ml-1 px-0"
-      href="%url;cgl=on" target="_blank">
-      <span class="fa fa-chain-broken fa-lg" title="[*cancel GeneWeb links]"></span>
-    </a>
-    <a role="button" class="btn btn-link ml-1 px-0"
       href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span>
     </a>
   </div>
@@ -85,10 +81,10 @@
   <tr class="descends_table_header align-middle">
     %reset_count;
     %if;(evar.num="on")
-      <th class="pl-2" rowspan="2" title="[*n° d'Aboville]">№</th>
+      <th class="pl-2 text-center align-middle" rowspan="2" title="[*n° d'Aboville]">№</th>
       %incr_count;
     %end;
-    <th class="pl-2" rowspan="2">[*person/persons]0</th>
+    <th class="pl-2 text-center align-middle" rowspan="2">[*person/persons]0</th>
     %incr_count;
     %if;(evar.birth="on" and evar.birth_place="on")
       <th class="text-center" colspan="2">[*birth]</th>
@@ -116,7 +112,7 @@
       <th class="text-center" rowspan="2">[*date of marriage]</th>
       %incr_count;
     %elseif;(evar.marr_date!="on" and evar.marr_place="on" and evar.child!="on")
-      <th class="text-center" rowspan="2">[*marriage place]</th>
+      <th class="text-center text-middle" rowspan="2">[*marriage place]</th>
       %incr_count;
     %elseif;(evar.marr_date!="on" and evar.marr_place!="on" and evar.child="on")
       <th class="text-center" rowspan="2" title="[*nb children]/[nb children] [total]">
@@ -139,7 +135,7 @@
       %incr_count;
     %end;
     %if;(evar.occu="on")
-      <th class="pl-2" rowspan="2">[*occupation/occupations]1</th>
+      <th class="pl-2 align-middle" rowspan="2">[*occupation/occupations]1</th>
       %incr_count;
     %end;
     </tr>
@@ -192,20 +188,19 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 
   %if;(evar.num="on" and famx=1)
     %if;("yyy"="desc")
-      <td class="border-left-0" %rowspan;>
+      <td class="border-left-0 text-center align-middle" %rowspan;>
       %if;("ch_cnt"="1" and not cancel_links)<a href="#prefx" title="[*link back to parents]">%end;
       %labl;
       %if;("ch_cnt"="1" and not cancel_links)</a>%end;
       </td>
     %elseif;(evar.t="I")
       %if;(has_families and nb_families>1)
-        <td class="border-left-0">%labl0;%if;(nb_families>1)%apply;letter(family_cnt).%end;</td>
+        <td class="border-left-0 text-center align-middle">%labl0;%if;(nb_families>1)%apply;letter(family_cnt).%end;</td>
       %else;
         <td></td>
       %end;
     %end;
   %end;
-%( attention has_sources vérifie toutes les sources, manque un simple has_person_source %)
   %if;(famx=1)
     %if;("yyy"="desc")
       <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2%nn;
@@ -228,14 +223,23 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;
         >
         %incr_count1;
-        %if;(xxx.has_image)<img src="%xxx.image_url;" class="align-self-center float-left" height="80px"%/>%end;
-        %apply;image_MF("xxx")
-        %apply;link%with;%xxx.access;%and;
-          %xxx;
-        %end
-        %if;(evar.title="on")%xxx.title;%end
+        <div class="d-flex justify-content-between">
+          %if;(evar.image="on" and xxx.has_image)
+            <div></div>
+          %end;
+          <div class="align-self-center mr-2">
+            %apply;image_MF("xxx")
+            %apply;link%with;%xxx.access;%and;
+              %xxx;
+            %end;
+            %if;(evar.title="on")%xxx.title;%end;
+          </div>
+          %if;(evar.image="on" and xxx.has_image)
+            <img src="%xxx.image_url;" class="rounded align-self-center" height="%if;(evar.px!="")%evar.px;%else;60%end;px">
+          %end;
+        </div>
       </td>
-   %elseif;(evar.t="I")
+    %elseif;(evar.t="I")
       <td class='align-middle text-right%if;(evar.nowrap="on") text-nowrap%end;%nn;
         %if;(evar.notes="on")
           %if;("yyy"="desc")
@@ -265,19 +269,29 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
                         %if;(xxx.has_psources)%apply;capitalize(xxx.psource)%end;'
-          title="%if;(xxx.has_notes and not xxx.has_psources)[*note/notes]11%nn;
-                %elseif;(not xxx.has_notes and xxx.has_psources)[*source/sources]11%nn;
-                %elseif;(xxx.has_notes and xxx.has_psources)[*note/notes]1 [and] [source/sources]11%nn;
+          title="%if;(xxx.has_notes and not xxx.has_psources)[*note/notes]1%nn;
+                %elseif;(not xxx.has_notes and xxx.has_psources)[*source/sources]1%nn;
+                %elseif;(xxx.has_notes and xxx.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
                 %end;"
         %end;
         >
         %incr_count1;
-        %if;(xxx.has_image)<img src="%xxx.image_url;" class="align-self-center float-left" height="80px"%/>%end;
-        %apply;image_MF("xxx")
-        %apply;link%with;%xxx.access;%and;
-          %xxx;
-        %end;
-        %if;(evar.title="on")%xxx.title;%end;
+        <div class="d-flex justify-content-between">
+          %if;(evar.image="on" and xxx.has_image)
+            <img src="%xxx.image_url;" class="rounded align-self-center" 
+             height="%if;(evar.px!="")%evar.px;%else;60%end;px">
+          %end;
+          <div class="align-self-center px-1">
+            %apply;image_MF("xxx")
+            %apply;link%with;%xxx.access;%and;
+              %xxx;
+            %end;
+            %if;(evar.title="on")%xxx.title;%end;
+          </div>
+          %if;(evar.image="on" and xxx.has_image)
+            <div></div>
+          %end;
+        </div>
       </td>
     %end;
   %end;
@@ -685,7 +699,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %apply;image_MF("xxx.spouse")
         %apply;link%with;%xxx.spouse.access;%and;
           %xxx.spouse.first_name; %xxx.spouse.surname;
-        %end
+        %end;
         %xxx.spouse.title;
       %end;
     %end;
@@ -745,7 +759,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %apply;image_MF("xxx.spouse")
       %apply;link%with;%xxx.spouse.access;
       %and;%xxx.spouse.first_name; %xxx.spouse.surname;
-      %end
+      %end;
       %xxx.spouse.title;
       %(&nbsp; (%xxx.nb_children;
       %if;(1=0 or 1=0 and xxx.spouse.has_families and xxx.spouse.nb_children<xxx.spouse.nb_children_total)
@@ -777,7 +791,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           %end;
         %end;
       %end;
-    %end
+    %end;
   %else;
     %apply;list_row("xxx", nnpref, fam_cnt, ch_cnt)
   %end;
@@ -794,13 +808,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           %apply;one_level("child", lv+1, max_l, npref, fam, child_cnt)
         %end;
       %end;
-    %end
+    %end;
   %else;
     %apply;one_family("self", npref)
   %end;
 %end;
 
-%define;rebuild_url(mmm,xxx,vvv,nnn,ccc)
+%define;rebuild_url(mmm,xxx,vvv,nnn,ccc,iii,ppp)
   %let;new_url;%prefix;m=mmm;%nn;
   %access;;t=xxx;%nn;
   %if;(evar.num="on")
@@ -845,7 +859,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %if;(evar.gen="on")
     gen=on;%nn;
   %end;
-  v=vvv;notes=nnn;cgl=ccc%in;
+  vvvnnnccciiippp%in;
   %new_url;
 %end;
 
@@ -858,10 +872,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%apply;rebuild_url%with;A
             %and;Z;
-            %and;%if;(evar.v="" or evar.v<=2)2%else;%evar.v;%end;
-            %and;%if;(evar.notes="on")on%else;off%end;
-            %and;%if;(evar.cgl="on")on%else;off%end;
-            %end">
+            %and;%if;(evar.v="" or evar.v<=2)v=2;%else;v=%evar.v;;%end;
+            %and;%if;(evar.notes="on")notes=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
+            %end;">
             <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>%end;
     <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
@@ -872,10 +888,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %if;(evar.v>=1)<a
           href="%apply;rebuild_url%with;D
                 %and;%evar.t;
-                %and;%expr(evar.v-1)
-                %and;%if;(evar.notes="on")on%else;off%end;
-                %and;%if;(evar.cgl="on")on%else;off%end;
-                %end" class="btn" title="-1 [generation/generations]0">-</a>%end;
+                %and;v=%expr(evar.v-1);
+                %and;%if;(evar.notes="on")notes=on;%end;
+                %and;%if;(evar.cgl="on")cgl=on;%end;
+                %and;%if;(evar.image="on")image=on;%end;
+                %and;%if;(evar.px!="")px=%evar.px;%end;
+                %end;" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
       <input class="form-control text-center" size="12"
         value="%if;(evar.v="")0%else;%evar.v;%end;%sp;
@@ -884,55 +902,89 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       <span class="input-group-btn">
         <a href="%apply;rebuild_url%with;D
                  %and;%evar.t;
-                 %and;%expr(evar.v+1)
-                 %and;%if;(evar.notes="on")on%else;off%end;
-                 %and;%if;(evar.cgl="on")on%else;off%end;
-                 %end" class="btn" title="+1 [generation/generations]0">+</a>
+                 %and;v=%expr(evar.v+1);
+                 %and;%if;(evar.notes="on")notes=on;%end;
+                 %and;%if;(evar.cgl="on")cgl=on;%end;
+                 %and;%if;(evar.image="on")image=on;%end;
+                 %and;%if;(evar.px!="")px=%evar.px;%end;
+                 %end;" class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
       </span>
     </div>
   </div>
-
+  
   <div class="form-inline">
     %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
          href="%apply;rebuild_url%with;D
                 %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
-                %and;%evar.v;
-                %and;%if;(evar.notes="on")on%else;off%end;
-                %and;%if;(evar.cgl="on")on%else;off%end;
+                %and;v=%evar.v;;
+                %and;%if;(evar.notes="on")notes=on;%end;
+                %and;%if;(evar.cgl="on")cgl=on;%end;
+                %and;%if;(evar.image="on")image=on;%end;
+                %and;%if;(evar.px!="")px=%evar.px;%end;
                 %end;">
-                <i class="fa fa-table fa-lg fa-fw mr-1"></i>%nn;
+                <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
         %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
       </a>
     %end;
+    %if;(evar.image="on")
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+       href="%apply;rebuild_url%with;D
+             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+             %and;v=%evar.v;;
+             %and;%if;(evar.notes="on")notes=on;%end;
+             %and;%if;(evar.cgl="on")cgl=on;%end;
+             %and;%if;(evar.image="on")image=on;%end;
+             %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
+             %end;"
+       title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
+    %end;
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+     href="%apply;rebuild_url%with;D
+           %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+           %and;v=%evar.v;;
+           %and;%if;(evar.notes="on")notes=on;%end;
+           %and;%if;(evar.cgl="on")cgl=on;%end;
+           %and;%if;(evar.image!="on")image=on;%end;
+           %and;%if;(evar.px!="")px=%evar.px;%end;
+           %end;">
+            <i class="fa fa-picture-o fa-lg fa-fw
+             %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
+     %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
+    </a>
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-            %and;%evar.v;
-            %and;%if;(evar.notes="on")off%else;on%end;
-            %and;%if;(evar.cgl="on")on%else;off%end;
+            %and;v=%evar.v;;
+            %and;%if;(evar.notes!="on")notes=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;"
             title="small arrow in corner shows existence of note or source">
-             <i class="fa fa-cog fa-lg fa-fw mr-1"></i>%nn;
-      %if;(evar.notes="off" or evar.notes="")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
+              <i class="fa fa-file-text-o fa-lg fa-fw
+               %if;(evar.notes="on")text-danger%end; mr-1"></i>%nn;
+      %if;(evar.notes="" or evar.notes!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
         <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
     </a>
-    %if;(evar.cgl="" or evar.cgl="off")
+    %if;(evar.cgl="" or evar.cgl!="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
         href="%apply;rebuild_url%with;D
               %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-              %and;%evar.v;
-              %and;off
-              %and;%if;(evar.cgl="on")off%else;on%end;
+              %and;v=%evar.v;;
+              %and;
+              %and;%if;(evar.cgl!="on")cgl=on;%end;
+              %and;%if;(evar.image="on")image=on;%end;
+              %and;
               %end;"
               title="Cancel url links in whole page">
-        <i class="fa fa-cog fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
+        <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
       </a>
     %end;
   </div>
 %end;
 
-<table class="table table-sm table-hover descends_table mt-2">
+<table class="table table-sm table-hover descends_table mt-1">
   %if;(evar.t="A")
     %let;nb_col;1%in;
     %apply;one_person("self", 0, evar.v, "", 0, 0)

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -228,6 +228,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;
         >
         %incr_count1;
+        %if;(xxx.has_image)<img src="%xxx.image_url;" class="align-self-center float-left" height="80px"%/>%end;
         %apply;image_MF("xxx")
         %apply;link%with;%xxx.access;%and;
           %xxx;
@@ -238,14 +239,14 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       <td class='align-middle text-right%if;(evar.nowrap="on") text-nowrap%end;%nn;
         %if;(evar.notes="on")
           %if;("yyy"="desc")
-            %if;(xxx.has_notes and not xxx.has_psources) note%nn;
-            %elseif;(not xxx.has_notes and xxx.has_psources) source%nn;
-            %elseif;(xxx.has_notes and xxx.has_psources) notesource%nn;
+            %if;(xxx.has_notes and not xxx.has_psources) notespouse%nn;
+            %elseif;(not xxx.has_notes and xxx.has_psources) sourcespouse%nn;
+            %elseif;(xxx.has_notes and xxx.has_psources) notesourcespouse%nn;
             %end;
           %elseif;("yyy"="spous")
-            %if;(xxx.has_notes and not xxx.has_psources) notes%nn;
-            %elseif;(not xxx.has_notes and xxx.has_psources) sources%nn;
-            %elseif;(xxx.has_notes and xxx.has_psources) notesources%nn;
+            %if;(xxx.has_notes and not xxx.has_psources) notespouse%nn;
+            %elseif;(not xxx.has_notes and xxx.has_psources) sourcespouse%nn;
+            %elseif;(xxx.has_notes and xxx.has_psources) notesourcespouse%nn;
             %end;
           %end;
         %end;'
@@ -271,6 +272,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;
         >
         %incr_count1;
+        %if;(xxx.has_image)<img src="%xxx.image_url;" class="align-self-center float-left" height="80px"%/>%end;
         %apply;image_MF("xxx")
         %apply;link%with;%xxx.access;%and;
           %xxx;
@@ -306,7 +308,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                (has_birth_source or has_baptism_source)) notesource%nn;
           %end;
         %end;'
-        %rowspan;
     %else;
       <td class='align-middle%nn;
         %if;(evar.notes="on")
@@ -318,49 +319,47 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                (xxx.has_birth_source or xxx.has_baptism_source)) notesource%nn;
           %end;
         %end;'
-        %rowspan;
     %end;
-        %if;(evar.notes="on")
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-          data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
-                          %if;(has_birth_note)%if;(has_baptism_note)[*birth][:] %end;%birth_note;%end;
-                          %if;(has_baptism_note)[*baptism][:] %baptism_note;%end;
-                        %elseif;(xxx.has_birth_note or xxx.has_baptism_note)
-                          %if;(xxx.has_birth_note)%if;(xxx.has_baptism_note)[*birth][:] %end;%xxx.birth_note;%end;
-                          %if;(xxx.has_baptism_note)[*baptism][:] %xxx.baptism_note;%end;
+    %rowspan;
+    %if;(evar.notes="on")
+      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+      data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
+                      %if;(has_birth_note)%if;(has_baptism_note)[*birth][:] %end;%birth_note;%end;
+                      %if;(has_baptism_note)[*baptism][:] %baptism_note;%end;
+                    %elseif;(xxx.has_birth_note or xxx.has_baptism_note)
+                      %if;(xxx.has_birth_note)%if;(xxx.has_baptism_note)[*birth][:] %end;%xxx.birth_note;%end;
+                      %if;(xxx.has_baptism_note)[*baptism][:] %xxx.baptism_note;%end;
+                    %end;
+                    %if;(("yyy"="desc" and (has_birth_source or has_baptism_source))
+                           or (xxx.has_birth_source or xxx.has_baptism_source))
+                      %if;(("yyy"="desc" and (has_birth_note or has_baptism_note))
+                          or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
+                      %end;
+                      %foreach;source;
+                        %let;birthbaptism;[birth], [baptism]%in;
+                        %if;((not has_baptism_note and not has_baptism_source) and (source_type=[birth] or source_type=birthbaptism))
+                          %apply;capitalize(source).
+                        %elseif;((has_baptism_note or has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
+                          <li>%apply;capitalize(source_type)[:] %source;.</li>
                         %end;
-                        %if;(("yyy"="desc" and (has_birth_source or has_baptism_source))
-                               or (xxx.has_birth_source or xxx.has_baptism_source))
-                          %if;(("yyy"="desc" and (has_birth_note or has_baptism_note))
-                              or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
-                          %end;
-                          %foreach;source;
-                            %let;birthbaptism;[birth], [baptism]%in;
-                            %if;(not has_baptism_note and not has_baptism_source) and (source_type=[birth] or source_type=birthbaptism))
-                              %apply;capitalize(source).
-                            %elseif;((has_baptism_note or has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
-                              <li>%apply;capitalize(source_type)[:] %source;.</li>
-                            %end;
-                          %end;
-                        %end;'
-            title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
-                     %if;(has_birth_note or has_baptism_note)[*note/notes]1%end;
-                     %if;(has_birth_source or has_baptism_source)
-                        %if;(not has_birth_note and not has_baptism_note)[*source/sources]1%else; [and] [source/sources]1%end;
-                     %end;
-                   %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
-                     %if;(xxx.has_birth_note or xxx.has_baptism_note)[*note/notes]1%end;
-                     %if;(xxx.has_birth_source or xxx.has_baptism_source)
-                        %if;(not xxx.has_birth_note and not xxx.has_baptism_note)
-                          [*source/sources]1%else; [and] [source/sources]1
-                        %end;
-                     %end;
-                   %end;'
-        %end;
+                      %end;
+                    %end;'
+        title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
+                 %if;((has_birth_note or has_baptism_note) and not (has_birth_source or has_baptism_source))[*note/notes]1%nn;
+                 %elseif;(not (has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[source/sources]1%nn;
+                 %elseif;((has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[*source/sources]1 [and] [source/sources]1%nn;
+                 %end;
+               %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
+                 %if;((xxx.has_birth_note or xxx.has_baptism_note) and not (xxx.has_birth_source or xxx.has_baptism_source))[*note/notes]1%nn;
+                 %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[source/sources]1%nn;
+                 %elseif;((xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[*note/notes]1 [and] [source/sources]1%nn;
+                 %end;
+               %end;'
+    %end;
       >
-        %if;xxx.has_approx_birth_place;
-          %xxx.approx_birth_place;
-        %end;
+    %if;xxx.has_approx_birth_place;
+      %xxx.approx_birth_place;
+    %end;
     </td>
   %end;
 
@@ -517,7 +516,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               data-content='%if;(has_comment)%comment;%end;
                             %if;(has_comment and fsources!="")<hr>%end;
                             %if;(fsources!="")%apply;capitalize(fsources)%end;'
-              title='%if;(has_fsources!="")
+              title='%if;(has_comment or fsources!="")
                       %if;(has_comment and fsources="")[*note/notes]1%nn;
                       %elseif;(not has_comment and fsources!="")[*source/sources]1%nn;
                       %elseif;(has_comment and fsources!="")[*note/notes]1 [and] [*source/sources]1%nn;
@@ -557,42 +556,15 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;("yyy"="desc")
       <td class='align-middle
         %if;(evar.notes="on")
-        %if;((has_death_note or has_burial_note) and not
-            (has_death_source or has_burial_source))note%elseif;
-            (not (has_death_note or has_burial_note) and
-            (has_death_source or has_burial_source))source%elseif;
-            ((has_death_note or has_burial_note) and
-            (has_death_source or has_burial_source))notesource%end;
+          %if;((has_death_note or has_burial_note) and not
+              (has_death_source or has_burial_source))note
+          %elseif;(not (has_death_note or has_burial_note) and
+              (has_death_source or has_burial_source))source
+          %elseif;((has_death_note or has_burial_note) and
+              (has_death_source or has_burial_source))notesource
+          %end;
         %end;'
-        %rowspan;
-        %if;(evar.notes="on")
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-          data-content='%if;(has_death_note or has_burial_note)
-                          %if;(has_death_note)%if;(has_burial_note)[*death][:] %end;%death_note;%end;
-                          %if;(has_burial_note)[*burial][:] %burial_note;%end;
-                        %end;
-                        %if;(has_death_source or has_burial_source)
-                          %if;(has_death_note or has_burial_note)<hr>%end;
-                          %foreach;source;
-                            %let;deathburial;[death], [burial]%in;
-                            %if;(source_type=[death] and not has_burial_source)
-                              %apply;capitalize(source).
-                            %elseif;((source_type=[burial] and not has_death_source and has_burial_source)
-                                     or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
-                                          and has_burial_source and has_death_source))
-                              <li>%apply;capitalize(source_type)[:] %source;.</li>
-                            %end;
-                          %end;
-                        %end;'
-            title='%if;(has_death_source or has_burial_source or has_death_note or has_burial_note)
-                     %if;((has_death_note or has_burial_note) and not (has_death_source or has_burial_source))[*note/notes]1
-                     %elseif;(not (has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*source/sources]1
-                     %elseif;((has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*note/notes]1 [and] [source/sources]1
-                     %end;
-                   %end;'
-        %end;
-      >
-    %elseif;("yyy"="spous")
+    %else;
       <td class='align-middle
         %if;(evar.notes="on")
           %if;((xxx.has_death_note or xxx.has_burial_note) and not
@@ -603,35 +575,72 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               (xxx.has_death_source or xxx.has_burial_source))notesource
           %end;
         %end;'
-        %rowspan;
-        %if;(evar.notes="on")
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-          data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
-                          %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
-                          %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
-                        %end;
-                        %if;(xxx.has_death_source or xxx.has_burial_source)
-                          %if;(xxx.has_death_note or xxx.has_burial_note)<hr>%end;
-                          %foreach;xxx.source;
-                            %let;deathburial;[death], [burial]%in;
-                            %if;(source_type=[death] and not xxx.has_burial_source)
-                              %apply;capitalize(xxx.source).
-                            %elseif;((source_type=[burial] and not xxx.has_death_source and xxx.has_burial_source)
-                                     or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
-                                          and xxx.has_burial_source and xxx.has_death_source))
-                              <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
-                            %end;
-                          %end;
-                        %end;'
-            title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
-                     %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
-                     %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
-                     %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
-                     %end;
-                   %end;'
-        %end;
-      >
     %end;
+    %rowspan;
+    %if;(evar.notes="on")
+      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+      data-content='%if;("yyy"="desc" (and has_death_note or has_burial_note))
+                      %if;(has_death_note)%if;(has_burial_note)[*death][:] %end;%death_note;%end;
+                      %if;(has_burial_note)[*burial][:] %burial_note;%end;
+                    %elseif;(xxx.has_death_note or xxx.has_burial_note)
+                      %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
+                      %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
+                    %end;
+                    %if;(("yyy"="desc" and (has_death_source or has_burial_source))
+                          or (xxx.has_death_source or xxx.has_burial_source))
+                      %if;(("yyy"="desc" and (has_death_note or has_burial_note))
+                          or (xxx.has_death_note or xxx.has_burial_note))<hr>
+                      %end;
+                      %foreach;source;
+                        %let;deathburial;[death], [burial]%in;
+                        %if;(source_type=[death] and not has_burial_source)
+                          %apply;capitalize(source).
+                        %elseif;((source_type=[burial] and not has_death_source and has_burial_source)
+                                 or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
+                                      and has_burial_source and has_death_source))
+                          <li>%apply;capitalize(source_type)[:] %source;.</li>
+                        %end;
+                      %end;
+                    %end;'
+        title='%if;("yyy"="desc" and (has_death_source or has_burial_source or has_death_note or has_burial_note))
+                 %if;((has_death_note or has_burial_note) and not (has_death_source or has_burial_source))[*note/notes]1
+                 %elseif;(not (has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*source/sources]1
+                 %elseif;((has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*note/notes]1 [and] [source/sources]1
+                 %end;
+               %elseif;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
+                  %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
+                  %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
+                  %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
+                  %end;
+               %end;'
+    %end;
+    %if;(evar.notes="on")
+      tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+      data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
+                      %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
+                      %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
+                    %end;
+                    %if;(xxx.has_death_source or xxx.has_burial_source)
+                      %if;(xxx.has_death_note or xxx.has_burial_note)<hr>%end;
+                      %foreach;xxx.source;
+                        %let;deathburial;[death], [burial]%in;
+                        %if;(source_type=[death] and not xxx.has_burial_source)
+                          %apply;capitalize(xxx.source).
+                        %elseif;((source_type=[burial] and not xxx.has_death_source and xxx.has_burial_source)
+                                 or ((source_type=[death] or source_type=[burial] or source_type=deathburial)
+                                      and xxx.has_burial_source and xxx.has_death_source))
+                          <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                        %end;
+                      %end;
+                    %end;'
+        title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
+                 %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
+                 %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
+                 %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
+                 %end;
+               %end;'
+    %end;
+      >
     %if;xxx.has_approx_death_place;
        %xxx.approx_death_place;
     %end;
@@ -724,13 +733,18 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %if;(wizard and not cancel_links)
         <a href="%prefix;m=MOD_FAM;i=%family.index;;ip=%index;" title="[*modify::family/families]0 %xxx; [and] %xxx.spouse;">
         %if;(slash_marriage_date != "")<span class="nowrap">%slash_marriage_date;</span>%else;<span class="fa fa-venus-mars
-          %if;((xxx.is_male and spouse.xxx.is_female) or (xxx.is_female and xxx.spouse.is_female))venus-mars%elseif;(xxx.is_male and spouse.xxx.is_male)mars-double%else;(xxx.is_female and spouse.xxx.is_female)venus-double%end; fa-rotate-180 small"></span>%end;</a>%nn;
+          %if;((xxx.is_male and spouse.xxx.is_female) or 
+              (xxx.is_female and xxx.spouse.is_female))venus-mars%nn;
+          %elseif;(xxx.is_male and spouse.xxx.is_male)mars-double%nn;
+          %else;(xxx.is_female and spouse.xxx.is_female)venus-double%nn;
+          %end; fa-rotate-180 small"></span>%end;</a>%nn;
       %else;
         %slash_marriage_date;%nn;
       %end;
       </span>
       %apply;image_MF("xxx.spouse")
-      %apply;link%with;%xxx.spouse.access;%and;
+      %apply;link%with;%xxx.spouse.access;%and;               %end;'
+
         %xxx.spouse.first_name; %xxx.spouse.surname;
       %end
       %xxx.spouse.title;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -826,49 +826,21 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %define;rebuild_url(mmm,xxx,vvv,nnn,ccc,iii,ppp)
   %let;new_url;%prefix;m=mmm;%nn;
   %access;;t=xxx;%nn;
-  %if;(evar.num="on")
-    num=on;%nn;
-  %end;
-  %if;(evar.nowrap="on")
-    nowrap=on;%nn;
-  %end;
-  %if;(evar.title="on")
-    title=on;%nn;
-  %end;
-  %if;(evar.birth="on")
-    birth=on;%nn;
-  %end;
-  %if;(evar.birth_place="on")
-    birth_place=on;%nn;
-  %end;
-  %if;(evar.marr= "on")
-    marr=on;%nn;
-  %end;
-  %if;(evar.marr_date="on")
-    marr_date=on;%nn;
-  %end;
-  %if;(evar.marr_place="on")
-    marr_place=on;%nn;
-  %end;
-  %if;(evar.child="on")
-    child=on;%nn;
-  %end;
-  %if;(evar.death="on")
-    death=on;%nn;
-  %end;
-  %if;(evar.death_place="on")
-    death_place=on;%nn;
-  %end;
-  %if;(evar.age="on")
-    age=on;%nn;
-  %end;
-  %if;(evar.occu="on")
-    occu=on;%nn;
-  %end;
-  %if;(evar.gen="on")
-    gen=on;%nn;
-  %end;
-  vvvnnnccciiippp%in;
+  %if;(evar.num="on")num=on;%nn;%end;
+  %if;(evar.nowrap="on")nowrap=on;%nn;%end;
+  %if;(evar.title="on")title=on;%nn;%end;
+  %if;(evar.birth="on")birth=on;%nn;%end;
+  %if;(evar.birth_place="on")birth_place=on;%nn;%end;
+  %if;(evar.marr= "on")marr=on;%nn;%end;
+  %if;(evar.marr_date="on")marr_date=on;%nn;%end;
+  %if;(evar.marr_place="on")marr_place=on;%nn;%end;
+  %if;(evar.child="on")child=on;%nn;%end;
+  %if;(evar.death="on")death=on;%nn;%end;
+  %if;(evar.death_place="on")death_place=on;%nn;%end;
+  %if;(evar.age="on")age=on;%nn;%end;
+  %if;(evar.occu="on")occu=on;%nn;%end;
+  %if;(evar.gen="on")gen=on;%nn;%end;
+  vvv;nnn;ccc;iii;ppp;%in;
   %new_url;
 %end;
 %( Boutons de configurations et d'options %)
@@ -880,8 +852,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     </a>
     %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%apply;rebuild_url%with;A
-            %and;Z;
-            %and;%if;(evar.v="" or evar.v<=2)v=2;%else;v=%evar.v;;%end;
+            %and;Z
+            %and;%if;(evar.v="" or evar.v<=2)v=2;%else;v=%evar.v;%end;
             %and;%if;(evar.ns="on")ns=on;%end;
             %and;%if;(evar.cgl="on")cgl=on;%end;
             %and;%if;(evar.image="on")image=on;%end;
@@ -902,7 +874,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %and;%if;(evar.cgl="on")cgl=on;%end;
                 %and;%if;(evar.image="on")image=on;%end;
                 %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;" class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">%nn;
+                %end;" 
+                class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">%nn;
           <i class="fa fa-minus fa-lg"></i>%nn;
         </a>
       %end;
@@ -916,7 +889,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %and;%if;(evar.cgl="on")cgl=on;%end;
                 %and;%if;(evar.image="on")image=on;%end;
                 %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;" class="btn btn-secondary" title="[*add] 1 [generation/generations]0">%nn;
+                %end;" 
+                class="btn btn-secondary" title="[*add] 1 [generation/generations]0">%nn;
          <i class="fa fa-plus fa-lg"></i>%nn;
        </a>
       %end;
@@ -924,34 +898,34 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   </div>
   <div class="d-flex">
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-     href="%apply;rebuild_url%with;D
-           %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-           %and;v=%evar.v;;
-           %and;%if;(evar.ns="on")ns=on;%end;
-           %and;%if;(evar.cgl="on")cgl=on;%end;
-           %and;%if;(evar.image!="on")image=on;%end;
-           %and;%if;(evar.px!="")px=%evar.px;%end;
-           %end;">
+      href="%apply;rebuild_url%with;D
+            %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+            %and;v=%evar.v;
+            %and;%if;(evar.ns="on")ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image!="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
+            %end;">
             <i class="fa fa-picture-o fa-lg fa-fw
              %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
      %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
     </a>
     %if;(evar.image="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-       href="%apply;rebuild_url%with;D
-             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-             %and;v=%evar.v;;
-             %and;%if;(evar.ns="on")ns=on;%end;
-             %and;%if;(evar.cgl="on")cgl=on;%end;
-             %and;%if;(evar.image="on")image=on;%end;
-             %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
-             %end;"
+        href="%apply;rebuild_url%with;D
+              %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+              %and;v=%evar.v;
+              %and;%if;(evar.ns="on")ns=on;%end;
+              %and;%if;(evar.cgl="on")cgl=on;%end;
+              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
+              %end;"
        title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
     %end;
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-            %and;v=%evar.v;;
+            %and;v=%evar.v;
             %and;%if;(evar.ns!="on")ns=on;%end;
             %and;%if;(evar.cgl="on")cgl=on;%end;
             %and;%if;(evar.image="on")image=on;%end;
@@ -967,11 +941,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
         href="%apply;rebuild_url%with;D
               %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-              %and;v=%evar.v;;
-              %and;
+              %and;v=%evar.v;
+              %and;ns=off
               %and;%if;(evar.cgl!="on")cgl=on;%end;
               %and;%if;(evar.image="on")image=on;%end;
-              %and;
+              %and;%if;(evar.px!="")px=%evar.px;%end;
               %end;"
               title="Cancel url links in whole page">
         <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
@@ -979,15 +953,15 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
     %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-         href="%apply;rebuild_url%with;D
-                %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
-                %and;v=%evar.v;;
-                %and;%if;(evar.ns="on")ns=on;%end;
-                %and;%if;(evar.cgl="on")cgl=on;%end;
-                %and;%if;(evar.image="on")image=on;%end;
-                %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;">
-                <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
+        href="%apply;rebuild_url%with;D
+              %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
+              %and;v=%evar.v;
+              %and;%if;(evar.ns="on")ns=on;%end;
+              %and;%if;(evar.cgl="on")cgl=on;%end;
+              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.px!="")px=%evar.px;%end;
+              %end;">
+              <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
         %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
       </a>
     %end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -216,7 +216,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %end;"
         %end;
         >
-        %incr_count1;
+        %apply;add_in_sorted_list(xxx.index)
         <div class="d-flex justify-content-between">
           <div class="align-self-center mr-2">
             %apply;image_MF("xxx")
@@ -250,7 +250,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %end;"
         %end;
         >
-        %incr_count1;
+        %apply;add_in_sorted_list(xxx.index)
         <div class="d-flex justify-content-between">
           %if;(evar.image="on" and xxx.has_image)
             <img src="%xxx.image_url;" class="rounded align-self-center"
@@ -351,7 +351,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                   %end;'
           %end;
           >
-            %incr_count1;
+            %apply;add_in_sorted_list(spouse.index)
             %if;(zzz.nb_families>1)%apply;letter(family_cnt)%end;
             %apply;image_MF("spouse")
             %apply;link%with;%spouse.access;%and;
@@ -879,6 +879,19 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
   </div>
 %end;
+
+%define;desc_count(xxx)
+  %foreach;descendant_level;
+    %if;(level=xxx)%number_of_descendants;%end;
+  %end;
+%end;
+
+%define;desc_count_l(xxx)
+  %foreach;descendant_level;
+    %if;(level=xxx)%number_of_descendants_at_level;%end;
+  %end;
+%end;
+
 %( Main %)
 <table class="table table-sm table-hover descends_table mt-1">
   %if;(evar.t="A")
@@ -890,12 +903,14 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %let;nb_col;%expr(count+1)%in;
     %let;max;%evar.v;%in;
     %reset_count;
-    %reset_count1;
+    %empty_sorted_list;
     %apply;one_child("self", "-1", "", 1)
     %for;lev;0;max;
       %if;(evar.gen="on")
         <tr>
-          <th colspan="%nb_col;">[*generation/generations]0 %expr(lev+1)</th>
+          <th colspan="%nb_col;">[*generation/generations]0 %expr(lev+1)
+          <span class="float-right mr-1" title="[*nb individuals] [descendants at the generation] %expr(lev+1)">%apply;desc_count_l(lev+1)</span>
+          </th>
         </tr>
       %end;
       %apply;one_level("self", 0, lev, "", "", 1)
@@ -903,15 +918,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 </table>
 
-%define;desc_count()
-  %foreach;descendant_level;
-    %if;(level=max_desc_level)%number_of_descendants;%end;
-  %end;
+%reset_count;
+%foreach;sorted_list_item;
+  %incr_count;
 %end;
 
-%if;(has_children)
-  <p>[*total][:] %apply;desc_count() [descendants] %if;(evar.marr="on" or evar.t="I")(%count1; [person/persons]1 [with] [spouse/spouses]1)%end;</p>
-%end;
+<p>[*total][:] %apply;desc_count(max_desc_level) [descendants] %if;(evar.marr="on" or evar.t="I")(%count; [person/persons]1 [with root, spouses and unknowns])</p>
 
 %import;trl;
 %import;copyr;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -210,8 +210,10 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;("yyy"="desc")
       <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
         %if;(evar.notes="on")
-          %if;(has_notes and not has_sources)note%elseif;(not has_notes and
-              has_sources)source%elseif;(has_notes and has_sources)notesource%end;
+          %if;(has_notes and not has_sources)note
+          %elseif;(not has_notes and has_sources)source
+          %elseif;(has_notes and has_sources)notesource
+          %end;
         %end;'
         %rowspan; colspan="2"
         %if;(evar.notes="on" and (has_notes or has_sources))
@@ -244,7 +246,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                xxx.has_sources)source%elseif;(xxx.has_notes and xxx.has_sources)notesource
           %end;
         %end;'
-        %if;("yyy"="desc" and (has_notes or has_sources))
+        %if;(evar.notes="on" and "yyy"="desc" and (has_notes or has_sources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;("yyy"="desc" and has_notes)%notes;%end;
                         %if;("yyy"="desc" and has_sources)
@@ -260,7 +262,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %elseif;(has_notes and has_sources)[*note/notes]1 [and] [source/sources]1
                 %end;"
         %end;
-        %if;("yyy"="spous" and (xxx.has_notes or xxx.has_sources))
+        %if;(evar.notes="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_sources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_sources)
@@ -556,12 +558,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;("yyy"="desc")
       <td class='align-middle
         %if;(evar.notes="on")
-        %if;((has_death_note or has_burial_note) and not
-            (has_death_source or has_burial_source))note%elseif;
-            (not (has_death_note or has_burial_note) and
-            (has_death_source or has_burial_source))source%elseif;
-            ((has_death_note or has_burial_note) and
-            (has_death_source or has_burial_source))notesource%end;
+          %if;((has_death_note or has_burial_note) and not
+              (has_death_source or has_burial_source))note
+          %elseif;(not (has_death_note or has_burial_note) and
+              (has_death_source or has_burial_source))source
+          %elseif;((has_death_note or has_burial_note) and
+              (has_death_source or has_burial_source))notesource
+          %end;
         %end;'
         %rowspan;
         %if;(evar.notes="on")

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -268,7 +268,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
-                        %if;(xxx.has_psources)%apply;capitalize(xxx.psource)%end;'
+                        %if;(xxx.has_psources)%apply;capitalize(xxx.psources)%end;'
           title="%if;(xxx.has_notes and not xxx.has_psources)[*note/notes]1%nn;
                 %elseif;(not xxx.has_notes and xxx.has_psources)[*source/sources]1%nn;
                 %elseif;(xxx.has_notes and xxx.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
@@ -383,7 +383,24 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %else;
       %foreach;xxx.family;
         %if;(family_cnt=fam_cnt)
-          <td class="%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2">
+          <td class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
+          %if;(evar.notes="on")
+              %if;(spouse.has_notes and not spouse.has_psources) notespouse%nn;
+              %elseif;(not spouse.has_notes and spouse.has_psources) sourcespouse%nn;
+              %elseif;(spouse.has_notes and spouse.has_psources) notesourcespouse%nn;
+              %end;
+          %end;'
+          %if;(evar.notes="on" and (spouse.has_notes or spouse.has_psources))
+            tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+            data-content='%if;(spouse.has_notes)%spouse.notes;%end;
+                          %if;(spouse.has_notes and spouse.has_psources)<hr>%end;
+                          %if;(spouse.has_psources)%apply;capitalize(spouse.psources)%end;'
+            title='%if;(spouse.has_notes and not spouse.has_psources)[*note/notes]1%nn;
+                  %elseif;(not spouse.has_notes and spouse.has_psources)[*source/sources]1%nn;
+                  %elseif;(spouse.has_notes and spouse.has_psources)[*note/notes]1 [and] [source/sources]1%nn;
+                  %end;'
+          %end;
+          >
             %incr_count1;
             %if;(zzz.nb_families>1)%apply;letter(family_cnt).%end;
             %apply;image_MF("spouse")
@@ -593,7 +610,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %rowspan;
     %if;(evar.notes="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-      data-content='%if;("yyy"="desc" (and has_death_note or has_burial_note))
+      data-content='%if;("yyy"="desc" and (has_death_note or has_burial_note))
                       %if;(has_death_note)%if;(has_burial_note)[*death][:] %end;%death_note;%end;
                       %if;(has_burial_note)[*burial][:] %burial_note;%end;
                     %elseif;(xxx.has_death_note or xxx.has_burial_note)
@@ -717,7 +734,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %else;
-      %apply;table_row("xxx", prfx, fff, family_cnt, "ch_cnt", count, "desc", "xxx", 0, 0)
+      %apply;table_row("xxx", prfx, fff, "", "ch_cnt", count, "desc", "xxx", 0, 0)
   %end;
 %end;
 

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -44,8 +44,13 @@
     %if;(referer != "")
       <a role="button" class="btn btn-link px-0" href="%referer;"><span class="fa fa-arrow-left fa-lg" title="<<"></span></a>
     %end;
-    <a role="button" class="btn btn-link ml-1 px-0" href="%url;cgl=on" target="_blank"><span class="fa fa-chain-broken fa-lg" title="[*cancel GeneWeb links]"></span></a>%nn;
-    <a role="button" class="btn btn-link ml-1 px-0" href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span></a>
+    <a role="button" class="btn btn-link ml-1 px-0" 
+      href="%url;cgl=on" target="_blank">
+      <span class="fa fa-chain-broken fa-lg" title="[*cancel GeneWeb links]"></span>
+    </a>%nn;
+    <a role="button" class="btn btn-link ml-1 px-0" 
+      href="%prefix;"><span class="fa fa-home fa-lg" title="[*home]"></span>
+    </a>
   </div>
 %end;
 
@@ -53,7 +58,8 @@
 
 %define;image_MF(xxx)
   %if;(wizard and not cancel_links)
-    <a href="%prefix;m=MOD_IND;i=%xxx.index;" title="[*modify::] %xxx.first_name;%if;(xxx.occ!="0").%xxx.occ;%end; %xxx.surname;">
+    <a href="%prefix;m=MOD_IND;i=%xxx.index;" 
+      title="[*modify::] %xxx.first_name;%if;(xxx.occ!="0").%xxx.occ;%end; %xxx.surname;">
   %end;
   %if;xxx.is_male;
     <i class="fa fa-mars male mr-1"></i>%nn;
@@ -98,9 +104,14 @@
       <th class="pl-2" rowspan="2">[*spouse/spouses]1</th>
       %incr_count;
     %end;
-    %if;((evar.marr_date="on" and evar.marr_place="on") or (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
-      <th class="text-center" colspan="%if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")3%else;2%end;">[*marriage/marriages]0</th>
-      %if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")%incr_count;%incr_count;%incr_count;%else;%incr_count;%incr_count;%end;
+    %if;((evar.marr_date="on" and evar.marr_place="on") or
+         (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
+      <th class="text-center" 
+        colspan="%if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")3%else;2%end;">
+        [*marriage/marriages]0
+      </th>
+      %if;(evar.marr_date="on" and evar.marr_place="on" and evar.child="on")
+        %incr_count;%incr_count;%incr_count;%else;%incr_count;%incr_count;%end;
     %elseif;(evar.marr_date="on" and evar.marr_place!="on" and evar.child!="on")
       <th class="text-center" rowspan="2">[*date of marriage]</th>
       %incr_count;
@@ -108,7 +119,9 @@
       <th class="text-center" rowspan="2">[*marriage place]</th>
       %incr_count;
     %elseif;(evar.marr_date!="on" and evar.marr_place!="on" and evar.child="on")
-      <th class="text-center" rowspan="2" title="[*nb children]/[nb children] [total]"><span class="fa fa-child"></span></th>
+      <th class="text-center" rowspan="2" title="[*nb children]/[nb children] [total]">
+        <span class="fa fa-child"></span>
+      </th>
       %incr_count;
     %end;
     %if;(evar.death="on" and evar.death_place="on")
@@ -135,15 +148,22 @@
       <th class="text-right pr-2" title="[*date of birth]">[*date/dates]0</th>
       <th class="pl-2" title="[*where born]/[birth place]">[*place]</th>
     %end;
-    %if;((evar.marr_date="on" and evar.marr_place="on") or (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
+    %if;((evar.marr_date="on" and evar.marr_place="on") or 
+         (evar.marr_date="on" and evar.child="on") or (evar.marr_place="on" and evar.child="on"))
       %if;(evar.marr_date="on")
-        <th class="%if;(evar.marr_place!="on")text-center%else;text-right pr-2%end;" title="[*date of marriage]">[*date/dates]0</th>
+        <th class="%if;(evar.marr_place!="on")text-center%else;text-right pr-2%end;" 
+          title="[*date of marriage]">[*date/dates]0
+        </th>
       %end;
       %if;(evar.marr_place="on")
-        <th class="%if;(evar.marr_date!="on")text-center%else;pl-2%end;" title="[*where married]/[marriage place]">[*place]</th>
+        <th class="%if;(evar.marr_date!="on")text-center%else;pl-2%end;" 
+          title="[*where married]/[marriage place]">[*place]
+        </th>
       %end;
       %if;(evar.child="on")
-        <th class="text-center px-2" title="[*nb children]/[*nb children] [total]"><span class="fa fa-child"></span></th>
+        <th class="text-center px-2" title="[*nb children]/[*nb children] [total]">
+          <span class="fa fa-child"></span>
+        </th>
       %end;
     %end;
     %if;(evar.death="on" and evar.death_place="on")
@@ -159,22 +179,53 @@ si t=I on affiche pas les données
 xxx est la personne concernée
 zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %)
-%define;table_row(xxx, prefx, fam_cnt, ch_count, yyy, zzz, ddd, nb_ch_desc)
+%define;table_row(xxx, prefx, fff, fam_cnt, ch_cnt, ch_count, yyy, zzz, ddd, nb_ch_desc)
   %let;famx;%if;(not has_families or evar.t="I")1%else;fam_cnt%end;%in;
   %let;zro;%if;("prefx"="-1")0%else;1%end;%in;
-  %let;rowspan;%if;(nb_families>1 and evar.t="H" and (evar.marr="on" or evar.marr_date="on" or evar.marr_place="on" or evar.child="on"))rowspan="%xxx.nb_families;"%end;%in;
+  %let;labl;%if;(zro=1)%if;("prefx"!="")prefxfff.%end;ch_count%else;1%end;%in;
+  %let;labl0;%if;(zro=1)%if;("prefx"!="")prefxfff.%end;ch_cnt%else;1%end;%in;
+  %let;rowspan;%if;(nb_families>1 and evar.t="H" and 
+                   (evar.marr="on" or evar.marr_date="on" or evar.marr_place="on"
+                    or evar.child="on"))rowspan="%xxx.nb_families;"%end;%in;
+
+  <tr id="%labl0">
+
   %if;(evar.num="on" and famx=1)
     %if;("yyy"="desc")
-      <td class="align-middle pl-2" %rowspan;>
-      %if;(zro=1)%if;("prefx"!="")prefx.%end;ch_count%else;1%end;
+      <td class="border-left-0" %rowspan;>
+      %if;("ch_cnt"="1" and not cancel_links)<a href="#prefx" title="[*link back to parents]">%end;
+      %labl;
+      %if;("ch_cnt"="1" and not cancel_links)</a>%end;
       </td>
     %elseif;(evar.t="I")
-      <td class="border-left-0"></td>
+      %if;(has_families and nb_families>1)
+        <td class="border-left-0">%labl0;%if;(nb_families>1)%apply;letter(family_cnt).%end;</td>
+      %else;
+        <td></td>
+      %end;
     %end;
   %end;
+
   %if;(famx=1)
     %if;("yyy"="desc")
-      <td class="align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2" %rowspan; colspan="2">
+      <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
+        %if;(evar.notes="on")
+          %if;(has_notes and not has_sources)note%elseif;(not has_notes and
+              has_sources)source%elseif;(has_notes and has_sources)notesource%end;
+        %end;'
+        %rowspan; colspan="2"
+        %if;(has_notes or has_sources)
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;(has_notes)%notes;%end;
+                        %if;(has_sources)
+                          <hr>
+                           %foreach;source;
+                             <li>%apply;capitalize(source_type)[:] %source;.</li>
+                            %end;
+                        %end;'
+          title="[*note/notes]1 [and] [source/sources]1"
+        %end;
+        >
         %incr_count1;
         %apply;image_MF("xxx")
         %apply;link%with;%xxx.access;%and;
@@ -182,9 +233,44 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end
         %if;(evar.title="on")%xxx.title;%end
       </td>
-    %elseif;(evar.t="I")
-      <td class="align-middle border-right-0 pl-1">%if;(zzz.nb_families>1)%apply;letter(family_cnt).%end;</td>
-      <td class="align-middle text-right border-left-0 pr-2 %if;(evar.nowrap="on")text-nowrap%end;">
+   %elseif;(evar.t="I")
+      <td class="align-middle border-right-0 pl-1"></td>
+      <td class='align-middle text-right border-left-0 pr-2 %if;(evar.nowrap="on")text-nowrap%end;
+        %if;(evar.notes="on")
+          %if;(xxx.has_notes and not xxx.has_sources)note
+          %elseif;(not xxx.has_notes and xxx.has_sources)source
+          %elseif;(xxx.has_notes and xxx.has_sources)notesource
+          %end;
+        %end;'
+        %if;("yyy"="desc" and (has_notes or has_sources))
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;("yyy"="desc" and has_notes)%notes;%end;
+                        %if;("yyy"="desc" and has_sources)
+                          <hr>
+                           %foreach;source;
+                             <li>%apply;capitalize(source_type)[:] %source;.</li>
+                            %end;
+                        %end;'
+          title="%if;(has_notes and not has_sources)[*note/notes]1
+                %elseif;(not has_notes and  has_sources)[source/sources]1
+                %elseif;(has_notes and  has_sources)[*note/notes]1 [and] [source/sources]1
+                %end;"
+        %end;
+        %if;("yyy"="spous" and (xxx.has_notes or xxx.has_sources))
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+          data-content='%if;(xxx.has_notes)%xxx.notes;%end;
+                        %if;(xxx.has_sources)
+                          <hr>
+                           %foreach;xxx.source;
+                             <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                            %end;
+                        %end;'
+          title="%if;(xxx.has_notes and not xxx.has_sources)[*note/notes]1
+                %elseif;(not xxx.has_notes and xxx.has_sources)[source/sources]1
+                %elseif;(xxx.has_notes and  xxx.has_sources)[*note/notes]1 [and] [source/sources]1
+                %end;"
+        %end;
+        >
         %incr_count1;
         %apply;image_MF("xxx")
         %apply;link%with;%xxx.access;%and;
@@ -194,10 +280,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       </td>
     %end;
   %end;
+
   %if;(evar.birth="on" and famx=1)
     <td class="align-middle text-right" %rowspan;>
       %if;(wizard and not cancel_links)
-        <a class="d-block" href="%prefix;m=MOD_IND;i=%xxx.index;#birth_" title="%if;(xxx.has_approx_birth_date)[*update::birth]%else;[*add::birth]%end; %xxx.first_name;%if;(xxx.occ!="0").%xxx.occ;%end; %xxx.surname;">
+        <a class="d-block" href="%prefix;m=MOD_IND;i=%xxx.index;#birth_"
+          title="%if;(xxx.has_approx_birth_date)[*update::birth]%else;[*add::birth]%end;
+          %xxx.first_name;%if;(xxx.occ!="0").%xxx.occ;%end; %xxx.surname;">
         %if;(xxx.has_approx_birth_date)%xxx.slash_approx_birth_date;%else;°%end;
         </a>
       %else;
@@ -205,31 +294,111 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     </td>
   %end;
+
   %if;(evar.birth_place="on" and famx=1)
-    <td class="align-middle" %rowspan;>
-      %if;xxx.has_approx_birth_place;
-        %xxx.approx_birth_place;
-      %end;
+    %if;("yyy"="desc")
+      <td class='align-middle
+        %if;(evar.notes="on")
+        %if;((has_birth_note or has_baptism_note) and not
+             (has_birth_source or has_baptism_source)) note
+        %elseif;(not (has_birth_note or has_baptism_note) and
+             (has_birth_source or has_baptism_source)) source
+        %elseif;((has_birth_note or has_baptism_note) and
+             (has_birth_source or has_baptism_source)) notesource%end;
+        %end;'
+        %rowspan;
+    %else;
+      <td class='align-middle
+        %if;(evar.notes="on")
+          %if;((xxx.has_birth_note or xxx.has_baptism_note) and not
+               (xxx.has_birth_source or xxx.has_baptism_source)) note
+          %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and
+               (xxx.has_birth_source or xxx.has_baptism_source)) source
+          %elseif;((xxx.has_birth_note or xxx.has_baptism_note) and
+               (xxx.has_birth_source or xxx.has_baptism_source)) notesource
+          %end;
+        %end;'
+        %rowspan;
+    %end;
+        tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+        data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
+                        %if;(has_birth_note)<li>[*birth][:] %birth_note;</li>%end;
+                        %if;(has_baptism_note)<li>[*baptism][:] %baptism_note;</li>%end;
+                      %elseif;(xxx.has_birth_note or xxx.has_baptism_note)
+                        %if;(xxx.has_birth_note)<li>[*birth][:] %xxx.birth_note;</li>%end;
+                        %if;(xxx.has_baptism_note)<li>[*baptism][:] %xxx.baptism_note;</li>%end;
+                      %end;
+                      %if;(("yyy"="desc" and (has_birth_source or has_baptism_source))
+                             or xxx.has_birth_source or xxx.has_baptism_source)
+                        %if;(("yyy"="desc" and has_birth_note or has_baptism_note)
+                            or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
+                        %end;
+                        %foreach;source;
+                          %if;(source_type=[birth] or source_type=[baptism])
+                            <li>%apply;capitalize(source_type)[:] %source;.</li>
+                          %end;
+                        %end;
+                      %end;'
+          title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
+                   %if;(has_birth_note or has_baptism_note)[*note/notes]1%end;
+                   %if;(has_birth_source or has_baptism_source)
+                      %if;(not has_birth_note and not has_baptism_note)[*source/sources]1%else; [and] [source/sources]1%end;
+                   %end;
+                 %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
+                   %if;(xxx.has_birth_note or xxx.has_baptism_note)[*note/notes]1%end;
+                   %if;(xxx.has_birth_source or xxx.has_baptism_source)
+                      %if;(not xxx.has_birth_note and not xxx.has_baptism_note)
+                        [*source/sources]1%else; [and] [source/sources]1
+                      %end;
+                   %end;
+                 %end;'
+      >
+          %if;xxx.has_approx_birth_place;
+            %xxx.approx_birth_place;
+          %end;
     </td>
   %end;
+
   %if;(evar.marr="on" and evar.t="H")
     %if;(xxx.nb_families=0)
       <td></td>
     %else;
       %foreach;xxx.family;
         %if;(family_cnt=fam_cnt)
-          <td class="%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2">
+          <td class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
+            %if;(evar.notes="on")
+              %if;(spouse.has_notes and not spouse.has_sources)note
+              %elseif;(not spouse.has_notes and spouse.has_sources)source
+              %elseif;(spouse.has_notes and spouse.has_sources)notesource
+              %end;
+            %end;'
+            %if;(spouse.has_notes or spouse.has_sources))
+              tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+              data-content='%if;(spouse.has_notes)%spouse.notes;%end;
+                            %if;(spouse.has_sources)
+                              <hr>
+                              %foreach;spouse.source;
+                                <li>%apply;capitalize(source_type)[:] %spouse.source;.</li>
+                              %end;
+                            %end;'
+              title='%if;(spouse.has_notes and not spouse.has_sources)[*note/notes]1
+                    %elseif;(not spouse.has_notes and spouse.has_sources)[source/sources]1
+                    %elseif;(spouse.has_notes and  spouse.has_sources)[*note/notes]1 [and] [source/sources]1
+                    %end;'
+            %end;
+            >
             %incr_count1;
             %if;(zzz.nb_families>1)%apply;letter(family_cnt).%end;
             %apply;image_MF("spouse")
-            %apply;link%with;%spouse.access;%and;
-              %spouse;
+            %apply;link%with;%spouse.access;
+              %and;%spouse;
             %end;
           </td>
         %end;
       %end;
     %end;
   %end;
+
   %if;(evar.marr_date="on")
     %if;(xxx.nb_families=0)
       <td></td>
@@ -241,9 +410,16 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class="align-middle text-right" %rowspan;>
           %if;(wizard and not cancel_links)
-            <a class="d-block" href="%prefix;m=MOD_FAM;i=%family.index;;ip=%index;" title="%if;(slash_marriage_date="")[*add::marriage/marriages]0%else;[*update::family/families]0%end; %xxx; [and] %xxx.spouse;">
-            %if;(slash_marriage_date != "")%slash_marriage_date;%else;<span class="fa fa-%nn;
-            %if;(xxx.sex!=xxx.spouse.sex)venus-mars%elseif;(xxx.is_male and xxx.sex=xxx.spouse.sex)mars-double text-secondary%else;venus-double text-danger%end;"></span>%end;</a>%nn;
+            <a class="d-block" href="%prefix;m=MOD_FAM;i=%family.index;;ip=%index;" 
+              title="%if;(slash_marriage_date="")[*add::marriage/marriages]0%else;
+              [*update::family/families]0%end; %xxx; [and] %xxx.spouse;">
+              %if;(slash_marriage_date != "")%slash_marriage_date;%else;<span class="fa fa-%nn;
+                %if;(xxx.sex!=xxx.spouse.sex)venus-mars%elseif;
+                  (xxx.is_male and xxx.sex=xxx.spouse.sex)mars-double text-secondary%else;
+                  venus-double text-danger
+                %end;"></span>
+              %end;
+            </a>%nn;
           %else;
             %slash_marriage_date;
           %end;
@@ -255,16 +431,46 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
+
   %if;(evar.marr_place="on")
     %if;(xxx.nb_families=0)
       <td></td>
     %else;
       %let;rowspan;rowspan="%if;(evar.t="I" and zzz.nb_families=1)2%else;1%end;"%in;
-      %foreach;xxx.family;
-        %if;((nb_families=1 and "yyy"="desc") or (nb_families>1 and
-            ((xxx.spouse=zzz and (ddd=family.index)) or
-             (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
-          <td class="align-middle" %rowspan;>
+      %foreach;family;
+        %let;find;%family.index;%in;
+        %if;((nb_families=1 and "yyy"="desc") or 
+             (nb_families>1 and 
+              ((xxx.spouse=zzz and ddd=family.index) or %(ddd=f.index to sort out remarriage between same pers %)
+                (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
+          <td class='align-middle
+            %if;(evar.notes="on")
+              %if;(has_marriage_note and not has_marriage_source)note
+              %elseif;(not has_marriage_note and has_marriage_source)source
+              %elseif;(has_marriage_note and has_marriage_source)notesource
+              %end;
+            %end;'
+            %rowspan;
+            tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+            data-content='%if;(has_marriage_note)
+                            <li>[*note/notes]1[:] %marriage_note;</li>
+                          %end;
+                          %if;(has_marriage_source)
+                            <hr>
+                            %foreach;xxx.family;
+                              %let;mevt;[marriage event] %family_cnt;%in;
+                              %if;(find=family.index)
+                                <li>[*source/sources]1[:] %marriage_source;.</li>
+                              %end;
+                            %end;
+                          %end;'
+            title='%if;(has_marriage_source or has_marriage_note)
+                     %if;(has_marriage_note and not has_marriage_source)[*note/notes]1
+                     %elseif;(not has_marriage_note and has_marriage_source)[*source/sources]1
+                     %elseif;(has_marriage_note and has_marriage_source)[*note/notes]1 [and] [source/sources]1
+                     %end;
+                   %end;'
+          >
           %if;(marriage_place != "")
             %marriage_place;
           %end;
@@ -277,6 +483,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
   %end;
   %reset_count2;
+
   %if;(zzz.has_families)
     %foreach;zzz.family;
       %if;zzz.has_children;
@@ -288,6 +495,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
   %let;nb_ch_tot_desc;%count2;%in;
   %reset_count2;
+
   %if;(evar.t="I")
     %if;(xxx.has_families)
       %foreach;xxx.family;
@@ -310,6 +518,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
   %end;
   %let;nb_ch_tot_spous;%count2;%in;
+
   %if;(evar.child="on")
     %if;(xxx.nb_families=0)
       <td></td>
@@ -320,11 +529,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             ((xxx.spouse=zzz and (ddd=family.index)) or
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class="align-middle text-center %if;(evar.nowrap="on")text-nowrap%end; px-1" %rowspan;>
+            %if;(nb_children>0 and not cancel_links)<a href="#%labl0;%if;(nb_families>1)%apply;letter(fam_cnt)%end;.1" title="[*link to children]">%end;
             %if;("yyy"="desc" and evar.t="I")
               %nb_ch_tot_desc;%if;(nb_ch_tot_desc!=nb_ch_tot_spous)/%nb_ch_tot_spous;%(!! nb_ch_tot_spous is wrong: gives father total of children?! %)%end;
             %else;
               nb_ch_desc%if;(nb_ch_desc!=nb_ch_tot_spous)/%nb_ch_tot_spous;%end;
             %end;
+            %if;(nb_children>0 and not cancel_links)</a>%end;
           </td>
         %end;
       %end;
@@ -333,6 +544,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
+
   %if;(evar.death="on" and famx=1)
     <td class="align-middle text-right" %rowspan;>
       %if;(wizard and not cancel_links)
@@ -344,19 +556,93 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     </td>
   %end;
+
   %if;(evar.death_place="on" and famx=1)
-    <td class="align-middle" %rowspan;>
-      %if;xxx.has_approx_death_date;
-        %xxx.approx_death_place;
-      %end;
-    </td>
+    %if;("yyy"="desc")
+      <td class='align-middle
+        %if;(evar.notes="on")
+        %if;((has_death_note or has_burial_note) and not
+            (has_death_source or has_burial_source))note%elseif;
+            (not (has_death_note or has_burial_note) and
+            (has_death_source or has_burial_source))source%elseif;
+            ((has_death_note or has_burial_note) and 
+            (has_death_source or has_burial_source))notesource%end;
+        %end;'
+        %rowspan;
+        tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+        data-content='%if;(has_death_note or has_burial_note)
+                        %if;(has_death_note)[*death][:] %death_note;%end;
+                        %if;(has_burial_note)[*burial][:] %burial_note;%end;
+                      %end;
+                      %if;(has_death_source or has_burial_source)
+                        <hr>
+                        %foreach;source;
+                          %if;(source_type=[death] and not has_burial_source)
+                            %apply;capitalize(source).
+                          %elseif;((source_type=[burial] and not has_death_source and has_burial_source)
+                                   or ((source_type=[death] or source_type=[burial])
+                                        and has_burial_source and has_death_source))
+                            <li>%apply;capitalize(source_type)[:] %source;.</li>
+                          %end;
+                        %end;
+                      %end;'
+          title='%if;(has_death_source or has_burial_source or has_death_note or has_burial_note)
+                   %if;((has_death_note or has_burial_note) and not (has_death_source or has_burial_source))[*note/notes]1
+                   %elseif;(not (has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*source/sources]1
+                   %elseif;((has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*note/notes]1 [and] [source/sources]1
+                   %end;
+                 %end;'
+      >
+    %elseif;("yyy"="spous")
+      <td class='align-middle
+        %if;(evar.notes="on")
+          %if;((xxx.has_death_note or xxx.has_burial_note) and not
+              (xxx.has_death_source or xxx.has_burial_source))note
+          %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and
+              (xxx.has_death_source or xxx.has_burial_source))source
+          %elseif;((xxx.has_death_note or xxx.has_burial_note) and 
+              (xxx.has_death_source or xxx.has_burial_source))notesource
+          %end;
+        %end;'
+        %rowspan;
+        tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
+        data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
+                        %if;(xxx.has_death_note)[*death][:] %xxx.death_note;%end;
+                        %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
+                      %end;
+                      %if;(has_death_source or has_burial_source)
+                        <hr>
+                        %foreach;xxx.source;
+                          %if;(source_type=[death] and not has_burial_source)
+                            %apply;capitalize(xxx.source).
+                          %elseif;((source_type=[burial] and not xxx.has_death_source and xxx.has_burial_source)
+                                   or ((source_type=[death] or source_type=[burial])
+                                        and xxx.has_burial_source and xxx.has_death_source))
+                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
+                          %end;
+                        %end;
+                      %end;'
+          title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
+                   %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
+                   %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
+                   %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1
+                   %end;
+                 %end;'
+      >
+    %end;
+    %if;xxx.has_approx_death_place;
+       %xxx.approx_death_place;
+    %end;
+      </td>
   %end;
+
   %if;(evar.age="on" and famx=1)
     <td class="align-middle" %rowspan;>
       %if;xxx.computable_death_age;%xxx.death_age;%end;
       %if;xxx.computable_age;%xxx.age;%end;
     </td>
   %end;
+
   %if;(evar.occu="on" and famx=1)
     <td class="align-middle" %rowspan;>
       %if;(xxx.has_occupation)
@@ -364,9 +650,10 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     </td>
   %end;
+  </tr>
 %end;
 
-%define;one_child(xxx, prefx)
+%define;one_child(xxx, prefx, fff, ch_cnt)
   %incr_count;
   %let;prfx;%if;("prefx"="-1")%else;prefx%end;%in;
   %if;(evar.t="A")
@@ -394,37 +681,28 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %elseif;xxx.has_families;
     %if;(evar.t="H")
       %foreach;family;
-        <tr>
-        %apply;table_row("xxx", prfx, family_cnt, count, "desc", "xxx", family.index, nb_children)
-        </tr>
+        %apply;table_row("xxx", prfx, fff, family_cnt, "ch_cnt", count, "desc", "xxx", family.index, nb_children)
       %end;
     %elseif;(evar.t="I")
-        <tr>
-        %apply;table_row("xxx", prfx, 1, count, "desc", "xxx", 0, nb_children)
-        </tr>
+        %apply;table_row("xxx", prfx, fff, family_cnt, "ch_cnt", count, "desc", "xxx", 0, nb_children)
       %if;(evar.marr="on" or evar.marr_date="on" or evar.marr_place="on" or evar.child="on")
         %foreach;family;
-          <tr>
-          %apply;table_row("xxx.spouse", prfx, 1, count, "spous", "xxx", family.index, nb_children)
-          </tr>
+          %apply;table_row("xxx.spouse", prfx, fff, family_cnt, "ch_cnt", count, "spous", "xxx", family.index, nb_children)
         %end;
       %end;
     %end;
   %else;
-    <tr>
-      %apply;table_row("xxx", prfx, family_cnt, count, "desc", "xxx", 0, 0)
-    </tr>
+      %apply;table_row("xxx", prfx, fff, family_cnt, "ch_cnt", count, "desc", "xxx", 0, 0)
   %end;
 %end;
 
 %define;one_family(xxx, prefx)
   %reset_count;
-    %let;prfx;prefx%in;
     %foreach;family;
-      %let;fam;%if;(evar.num="on")%apply;letter(family_cnt)%end;%in;
-      %let;nprfx;%if;(nb_families>1)%prfx;%fam;%else;%prfx;%end;%in;
+      %let;fam;%if;(evar.num="on" and nb_families>1)%apply;letter(family_cnt)%end;%in;
+      %(if;(nb_children>0)<tr><td id="#labl">one family: #labl</td></tr>%end;%)
       %foreach;xxx.child;
-        %apply;one_child("xxx", nprfx)
+        %apply;one_child("xxx", "prefx", "fam", child_cnt)
       %end;
     %end;
 %end;
@@ -466,7 +744,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-%( Tree traversal vertical %)
+%( Tree traversal vertical/ascendant %)
 %define;one_person(xxx, lv, max_l, prefx, fam_cnt, ch_cnt)
   %let;npref;prefx%in;
   %let;fam;%if;(fam_cnt>0)%apply;letter(fam_cnt)%end;%in;
@@ -490,16 +768,15 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-%(Tree traversal horizontal %)
-%define;one_level(xxx, lv, max_l, prefx, ch_cnt)
-  %let;npref;%if;("prefx"!="")prefx.%end;ch_cnt%nn;%in;
+%(Tree traversal horizontal/descendant %)
+%define;one_level(xxx, lv, max_l, prefx, fff, ch_cnt)
+  %let;npref;%if;("prefx"!="")prefxfff.%end;ch_cnt%nn;%in;
   %if;(lv<max_l)
     %if;xxx.has_families;
       %foreach;family;
-        %let;fam;%apply;letter(family_cnt)%in;
-        %let;nnpref;%if;(nb_families>1)%npref;%fam;%else;%npref;%end;%in;
+        %let;fam;%if;(nb_families>1)%apply;letter(family_cnt)%end;%in;
         %foreach;child;
-          %apply;one_level("child", lv+1, max_l, nnpref, child_cnt)
+          %apply;one_level("child", lv+1, max_l, npref, fam, child_cnt)
         %end;
       %end;
     %end
@@ -508,7 +785,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-%define;rebuild_url(mmm,xxx,vvv)
+%define;rebuild_url(mmm,xxx,vvv,nnn,ccc)
   %let;new_url;%prefix;m=mmm;%nn;
   %access;;t=xxx;%nn;
   %if;(evar.num="on")
@@ -553,31 +830,92 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %if;(evar.gen="on")
     gen=on;%nn;
   %end;
-  %if;(evar.cgl="on")
-    cgl=on;%nn;
-  %end;
-  v=vvv;%in;
+  v=vvv;notes=nnn;cgl=ccc%in;
   %new_url;
 %end;
 
 %if;(not cancel_links)
   <div class="form-inline">
     %if;(evar.marr="on" or evar.marr_place="on" or evar.marr_date="on")
-      <a role="button" class="btn btn-link ml-2 px-0 mb-1" href="%apply;rebuild_url%with;D%and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;%and;%evar.v;%end;"><i class="fa fa-table fa-lg fa-fw mr-1"></i>%nn;
-      %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0</a>
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1" 
+         href="%apply;rebuild_url%with;D
+                %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
+                %and;%evar.v;
+                %and;%if;(evar.notes="on")on%else;off%end;
+                %and;%if;(evar.cgl="on")on%else;off%end;
+                %end;">
+                <i class="fa fa-table fa-lg fa-fw mr-1"></i>%nn;
+        %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
+      </a>
     %end;
-    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" href="%prefix;m=D;%access;"><i class="fa fa-cog fa-lg fa-fw mr-1"></i>[*options] [descendants] </a>
-    %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" href="%apply;rebuild_url%with;A%and;Z;%and;%if;(evar.v="" or evar.v<=2)2%else;%evar.v;%end;%end"><span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>%end;
-    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;"><span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]</a>
+    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" 
+      href="%prefix;m=D;%access;"><i class="fa fa-cog fa-lg fa-fw mr-1">
+      </i>[*options] [descendants]
+    </a>
+    %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" 
+      href="%apply;rebuild_url%with;A
+            %and;Z;
+            %and;%if;(evar.v="" or evar.v<=2)2%else;%evar.v;%end;
+            %and;%if;(evar.notes="on")on%else;off%end;
+            %and;%if;(evar.cgl="on")on%else;off%end;
+            %end">
+            <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>%end;
+    <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1" 
+      href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
+      <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]
+    </a>
     <div class="input-group mx-2 mb-1">
       <span class="input-group-btn">
-        %if;(evar.v>=1)<a href="%apply;rebuild_url%with;D%and;%evar.t;%and;%expr(evar.v-1)%end" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
+        %if;(evar.v>=1)<a 
+          href="%apply;rebuild_url%with;D
+                %and;%evar.t;
+                %and;%expr(evar.v-1)
+                %and;%if;(evar.notes="on")on%else;off%end;
+                %and;%if;(evar.cgl="on")on%else;off%end;
+                %end" class="btn btn-secondary" title="-1 [generation/generations]0">-</a>%end;
       </span>
-      <input class="form-control text-center" size="12" value="%if;(evar.v="")0%else;%evar.v;%end; %if;(evar.v>1)[generation/generations]1%else;[generation/generations]0%end;" title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
+      <input class="form-control text-center" size="12" 
+        value="%if;(evar.v="")0%else;%evar.v;%end;%sp;
+          %if;(evar.v>1)[generation/generations]1%else;[generation/generations]0%end;" 
+        title="%apply;a_of_b%with;[*number]0%and;[generation/generations]1%end;" disabled>
       <span class="input-group-btn">
-        <a href="%apply;rebuild_url%with;D%and;%evar.t;%and;%expr(evar.v+1)%end" class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
+        <a href="%apply;rebuild_url%with;D
+                 %and;%evar.t;
+                 %and;%expr(evar.v+1)
+                 %and;%if;(evar.notes="on")on%else;off%end;
+                 %and;%if;(evar.cgl="on")on%else;off%end;
+                 %end" class="btn btn-secondary" title="+1 [generation/generations]0">+</a>
       </span>
     </div>
+  </div>
+
+%( Check colors with note, source, notesource in css.css %)
+  <div class="form-inline">
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1" 
+      href="%apply;rebuild_url%with;D
+            %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+            %and;%evar.v;
+            %and;%if;(evar.notes="on")off%else;on%end;
+            %and;%if;(evar.cgl="on")on%else;off%end;
+            %end;"
+            title="small arrow in corner shows existence of note or source">
+             <i class="fa fa-cog fa-lg fa-fw mr-1"></i>%nn;
+      %if;(evar.notes="off" or evar.notes="")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
+        [indicators] <span style="color:#FFA07A">[note/notes]1</span>, <span style="color:#90EE90">[source/sources]1</span>, 
+        <span style="color:#87CEFA">[note/notes]1 [and] [source/sources]1</span>
+    </a>
+    %if;(evar.cgl="" or evar.cgl="off")
+    <a role="button" class="btn btn-link ml-2 px-0 mb-1" 
+      href="%apply;rebuild_url%with;D
+            %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+            %and;%evar.v;
+            %and;off
+            %and;%if;(evar.cgl="on")off%else;on%end;
+            %end;"
+            title="Cancel url links in whole page">
+      <i class="fa fa-cog fa-lg fa-fw mr-1"></i> [*cancel GeneWeb links]
+    </a>
+    %end;
   </div>
 %end;
 
@@ -592,14 +930,14 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %let;max;%evar.v;%in;
     %reset_count;
     %reset_count1;
-    %apply;one_child("self", "-1")
+    %apply;one_child("self", "-1", "", 1)
     %for;lev;0;max;
       %if;(evar.gen="on")
         <tr>
           <th colspan="%nb_col;">[*generation/generations]0 %expr(lev+1)</th>
         </tr>
       %end;
-      %apply;one_level("self", 0, lev, "", 1)
+      %apply;one_level("self", 0, lev, "", "", 1)
     %end;
   %end;
 </table>
@@ -616,5 +954,18 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %import;copyr;
 </div>
 %import;js;
+<script>
+// Initialize Bootstrap tooltip and popover component, dismiss on next click function
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+$(function () {
+  $('[data-toggle="popover"]').popover()
+})
+$('.popover-dismiss').popover({
+  trigger: 'focus'
+})
+</script>
+
 </body>
 </html>

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -131,7 +131,7 @@
       %incr_count;
     %end;
     %if;(evar.age="on")
-      <th rowspan="2">[*age]</th>
+      <th class="align-middle text-center" rowspan="2">[*age]</th>
       %incr_count;
     %end;
     %if;(evar.occu="on")

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -217,7 +217,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
         %rowspan;
         %if;(evar.notes="on" and (has_notes or has_psources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
                         %if;(has_notes and has_psources)<hr>%end;
                         %if;(has_psources)%apply;capitalize(psources)%end;'
@@ -261,7 +261,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %end;"
         %end;
         %if;(evar.notes="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_psources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
+          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
                         %if;(xxx.has_psources)%apply;capitalize(xxx.psource)%end;'
@@ -505,21 +505,21 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class='align-middle text-center %if;(evar.nowrap="on")text-nowrap%end; px-1
             %if;(evar.notes="on")
-              %if;(has_comment and fsources="") note%nn;
-              %elseif;(not has_comment and fsources!="") source%nn;
-              %elseif;(has_comment and fsources!="") notesource%nn;
+              %if;(has_comment and not has_fsources) note%nn;
+              %elseif;(not has_comment and has_fsources) source%nn;
+              %elseif;(has_comment and has_fsources) notesource%nn;
               %end;
             %end;'
             %rowspan;
             %if;(evar.notes="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
               data-content='%if;(has_comment)%comment;%end;
-                            %if;(has_comment and fsources!="")<hr>%end;
-                            %if;(fsources!="")%apply;capitalize(fsources)%end;'
-              title='%if;(has_comment or fsources!="")
-                      %if;(has_comment and fsources="")[*note/notes]1%nn;
-                      %elseif;(not has_comment and fsources!="")[*source/sources]1%nn;
-                      %elseif;(has_comment and fsources!="")[*note/notes]1 [and] [*source/sources]1%nn;
+                            %if;(has_comment and has_fsources)<hr>%end;
+                            %if;(has_fsources)%apply;capitalize(fsources)%end;'
+              title='%if;(has_comment or has_fsources)
+                      %if;(has_comment and not has_fsources)[*note/notes]1%nn;
+                      %elseif;(not has_comment and has_fsources)[*source/sources]1%nn;
+                      %elseif;(has_comment and has_fsources)[*note/notes]1 [and] [*source/sources]1%nn;
                       %end;
                      %end;'
             %end;
@@ -743,9 +743,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
       </span>
       %apply;image_MF("xxx.spouse")
-      %apply;link%with;%xxx.spouse.access;%and;               %end;'
-
-        %xxx.spouse.first_name; %xxx.spouse.surname;
+      %apply;link%with;%xxx.spouse.access;
+      %and;%xxx.spouse.first_name; %xxx.spouse.surname;
       %end
       %xxx.spouse.title;
       %(&nbsp; (%xxx.nb_children;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -185,7 +185,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                     or evar.child="on"))rowspan="%xxx.nb_families;"%end;%in;
 
   <tr id="%labl0">
-
+%( numéro d'Aboville %)
   %if;(evar.num="on" and famx=1)
     %if;("yyy"="desc")
       <td class="border-left-0 text-center align-middle" %rowspan;>
@@ -201,17 +201,18 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
+%( Descendant et son conjoint en mode I %)  
   %if;(famx=1)
     %if;("yyy"="desc")
       <td class='align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2%nn;
-        %if;(evar.notes="on")
+        %if;(evar.ns="on")
           %if;(has_notes and not has_psources) note%nn;
           %elseif;(not has_notes and has_psources) source%nn;
           %elseif;(has_notes and has_psources) notesource%nn;
           %end;
         %end;'
         %rowspan;
-        %if;(evar.notes="on" and (has_notes or has_psources))
+        %if;(evar.ns="on" and (has_notes or has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
                         %if;(has_notes and has_psources)<hr>%end;
@@ -241,7 +242,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       </td>
     %elseif;(evar.t="I")
       <td class='align-middle text-right%if;(evar.nowrap="on") text-nowrap%end;%nn;
-        %if;(evar.notes="on")
+        %if;(evar.ns="on")
           %if;("yyy"="desc")
             %if;(xxx.has_notes and not xxx.has_psources) notespouse%nn;
             %elseif;(not xxx.has_notes and xxx.has_psources) sourcespouse%nn;
@@ -254,7 +255,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %end;
           %end;
         %end;'
-        %if;(evar.notes="on" and "yyy"="desc" and (has_notes or has_psources))
+        %if;(evar.ns="on" and "yyy"="desc" and (has_notes or has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(has_notes)%notes;%end;
                         %if;(has_notes and has_psources)<hr>%end;
@@ -264,7 +265,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                 %elseif;(has_notes and has_psources)[*note/notes]1 [and] [source/sources]1%nn;
                 %end;"
         %end;
-        %if;(evar.notes="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_psources))
+        %if;(evar.ns="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
@@ -295,7 +296,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       </td>
     %end;
   %end;
-
+%( Date de naissance %)
   %if;(evar.birth="on" and famx=1)
     <td class="align-middle text-right" %rowspan;>
       %if;(wizard and not cancel_links)
@@ -309,11 +310,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     </td>
   %end;
-
+%( Lieu de naissance %)
   %if;(evar.birth_place="on" and famx=1)
     %if;("yyy"="desc")
       <td class='align-middle%nn;
-        %if;(evar.notes="on")
+        %if;(evar.ns="on")
           %if;((has_birth_note or has_baptism_note) and not
                (has_birth_source or has_baptism_source)) note%nn;
           %elseif;(not (has_birth_note or has_baptism_note) and
@@ -324,7 +325,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
     %else;
       <td class='align-middle%nn;
-        %if;(evar.notes="on")
+        %if;(evar.ns="on")
           %if;((xxx.has_birth_note or xxx.has_baptism_note) and not
                (xxx.has_birth_source or xxx.has_baptism_source)) note%nn;
           %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and
@@ -335,7 +336,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
     %end;
     %rowspan;
-    %if;(evar.notes="on")
+    %if;(evar.ns="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
       data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
                       %if;(has_birth_note)%if;(has_baptism_note)[*birth][:] %end;%birth_note;%end;
@@ -376,7 +377,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
     </td>
   %end;
-
+%( En mode H, conjoints %)
   %if;(evar.marr="on" and evar.t="H")
     %if;(xxx.nb_families=0)
       <td></td>
@@ -384,13 +385,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %foreach;xxx.family;
         %if;(family_cnt=fam_cnt)
           <td class='%if;(xxx.nb_families > 1)border-bottom-0%end; align-middle %if;(evar.nowrap="on")text-nowrap%end; pl-2
-          %if;(evar.notes="on")
+          %if;(evar.ns="on")
               %if;(spouse.has_notes and not spouse.has_psources) notespouse%nn;
               %elseif;(not spouse.has_notes and spouse.has_psources) sourcespouse%nn;
               %elseif;(spouse.has_notes and spouse.has_psources) notesourcespouse%nn;
               %end;
           %end;'
-          %if;(evar.notes="on" and (spouse.has_notes or spouse.has_psources))
+          %if;(evar.ns="on" and (spouse.has_notes or spouse.has_psources))
             tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
             data-content='%if;(spouse.has_notes)%spouse.notes;%end;
                           %if;(spouse.has_notes and spouse.has_psources)<hr>%end;
@@ -412,7 +413,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
-
+%( Date de mariage %)
   %if;(evar.marr_date="on")
     %if;(xxx.nb_families=0)
       <td></td>
@@ -445,7 +446,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
-
+%( Lieu de mariage %)
   %if;(evar.marr_place="on")
     %if;(xxx.nb_families=0)
       <td></td>
@@ -457,14 +458,14 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               ((xxx.spouse=zzz and ddd=family.index) or
                 (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class='align-middle%nn;
-            %if;(evar.notes="on")
+            %if;(evar.ns="on")
               %if;(has_marriage_note and not has_marriage_source) note%nn;
               %elseif;(not has_marriage_note and has_marriage_source) source%nn;
               %elseif;(has_marriage_note and has_marriage_source) notesource%nn;
               %end;
             %end;'
             %rowspan;
-            %if;(evar.notes="on")
+            %if;(evar.ns="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
               data-content='%if;(has_marriage_note)%marriage_note;%end;
                             %if;(has_marriage_note and has_marriage_source)<hr>%end;
@@ -489,7 +490,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
   %end;
   %reset_count2;
-
+%( Calcul nombre total d'enfants %)
   %if;(zzz.has_families)
     %foreach;zzz.family;
       %if;zzz.has_children;
@@ -501,7 +502,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
   %let;nb_ch_tot_desc;%count2;%in;
   %reset_count2;
-
+%( Calcul nombre d'enfants de l'époux %)
   %if;(evar.t="I")
     %if;(xxx.has_families)
       %foreach;xxx.family;
@@ -524,7 +525,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
   %end;
   %let;nb_ch_tot_spous;%count2;%in;
-
+%( Nombre d'enfants %)
   %if;(evar.child="on")
     %if;(xxx.nb_families=0)
       <td></td>
@@ -535,14 +536,14 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             ((xxx.spouse=zzz and (ddd=family.index)) or
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class='align-middle text-center %if;(evar.nowrap="on")text-nowrap%end; px-1
-            %if;(evar.notes="on")
+            %if;(evar.ns="on")
               %if;(has_fnotes and not has_fsources) note%nn;
               %elseif;(not has_fnotes and has_fsources) source%nn;
               %elseif;(has_fnotes and has_fsources) notesource%nn;
               %end;
             %end;'
             %rowspan;
-            %if;(evar.notes="on")
+            %if;(evar.ns="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
               data-content='%if;(has_fnotes)%fnotes;%end;
                             %if;(has_fnotes and has_fsources)<hr>%end;
@@ -570,7 +571,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %end;
-
+%( Date de décès %)
   %if;(evar.death="on" and famx=1)
     <td class="align-middle text-right" %rowspan;>
       %if;(wizard and not cancel_links)
@@ -582,11 +583,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     </td>
   %end;
-
+%( Lieu de décès %)
   %if;(evar.death_place="on" and famx=1)
     %if;("yyy"="desc")
       <td class='align-middle
-        %if;(evar.notes="on")
+        %if;(evar.ns="on")
           %if;((has_death_note or has_burial_note) and not
               (has_death_source or has_burial_source))note
           %elseif;(not (has_death_note or has_burial_note) and
@@ -597,7 +598,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
     %else;
       <td class='align-middle
-        %if;(evar.notes="on")
+        %if;(evar.ns="on")
           %if;((xxx.has_death_note or xxx.has_burial_note) and not
               (xxx.has_death_source or xxx.has_burial_source))note
           %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and
@@ -608,7 +609,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %end;'
     %end;
     %rowspan;
-    %if;(evar.notes="on")
+    %if;(evar.ns="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
       data-content='%if;("yyy"="desc" and (has_death_note or has_burial_note))
                       %if;(has_death_note)%if;(has_burial_note)[*death][:] %end;%death_note;%end;
@@ -645,7 +646,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                   %end;
                %end;'
     %end;
-    %if;(evar.notes="on")
+    %if;(evar.ns="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
       data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
                       %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
@@ -677,14 +678,14 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
       </td>
   %end;
-
+%( Age %)
   %if;(evar.age="on" and famx=1)
     <td class="align-middle" %rowspan;>
       %if;xxx.computable_death_age;%xxx.death_age;%end;
       %if;xxx.computable_age;%xxx.age;%end;
     </td>
   %end;
-
+%( Profession %)
   %if;(evar.occu="on" and famx=1)
     <td class="align-middle" %rowspan;>
       %if;(xxx.has_occupation)
@@ -696,7 +697,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %end;
 
 %define;one_child(xxx, prefx, fff, ch_cnt)
-  %incr_count;
+  %incr_count; 
+  %( Les enfants d'une personne sont numérotés de 1 à n indépendamment du nombre de mariages %)
   %let;prfx;%if;("prefx"="-1")%else;prefx%end;%in;
   %if;(evar.t="A")
     <br>%prfx; %apply;image_MF("xxx")
@@ -738,7 +740,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-%define;one_family(xxx, prefx)
+%define;families_of_one_p(xxx, prefx)
   %reset_count;
     %foreach;family;
       %let;fam;%if;(evar.num="on" and nb_families>1)%apply;letter(family_cnt)%end;%in;
@@ -756,8 +758,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %apply;image_MF("xxx")
   %apply;link%with;%xxx.access;%and;
       %xxx.first_name; %xxx.surname;%nn;
-      %end;%nn;
-  %xxx.title;%nn;
+      %end;
+  %if;(xxx.title!="")&nbsp;%xxx.title;%nn;%end;
   %if;(has_families)
     %foreach;family;
       <span class="text-nowrap mx-1">&%if;(nb_families>1)%apply;letter(family_cnt)%end;
@@ -790,7 +792,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-%( Tree traversal vertical/ascendant %)
+%( Parcours de l'arbre ascendant, niveau par niveau %)
 %define;one_person(xxx, lv, max_l, prefx, fam_cnt, ch_cnt)
   %let;npref;prefx%in;
   %let;fam;%if;(fam_cnt>0)%apply;letter(fam_cnt)%end;%in;
@@ -814,9 +816,10 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-%(Tree traversal horizontal/descendant %)
-%define;one_level(xxx, lv, max_l, prefx, fff, ch_cnt)
-  %let;npref;%if;("prefx"!="")prefxfff.%end;ch_cnt%nn;%in;
+%( Parcours de l'arbre, horizontal, niveau par niveau descendant %)
+%( A chaque niveau, prefx et faml (lettre) définissent le préfixe d'Aboville %)
+%define;one_level(xxx, lv, max_l, prefx, faml, ch_cnt)
+  %let;npref;%if;("prefx"!="")prefxfaml.%end;ch_cnt%nn;%in;
   %if;(lv<max_l)
     %if;xxx.has_families;
       %foreach;family;
@@ -827,7 +830,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %end;
     %end;
   %else;
-    %apply;one_family("self", npref)
+    %apply;families_of_one_p("self", npref)
   %end;
 %end;
 
@@ -879,7 +882,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   vvvnnnccciiippp%in;
   %new_url;
 %end;
-
+%( Boutons de configurations et d'options %)
 %if;(not cancel_links)
   <div class="form-inline">
     <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
@@ -890,7 +893,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       href="%apply;rebuild_url%with;A
             %and;Z;
             %and;%if;(evar.v="" or evar.v<=2)v=2;%else;v=%evar.v;;%end;
-            %and;%if;(evar.notes="on")notes=on;%end;
+            %and;%if;(evar.ns="on")ns=on;%end;
             %and;%if;(evar.cgl="on")cgl=on;%end;
             %and;%if;(evar.image="on")image=on;%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
@@ -906,7 +909,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           href="%apply;rebuild_url%with;D
                 %and;%evar.t;
                 %and;v=%expr(evar.v-1);
-                %and;%if;(evar.notes="on")notes=on;%end;
+                %and;%if;(evar.ns="on")ns=on;%end;
                 %and;%if;(evar.cgl="on")cgl=on;%end;
                 %and;%if;(evar.image="on")image=on;%end;
                 %and;%if;(evar.px!="")px=%evar.px;%end;
@@ -920,7 +923,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         <a href="%apply;rebuild_url%with;D
                  %and;%evar.t;
                  %and;v=%expr(evar.v+1);
-                 %and;%if;(evar.notes="on")notes=on;%end;
+                 %and;%if;(evar.ns="on")ns=on;%end;
                  %and;%if;(evar.cgl="on")cgl=on;%end;
                  %and;%if;(evar.image="on")image=on;%end;
                  %and;%if;(evar.px!="")px=%evar.px;%end;
@@ -935,7 +938,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
          href="%apply;rebuild_url%with;D
                 %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
                 %and;v=%evar.v;;
-                %and;%if;(evar.notes="on")notes=on;%end;
+                %and;%if;(evar.ns="on")ns=on;%end;
                 %and;%if;(evar.cgl="on")cgl=on;%end;
                 %and;%if;(evar.image="on")image=on;%end;
                 %and;%if;(evar.px!="")px=%evar.px;%end;
@@ -944,23 +947,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
       </a>
     %end;
-    %if;(evar.image="on")
-      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
-       href="%apply;rebuild_url%with;D
-             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
-             %and;v=%evar.v;;
-             %and;%if;(evar.notes="on")notes=on;%end;
-             %and;%if;(evar.cgl="on")cgl=on;%end;
-             %and;%if;(evar.image="on")image=on;%end;
-             %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
-             %end;"
-       title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
-    %end;
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
      href="%apply;rebuild_url%with;D
            %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
            %and;v=%evar.v;;
-           %and;%if;(evar.notes="on")notes=on;%end;
+           %and;%if;(evar.ns="on")ns=on;%end;
            %and;%if;(evar.cgl="on")cgl=on;%end;
            %and;%if;(evar.image!="on")image=on;%end;
            %and;%if;(evar.px!="")px=%evar.px;%end;
@@ -969,19 +960,31 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
              %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
      %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
     </a>
+    %if;(evar.image="on")
+      <a role="button" class="btn btn-link ml-2 px-0 mb-1"
+       href="%apply;rebuild_url%with;D
+             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
+             %and;v=%evar.v;;
+             %and;%if;(evar.ns="on")ns=on;%end;
+             %and;%if;(evar.cgl="on")cgl=on;%end;
+             %and;%if;(evar.image="on")image=on;%end;
+             %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
+             %end;"
+       title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
+    %end;
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
             %and;v=%evar.v;;
-            %and;%if;(evar.notes!="on")notes=on;%end;
+            %and;%if;(evar.ns!="on")ns=on;%end;
             %and;%if;(evar.cgl="on")cgl=on;%end;
             %and;%if;(evar.image="on")image=on;%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;"
             title="small arrow in corner shows existence of note or source">
               <i class="fa fa-file-text-o fa-lg fa-fw
-               %if;(evar.notes="on")text-danger%end; mr-1"></i>%nn;
-      %if;(evar.notes="" or evar.notes!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
+               %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
+      %if;(evar.ns="" or evar.ns!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
         <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
     </a>
     %if;(evar.cgl="" or evar.cgl!="on")
@@ -1000,7 +1003,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %end;
   </div>
 %end;
-
+%( Main %)
 <table class="table table-sm table-hover descends_table mt-1">
   %if;(evar.t="A")
     %let;nb_col;1%in;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -35,8 +35,8 @@
 %end;
 
 <h1 class="d-inline-block">%nn;
-  %if;(evar.v!=0)%apply;a_of_b%with;[*descendants]%and;%self;%end;%else;%self;%end;
-   %if;(cancel_links) %apply;togend(evar.v)%end;
+  %if;(evar.v!=0)%apply;a_of_b%with;[*descendants]%and;%self;%end;%else;%self; ([no descendants])%end;
+   %if;(cancel_links and evar.v!=0) %apply;togend(evar.v)%end;
 </h1>
 
 %if;not cancel_links;
@@ -218,8 +218,8 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                         %if;(has_notes and has_psources)<hr>%end;
                         %if;(has_psources)%apply;capitalize(psources)%end;'
           title="%if;(has_notes and not has_psources)[*note/notes]1%nn;
-                %elseif;(not has_notes and has_psources)[source/sources]1%nn;
-                %elseif;(has_notes and has_psources)[*note/notes]1 [and] [*source/sources]1%nn;
+                %elseif;(not has_notes and has_psources)[*source/sources]1%nn;
+                %elseif;(has_notes and has_psources)[*note/notes]1 [and] [source/sources]1%nn;
                 %end;"
         %end;
         >
@@ -361,12 +361,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                     %end;'
         title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
                  %if;((has_birth_note or has_baptism_note) and not (has_birth_source or has_baptism_source))[*note/notes]1%nn;
-                 %elseif;(not (has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[source/sources]1%nn;
+                 %elseif;(not (has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[*source/sources]1%nn;
                  %elseif;((has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[*source/sources]1 [and] [source/sources]1%nn;
                  %end;
                %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
                  %if;((xxx.has_birth_note or xxx.has_baptism_note) and not (xxx.has_birth_source or xxx.has_baptism_source))[*note/notes]1%nn;
-                 %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[source/sources]1%nn;
+                 %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[*source/sources]1%nn;
                  %elseif;((xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[*note/notes]1 [and] [source/sources]1%nn;
                  %end;
                %end;'
@@ -1033,7 +1033,9 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
-<p>[*total][:] %apply;desc_count() [descendants] %if;(evar.marr="on" or evar.t="I")(%count1; [person/persons]1 [with] [spouse/spouses]1)%end;</p>
+%if;(has_children)
+  <p>[*total][:] %apply;desc_count() [descendants] %if;(evar.marr="on" or evar.t="I")(%count1; [person/persons]1 [with] [spouse/spouses]1)%end;</p>
+%end;
 
 %import;trl;
 %import;copyr;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -840,7 +840,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %if;(evar.age="on")age=on;%nn;%end;
   %if;(evar.occu="on")occu=on;%nn;%end;
   %if;(evar.gen="on")gen=on;%nn;%end;
-  vvv;nnn;ccc;iii;ppp;%in;
+  %if;("vvv"!="")vvv;%end;
+  %if;("nnn"!="")nnn;%end;
+  %if;("ccc"!="")ccc;%end;
+  %if;("iii"!="")iii;%end;
+  %if;("ppp"!="")ppp;%end;
+  %in;
   %new_url;
 %end;
 %( Boutons de configurations et d'options %)
@@ -853,13 +858,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %if;(evar.t!="A")<a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%apply;rebuild_url%with;A
             %and;Z
-            %and;%if;(evar.v="" or evar.v<=2)v=2;%else;v=%evar.v;%end;
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.v="" or evar.v<=2)v=2%else;v=%evar.v;%end;
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;">
-            <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>
+      <span class="fa fa-sitemap fa-lg fa-fw fa-rotate-180 mr-1"></span>[*table] [ancestors]</a>
     %end;
     <a role="button" class="btn btn-link ml-1 my-0 px-0 mb-1"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
@@ -869,10 +874,10 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       %if;(evar.v="" or evar.v="0")disabled" aria-disabled="true"%else;"%end;
       href="%apply;rebuild_url%with;D
             %and;%evar.t;
-            %and;%if;(evar.v>1)v=%expr(evar.v-1);%else;v=0;%end;
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.v>1)v=%expr(evar.v-1)%else;v=0%end;
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;" title="[*delete] 1 [generation/generations]0">%nn;
       <i class="fa fa-minus fa-lg"></i>%nn;
@@ -880,10 +885,10 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     <a role="button" class="btn pl-2"
       href="%apply;rebuild_url%with;D
             %and;%evar.t;
-            %and;v=%expr(evar.v+1);
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;v=%expr(evar.v+1)
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;" title="[*add] 1 [generation/generations]0">%nn;
       <i class="fa fa-plus fa-lg"></i>%nn;
@@ -897,24 +902,23 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
             %and;v=%evar.v;
-            %and;%if;(evar.ns="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image!="on")image=on;%end;
+            %and;%if;(evar.ns="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image!="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;">
-            <i class="fa fa-picture-o fa-lg fa-fw
-             %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
-     %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
+      <i class="fa fa-picture-o fa-lg fa-fw %if;(evar.image="on")text-danger%end; mr-1"></i>%nn;
+      %if;(evar.image="" or evar.image!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [image/images]1
     </a>
     %if;(evar.image="on")
       <a role="button" class="btn btn-link ml-2 px-0 mb-1"
         href="%apply;rebuild_url%with;D
               %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
               %and;v=%evar.v;
-              %and;%if;(evar.ns="on")ns=on;%end;
-              %and;%if;(evar.cgl="on")cgl=on;%end;
-              %and;%if;(evar.image="on")image=on;%end;
-              %and;%if;(evar.px="")px=90;%elseif;(evar.px="90")px=120;%end;
+              %and;%if;(evar.ns="on")ns=on%end;
+              %and;%if;(evar.cgl="on")cgl=on%end;
+              %and;%if;(evar.image="on")image=on%end;
+              %and;%if;(evar.px="")px=90%elseif;(evar.px="90")px=120%end;
               %end;"
        title="%if;(evar.px="120")60%elseif;(evar.px!="")120%else;90%end; px"><i class="fa %if;(evar.px="120")fa-compress%else;fa-expand%end; fa-lg fa-fw mr-1"></i>[*modify] [image/images]1</a>
     %end;
@@ -922,14 +926,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       href="%apply;rebuild_url%with;D
             %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
             %and;v=%evar.v;
-            %and;%if;(evar.ns!="on")ns=on;%end;
-            %and;%if;(evar.cgl="on")cgl=on;%end;
-            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.ns!="on")ns=on%end;
+            %and;%if;(evar.cgl="on")cgl=on%end;
+            %and;%if;(evar.image="on")image=on%end;
             %and;%if;(evar.px!="")px=%evar.px;%end;
             %end;"
-            title="small arrow in corner shows existence of note or source">
-              <i class="fa fa-file-text-o fa-lg fa-fw
-               %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
+      title="small arrow in corner shows existence of note or source">
+      <i class="fa fa-file-text-o fa-lg fa-fw %if;(evar.ns="on")text-danger%end; mr-1"></i>%nn;
       %if;(evar.ns="" or evar.ns!="on")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end;%sp;
         <span class="notecolor">[note/notes]1</span> <span class="notesourcecolor">[and]</span> <span class="sourcecolor">[source/sources]1</span>
     </a>
@@ -939,11 +942,11 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               %and;%if;(evar.t="H")H%elseif;(evar.t="I")I%end;
               %and;v=%evar.v;
               %and;ns=off
-              %and;%if;(evar.cgl!="on")cgl=on;%end;
-              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.cgl!="on")cgl=on%end;
+              %and;%if;(evar.image="on")image=on%end;
               %and;%if;(evar.px!="")px=%evar.px;%end;
               %end;"
-              title="Cancel url links in whole page">
+        title="Cancel url links in whole page">
         <i class="fa fa-chain-broken fa-lg fa-fw mr-1"></i>%nn;[*cancel GeneWeb links]
       </a>
     %end;
@@ -952,12 +955,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
         href="%apply;rebuild_url%with;D
               %and;%if;(evar.t="H")I%elseif;(evar.t="I")H%end;
               %and;v=%evar.v;
-              %and;%if;(evar.ns="on")ns=on;%end;
-              %and;%if;(evar.cgl="on")cgl=on;%end;
-              %and;%if;(evar.image="on")image=on;%end;
+              %and;%if;(evar.ns="on")ns=on%end;
+              %and;%if;(evar.cgl="on")cgl=on%end;
+              %and;%if;(evar.image="on")image=on%end;
               %and;%if;(evar.px!="")px=%evar.px;%end;
               %end;">
-              <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
+        <i class="fa fa-th%if;(evar.t="I")-large%end; fa-lg fa-fw mr-1"></i>%nn;
         %if;(evar.t="H")[*visualize/show/hide/summary]1%else;[*visualize/show/hide/summary]2%end; [spouses info]0
       </a>
     %end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -505,21 +505,21 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
              (xxx=zzz and family_cnt=fam_cnt and evar.t="H"))))
           <td class='align-middle text-center %if;(evar.nowrap="on")text-nowrap%end; px-1
             %if;(evar.notes="on")
-              %if;(has_comment and not has_fsources) note%nn;
-              %elseif;(not has_comment and has_fsources) source%nn;
-              %elseif;(has_comment and has_fsources) notesource%nn;
+              %if;(has_fnotes and not has_fsources) note%nn;
+              %elseif;(not has_fnotes and has_fsources) source%nn;
+              %elseif;(has_fnotes and has_fsources) notesource%nn;
               %end;
             %end;'
             %rowspan;
             %if;(evar.notes="on")
               tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-              data-content='%if;(has_comment)%comment;%end;
-                            %if;(has_comment and has_fsources)<hr>%end;
+              data-content='%if;(has_fnotes)%fnotes;%end;
+                            %if;(has_fnotes and has_fsources)<hr>%end;
                             %if;(has_fsources)%apply;capitalize(fsources)%end;'
-              title='%if;(has_comment or has_fsources)
-                      %if;(has_comment and not has_fsources)[*note/notes]1%nn;
-                      %elseif;(not has_comment and has_fsources)[*source/sources]1%nn;
-                      %elseif;(has_comment and has_fsources)[*note/notes]1 [and] [*source/sources]1%nn;
+              title='%if;(has_fnotes or has_fsources)
+                      %if;(has_fnotes and not has_fsources)[*note/notes]1%nn;
+                      %elseif;(not has_fnotes and has_fsources)[*source/sources]1%nn;
+                      %elseif;(has_fnotes and has_fsources)[*note/notes]1 [and] [*source/sources]1%nn;
                       %end;
                      %end;'
             %end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -165,7 +165,7 @@
 %(
 si t=H on active rowspan pour les données de l’individu et du couple
 si t=I on affiche pas les données
-xxx est la personne concernée
+xxx est la personne concernée (self)
 zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
 %)
 %define;table_row(xxx, prefx, fff, fam_cnt, ch_cnt, ch_count, yyy, zzz, ddd, nb_ch_desc)
@@ -234,29 +234,12 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
     %elseif;(evar.t="I")
       <td class='align-middle text-right%if;(evar.nowrap="on") text-nowrap%end;%nn;
         %if;(evar.ns="on")
-          %if;("yyy"="desc")
-            %if;(xxx.has_notes and not xxx.has_psources) notespouse%nn;
-            %elseif;(not xxx.has_notes and xxx.has_psources) sourcespouse%nn;
-            %elseif;(xxx.has_notes and xxx.has_psources) notesourcespouse%nn;
-            %end;
-          %elseif;("yyy"="spous")
-            %if;(xxx.has_notes and not xxx.has_psources) notespouse%nn;
-            %elseif;(not xxx.has_notes and xxx.has_psources) sourcespouse%nn;
-            %elseif;(xxx.has_notes and xxx.has_psources) notesourcespouse%nn;
-            %end;
+          %if;(xxx.has_notes and not xxx.has_psources) notespouse%nn;
+          %elseif;(not xxx.has_notes and xxx.has_psources) sourcespouse%nn;
+          %elseif;(xxx.has_notes and xxx.has_psources) notesourcespouse%nn;
           %end;
         %end;'
-        %if;(evar.ns="on" and "yyy"="desc" and (has_notes or has_psources))
-          tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
-          data-content='%if;(has_notes)%notes;%end;
-                        %if;(has_notes and has_psources)<hr>%end;
-                        %if;(has_psources)%apply;capitalize(source)%end;'
-          title="%if;(has_notes and not has_psources)[*note/notes]1%nn;
-                %elseif;(not has_notes and has_psources)[*source/sources]1%nn;
-                %elseif;(has_notes and has_psources)[*note/notes]1 [and] [source/sources]1%nn;
-                %end;"
-        %end;
-        %if;(evar.ns="on" and "yyy"="spous" and (xxx.has_notes or xxx.has_psources))
+        %if;(evar.ns="on" and (xxx.has_notes or xxx.has_psources))
           tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="right" data-html="true"
           data-content='%if;(xxx.has_notes)%xxx.notes;%end;
                         %if;(xxx.has_notes and xxx.has_psources)<hr>%end;
@@ -281,7 +264,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
             %end;
             %if;(evar.title="on")%xxx.title;%end;
           </div>
-
         </div>
       </td>
     %end;
@@ -302,18 +284,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %( Lieu de naissance %)
   %if;(evar.birth_place="on" and famx=1)
-    %if;("yyy"="desc")
-      <td class='align-middle%nn;
-        %if;(evar.ns="on")
-          %if;((has_birth_note or has_baptism_note) and not
-               (has_birth_source or has_baptism_source)) note%nn;
-          %elseif;(not (has_birth_note or has_baptism_note) and
-               (has_birth_source or has_baptism_source)) source%nn;
-          %elseif;((has_birth_note or has_baptism_note) and
-               (has_birth_source or has_baptism_source)) notesource%nn;
-          %end;
-        %end;'
-    %else;
       <td class='align-middle%nn;
         %if;(evar.ns="on")
           %if;((xxx.has_birth_note or xxx.has_baptism_note) and not
@@ -324,47 +294,25 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
                (xxx.has_birth_source or xxx.has_baptism_source)) notesource%nn;
           %end;
         %end;'
-    %end;
     %rowspan;
     %if;(evar.ns="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-      data-content='%if;("yyy"="desc" and (has_birth_note or has_baptism_note))
-                      %if;(has_birth_note)%if;(has_baptism_note)[*birth][:] %end;%birth_note;%end;
-                      %if;(has_baptism_note)[*baptism][:] %baptism_note;%end;
-                    %elseif;(xxx.has_birth_note or xxx.has_baptism_note)
+      data-content='%if;(xxx.has_birth_note or xxx.has_baptism_note)
                       %if;(xxx.has_birth_note)%if;(xxx.has_baptism_note)[*birth][:] %end;%xxx.birth_note;%end;
                       %if;(xxx.has_baptism_note)[*baptism][:] %xxx.baptism_note;%end;
                     %end;
-                    %if;(("yyy"="desc" and (has_birth_source or has_baptism_source))
-                           or (xxx.has_birth_source or xxx.has_baptism_source))
-                      %if;(("yyy"="desc" and (has_birth_note or has_baptism_note))
-                          or (xxx.has_birth_note or xxx.has_baptism_note))<hr>
-                      %end;
+                    %if;(xxx.has_birth_source or xxx.has_baptism_source)
+                      %if;(xxx.has_birth_note or xxx.has_baptism_note)<hr>%end;
                       %let;birthbaptism;[birth], [baptism]%in;
-                      %if;("yyy"="desc")
-                        %foreach;source;
-                          %if;(not has_baptism_note and ((not has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
-                            %apply;capitalize(source).
-                          %elseif;((has_baptism_note or has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
-                            <li>%apply;capitalize(source_type)[:] %source;.</li>
-                          %end;
-                        %end;
-                      %else;
-                        %foreach;xxx.source;
-                          %if;(not xxx.has_baptism_note and ((not xxx.has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
-                            %apply;capitalize(xxx.source).
-                          %elseif;((xxx.has_baptism_note or xxx.has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
-                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
-                          %end;
+                      %foreach;xxx.source;
+                        %if;(not xxx.has_baptism_note and ((not xxx.has_baptism_source and source_type=[birth]) or source_type=birthbaptism))
+                          %apply;capitalize(xxx.source).
+                        %elseif;((xxx.has_baptism_note or xxx.has_baptism_source) and (source_type=[birth] or source_type=[baptism]))
+                          <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
                         %end;
                       %end;
                     %end;'
-        title='%if;("yyy"="desc" and (has_birth_source or has_baptism_source or has_birth_note or has_baptism_note))
-                 %if;((has_birth_note or has_baptism_note) and not (has_birth_source or has_baptism_source))[*note/notes]1%nn;
-                 %elseif;(not (has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[*source/sources]1%nn;
-                 %elseif;((has_birth_note or has_baptism_note) and (has_birth_source or has_baptism_source))[*source/sources]1 [and] [source/sources]1%nn;
-                 %end;
-               %elseif;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
+        title='%if;(xxx.has_birth_source or xxx.has_baptism_source or xxx.has_birth_note or xxx.has_baptism_note)
                  %if;((xxx.has_birth_note or xxx.has_baptism_note) and not (xxx.has_birth_source or xxx.has_baptism_source))[*note/notes]1%nn;
                  %elseif;(not (xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[*source/sources]1%nn;
                  %elseif;((xxx.has_birth_note or xxx.has_baptism_note) and (xxx.has_birth_source or xxx.has_baptism_source))[*note/notes]1 [and] [source/sources]1%nn;
@@ -585,18 +533,6 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %( Lieu de décès %)
   %if;(evar.death_place="on" and famx=1)
-    %if;("yyy"="desc")
-      <td class='align-middle
-        %if;(evar.ns="on")
-          %if;((has_death_note or has_burial_note) and not
-              (has_death_source or has_burial_source))note
-          %elseif;(not (has_death_note or has_burial_note) and
-              (has_death_source or has_burial_source))source
-          %elseif;((has_death_note or has_burial_note) and
-              (has_death_source or has_burial_source))notesource
-          %end;
-        %end;'
-    %else;
       <td class='align-middle
         %if;(evar.ns="on")
           %if;((xxx.has_death_note or xxx.has_burial_note) and not
@@ -607,55 +543,29 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
               (xxx.has_death_source or xxx.has_burial_source))notesource
           %end;
         %end;'
-    %end;
     %rowspan;
     %if;(evar.ns="on")
       tabindex="0" data-trigger="focus" data-toggle="popover" data-placement="bottom" data-html="true"
-      data-content='%if;("yyy"="desc" and (has_death_note or has_burial_note))
-                      %if;(has_death_note)[*death][:] %death_note;%end;
-                      %if;(has_burial_note)[*burial][:] %burial_note;%end;
-                    %elseif;(xxx.has_death_note or xxx.has_burial_note)
+      data-content='%if;(xxx.has_death_note or xxx.has_burial_note)
                       %if;(xxx.has_death_note)%if;(xxx.has_burial_note)[*death][:] %end;%xxx.death_note;%end;
                       %if;(xxx.has_burial_note)[*burial][:] %xxx.burial_note;%end;
                     %end;
-                    %if;(("yyy"="desc" and (has_death_source or has_burial_source))
-                          or (xxx.has_death_source or xxx.has_burial_source))
-                      %if;(("yyy"="desc" and (has_death_note or has_burial_note))
-                          or (xxx.has_death_note or xxx.has_burial_note))<hr>
-                      %end;
+                    %if;(xxx.has_death_source or xxx.has_burial_source)
+                      %if;(xxx.has_death_note or xxx.has_burial_note)<hr>%end;
                       %let;deathburial;[death], [burial]%in;
-                      %if;("yyy"="desc")
-                        %foreach;source;
-                          %if;(not has_burial_note and ((not has_burial_source and source_type=[death]) or source_type=deathburial))
-                            %apply;capitalize(source).
-                          %elseif;((has_burial_note or has_burial_source) and (source_type=[death] or source_type=[burial]))
-                            %if;(source_type=[burial] and is_cremated)
-                               <li>%apply;capitalize([cremation])[:] %source;.</li>
-                            %else;
-                              <li>%apply;capitalize(source_type)[:] %source;.</li>
-                            %end;
-                          %end;
-                        %end;
-                      %else;
-                        %foreach;xxx.source;
-                          %if;(not xxx.has_burial_note and ((not xxx.has_burial_source and source_type=[death]) or source_type=deathburial))
-                            %apply;capitalize(xxx.source).
-                          %elseif;((xxx.has_burial_note or xxx.has_burial_source) and (source_type=[death] or source_type=[burial]))
-                            %if;(source_type=[burial] and xxx.is_cremated)
-                               <li>%apply;capitalize([cremation])[:] %xxx.source;.</li>
-                            %else;
-                              <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
-                            %end;
+                      %foreach;xxx.source;
+                        %if;(not xxx.has_burial_note and ((not xxx.has_burial_source and source_type=[death]) or source_type=deathburial))
+                          %apply;capitalize(xxx.source).
+                        %elseif;((xxx.has_burial_note or xxx.has_burial_source) and (source_type=[death] or source_type=[burial]))
+                          %if;(source_type=[burial] and xxx.is_cremated)
+                             <li>%apply;capitalize([cremation])[:] %xxx.source;.</li>
+                          %else;
+                            <li>%apply;capitalize(source_type)[:] %xxx.source;.</li>
                           %end;
                         %end;
                       %end;
                     %end;'
-        title='%if;("yyy"="desc" and (has_death_source or has_burial_source or has_death_note or has_burial_note))
-                 %if;((has_death_note or has_burial_note) and not (has_death_source or has_burial_source))[*note/notes]1
-                 %elseif;(not (has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*source/sources]1
-                 %elseif;((has_death_note or has_burial_note) and (has_death_source or has_burial_source))[*note/notes]1 [and] [source/sources]1
-                 %end;
-               %elseif;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
+        title='%if;(xxx.has_death_source or xxx.has_burial_source or xxx.has_death_note or xxx.has_burial_note)
                   %if;((xxx.has_death_note or xxx.has_burial_note) and not (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1
                   %elseif;(not (xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*source/sources]1
                   %elseif;((xxx.has_death_note or xxx.has_burial_note) and (xxx.has_death_source or xxx.has_burial_source))[*note/notes]1 [and] [source/sources]1

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -865,41 +865,32 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
       href="%prefix;m=D;t=T;%access;;v=%evar.v;;image=on;">
       <span class="fa fa-sitemap fa-lg fa-fw mr-1"></span>[*descendants tree]
     </a>
-    <div class="mr-5">
-      %if;(evar.v>=1)
-        <a role="button" class="btn"
-          href="%apply;rebuild_url%with;D
-                %and;%evar.t;
-                %and;v=%expr(evar.v-1);
-                %and;%if;(evar.ns="on")ns=on;%end;
-                %and;%if;(evar.cgl="on")cgl=on;%end;
-                %and;%if;(evar.image="on")image=on;%end;
-                %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;" 
-                class="btn btn-secondary" title="[*delete] 1 [generation/generations]0">%nn;
-          <i class="fa fa-minus fa-lg"></i>%nn;
-        </a>
-      %else;
-        <span class="btn btn-secondary disabled" aria-disabled="true" title="[*delete] 1 [generation/generations]0">
-          <i class="fa fa-minus fa-lg" ></i>
-        </span>
-      %end;
-      %(if;((evar.v="" or evar.v="0") and evar.v<desc_level%)
-        <a role="button" class="btn"
-          href="%apply;rebuild_url%with;D
-                %and;%evar.t;
-                %and;v=%expr(evar.v+1);
-                %and;%if;(evar.ns="on")ns=on;%end;
-                %and;%if;(evar.cgl="on")cgl=on;%end;
-                %and;%if;(evar.image="on")image=on;%end;
-                %and;%if;(evar.px!="")px=%evar.px;%end;
-                %end;" 
-                class="btn btn-secondary" title="[*add] 1 [generation/generations]0">%nn;
-         <i class="fa fa-plus fa-lg"></i>%nn;
-       </a>
-      %(end;%)
-      <span class="text-primary mt-2">%apply;togend%with;%if;(evar.v="")0%else;%evar.v;%end;%end;</span>
-    </div>
+    <a role="button" class="btn pl-3
+      %if;(evar.v="" or evar.v="0")disabled" aria-disabled="true"%else;"%end;
+      href="%apply;rebuild_url%with;D
+            %and;%evar.t;
+            %and;%if;(evar.v>1)v=%expr(evar.v-1);%else;v=0;%end;
+            %and;%if;(evar.ns="on")ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
+            %end;" title="[*delete] 1 [generation/generations]0">%nn;
+      <i class="fa fa-minus fa-lg"></i>%nn;
+    </a>
+    <a role="button" class="btn pl-2"
+      href="%apply;rebuild_url%with;D
+            %and;%evar.t;
+            %and;v=%expr(evar.v+1);
+            %and;%if;(evar.ns="on")ns=on;%end;
+            %and;%if;(evar.cgl="on")cgl=on;%end;
+            %and;%if;(evar.image="on")image=on;%end;
+            %and;%if;(evar.px!="")px=%evar.px;%end;
+            %end;" title="[*add] 1 [generation/generations]0">%nn;
+      <i class="fa fa-plus fa-lg"></i>%nn;
+    </a>
+    <span class="text-primary pl-1 mt-2">
+      %apply;togend%with;%if;(evar.v="")0%else;%evar.v;%end;%end;
+    </span>
   </div>
   <div class="d-flex">
     <a role="button" class="btn btn-link ml-2 px-0 mb-1"

--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -187,7 +187,7 @@ fr: Saisissez une succession de lettres de module avec son chiffre d’option da
               <a class="dropdown-item" href="%prefix;m=A;%access;"><span class="fa fa-cog fa-fw"></span>  [*ancestors]</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" id="anc_tree" href="%prefix;m=A;t=T;v=5;image=on;marriage=on;%access;" %laY;><span class="fa fa-sitemap fa-rotate-180 fa-fw"></span>  [*ascendants tree]</a>
-              <a class="dropdown-item" href="%prefix;m=A;t=Z;v=7;maxv=%max_anc_level;;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;ns=on;image=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [ancestors]</a>
+              <a class="dropdown-item" href="%prefix;m=A;t=Z;v=7;maxv=%max_anc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;age=on;occu=on;gen=on;ns=on;image=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [ancestors]</a>
               <a class="dropdown-item" href="%prefix;m=A;t=G;v=3;maxv=%max_anc_level;;siblings=on;alias=on;spouse=on;parents=on;rel=on;witn=on;notes=on;src=on;hide=on;%access;"><span class="fa fa-newspaper-o fa-fw"></span>  [*long display]</a>%nn;
               <a class="dropdown-item" href="%prefix;m=A;t=F;tf1=sb;v=%max_anc_level;;maxv=%max_anc_level;;i=%index;"><span class="fa fa-reorder fa-fw"></span>  [*surnames branch]</a>
             </div>

--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -200,7 +200,7 @@ fr: Saisissez une succession de lettres de module avec son chiffre d’option da
               <a class="dropdown-item" href="%prefix;m=D;%access;"><span class="fa fa-cog fa-fw"></span>  [*descendants]</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="%prefix;m=D;t=T;v=4;image=on;%access"%if;(not has_parents) %laY;%end;><span class="fa fa-sitemap fa-fw"></span>  [*descendants tree]</a>
-              <a class="dropdown-item" href="%prefix;m=D;t=H;v=%max_desc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [descendants]</a>
+              <a class="dropdown-item" href="%prefix;m=D;t=I;v=%max_desc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;notes=on;image=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [descendants]</a>
               <a class="dropdown-item" href="%prefix;m=D;t=L;v=3;maxv=%max_desc_level;;siblings=on;alias=on;spouse=on;parents=on;rel=on;witn=on;notes=on;src=on;hide=on;%access;"><span class="fa fa-newspaper-o fa-fw"></span>  [*long display]</a>
               <a class="dropdown-item" href="%prefix;m=D;t=A;num=on;v=%max_desc_level;;%access"><span class="fa fa-code-fork fa-flip-vertical fa-fw"></span>  D’Aboville</a>
             </div>

--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -187,7 +187,7 @@ fr: Saisissez une succession de lettres de module avec son chiffre d’option da
               <a class="dropdown-item" href="%prefix;m=A;%access;"><span class="fa fa-cog fa-fw"></span>  [*ancestors]</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" id="anc_tree" href="%prefix;m=A;t=T;v=5;image=on;marriage=on;%access;" %laY;><span class="fa fa-sitemap fa-rotate-180 fa-fw"></span>  [*ascendants tree]</a>
-              <a class="dropdown-item" href="%prefix;m=A;t=Z;image=%evar.image;;v=7;maxv=%max_anc_level;;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [ancestors]</a>
+              <a class="dropdown-item" href="%prefix;m=A;t=Z;v=7;maxv=%max_anc_level;;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;ns=on;image=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [ancestors]</a>
               <a class="dropdown-item" href="%prefix;m=A;t=G;v=3;maxv=%max_anc_level;;siblings=on;alias=on;spouse=on;parents=on;rel=on;witn=on;notes=on;src=on;hide=on;%access;"><span class="fa fa-newspaper-o fa-fw"></span>  [*long display]</a>%nn;
               <a class="dropdown-item" href="%prefix;m=A;t=F;tf1=sb;v=%max_anc_level;;maxv=%max_anc_level;;i=%index;"><span class="fa fa-reorder fa-fw"></span>  [*surnames branch]</a>
             </div>
@@ -200,7 +200,7 @@ fr: Saisissez une succession de lettres de module avec son chiffre d’option da
               <a class="dropdown-item" href="%prefix;m=D;%access;"><span class="fa fa-cog fa-fw"></span>  [*descendants]</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" href="%prefix;m=D;t=T;v=4;image=on;%access"%if;(not has_parents) %laY;%end;><span class="fa fa-sitemap fa-fw"></span>  [*descendants tree]</a>
-              <a class="dropdown-item" href="%prefix;m=D;t=I;v=%max_desc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;notes=on;image=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [descendants]</a>
+              <a class="dropdown-item" href="%prefix;m=D;t=I;v=%max_desc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;death_age=on;occu=on;gen=on;ns=on;image=on;%access;"><span class="fa fa-table fa-fw"></span>  [*table] [descendants]</a>
               <a class="dropdown-item" href="%prefix;m=D;t=L;v=3;maxv=%max_desc_level;;siblings=on;alias=on;spouse=on;parents=on;rel=on;witn=on;notes=on;src=on;hide=on;%access;"><span class="fa fa-newspaper-o fa-fw"></span>  [*long display]</a>
               <a class="dropdown-item" href="%prefix;m=D;t=A;num=on;v=%max_desc_level;;%access"><span class="fa fa-code-fork fa-flip-vertical fa-fw"></span>  D’Aboville</a>
             </div>

--- a/hd/etc/perso_module/arbre_vertical.txt
+++ b/hd/etc/perso_module/arbre_vertical.txt
@@ -11,7 +11,7 @@
   %if;(mmm=1)marriage=on;%end;
   %if;(evar.vh!="")vh=%evar.vh;;%end;
   %if;(evart!="")t=ttt;%end;
-  %if;(vvv!=3)v=vvv%end;#a%in;
+  %if;(vvv!=3)v=vvv%end;%if;(evar.m!="A")#a%end;%in;
   %new_url;
 %end;
 

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -28,6 +28,18 @@ fr: dictionnaire des %s
 en: compiled on %s from commit %s
 fr: compilé le %s à partir du commit %s
 
+    indicators
+en: markers for
+fr: les indicateurs de
+
+    link to children
+en: link to children
+fr: lien vers les enfants
+
+    link back to parents
+en: link back to parents
+fr: lien retour vers les parents
+
     presentation
 de: Präsentation
 en: Presentation

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -28,10 +28,6 @@ fr: dictionnaire des %s
 en: compiled on %s from commit %s
 fr: compilé le %s à partir du commit %s
 
-    indicators
-en: markers for
-fr: les indicateurs de
-
     link to children
 en: link to children
 fr: lien vers les enfants
@@ -14120,12 +14116,12 @@ ca: Podeu seleccionar una altre llengua, hi ha disponibles les següents:
 cs: Zvolte jazyk pro prohlížení databáze:
 da: Du kan vælge fremstilling på et andet sprog blandt de følgende:
 de: Blick auf:
-en: View in:
+en: view in:
 eo: Vi povas elekti alian lingvon inter la sekvantajn:
 es: Ver en:
 et: Võid valida ka mõne muu keele järgnevatest:
 fi: Näytä:
-fr: Afficher en :
+fr: afficher en :
 is: Þú getur valið milli eftirfarandi tungumála:
 it: Vista in:
 lv: Jūs variet apskatīt datu bāzi arī citās sekojošās valodās:

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -1,3 +1,7 @@
+    with root, spouses and unknowns
+en: with root ancestor, spouses and unknowns
+fr: avec l'ancêtre racine, les conjoints et les inconnus
+
     choose a genealogy
 en: choose a genealogy
 fr: choisir une généalogie

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -2107,6 +2107,11 @@ and eval_simple_str_var conf base env (_, p_auth) =
             if conf.pure_xhtml then Util.check_xhtml s else s
           else ""
       | _ -> raise Not_found ]
+  | "fsources" ->
+      match get_env "fam" env with
+      [ Vfam _ fam _ m_auth ->
+        sou base (get_fsources fam)
+      | _ -> "" ]
   | "max_anc_level" ->
       match get_env "max_anc_level" env with
       [ Vint i -> string_of_int i
@@ -3502,14 +3507,6 @@ and eval_bool_person_field conf base env (p, p_auth) =
   | "has_psources" ->
       if (is_hide_names conf p) && not p_auth then False
       else sou base (get_psources p) <> ""
-  | "has_fsources" ->
-      if (is_hide_names conf p) && not p_auth then False
-      else
-        List.exists
-          (fun ifam ->
-             let fam = foi base ifam in
-             p_auth && sou base (get_fsources fam) <> "")
-          (Array.to_list (get_family p))
   | "has_public_name" ->
       if not p_auth && (is_hide_names conf p) then False
       else sou base (get_public_name p) <> ""

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -2427,6 +2427,18 @@ and eval_compound_var conf base env ((a, _) as ep) loc =
               VVstring (eval_num conf (Sosa.of_int (cnt - 1)) sl)
           | _ -> raise Not_found ]
       | _ -> raise Not_found ]
+  | ["number_of_descendants_at_level" :: sl] ->
+      match get_env "level" env with
+      [ Vint i ->
+          match get_env "desc_level_table" env with
+          [ Vdesclevtab t ->
+              let cnt =
+                Array.fold_left (fun cnt v -> if v = i then cnt + 1 else cnt)
+                  0 (fst (Lazy.force t))
+              in
+              VVstring (eval_num conf (Sosa.of_int (cnt)) sl)
+          | _ -> raise Not_found ]
+      | _ -> raise Not_found ]
   | ["parent" :: sl] ->
       match get_env "parent" env with
       [ Vind p ->

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -3940,6 +3940,21 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) =
               | _ -> Date.string_of_ondate conf d ]
           | _ -> "" ]
       | _ -> raise Not_found ]
+  | "psources" ->
+      if p_auth && not conf.no_note then
+        let env = [('i', fun () -> Util.default_image_name base p)] in
+        let s = sou base (get_psources p) in
+        let s = string_with_macros conf env s in
+        let lines = Wiki.html_of_tlsw conf s in
+        let wi =
+          {Wiki.wi_mode = "NOTES"; Wiki.wi_cancel_links = conf.cancel_links;
+           Wiki.wi_file_path = Notes.file_path conf base;
+           Wiki.wi_person_exists = person_exists conf base;
+           Wiki.wi_always_show_link = conf.wizard || conf.friend}
+        in
+        let s = Wiki.syntax_links conf wi (String.concat "\n" lines) in
+        if conf.pure_xhtml then Util.check_xhtml s else s
+      else ""
   | "slash_burial_date" ->
       match get_burial p with
       [ Buried cod ->

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -3480,6 +3480,11 @@ and eval_bool_person_field conf base env (p, p_auth) =
   | "has_first_names_aliases" ->
       if not p_auth && (is_hide_names conf p) then False
       else get_first_names_aliases p <> []
+  | "has_fsources" ->
+      match get_env "fam" env with
+      [ Vfam _ fam _ m_auth ->
+        m_auth && sou base (get_fsources fam) <> ""
+      | _ -> False ]
   | "has_history" ->
       let fn = sou base (get_first_name p) in
       let sn = sou base (get_surname p) in

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -1847,7 +1847,7 @@ and eval_simple_bool_var conf base env (p, p_auth) =
       match get_env "sosa_ref" env with
       [ Vsosa_ref v -> Lazy.force v <> None
       | _ -> raise Not_found ]
-  | "has_comment" ->
+  | "has_comment" | "has_fnotes" ->
       let mode_local =
         match get_env "fam_link" env with
         [ Vfam ifam _ (_, _, ip) _ -> False
@@ -1948,7 +1948,7 @@ and eval_simple_str_var conf base env (_, p_auth) =
       [ Vstring s -> s
       | _ -> raise Not_found ]
   | "child_cnt" -> string_of_int_env "child_cnt" env
-  | "comment" ->
+  | "comment" | "fnotes" ->
       match get_env "fam" env with
       [ Vfam _ fam _ m_auth ->
           if m_auth && not conf.no_note then
@@ -3494,7 +3494,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
   | "has_image" -> Util.has_image conf base p
   | "has_nephews_or_nieces" -> has_nephews_or_nieces conf base p
   | "has_nobility_titles" -> p_auth && nobtit conf base p <> []
-  | "has_notes" -> p_auth && not conf.no_note && sou base (get_notes p) <> ""
+  | "has_notes" | "has_pnotes" -> p_auth && not conf.no_note && sou base (get_notes p) <> ""
   | "has_occupation" -> p_auth && sou base (get_occupation p) <> ""
   | "has_parents" ->
       IFDEF API THEN
@@ -3874,7 +3874,7 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) =
                    conf.command (get_key_index p)))
           ELSE "0" END
       | _ -> string_of_int (Array.length (get_family p)) ]
-  | "notes" ->
+  | "notes" | "pnotes" ->
       if p_auth && not conf.no_note then
         let env = [('i', fun () -> Util.default_image_name base p)] in
         let s = sou base (get_notes p) in

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -1865,6 +1865,11 @@ and eval_simple_bool_var conf base env (p, p_auth) =
       [ Vfam _ fam _ m_auth ->
           m_auth && not conf.no_note && sou base (get_marriage_note fam) <> ""
       | _ -> raise Not_found ]
+  | "has_marriage_source" ->
+      match get_env "fam" env with
+      [ Vfam _ fam _ m_auth ->
+          m_auth && sou base (get_marriage_src fam) <> ""
+      | _ -> raise Not_found ]
   | "has_relation_her" ->
       match get_env "rel" env with
       [ Vrel {r_moth = Some _} None -> True
@@ -2073,6 +2078,23 @@ and eval_simple_str_var conf base env (_, p_auth) =
       [ Vfam _ fam _ m_auth ->
           if m_auth && not conf.no_note then
             let s = sou base (get_marriage_note fam) in
+            let s = string_with_macros conf [] s in
+            let lines = Wiki.html_of_tlsw conf s in
+            let wi =
+              {Wiki.wi_mode = "NOTES"; Wiki.wi_cancel_links = conf.cancel_links;
+               Wiki.wi_file_path = Notes.file_path conf base;
+               Wiki.wi_person_exists = person_exists conf base;
+               Wiki.wi_always_show_link = conf.wizard || conf.friend}
+            in
+            let s = Wiki.syntax_links conf wi (String.concat "\n" lines) in
+            if conf.pure_xhtml then Util.check_xhtml s else s
+          else ""
+      | _ -> raise Not_found ]
+  | "marriage_source" ->
+      match get_env "fam" env with
+      [ Vfam _ fam _ m_auth ->
+          if m_auth then
+            let s = sou base (get_marriage_src fam) in
             let s = string_with_macros conf [] s in
             let lines = Wiki.html_of_tlsw conf s in
             let wi =
@@ -3232,6 +3254,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
       else get_aliases p <> []
   | "has_baptism_date" -> p_auth && get_baptism p <> Adef.codate_None
   | "has_baptism_place" -> p_auth && sou base (get_baptism_place p) <> ""
+  | "has_baptism_source" -> p_auth && sou base (get_baptism_src p) <> ""
   | "has_baptism_note" ->
       p_auth && not conf.no_note && sou base (get_baptism_note p) <> ""
   | "has_baptism_witnesses" ->
@@ -3245,6 +3268,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
             else loop events ]
   | "has_birth_date" -> p_auth && get_birth p <> Adef.codate_None
   | "has_birth_place" -> p_auth && sou base (get_birth_place p) <> ""
+  | "has_birth_source" -> p_auth && sou base (get_birth_src p) <> ""
   | "has_birth_note" ->
       p_auth && not conf.no_note && sou base (get_birth_note p) <> ""
   | "has_birth_witnesses" ->
@@ -3263,6 +3287,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
         | _ -> False ]
       else False
   | "has_burial_place" -> p_auth && sou base (get_burial_place p) <> ""
+  | "has_burial_source" -> p_auth && sou base (get_burial_src p) <> ""
   | "has_burial_note" ->
       p_auth && not conf.no_note && sou base (get_burial_note p) <> ""
   | "has_burial_witnesses" ->
@@ -3371,6 +3396,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
       [ Death _ _ -> p_auth
       | _ -> False ]
   | "has_death_place" -> p_auth && sou base (get_death_place p) <> ""
+  | "has_death_source" -> p_auth && sou base (get_death_src p) <> ""
   | "has_death_note" ->
       p_auth && not conf.no_note && sou base (get_death_note p) <> ""
   | "has_death_witnesses" ->


### PR DESCRIPTION
#### Nouveautés sur les tableaux ascendant/descendant (ancsosa/destable):
* Ajouts des portraits, des notes et des sources aux tableaux : de nouveaux indicateurs colorés bleu (note), jaune (source) et vert (note et source) dans les coins supérieurs des cellules personne, lieux de naissance, mariage, décès et nombres d'enfants permettent d’afficher leurs notes et sources spécifiques dans une petite fenêtre supplémentaire. Trois nouveaux boutons d’options supplémentaires en haut des tableaux permettent de manipuler les nouvelles variables d’URL :  `ns=on` affiche les notes et sources, `image=on` affiche les images et `px=80` modifie la taille des images en pixel. Ces options sont activées par défaut pour les liens aux tableaux de la barre de menu (menubar) et les formulaires d’options ascendant/descendant (ancmenu/desmenu).

* Ajout de liens de navigation sur les tableaux descendant entre le nombre d'enfants des parents et le premier enfant d’une famille ainsi qu’un lien retour sur le numéro d’Aboville du premier enfant vers ses parents.
<hr/>

* [x] ajouter des tooltips `title=""` sur les liens enfants/parents pour expliciter la navigation
* [x] il manque le code Javascript spécifique à Bootstrap pour le bon fonctionnement des tooltips et popovers (à voir si l'on garde le comportement “dismiss on next click” car avec on ne peut plus copier le contenu des popovers)
* [x] personne : `has_sources` est trop gourmand, implémentation et utilisation de `has_psource` 
* [x]  header sur 2 lignes sur le tableau ascendant
* [X] ajouter les notes et sources familles (`%comment;` et `%fsources;`) sur le nombre d'enfants
* [x] vérifier les notes et sources de mariage pour les familles multiples complexes
* [x] comptage par génération (repris du commit de la PR #572)

Problèmes/bugs : 
* `source_type` est parfois concaténé quand deux sources ont la même entrée, difficile à gérer tous les cas > géré partiellement pour les cas `birth, baptism`, `death, burial` et `birth, death` > voir #581 
* les apostrophes droites présentes en note ou source échappent `data-content` ce qui affiche la « fin » des données dans la cellule du tableau.
* supprimer la balise `<p></p>` de `%marriage_source;` absente des autres sources, qui induit un saut de ligne et empêche le bon fonctionnement du  `%apply;capitalize`.

Améliorations/idées/remarques :
* transférer les `<br>` de copyr au moins sur destable.txt seulement (ajouter déjà un `class="hidden-print"` sur ces sauts de lignes ?)
* ajouter des liens vers les formulaires sur ancsosa
* ajouter une navigation qui reste dans les tableaux
* gérer le niveau de descendants max (ne pas afficher le bouton + si v est au max)