### PR TITLE
Fix distrib-6-08-ocaml-4-xx

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -63,7 +63,7 @@ GeneWeb version 6.06
   relatives outputs. Add a few new options in the ascendants/descendants 
   list/tree.
 * The way a date is displayed is now completely depedant of the "date order"
-  in the language dictionnary. For exemple, if your date order is dd/mm/yyyy,
+  in the language dictionary. For example, if your date order is dd/mm/yyyy,
   your date will be 01/02/1880. If instead it's d/m/yyyy, it will be displayed
   as 1/2/1880. Format accepted now are : 
   - dmyyyy
@@ -168,7 +168,7 @@ GeneWeb version 6.04
 * Added an option in the ged2gwb tool. It behaves like previously, i.e. default
   relation for a couple is Married. If someone prefer, one can use the option
   -rs_no_mention to set the relation status to NoMention.
-* Added a new intruction in the template langage : FOR.
+* Added a new instruction in the template langage : FOR.
   It is a simple instruction, and could be improved later but for now it works
   like this :
   for (i=MIN; i<MAX; i++) => in template language : %for;i;MIN;MAX .... %end;
@@ -184,7 +184,7 @@ GeneWeb version 6.04
 * Added an option to *not* try a getHostByName. Could slow down on windows. 
   One should add -no_host_address to gwd to use this feature.
 * New implementation of the fonction that calculate if a person has a sosa 
-  number or not. Much more efficent than the previous one !
+  number or not. Much more efficient than the previous one !
 * It is now NOT possible to add or modify a family in which the first
   name or the surname of a person is not specify. => It can break the 
   generation of the gw file.
@@ -194,9 +194,9 @@ GeneWeb version 6.04
 * Added an "happy birthday" for the wedding anniversary in the
   individual page
 * Added the operator '/' (DIV) in the template language
-* Fix the calculs in case there is more than a thousand number in templm
+* Fix the calculus in case there is more than a thousand number in templm
 * Fix the duplicates of adresse in gwc2. Now the book of places if
-  working completly in gwc1 and gwc2
+  working completely in gwc1 and gwc2
 
 Daniel de Rauglaudre:
 * Fix bug (limitation of the int size in OCaml). Now in 64 bits architecture,
@@ -237,7 +237,7 @@ GeneWeb version 6.03
   many results"
 * Added a book of places (see a.gwf to specify the maximum number of
   event that can be corrected in one pass. 
-  !!! Beware !!! This functionnality is not completly functionnal when
+  !!! Beware !!! This functionality is not completely functional when
   using gwc2. You can not edit twice the same place. If you want to
   edit more than one time one place, you have to do a consang between
   each modifications (because it will recalculate the indexs).
@@ -349,7 +349,7 @@ GeneWeb version 5.02
   messages not yet validated (in red) to allow them to possibly delete
   them.
 * ... other things added, modified or fixed. These changes were not recorded
-  here, because lazyness...
+  here, because laziness...
 
 GeneWeb version 5.01
 --------------------
@@ -382,7 +382,7 @@ The new version number (5.00) is in honour of this new encoding.
     and HTML syntax can be both used in the same page. The Wiki syntax is:
     - Lines starting with from 1 to 6 '=' and ending with the same number
       of '=' are section titles (1 = most important.. 6 = less important).
-      If the text is modifiable, they can be independantly editable (a
+      If the text is modifiable, they can be independently editable (a
       link "(modify)" is displayed to allow it).
     - An empty line makes a new paragraph.
     - Group of at least 2 lines starting with space and with an empty
@@ -405,7 +405,7 @@ The new version number (5.00) is in honour of this new encoding.
       Simplified syntaxes: if oc = 0, [[fn/sn/t]] can be used, and
       [[fn/sn]] is equivalent to [[fn/sn/0/fn sn]].
     - The syntax [[[name/text]]] makes a link to a "miscelleneous note"
-      (new feature), an independant page which can be edited (if updating
+      (new feature), an independent page which can be edited (if updating
       allowed), and using Wiki syntax also. The page name is 'name' (only
       letters, digits and '_' allowed) and 'text' is displayed as link. If
       the page does not exist, the link is displayed in red. These new
@@ -990,7 +990,7 @@ GeneWeb version 4.01
   - [17 Mar 01] Fixed problem of displaying of history of updates: it
     was sometimes very very slow.
   - [15 Mar 01] Fixed bug: when merging two men (the problem did not
-    happen for women), the witnesses of mariage of the second man were
+    happen for women), the witnesses of marriage of the second man were
     incompletely reported to the first one (they are indicated as witness
     in the first man page, but not in their own personal page in the
     "relation" section).
@@ -1025,7 +1025,7 @@ GeneWeb version 4.01
   - [26 Mar 01] (technical point) Grouped together all lang/*/start.txt in
     one only file lang/start.txt, easier to manipulate (at least for me!)
   - [14 Mar 01] Changed the French translation of "nth cousin":
-    indeed, in French, the "nth cousin" is translated, litterally, by
+    indeed, in French, the "nth cousin" is translated, literally, by
     "cousin of the pth degree" where "p" is "n+1": e.g. a "4th cousin" is
     "a cousin of the 5th degree". Perhaps the same thing has to be done
     in other languages...
@@ -1158,7 +1158,7 @@ GeneWeb version 3.11
     wide for printers. In tree displaying, a link is proposed in the upper
     right corner of the page. When clicking on it, a page is proposed for
     a parametrizable display of the tree by slices.
-  - [29 Jan 01] For GeneWeb sites accomodating many databases: to
+  - [29 Jan 01] For GeneWeb sites accommodating many databases: to
     avoid the creation of too many files in the same directories, added
     the ability to put them in sub-sub-directories. A database file can
     be installed in a sub-directory of its first character,
@@ -1252,7 +1252,7 @@ GeneWeb version 3.11
   - [26 Jan 01] Added two macros usable in header or trailer files: %p
     which is replaced by the prefix of the current URL (the whole address
     up to the question mark) and %s by its suffix (after the question
-    mark). In personal pages, this suffix is independant from the index:
+    mark). In personal pages, this suffix is independent from the index:
     can therefore be used to specify a bookmarkable address.
 
 * Lexicon (lang/lexicon.txt)
@@ -1383,7 +1383,7 @@ GeneWeb version 3.09
   - [11 Oct 00] Important improvement: added a system of template
     files for the personal pages. It is therefore possible to change the
     displaying of the personal pages, by editing the template. It is also
-    possible, for a site accomodating several databases, to have a
+    possible, for a site accommodating several databases, to have a
     personal template file specific to each database.
 
 * Lexicon (lang/lexicon.txt) and welcome pages (lang/*/start.txt)
@@ -1564,7 +1564,7 @@ GeneWeb version 3.07
 
 * New feature
   - [18 Aug 00] Added a program "gwtp" (CGI) to upload and download GeneWeb
-    databases in a site which accomodate some (undocumented program for the
+    databases in a site which accommodate some (undocumented program for the
     moment).
 
 * Distribution
@@ -1873,7 +1873,7 @@ GeneWeb version 3.03
     not use cookies.
   - [12 Mar 00] In ancestors page, added male and female lines.
   - [11 Mar 00] In personal pages, the images defined by external URL (i.e.
-    accomodated in other Web sites) are now reduced as are local images.
+    accommodated in other Web sites) are now reduced as are local images.
   - [11 Mar 00] The information "relationship to" is no more transformed
     into "married to" when "non-friend" browsing (it was supposed to protect
     private life, but seems to have more drawbacks than advantages).
@@ -2056,7 +2056,7 @@ GeneWeb version 3.01
   - [Nov 5, 99] Accept roman digits in years of French Republican dates.
 
 * GeneWeb to Gedcom (gwb2ged)
-  - [Nov 18, 99] Prints a space before the slash preceeding the surname
+  - [Nov 18, 99] Prints a space before the slash preceding the surname
     in the NAME tag.
 
 * Documentation
@@ -2168,7 +2168,7 @@ GeneWeb version 2.07
   - [Sep 9, 99] Added Swedish version (Lars Gustavsson).
   - [Sep 8, 99] Fixed lot of typos and errors in English version
     (thanks to Lars Gustavsson).
-  - [Sep 6, 99] Fixed problem in Windows: if the user choosed a
+  - [Sep 6, 99] Fixed problem in Windows: if the user chose a
     language by writing it in uppercase letters, some phrases where
     displayed in English language between brackets (no matter which
     language was selected), indicating that the language was not found
@@ -2457,7 +2457,7 @@ GeneWeb version 2.03
 * Setup program
   - [Jun 7, 99] Added a Spanish version (Luis Castro Guzman).
   - [Jun 1, 99] The location to open is now always "http://localhost:2316/",
-    independant from the selected language (no more need to end the location
+    independent from the selected language (no more need to end the location
     with "fr" or "en"): the page is displayed in the selected language.
   - [May 15, 99] Added deletion of ".gwo" file after then "gwc" operation.
   - [May 9, 99] Added predefined palette combination in "database parameters";
@@ -2877,7 +2877,7 @@ GeneWeb Version 1.09
 
 * Gedcom to GeneWeb (ged2gwb)
   - Delete of duplicated FAMS which sometimes happen in erroneous Gedcoms.
-  - Delete families from GEDCOM when parents dont have the good sex.
+  - Delete families from GEDCOM when parents don't have the good sex.
   - Added displaying of line number when syntax errors and unrecognized dates.
   - Get sources if defined by pointer (but just the 1st line).
   - Added option "-no_nd" (no negative dates), not to interpret years preceded
@@ -2907,7 +2907,7 @@ GeneWeb Version 1.09
   - In "search", added ability to write "I" instead of "Ier" (french form).
     Ex: "Charles I" or "Charles Ier" are both accepted.
   - Added ability to add ";opt=no_index" at end of requests to get an
-    equivalent link independant from the persons' index number (useful
+    equivalent link independent from the persons' index number (useful
     to put direct links in Web pages).
   - Added text "Parents of" in top of pages of missing ancestors.
   - Fixed still several bugs (accents) due to new ANSEL encoding.
@@ -3181,7 +3181,7 @@ GeneWeb Version 1.0 beta.8
 
 * gwd:
   - added cgi mode (option -cgi)
-  - Less general for acces by approximative spelling: ex: first name "agns"
+  - Less general for access by approximative spelling: ex: first name "agns"
     will not yet answer: "Agnes" and "Gunza", but just "Agnes".
   - Unix version: time out limited to 120 seconds instead of 60
   - Descendants by list limited to 8 instead of 5

--- a/ICHANGES
+++ b/ICHANGES
@@ -669,7 +669,7 @@ GeneWeb Version 3.05
     is missing in all languages! Used "bsi_err.htm" instead.
 
 * GeneWeb daemon/CGI (gwd)
-  - [04 Jun 00] Check about titles dates no more done agains the death date,
+  - [04 Jun 00] Check about titles dates no more done against the death date,
     since titles can be given after death.
   - [19 May 00] Added a small + in display ancestors horizontally. Seems
     more pretty :-)
@@ -757,7 +757,7 @@ GeneWeb Version 3.03
     even for persons having only the year in their date (fixed by testing
     the field "delta" in the date record).
   - [01 Feb 00] Added indentation in forum to make it more readable.
-  - [25 Jan 00] Display the number of persons in some more pages. Dont
+  - [25 Jan 00] Display the number of persons in some more pages. Don't
     display it when number <= 1.
   - [25 Jan 00] Changed the limit for public persons to 150 years instead
     of 100 years: persons must have been born and dead before 150 years
@@ -852,7 +852,7 @@ GeneWeb Version 3.00
   - [Nov 1, 99] Print relations only for friends and wizards.
   - [Oct 31, 99] Added macro %k for images in order to have the same request
     for any database in any language. And several changes to make the DOC
-    request independant from the database.
+    request independent from the database.
   - [Oct 25, 99] Modified the treatment of nth (overflowing after 100)
     to display the number itself (better than just "n-th").
   - [Oct 25, 99] Commented the loading of the whole persons and families
@@ -1024,7 +1024,7 @@ GeneWeb Version 2.02
     is corrupted for some reason, this was not a good error message!
   - [Apr 28, 99] Added the ability to add a file named "refuse.txt" to
     explain reasons of gwd exclusion.
-  - [Apr 24, 99] Dont print "+" in short dates for died person if there is
+  - [Apr 24, 99] Don't print "+" in short dates for died person if there is
     no death date and if the person is older than 120 years, as it was
     done in 2.01 for long dates displaying.
 
@@ -1053,7 +1053,7 @@ GeneWeb Version 2.01
     parts, using cmxa files, because Windows 98 (or maybe Cygnus) does not
     work with this too long line, I don't know why. No difference in Unix.
   - [Apr 6, 99] Big cleanup about titles (hopefully not introducing bugs).
-  - [Apr 3, 99] Dont print "died" in personal page if this is the only
+  - [Apr 3, 99] Don't print "died" in personal page if this is the only
     information (no date, no place) and if it is older than 120 years.
   - [Mar 22, 99] Ability to put "*" (to match any characters) in lines in
     exclude file.
@@ -1128,7 +1128,7 @@ GeneWeb Version 1.10
     many accesses to the base (unnecessary accesses to "persons").
   - [13/12/98] In src/num.ml, display at least "0" when number is 0!
   - [12/12/98] Fixed horrible programming of base patches applying, which
-    resulted in much memory allocation and time loosing for bases having many
+    resulted in much memory allocation and time losing for bases having many
     added "things" (persons, families, strings). Now the code is cleaner.
     Consequence: saved speed and memory allocation in such bases in gwd,
     gwu, gwb2ged.
@@ -1169,7 +1169,7 @@ GeneWeb Version 1.09
        base?em=R;ei=31440&m=NG&n=somebody&t=PN
      and ability to write in a direct link:
        base?em=R;ep=jack;en=nicholson;eoc=3&m=NG&n=somebody&t=PN
-     to be somewhat independant from the index of "jack nicholson" in
+     to be somewhat independent from the index of "jack nicholson" in
      the base.
   - Hidden options in requests:
        ";opt=from" in personal pages, gives the .gw origin file (if any)
@@ -1305,7 +1305,7 @@ GeneWeb Version 1.03
 --------------------
 
 * gwd:
-  - ascend.ml & relation.ml: print upto faster thanks to maxlen added (l=...)
+  - ascend.ml & relation.ml: print up to faster thanks to maxlen added (l=...)
   - capitalization of all letters with accents is now ok
   - added "gwd.xcl" to exclude connexions
 

--- a/contrib/gwbase/etc/popule.ml
+++ b/contrib/gwbase/etc/popule.ml
@@ -272,7 +272,7 @@ value speclist =
    ("-n", Arg.Int (fun i -> ngen.val := i),
     "nb of generations (" ^ string_of_int ngen.val ^ ")");
    ("-g", Arg.Int (fun i -> gyear.val := i),
-    "age at mariage (" ^ string_of_int gyear.val ^ ")")]
+    "age at marriage (" ^ string_of_int gyear.val ^ ")")]
 ;
 value anonfun i = bname.val := i;
 value usage = "Usage: popule base [args]";

--- a/contrib/gwdiff/README
+++ b/contrib/gwdiff/README
@@ -9,7 +9,7 @@ far it needs your help to know what to compare. Two modes are available:
 
  - descendants of all ascendants (option -ad): it will found ascendants of the 
     person you have found in both databases that are available in both data
-    bases. For each top person identified, it will compare its decendants in
+    bases. For each top person identified, it will compare its descendants in
     both databases.
 
 USAGE:

--- a/contrib/misc/birthdays
+++ b/contrib/misc/birthdays
@@ -21,7 +21,7 @@
 #		    e. g. 12 for december    (optional)
 # 
 # crontab usage:
-#   put the script in your home path (or whereever your sysadmin
+#   put the script in your home path (or wherever your sysadmin
 #   permitted you to do so) and put the following two lines
 #   (without the  "#", fill in your correct link) into your crontab:
 #

--- a/etc/a.gwf
+++ b/etc/a.gwf
@@ -98,14 +98,14 @@ supervisor=
 
 # Notify change program (e.g. shell script) to be executed for each
 # database change. First argument is the name of the base, then the
-# individual and finaly the action performed.
+# individual and finally the action performed.
 # If you want to test a specific change, such as, delete an individual,
 # you should test the fourth argument as equal to dp (delete person).
 # You can check the list of possible modifications in the updhist.txt file
 # (see update_text).
 # notify_change=
 
-# Wizard loosing his powers, becoming just a "friend"
+# Wizard losing his powers, becoming just a "friend"
 # Set it to "yes" or "no"
 wizard_just_friend=no
 
@@ -339,7 +339,7 @@ expand_env=no
 #    var_foo=my home is ${HOME}, guys!
 # the customized variable %vfoo; is expanded into:
 #    my home is /home/smith, guys!
-# The default is "no" because it may be a security hole to allow accomodated
+# The default is "no" because it may be a security hole to allow accommodated
 # databases in a Web site to show the environment variables of the command
 # gwd. Check that before putting "expand_env" to "yes".
 

--- a/ged2gwb/ged2gwb.ml
+++ b/ged2gwb/ged2gwb.ml
@@ -3090,7 +3090,7 @@ be - First names enclosed -
        names, the first of this names becomes the person \"first name\" and
        the complete GEDCOM first name part a \"first name alias\".");
    ("-no_efn", Arg.Clear extract_first_names, "  \
-- Dont extract first names - [default]
+- Don't extract first names - [default]
        Cancels the previous option.");
    ("-epn", Arg.Set extract_public_names, "  \
 - Extract public names - [default]

--- a/ged2gwb/ged2gwb2.ml
+++ b/ged2gwb/ged2gwb2.ml
@@ -2638,7 +2638,7 @@ be - First names enclosed -
        names, the first of this names becomes the person \"first name\" and
        the complete GEDCOM first name part a \"first name alias\".");
    ("-no_efn", Arg.Clear extract_first_names, "  \
-- Dont extract first names - [default]
+- Don't extract first names - [default]
        Cancels the previous option.");
    ("-epn", Arg.Set extract_public_names, "  \
 - Extract public names - [default]

--- a/gwtp/README
+++ b/gwtp/README
@@ -1,6 +1,6 @@
 What is gwtp?
 
-Gwtp is a CGI program allowing owners of databases accomodated in a
+Gwtp is a CGI program allowing owners of databases accommodated in a
 GeneWeb site to upload and download their databases on the site and
 change their configuration parameters.
 
@@ -38,7 +38,7 @@ enter a database name and a password.
 
 Adding an user
 
-To add a new accomodated database, just add a line in the passwd file
+To add a new accommodated database, just add a line in the passwd file
 of the directory $tmp above, holding:
     base:passwd
 

--- a/gwtp/gwtp.ml
+++ b/gwtp/gwtp.ml
@@ -631,7 +631,7 @@ value insert_file env bdir name =
         let oc = open_out (Filename.concat bdir name) in
         output_substring oc contents (j + 1) len;
         flush oc;
-        printf "File \"%s\" transfered.\n" name;
+        printf "File \"%s\" transferred.\n" name;
         close_out oc;
       }
       else ();
@@ -755,7 +755,7 @@ value send_gedcom_file str env b tok f fname =
 ";
     flush stdout;
     make_gedcom_file env b;
-    printf "\nGedcom file transfered.\n";
+    printf "\nGedcom file transferred.\n";
     flush stdout;
     ged2gwb b;
     printf "New database created.\n";
@@ -893,7 +893,7 @@ value send_file str env b tok f fname =
         }
     | Refuse ->
         do {
-          printf "Database is already being transfered.<br>\n";
+          printf "Database is already being transferred.<br>\n";
           printf "Please try again later.\n";
         } ];
     flush stdout;
@@ -935,7 +935,7 @@ value gwtp_receive str env b tok =
       do {
         printf "content-type: bin/geneweb";
         crlf ();
-        printf "content-disposition: attachement; filename=%s" fname;
+        printf "content-disposition: attachment; filename=%s" fname;
         crlf ();
         crlf ();
         let ic = open_in (Filename.concat bdir fname) in
@@ -1227,7 +1227,7 @@ value speclist =
     "<etc>: directory for passwd, default.gwf and lang files; default: " ^
     gwtp_tmp.val);
    ("-site", Arg.String (fun x -> gw_site.val := x),
-    "<url>: site (if any) where databases are accomodated");
+    "<url>: site (if any) where databases are accommodated");
    ("-noup", Arg.Set no_upload, "no upload");
    ("-tmout", Arg.Float (fun x -> token_tmout.val := x),
     "<sec>: tokens time out; default = " ^

--- a/hd/etc/templ502/updfam.txt
+++ b/hd/etc/templ502/updfam.txt
@@ -333,6 +333,12 @@ function changeCalendar(e,v,m,c) {
     <tr>
       %apply;death("paxcnt","xx","true")
     </tr>
+    <tr>
+      <td><label for="paxcnt_occupation">[*occupation/occupations]0</label></td>
+      <td colspan="4">
+        <input name="paxcnt_occupation" size="40" maxlength="200" value="%xx.create.occupation" id="paxcnt_occupation"%/>
+      </td>
+    </tr>
   </table>
 %end;
 
@@ -583,6 +589,12 @@ function changeCalendar(e,v,m,c) {
         </label>
       </td>
       %apply;death("chxcnt", "child", "false")
+    </tr>
+    <tr>
+      <td><label for="chxcnt_occupation">[*occupation/occupations]0</label></td>
+      <td colspan="4">
+        <input name="chxcnt_occupation" size="40" maxlength="200" value="%child.create.occupation;" id="chxcnt_occupation"%/>
+      </td>
     </tr>
   </table>
 %end;

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -7050,14 +7050,14 @@ oc: data del maridatge
 pt: data de casamento
 sv: Datum för giftermål
 
-    marriage had occured after the death of %t
+    marriage had occurred after the death of %t
 af: huwelik plaasgevind het nadat %t dood
 bg: е сключен бракът място след смъртта на %t
 ca: el matrimoni es va dur a terme després de la mort de %t
 cs: manželství se konalo po smrti %t
 da: ægteskabet fandt sted efter %t død
 de: die Ehe wurde nach dem Tod von %t geschlossen
-en: marriage had occured after the death of %t
+en: marriage had occurred after the death of %t
 eo: geedzeco okazis post %t morto
 es: matrimonio después de la muerte de %t
 et: abiellusid pärast %t surma
@@ -7080,14 +7080,14 @@ sl: poroka je potekala po smrti %t
 sv: äktenskapet ägde rum efter %t döden
 zh: 結婚後%t死亡的地方
 
-    marriage had occured before the birth of %t
+    marriage had occurred before the birth of %t
 af: huwelik plaasgevind het voor %t geboorte
 bg: е сключен бракът преди раждането на %t
 ca: el matrimoni es va dur a terme abans del naixement de %t
 cs: manželství bylo uzavřeno před narozením %t
 da: Ægteskabet fandt sted før %t fødslen
 de: die Ehe wurde vor der Geburt von %t geschlossen
-en: marriage had occured before the birth of %t
+en: marriage had occurred before the birth of %t
 eo: geedzeco okazis antaŭ ol %t naskiĝo
 es: matrimonio antes del nacimiento de %t
 et: abielu toimus enne %t sündi

--- a/man/ged2gwb.1
+++ b/man/ged2gwb.1
@@ -70,7 +70,7 @@ names, the first of this names becomes the person "first name" and
 the complete GEDCOM first name part a "first name alias".
 .TP
 .B \-no_efn   
-- Dont extract first names - [default]
+- Don't extract first names - [default]
 .br
 Cancels the previous option.
 .TP

--- a/src/argl.ml
+++ b/src/argl.ml
@@ -19,11 +19,11 @@ value action_arg s sl =
         match sl with
         [ [s :: sl] ->
             try do { f (int_of_string s); Some sl } with
-            [ Failure "int_of_string" -> None ]
+            [ Failure _ -> None ]
         | [] -> None ]
       else
         try do { f (int_of_string s); Some sl } with
-        [ Failure "int_of_string" -> None ]
+        [ Failure _ -> None ]
   | Arg.Float f ->
       if s = "" then
         match sl with

--- a/src/check.mli
+++ b/src/check.mli
@@ -1,7 +1,7 @@
 (* $Id: check.mli,v 5.7 2007-01-19 01:53:16 ddr Exp $ *)
 (* Copyright (c) 2006-2007 INRIA *)
 
-(* checking database ; independant from its implementation on disk *)
+(* checking database ; independent from its implementation on disk *)
 
 open Gwdb;
 open CheckItem;

--- a/src/db1link.ml
+++ b/src/db1link.ml
@@ -512,7 +512,7 @@ value notice_sex gen p s =
   if p.m_sex = Neuter then p.m_sex := s
   else if p.m_sex = s || s = Neuter then ()
   else do {
-    printf "\nInconcistency about the sex of\n  %s %s\n"
+    printf "\nInconsistency about the sex of\n  %s %s\n"
       (p_first_name gen.g_base p) (p_surname gen.g_base p);
     check_error gen
   }

--- a/src/gwc.ml
+++ b/src/gwc.ml
@@ -44,8 +44,7 @@ value next_family_fun_templ gwo_list fi = do {
         [ Some ic ->
             match
               try Some (input_value ic : gw_syntax) with
-              [ End_of_file -> None
-              | Failure "input_value: truncated object" -> None ] (* https://caml.inria.fr/mantis/view.php?id=7142 *)
+              [ End_of_file -> None ]
             with
             [ Some fam -> Some fam
             | None -> do {

--- a/src/gwc2.ml
+++ b/src/gwc2.ml
@@ -56,8 +56,7 @@ value next_family_fun_templ gwo_list fi = do {
         [ Some ic ->
             match
               try Some (input_value ic : gw_syntax) with
-              [ End_of_file -> None
-              | Failure "input_value: truncated object" -> None ] (* https://caml.inria.fr/mantis/view.php?id=7142 *)
+              [ End_of_file -> None ]
             with
             [ Some fam -> Some fam
             | None -> do {

--- a/src/history_diff.ml
+++ b/src/history_diff.ml
@@ -290,7 +290,7 @@ value load_person_history conf fname = do {
             let v : gen_record = input_value ic in
             history.val := [v :: history.val]
           }
-        with [ End_of_file -> () | Failure "input_value: truncated object" -> () ]; (* https://caml.inria.fr/mantis/view.php?id=7142 *)
+        with [ End_of_file -> () ];
         close_in ic
       }
   | None -> () ];
@@ -1177,7 +1177,7 @@ value eval_predefined_apply conf env f vl =
         in
         let time = String.sub date_txt 11 8 in
         Date.string_of_date conf date ^ ", " ^ time
-      with [ Failure "int_of_string" -> date_txt ]
+      with [ Failure _ -> date_txt ]
   | _ -> raise Not_found ]
 ;
 

--- a/src/i18n
+++ b/src/i18n
@@ -274,8 +274,8 @@ M/F
 main title
 male/female/neuter
 male line/female line
-marriage had occured after the death of %t
-marriage had occured before the birth of %t
+marriage had occurred after the death of %t
+marriage had occurred before the birth of %t
 marriage date
 marriage place
 marriage src

--- a/src/name.ml
+++ b/src/name.ml
@@ -78,7 +78,7 @@ value unaccent_utf_8 lower s i =
               try
                 let c = Char.lowercase (Char.chr (Char.code s.[i+1] + 0x40)) in
                 String.make 1 c
-              with Invalid_argument "Char.chr" -> "" ]
+              with Invalid_argument _ -> "" ]
       | 0xC4 ->
           match Char.code s.[i+1] with
           [ 0x80 | 0x82 | 0x84 -> f "A"

--- a/src/perso.ml
+++ b/src/perso.ml
@@ -355,7 +355,7 @@ value find_sosa_aux conf base a p t_sosa =
       (* Dans le cas ou le fichier tstab n'est plus à jour, on supprime *)
       (* le fichier pour qu'il se régénère la prochaine fois.           *)
       try gene_find zil with
-      [ Invalid_argument "index out of bounds" ->
+      [ Invalid_argument msg when msg = "index out of bounds" ->
           do {
             Update.delete_topological_sort conf base;
             Left []
@@ -1413,7 +1413,7 @@ value rec compare_ls sl1 sl2 =
       (* les performances à cause du try..with.                *)
       let c =
         try Pervasives.compare (int_of_string s1) (int_of_string s2)
-        with [ Failure "int_of_string" -> Gutil.alphabetic_order s1 s2 ]
+        with [ Failure _ -> Gutil.alphabetic_order s1 s2 ]
       in
       if c = 0 then compare_ls sl1 sl2 else c
   | ([_ :: _], []) -> 1

--- a/src/update.ml
+++ b/src/update.ml
@@ -395,13 +395,13 @@ value print_warning conf base =
         (print_someone_strong conf base anc)
   | MarriageDateAfterDeath p ->
       Wserver.wprint
-        (fcapitale (ftransl conf "marriage had occured after the death of %t"))
+        (fcapitale (ftransl conf "marriage had occurred after the death of %t"))
         (fun _ ->
            Printf.sprintf "%s%s" (print_someone_strong conf base p)
              (Date.short_dates_text conf base p))
   | MarriageDateBeforeBirth p ->
       Wserver.wprint
-        (fcapitale (ftransl conf "marriage had occured before the birth of %t"))
+        (fcapitale (ftransl conf "marriage had occurred before the birth of %t"))
         (fun _ ->
            Printf.sprintf "%s%s" (print_someone_strong conf base p)
              (Date.short_dates_text conf base p))

--- a/src/wiki.ml
+++ b/src/wiki.ml
@@ -332,7 +332,7 @@ value summary_of_tlsw_lines conf short lines =
       ([], 0, first_cnt, sections_nums) lines
   in
   if cnt <= first_cnt + 2 then
-    (* less that 3 paragraphs : summary abandonned *)
+    (* less that 3 paragraphs : summary abandoned *)
     ([], [])
   else
     let rev_summary =

--- a/wserver/wserver.ml
+++ b/wserver/wserver.ml
@@ -332,7 +332,7 @@ value treat_connection tmout callback addr fd = do {
   in
   try callback (addr, request) script_name contents with
   [ Unix.Unix_error Unix.EPIPE "write" _ -> ()
-  | Sys_error "Broken pipe" -> ()
+  | Sys_error msg when msg = "Broken pipe" -> ()
   | exc -> print_err_exc exc ];
   try wflush () with _ -> ();
   try flush stderr with _ -> ();
@@ -661,7 +661,7 @@ value f addr_opt port tmout max_clients g =
           [ Unix.Unix_error Unix.ECONNRESET "accept" _ -> ()
           | Unix.Unix_error (Unix.EBADF | Unix.ENOTSOCK) "accept" _ as x ->
               (* oops! *) raise x
-          | Sys_error "Broken pipe" -> ()
+          | Sys_error msg when msg = "Broken pipe" -> ()
           | exc -> print_err_exc exc ];
           try wflush () with [ Sys_error _ -> () ];
           try flush stdout with [ Sys_error _ -> () ];


### PR DESCRIPTION
Fix several English typos
Fix compiler warnings
Add occupations in /hd/etc/templ502/updfam.txt (fix #642)