### PR TITLE
if i0!="", then transform i0=;i1=;i2=;i3= ... into i0=;i1=;i0=;i2=;i0=;i3=;... for m=RLM

### DIFF
--- a/src/dag.ml
+++ b/src/dag.ml
@@ -23,17 +23,22 @@ module Pset =
 ;
 
 (* input dag *)
+(* collect in a set the elements of a dag *)
 
 value get_dag_elems conf base =
   loop None Pset.empty 1 where rec loop prev_po set i =
     let s = string_of_int i in
+    (* find "person origin" in env  (p=;n=; or i=;) *)
     let po = Util.find_person_in_env conf base s in
     let po =
       match po with
+      (* if None, use prev_po (Who is this?? *)
       [ None -> prev_po
       | x -> x ]
     in
+    (* find other person in env (ss=index;) until first missing integer 1 to n *)
     let so = Util.p_getenv conf.env ("s" ^ s) in
+    (* for each pair po, sp, collect in set branch_of_sosa *)
     match (po, so) with
     [ (Some p, Some s) ->
         let set =

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -2421,6 +2421,13 @@ and eval_compound_var conf base env ((a, _) as ep) loc =
           let ep = make_ep conf base (get_key_index p) in
           eval_person_field_var conf base env ep loc sl
       | None -> raise Not_found ]
+  | ["qvar"; v :: sl] ->
+      let v0 = int_of_string v in
+      if v0 >= 0 && v0 < nb_of_persons base then
+        let ep = make_ep conf base (Adef.iper_of_int v0) in
+        if is_hidden (fst ep) then raise Not_found
+        else eval_person_field_var conf base env ep loc sl
+      else raise Not_found
   | ["related" :: sl] ->
       match get_env "rel" env with
       [ Vrel {r_type = rt} (Some p) ->


### PR DESCRIPTION
RLM asks for a set of paths between pairs of individuals. When these paths all originate from the same individual, this proposal greatly simplifies the url, and the mechanism to update the tree proposed in upddag.txt.
The diff on relation.ml does not facilitate understanding the proposed new code! After a test on the presence of i0=xxx, print_multi calls  build_pl_r or build_pl to build up the expected pl list.

In perso.ml, a new function (%qvar.index.xxx;) performs a similar task as %pvar.i.xxx; except that it expects directly an index value rather that obtaining this index from %evar.i;

Two new functions (%svar.i.xxx; and %tvar.index.sosa_n.xxx;) perform a similar task based on the sosa_n of person index. For %savr; the information is obtained from the url which provides si= for the sosa_n, and possibly ni/pi= for the associated sosa_ref. If there is no ni/pi, the "previous" value is used (previous = lower values of i). 