### PR TITLE
Enhance WiKi link syntax: [[Fn/Sn/oc]] now prints Fn Sn if oc is a number

### DIFF
--- a/src/notesLinks.ml
+++ b/src/notesLinks.ml
@@ -126,8 +126,11 @@ value misc_notes_link s i =
                 [ Not_found ->
                     ("", String.sub b (l + 1) (String.length b - l - 1)) ]
               in
+              let oc1 = try int_of_string name with [ Failure _ -> -1 ] in
               let oc = try int_of_string oc with [ Failure _ -> 0 ] in
-              (fn, sn, oc, name)
+              if oc1 = -1 then (fn, sn, oc, name)
+              else (*if not Wiki.wi_person_exists (fn, sn, oc1) then (fn, sn, oc, name)
+              else*)(fn, sn, oc1, fn ^ " " ^ sn)
             with
             [ Not_found ->
                 let sn = String.sub b k (String.length b - k) in


### PR DESCRIPTION
Could be improved if a test for existence of Fn Sn oc was made