### PR TITLE
Fix English typos

### DIFF
--- a/ged2gwb/ged2gwb.ml
+++ b/ged2gwb/ged2gwb.ml
@@ -3926,7 +3926,7 @@ be - First names enclosed -
        names, the first of this names becomes the person \"first name\" and
        the complete GEDCOM first name part a \"first name alias\".");
    ("-no_efn", Arg.Clear extract_first_names, "  \
-- Dont extract first names - [default]
+- Don't extract first names - [default]
        Cancels the previous option.");
    ("-epn", Arg.Set extract_public_names, "  \
 - Extract public names - [default]

--- a/ged2gwb/ged2gwb2.ml
+++ b/ged2gwb/ged2gwb2.ml
@@ -3644,7 +3644,7 @@ be - First names enclosed -
        names, the first of this names becomes the person \"first name\" and
        the complete GEDCOM first name part a \"first name alias\".");
    ("-no_efn", Arg.Clear extract_first_names, "  \
-- Dont extract first names - [default]
+- Don't extract first names - [default]
        Cancels the previous option.");
    ("-epn", Arg.Set extract_public_names, "  \
 - Extract public names - [default]

--- a/gwtp/gwtp.ml
+++ b/gwtp/gwtp.ml
@@ -935,7 +935,7 @@ value gwtp_receive str env b tok =
       do {
         printf "content-type: bin/geneweb";
         crlf ();
-        printf "content-disposition: attachement; filename=%s" fname;
+        printf "content-disposition: attachment; filename=%s" fname;
         crlf ();
         crlf ();
         let ic = open_in (Filename.concat bdir fname) in

--- a/src/api_saisie_write.ml
+++ b/src/api_saisie_write.ml
@@ -994,14 +994,14 @@ let compute_warnings conf base resp =
             | MarriageDateAfterDeath p ->
                 let w =
                 Printf.sprintf
-                  (fcapitale (ftransl conf "marriage had occured after the death of %t"))
+                  (fcapitale (ftransl conf "marriage had occurred after the death of %t"))
                   (fun _ -> print_someone_dates p)
                 in
                 w :: wl
             | MarriageDateBeforeBirth p ->
                 let w =
                 Printf.sprintf
-                  (fcapitale (ftransl conf "marriage had occured before the birth of %t"))
+                  (fcapitale (ftransl conf "marriage had occurred before the birth of %t"))
                   (fun _ -> print_someone_dates p)
                 in
                 w :: wl


### PR DESCRIPTION
Found with Lintian (Debian)
https://lintian.debian.org/full/bubulle@debian.org.html#geneweb_6.08_x2bgit20180420_x2bdfsg-2

No conflicts with a2line:bs4beta and a2line:gwsetup.

"occuRRed" : they are already corrected in hd/lang/lex_utf8.txt
https://github.com/geneweb/geneweb/commit/d6bec129e9cad750c9e25e21fc0f9e1d56cf147f#diff-6e7ea3c09c36ffbdfda5fdc024624863