### PR TITLE
Remove unnecessary empty menu item

### DIFF
--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -109,7 +109,6 @@ fr: Saisissez une succession de lettres de module avec son chiffre d’option da
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle %if;(evar.m="CHG_EVT_IND_ORD" or evar.m="SND_IMAGE" or evar.m="MRG" or evar.m="DEL_IND")active%end;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="[*tools] [person/persons]0"><span class="fa fa-cog"></span></a>
             <div class="dropdown-menu">
-              <a class="dropdown-item" id="mod_ind" href="%prefix;m=MOD_IND;i=%index;" %laP;></a>
               <a class="dropdown-item" href="%prefix;m=CHG_EVT_IND_ORD;i=%index;" title="[*changed order of person's events]"><span class="fa fa-unsorted fa-fw"></span>  [*invert::event/events]1</a>
               %if;(bvar.can_send_image != "no" and image = "" and first_name != "?" and surname != "?")
                 <a class="dropdown-item" href="%prefix;m=SND_IMAGE;i=%index;" %laI;><span class="fa fa-file-image-o fa-fw"></span>  %if;has_image;[*modify picture]%else;[*add picture]%end;</a>


### PR DESCRIPTION
There is an empty menu item in the person tools submenu that links to editing the individual.