### PR TITLE
update_nldb was not counting WLwizard when WiKi was, hence offset in …

### DIFF
--- a/src/update_nldb.ml
+++ b/src/update_nldb.ml
@@ -32,7 +32,7 @@ value notes_links s =
             [(key, link) :: list_ind]
           in
           loop list_nt list_ind (pos + 1) j
-      | NotesLinks.WLwizard j _ _ -> loop list_nt list_ind pos j
+      | NotesLinks.WLwizard j _ _ -> loop list_nt list_ind (pos + 1) j
       | NotesLinks.WLnone -> loop list_nt list_ind pos (i + 1) ]
 ;
 


### PR DESCRIPTION
…notes positionning

Offset was marginally annoying, and happened only if Wizard reference [[w:Wizard/text]] were present at the beginning of the note file.

The problem has been there probably since beginning of times!