### PR TITLE
Fix : Arg.Bad Exception ignored when CLI parsing is done

### DIFF
--- a/gwb2ged/gwb2ged.ml
+++ b/gwb2ged/gwb2ged.ml
@@ -56,6 +56,8 @@ value encode s =
       if Mutil.utf_8_db.val then s else Mutil.utf_8_of_iso_8859_1 s ]
 ;
 
+value max_len = 78;
+
 value br = "<br>";
 value find_br s ini_i =
   let ini = "<br" in
@@ -72,40 +74,14 @@ value find_br s ini_i =
     else br
 ;
 
-value max_len = 78; 
-
-(** output text, with CONT/CONC tag using a gedcom file stream
-    GEDCOM lines are limited to 255 characters. 
-    However, the CONCatenation or CONTinuation tags can be used to expand a field beyond this limit.
-    lines are cut and align with max_len characters for easy display/printing
-    @see <https://www.familysearch.org/developers/docs/gedcom/> GEDCOM STANDARD 5.5, Appendix A CONC and CONT tag
-    @param oc specifies output base stream (gedcom file)
-    @param tagn specifies the current gedcom tag level (0, 1, ...)
-    @param s specifies text to output already encode with gedcom charset (see encode function)
-    @param len specifies the number of characters (char or wide char) already outputed in gedcom file 
-    @param i specifies the last char index (index to s -- one byte char) *)
 value rec display_note_aux oc tagn s len i =
-  let j = ref i in
-  (* read wide char (case charset UTF-8) or char (other charset) in s string*)
-  let rec output_onechar () = 
-    if j.val = String.length s then do { decr j; }
-   (* non wide char / UTF-8 char *)
-    else if charset.val <> Utf8 then output_char oc s.[i]
-   (* 1 to 4 bytes UTF-8 wide char *)
-    else if i = j.val || Name.nbc s.[j.val] = -1 then do {
-      output_char oc s.[j.val];
-      incr j;
-      output_onechar ()
-    }
-    else do { decr j; }
-  in
-  if j.val = String.length s then fprintf oc "\n"
+  if i = String.length s then fprintf oc "\n"
   else
-    (* \n, <br>, <br \> : cut text for CONTinuate with new gedcom line *)
+    let c = if s.[i] = '\n' then ' ' else s.[i] in
     let br = find_br s i in
     if i <= String.length s - String.length br &&
-       String.lowercase_ascii (String.sub s i (String.length br)) = br 
-    then do {
+       String.lowercase_ascii (String.sub s i (String.length br)) = br then
+       do {
       fprintf oc "\n%d CONT " (succ tagn);
       let i = i + String.length br in
       let i = if i < String.length s && s.[i] = '\n' then i + 1 else i in
@@ -116,16 +92,34 @@ value rec display_note_aux oc tagn s len i =
       let i = if i < String.length s then i + 1 else i in
       display_note_aux oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONT ")) i
     }
-    (* cut text at max length for CONCat with next gedcom line *)
     else if len = max_len then do {
-      fprintf oc "\n%d CONC " (succ tagn);
-      display_note_aux oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONC ")) i
+      let j = ref i in
+      let rec display_and_break () =
+        if j.val = String.length s then ()
+        else
+          let c = if s.[j.val] = '\n' then ' ' else s.[j.val] in
+          if c = ' ' || Name.nbc c = 1 then do {
+            (* new line, the char will be printed by the next call to
+               display_note_aux *)
+            fprintf oc "\n%d CONC " (succ tagn);
+            decr j;
+          }
+          else do {
+            (* multi-byte char *)
+            output_char oc c;
+            incr j;
+            display_and_break ()
+          }
+      in
+      display_and_break ();
+      if j.val = String.length s then
+        fprintf oc "\n"
+      else
+        display_note_aux oc tagn s
+          (String.length ((string_of_int (succ tagn)) ^ " CONC "))
+          (j.val + 1)
     }
-    (* continue same gedcom line *) 
-    else do {
-      output_onechar ();
-      display_note_aux oc tagn s (len + 1) (j.val + 1)
-    }
+    else do { output_char oc c; display_note_aux oc tagn s (len + 1) (i + 1) }
 ;
 
 value display_note oc tagn s =

--- a/gwb2ged/gwb2ged.ml
+++ b/gwb2ged/gwb2ged.ml
@@ -74,52 +74,66 @@ value find_br s ini_i =
     else br
 ;
 
+(** [display_note_aux oc tagn s len i] outputs text [s] with CONT/CONC
+    tag. GEDCOM lines are limited to 255 characters. However, the
+    CONCatenation or CONTinuation tags can be used to expand a field
+    beyond this limit. Lines are cut and align with [max_len]
+    characters for easy display/printing.
+    @see <https://www.familysearch.org/developers/docs/gedcom/> GEDCOM
+    STANDARD 5.5, Appendix A CONC and CONT tag
+    @param oc specifies output channel
+    @param tagn specifies the current gedcom tag level (0, 1, ...)
+    @param s specifies text to print to the output channel (already
+    encode with gedcom charset)
+    @param len specifies the number of characters (char or wide char)
+    already printed
+    @param i specifies the last char index (index to s -- one byte
+    char) *)
 value rec display_note_aux oc tagn s len i =
-  if i = String.length s then fprintf oc "\n"
+  let j = ref i in
+  (* read wide char (case charset UTF-8) or char (other charset) in s string*)
+  let rec output_onechar () =
+    if j.val = String.length s then decr j
+    (* non wide char / UTF-8 char *)
+    else if charset.val <> Utf8 then output_char oc s.[i]
+    (* 1 to 4 bytes UTF-8 wide char *)
+    else if i = j.val || Name.nbc s.[j.val] = -1 then do {
+      output_char oc s.[j.val];
+      incr j;
+      output_onechar ()
+    }
+    else decr j
+  in
+  if j.val = String.length s then fprintf oc "\n"
   else
-    let c = if s.[i] = '\n' then ' ' else s.[i] in
+    (* \n, <br>, <br \> : cut text for CONTinuate with new gedcom line *)
     let br = find_br s i in
     if i <= String.length s - String.length br &&
-       String.lowercase_ascii (String.sub s i (String.length br)) = br then
-       do {
+       String.lowercase_ascii (String.sub s i (String.length br)) = br
+    then do {
       fprintf oc "\n%d CONT " (succ tagn);
       let i = i + String.length br in
       let i = if i < String.length s && s.[i] = '\n' then i + 1 else i in
-      display_note_aux oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONT ")) i
+      display_note_aux
+        oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONT ")) i
     }
     else if s.[i] = '\n' then do {
       fprintf oc "\n%d CONT " (succ tagn);
       let i = if i < String.length s then i + 1 else i in
-      display_note_aux oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONT ")) i
+      display_note_aux
+        oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONT ")) i
     }
+    (* cut text at max length for CONCat with next gedcom line *)
     else if len = max_len then do {
-      let j = ref i in
-      let rec display_and_break () =
-        if j.val = String.length s then ()
-        else
-          let c = if s.[j.val] = '\n' then ' ' else s.[j.val] in
-          if c = ' ' || Name.nbc c = 1 then do {
-            (* new line, the char will be printed by the next call to
-               display_note_aux *)
-            fprintf oc "\n%d CONC " (succ tagn);
-            decr j;
-          }
-          else do {
-            (* multi-byte char *)
-            output_char oc c;
-            incr j;
-            display_and_break ()
-          }
-      in
-      display_and_break ();
-      if j.val = String.length s then
-        fprintf oc "\n"
-      else
-        display_note_aux oc tagn s
-          (String.length ((string_of_int (succ tagn)) ^ " CONC "))
-          (j.val + 1)
+      fprintf oc "\n%d CONC " (succ tagn);
+      display_note_aux
+        oc tagn s (String.length ((string_of_int (succ tagn)) ^ " CONC ")) i
     }
-    else do { output_char oc c; display_note_aux oc tagn s (len + 1) (i + 1) }
+    (* continue same gedcom line *)
+    else do {
+      output_onechar ();
+      display_note_aux oc tagn s (len + 1) (j.val + 1)
+    }
 ;
 
 value display_note oc tagn s =

--- a/src/argl.ml
+++ b/src/argl.ml
@@ -71,9 +71,7 @@ value rec parse_arg s sl =
   fun
   [ [(name, action, _) :: spec_list] ->
       let i = common_start s name in
-      if i = String.length name then
-        try action_arg (String.sub s i (String.length s - i)) sl action with
-        [ Arg.Bad _ -> parse_arg s sl spec_list ]
+      if i = String.length name then action_arg (String.sub s i (String.length s - i)) sl action
       else parse_arg s sl spec_list
   | [] -> None ]
 ;


### PR DESCRIPTION
in Ged2gwb, Gwb2ged, etc... argument parsing can raise exception from action value in spec_list but exceptions are ignored in Argl.ml,
example : in Ged2gwb 
> raise (Arg.Bad "bad -charset value") is ignored when arg list contains wrong CHARSET and parsing continues...
> so, the error message in this case is outputed with raise (Arg.Bad "Cannot treat several databases")

User therefore sees a wrong error message
==> parse_arg function fixed for to not handle exception (i.e : see handle at parse_arg_list function level)