### PR TITLE
Adjust horizontal trees to replace implex subtree by “see above”

### DIFF
--- a/hd/etc/anclist.txt
+++ b/hd/etc/anclist.txt
@@ -93,16 +93,16 @@
       %if;(pp.has_parents)
         %apply;ancestors_horizontally(
           "pp.father", xx - 1, "ss1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;",
-          "ss1&nbsp;+--&nbsp;", "ss1&nbsp;|&nbsp;&nbsp;&nbsp;", zz*2)
+          "ss1&nbsp;┌──&nbsp;", "ss1&nbsp;|&nbsp;&nbsp;&nbsp;", zz*2)
       %end;
       <samp>ss2</samp><a id="sosa_%pp.sosa;" href="%prefix;%pp.access;">%pp;</a>%pp.title;%pp.dates;<br>
       %if;(pp.has_parents)
         %apply;ancestors_horizontally(
           "pp.mother", xx - 1, "ss3&nbsp;|&nbsp;&nbsp;&nbsp;",
-          "ss3&nbsp;+--&nbsp;", "ss3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;", zz*2+1)
+          "ss3&nbsp;└──&nbsp;", "ss3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;", zz*2+1)
       %end;
     %else;
-      <samp>ss2</samp>See <a href="%prefix;%pp.access;">%pp;</a> => <a href="#sosa_%pp.sosa;">above</a><br>
+      <samp>ss2</samp><a href="%prefix;%pp.access;">%pp;</a> (<a href="#sosa_%pp.sosa;" title="[implex/implexes]0, [see above]">↑</a>)<br>
     %end;
   %end;
 %end;
@@ -130,9 +130,9 @@
     <p>
     %apply;togen(xx).
     </p>
-    <table><tr><td style="white-space:nowrap">
+    <table><tr><td style="font-family:monospace;white-space:nowrap;line-height:1.2em;">
     %apply;ancestors_horizontally(
-      "self", xx, "&nbsp;&nbsp;&nbsp;", "--&nbsp;", "&nbsp;&nbsp;&nbsp;", 1)
+      "self", xx, "&nbsp;&nbsp;&nbsp;", "──&nbsp;", "&nbsp;&nbsp;&nbsp;", 1)
     </td></tr></table>
 
   %elseif;(evar.t = "E" and evar.sort != "")

--- a/hd/etc/anclist.txt
+++ b/hd/etc/anclist.txt
@@ -87,18 +87,22 @@
   %end;
 %end;
 
-%define;ancestors_horizontally(pp, xx, ss1, ss2, ss3)
+%define;ancestors_horizontally(pp, xx, ss1, ss2, ss3, zz)
   %if;(xx > 0)
-    %if;(pp.has_parents)
-      %apply;ancestors_horizontally(
-        "pp.father", xx - 1, "ss1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;",
-        "ss1&nbsp;+--&nbsp;", "ss1&nbsp;|&nbsp;&nbsp;&nbsp;")
-    %end;
-    <samp>ss2</samp><a href="%prefix;%pp.access;">%pp;</a>%pp.title;%pp.dates;<br>
-    %if;(pp.has_parents)
-      %apply;ancestors_horizontally(
-        "pp.mother", xx - 1, "ss3&nbsp;|&nbsp;&nbsp;&nbsp;",
-        "ss3&nbsp;+--&nbsp;", "ss3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;")
+    %if;(pp.sosa=zz or (not browsing_with_sosa_ref))
+      %if;(pp.has_parents)
+        %apply;ancestors_horizontally(
+          "pp.father", xx - 1, "ss1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;",
+          "ss1&nbsp;+--&nbsp;", "ss1&nbsp;|&nbsp;&nbsp;&nbsp;", zz*2)
+      %end;
+      <samp>ss2</samp><a id="sosa_%pp.sosa;" href="%prefix;%pp.access;">%pp;</a>%pp.title;%pp.dates;<br>
+      %if;(pp.has_parents)
+        %apply;ancestors_horizontally(
+          "pp.mother", xx - 1, "ss3&nbsp;|&nbsp;&nbsp;&nbsp;",
+          "ss3&nbsp;+--&nbsp;", "ss3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;", zz*2+1)
+      %end;
+    %else;
+      <samp>ss2</samp>See <a href="%prefix;%pp.access;">%pp;</a> => <a href="#sosa_%pp.sosa;">above</a><br>
     %end;
   %end;
 %end;
@@ -128,7 +132,7 @@
     </p>
     <table><tr><td style="white-space:nowrap">
     %apply;ancestors_horizontally(
-      "self", xx, "&nbsp;&nbsp;&nbsp;", "--&nbsp;", "&nbsp;&nbsp;&nbsp;")
+      "self", xx, "&nbsp;&nbsp;&nbsp;", "--&nbsp;", "&nbsp;&nbsp;&nbsp;", 1)
     </td></tr></table>
 
   %elseif;(evar.t = "E" and evar.sort != "")

--- a/hd/etc/anclist.txt
+++ b/hd/etc/anclist.txt
@@ -1,7 +1,7 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="%if;(bvar.default_lang!="" and evar.lang="")%bvar.default_lang;%elseif;(evar.lang!="")%evar.lang;%else;en%end;">
 <head>
-  <!-- $Id: anclist.txt,v 5.5 2007-07-25 13:15:18 ddr Exp $ -->
+  <!-- $Id: anclist.txt,v 7.00 2018-04-26 13:15:18 ddr Exp $ -->
   <title>%nn;
     %if;(evar.t = "F")- [*surnames branch] -%nn;
     %else
@@ -58,6 +58,23 @@
   </div>
 %end;
 
+%define;buttons()
+  <div class="form-inline ml-5 mt-1 mb-2">
+    <div class="mx-2">
+      <a href="%prefix_no_iz;%nn;
+               %foreach;env_binding;%if;(env.key!="repeat")%env.key;=%env.val;;%end;%end;
+               %if;(evar.repeat!="on")repeat=on;%end;"
+          class="btn btn-outline-secondary btn-sm border-0 px-0 small"
+          title="%if;(evar.repeat="on")[*visualize/show/hide/summary]2%else;%nn;
+          [*visualize/show/hide/summary]1%end; [implex/implexes]1">
+        <i class="fa fa-random fa-fw"></i>
+        <i class="fa fa-toggle-%if;(evar.repeat="on")on%else;off%end; text-muted"></i>
+      </a>
+    </div>
+  </div>
+%end;
+
+
 %define;tothegen(xx)
   [*to the %s generation:::xx]%nn;
 %end;
@@ -89,7 +106,7 @@
 
 %define;ancestors_horizontally(pp, xx, ss1, ss2, ss3, zz)
   %if;(xx > 0)
-    %if;(pp.sosa=zz or (not browsing_with_sosa_ref))
+    %if;(pp.sosa=zz or (not browsing_with_sosa_ref) or evar.repeat="on")
       %if;(pp.has_parents)
         %apply;ancestors_horizontally(
           "pp.father", xx - 1, "ss1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;",
@@ -127,9 +144,11 @@
       %if;(bvar.max_anc_level = "")%apply;min(evar.v, max_anc_level, 7)
       %else;%apply;min(evar.v, max_anc_level, bvar.max_anc_level)%end;
     %in;
+    <div class="row">
+      <span>%apply;togen(xx).</span>
+      %apply;buttons()
+    </div>
     <p>
-    %apply;togen(xx).
-    </p>
     <table><tr><td style="font-family:monospace;white-space:nowrap;line-height:1.2em;">
     %apply;ancestors_horizontally(
       "self", xx, "&nbsp;&nbsp;&nbsp;", "──&nbsp;", "&nbsp;&nbsp;&nbsp;", 1)

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -159,7 +159,7 @@
             %if;(spouse.first_name != "?" and spouse.surname != "?")
               %if;(family_cnt > 1),%sp;%end;
               %apply;image_MF("spouse")
-              %apply;link(spouse.access, spouse, spouse.index)
+              %apply;link("spouse")
             %end;
           %end;
         %end;
@@ -207,17 +207,40 @@
   %end;
 %end;
 
-%define;link(aa, xx, ind)
-  %if;(evar.cgl = "on")xx%else;<a id="iind" href="%prefix;aa">xx</a>%end;
+%define;link(xx)
+    %if;(evar.cgl = "on")%xx;%else;<a id="i%xx.index;" href="%prefix;%xx.access;">%xx;</a>%end;
 %end;
 
-%define;link2(xx, ind)
-  %if;(evar.cgl = "on")%xx;%else;<a id="iind" href="%prefix;%xx.access;">%xx;</a>%end;
+%define;link0(xx)
+  %let;bb;
+    %if;(xx.same!="")
+      %ancestor.same;
+    %else;%ancestor;%end;
+  %in;
+  %if;(evar.cgl = "on")%bb;%else;<a id="i%xx.index;" href="%prefix;%xx.access;">%bb;</a>%end;
+%end;
+
+%define;link1(xx)
+  %let;bb;
+    %if;(xx.same!="")
+      %if(evar.sosab = 16)%xx.same.hexa;
+      %elseif(evar.sosab = 8)%xx.same.octal;
+      %else;%xx.same;
+      %end;
+    %else;
+      %xx;
+    %end;
+  %in;
+  %if;(evar.cgl = "on")%bb;%else;<a id="i%xx.index;" href="%prefix;%xx.access;">%bb;</a>%end;
+%end;
+
+%define;link2(xx)
+  %if;(evar.cgl = "on")%xx;%else;<a id="i%xx.index;" href="%prefix;%xx.access;">%xx;</a>%end;
   %xx.title;%xx.dates;
 %end;
 
-%define;my_link(aa, xx, rr, ind)
-  %if;(evar.cgl = "on" or rr)xx%else;<a id="iind" href="%prefix;aa">xx</a>%end;
+%define;my_link(xx)
+  %if;(evar.cgl = "on" or xx.is_restricted)%xx;%else;<a id="i%xx.index" href="%prefix;%xx.access;">%xx;</a>%end;
 %end;
 
 %define;somebody_extra_info(xx)
@@ -226,7 +249,7 @@
     %foreach;xx.relation;%nl;
       (%relation_type;:
       %if;has_relation_him;
-        %apply;link2(relation_him.var, relation_him.index)
+        %apply;link2("relation_him")
         %if;(relation_him.sosa_in_list != ""),
           [see] <a href="#%relation_him.sosa_in_list;">%nn;
           %relation_him.sosa_in_list;</a>%nn;
@@ -234,7 +257,7 @@
       %end;
       %if;has_relation_her;
         %if;has_relation_him;,%nl;%end;
-        %apply;link2(relation_her.var, relation_her.index)
+        %apply;link2("relation_her")
         %if;(relation_her.sosa_in_list != ""),
           [see] <a href="#%relation_her.sosa_in_list;">%nn;
           %relation_her.sosa_in_list;</a>%nn;
@@ -243,7 +266,7 @@
     %end;
     %foreach;xx.related;%nl;
       (%related_type;:
-       %apply;link2(related.var, related.index)
+       %apply;link2("related")
        %if;(related.sosa_in_list != ""),
          [see] <a href="#%related.sosa_in_list;">%nn;
          %related.sosa_in_list;</a>%nn;
@@ -687,7 +710,7 @@
         %if;(evar.witn = "on" and has_witnesses)([witness/witnesses]1:
           %foreach;witness;
             %if;(not is_first),%nl;%end;
-            %apply;link2(witness.var, witness.index)
+            %apply;link2("witness")
           %end;),
         %end;
         %if;(evar.comm = "on" and (has_comment or has_marriage_note))
@@ -905,9 +928,7 @@
     <div class="d-flex justify-content-between">
       <div class="align-self-center mr-2">
         %apply;image_MF("ancestor")
-        %apply;link%with;%ancestor.access;%and;
-          %ancestor;%and;%ancestor.index;
-        %end;
+        %apply;link("ancestor")
         %if;(evar.title="on")%ancestor.title;%end;
         %if;(ancestor.same != "" and evar.repeat = "on")
           %sp;→
@@ -984,9 +1005,7 @@
         %if;(family_cnt = 1)
           <td class="align-middle" %if;(ancestor.nb_families > 1) %end;>
             %apply;image_MF("spouse")
-            %apply;link%with;%spouse.access;%and;
-              %spouse;%and;%spouse.index;
-            %end;
+            %apply;link("spouse")
           </td>
         %end;
       %end;
@@ -1171,9 +1190,7 @@
               %end;
               >
               %apply;image_MF("spouse")
-              %apply;link%with;%spouse.access;%and;
-                %spouse;%and;%spouse.index;
-              %end;
+              %apply;link("spouse")
             </td>
           %end;
           %if;(evar.marr_date = "on")
@@ -1429,11 +1446,7 @@
                     %if;(ancestor.same = "")%incr_count;%end;
                     %ancestor.anc_sosa;%sp;
                     %if;(ancestor.same != "")=&gt;%else;-%end;%sp;
-                    %apply;link%with;%ancestor.access;%and;
-                      %if;(ancestor.same != "")%ancestor.same;
-                      %else;%ancestor;%end;
-                      %and;%ancestor.index;
-                    %end;
+                    %apply;link0("ancestor")
                     %if;(ancestor.same = "")%ancestor.title;%ancestor.dates;
                     %else;
                       %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)
@@ -1468,15 +1481,7 @@
             %else;%ancestor.anc_sosa;
             %end;%sp;
             %if;(ancestor.same != "")=&gt;%else;-%end;%sp;
-            %apply;link%with;%ancestor.access;%and;
-               %if;(ancestor.same != "")%nn;
-                 %if(evar.sosab = 16)%ancestor.same.hexa;
-                 %elseif(evar.sosab = 8)%ancestor.same.octal;
-                 %else;%ancestor.same;
-                 %end;
-               %else;%ancestor;
-               %end;%and;%ancestor.index;
-            %end;
+            %apply;link1("ancestor")
             %if;(ancestor.same != "")
               %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)<br>
             %end;
@@ -1691,7 +1696,7 @@
                   <td> &nbsp; </td>
                   <td>
                     %apply;image_MF("ancestor")
-                    %apply;link(ancestor.access, ancestor, ancestor.index)
+                    %apply;link("ancestor")
                     %ancestor.title;
                   </td>
                   %apply;display_missing_ancestor_info("ancestor")
@@ -1710,7 +1715,7 @@
                     <td align="center"> x </td>
                     <td>
                       %apply;image_MF("ancestor.mother")
-                      %apply;link(ancestor.mother.access, ancestor.mother, ancestor.mother.index)
+                      %apply;link("ancestor.mother")
                       %ancestor.mother.title;
                     </td>
                     %apply;display_missing_ancestor_info("ancestor.mother")
@@ -1729,7 +1734,7 @@
                     <td align="center"> x </td>
                     <td>
                       %apply;image_MF("ancestor.father")
-                      %apply;link(ancestor.father.access, ancestor.father, ancestor.father.index)
+                      %apply;link("ancestor.father")
                       %ancestor.father.title;
                     </td>
                     %apply;display_missing_ancestor_info("ancestor.father")

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -159,7 +159,7 @@
             %if;(spouse.first_name != "?" and spouse.surname != "?")
               %if;(family_cnt > 1),%sp;%end;
               %apply;image_MF("spouse")
-              %apply;link(spouse.access, spouse)
+              %apply;link(spouse.access, spouse, spouse.index)
             %end;
           %end;
         %end;
@@ -207,17 +207,17 @@
   %end;
 %end;
 
-%define;link(aa, xx)
-  %if;(evar.cgl = "on")xx%else;<a href="%prefix;aa">xx</a>%end;
+%define;link(aa, xx, ind)
+  %if;(evar.cgl = "on")xx%else;<a id="iind" href="%prefix;aa">xx</a>%end;
 %end;
 
-%define;link2(xx)
-  %if;(evar.cgl = "on")%xx;%else;<a href="%prefix;%xx.access;">%xx;</a>%end;
+%define;link2(xx, ind)
+  %if;(evar.cgl = "on")%xx;%else;<a id="iind" href="%prefix;%xx.access;">%xx;</a>%end;
   %xx.title;%xx.dates;
 %end;
 
-%define;my_link(aa, xx, rr)
-  %if;(evar.cgl = "on" or rr)xx%else;<a href="%prefix;aa">xx</a>%end;
+%define;my_link(aa, xx, rr, ind)
+  %if;(evar.cgl = "on" or rr)xx%else;<a id="iind" href="%prefix;aa">xx</a>%end;
 %end;
 
 %define;somebody_extra_info(xx)
@@ -226,7 +226,7 @@
     %foreach;xx.relation;%nl;
       (%relation_type;:
       %if;has_relation_him;
-        %apply;link2(relation_him.var)
+        %apply;link2(relation_him.var, relation_him.index)
         %if;(relation_him.sosa_in_list != ""),
           [see] <a href="#%relation_him.sosa_in_list;">%nn;
           %relation_him.sosa_in_list;</a>%nn;
@@ -234,7 +234,7 @@
       %end;
       %if;has_relation_her;
         %if;has_relation_him;,%nl;%end;
-        %apply;link2(relation_her.var)
+        %apply;link2(relation_her.var, relation_her.index)
         %if;(relation_her.sosa_in_list != ""),
           [see] <a href="#%relation_her.sosa_in_list;">%nn;
           %relation_her.sosa_in_list;</a>%nn;
@@ -243,7 +243,7 @@
     %end;
     %foreach;xx.related;%nl;
       (%related_type;:
-       %apply;link2(related.var)
+       %apply;link2(related.var, related.index)
        %if;(related.sosa_in_list != ""),
          [see] <a href="#%related.sosa_in_list;">%nn;
          %related.sosa_in_list;</a>%nn;
@@ -253,13 +253,13 @@
 %end;
 
 %define;somebody(xx)
-  <b>%apply;my_link(xx.access, xx, xx.is_restricted)</b>%nn;
+  <b>%apply;my_link(xx.access, xx, xx.is_restricted, xx.index)</b>%nn;
   %apply;somebody_long_info("xx")
   %apply;somebody_extra_info("xx")
 %end;
 
 %define;somebody_spouse_parent(xx)
-  <b>%apply;my_link(spouse.xx.access, spouse.xx, spouse.is_restricted)</b>%nn;
+  <b>%apply;my_link(spouse.xx.access, spouse.xx, spouse.is_restricted, spouse.index)</b>%nn;
   %if;spouse.xx.has_nobility_titles;,
     <a href="%prefix;m=TT;sm=S;t=%spouse.xx.nobility_title.ident_key;
     ;p=%spouse.xx.nobility_title.place_key;">%nn;
@@ -570,7 +570,7 @@
 %end;
 
 %define;child_long_info(spec)
-  <b>%apply;my_link(child.access, child.child_name, child.is_restricted)%nn;</b>%nn;
+  <b>%apply;my_link(child.access, child.child_name, child.is_restricted, child.index)%nn;</b>%nn;
   %apply;somebody_long_info("child")
   %if;(child.sosa_in_list != "").
     %if;(evar.only != "on")[*see]%sp;
@@ -687,7 +687,7 @@
         %if;(evar.witn = "on" and has_witnesses)([witness/witnesses]1:
           %foreach;witness;
             %if;(not is_first),%nl;%end;
-            %apply;link2(witness.var)
+            %apply;link2(witness.var, witness.index)
           %end;),
         %end;
         %if;(evar.comm = "on" and (has_comment or has_marriage_note))
@@ -906,7 +906,7 @@
       <div class="align-self-center mr-2">
         %apply;image_MF("ancestor")
         %apply;link%with;%ancestor.access;%and;
-          %ancestor;
+          %ancestor;%and;%ancestor.index;
         %end;
         %if;(evar.title="on")%ancestor.title;%end;
         %if;(ancestor.same != "" and evar.repeat = "on")
@@ -985,7 +985,7 @@
           <td class="align-middle" %if;(ancestor.nb_families > 1) %end;>
             %apply;image_MF("spouse")
             %apply;link%with;%spouse.access;%and;
-              %spouse;
+              %spouse;%and;%spouse.index;
             %end;
           </td>
         %end;
@@ -1172,7 +1172,7 @@
               >
               %apply;image_MF("spouse")
               %apply;link%with;%spouse.access;%and;
-                %spouse;
+                %spouse;%and;%spouse.index;
               %end;
             </td>
           %end;
@@ -1432,8 +1432,12 @@
                     %apply;link%with;%ancestor.access;%and;
                       %if;(ancestor.same != "")%ancestor.same;
                       %else;%ancestor;%end;
+                      %and;%ancestor.index;
                     %end;
-                    %if;(ancestor.same = "")%ancestor.title;%ancestor.dates;%end;
+                    %if;(ancestor.same = "")%ancestor.title;%ancestor.dates;
+                    %else;
+                      %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)
+                    %end;
                   %end;
                 </li>%nl;
               %end;
@@ -1471,7 +1475,10 @@
                  %else;%ancestor.same;
                  %end;
                %else;%ancestor;
-               %end;
+               %end;%and;%ancestor.index;
+            %end;
+            %if;(ancestor.same != "")
+              %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)<br>
             %end;
             %if;(ancestor.same = "")%ancestor.title;%ancestor.dates;%end;
           </li>%nl;
@@ -1684,7 +1691,7 @@
                   <td> &nbsp; </td>
                   <td>
                     %apply;image_MF("ancestor")
-                    %apply;link(ancestor.access, ancestor)
+                    %apply;link(ancestor.access, ancestor, ancestor.index)
                     %ancestor.title;
                   </td>
                   %apply;display_missing_ancestor_info("ancestor")
@@ -1703,7 +1710,7 @@
                     <td align="center"> x </td>
                     <td>
                       %apply;image_MF("ancestor.mother")
-                      %apply;link(ancestor.mother.access, ancestor.mother)
+                      %apply;link(ancestor.mother.access, ancestor.mother, ancestor.mother.index)
                       %ancestor.mother.title;
                     </td>
                     %apply;display_missing_ancestor_info("ancestor.mother")
@@ -1722,7 +1729,7 @@
                     <td align="center"> x </td>
                     <td>
                       %apply;image_MF("ancestor.father")
-                      %apply;link(ancestor.father.access, ancestor.father)
+                      %apply;link(ancestor.father.access, ancestor.father, ancestor.father.index)
                       %ancestor.father.title;
                     </td>
                     %apply;display_missing_ancestor_info("ancestor.father")


### PR DESCRIPTION
PR for #607

This requires browsing_with_sosa_ref. A button should be added to the page and/or to the parameter page to ensure that sosa nav is turned on. To be done later.