### PR TITLE
Fixed history_d.

### DIFF
--- a/internal/history_diff.ml
+++ b/internal/history_diff.ml
@@ -23,19 +23,22 @@ let history_file fn sn occ =
   let s = space_to_unders (Name.lower sn) in
   f ^ "." ^ string_of_int occ ^ "." ^ s
 
-(* Le chemin du dossier history_d. *)
+(* history directory path *)
 let history_d conf =
   let path =
     match p_getenv conf.base_env "history_path" with
-      Some path -> path
-    | None -> ""
+    | Some path when path <> "" -> path
+    | _ -> "history_d"
   in
-  let bname = Util.base_path [] conf.bname in
-  let bname =
-    if Filename.check_suffix bname ".gwb" then bname else bname ^ ".gwb"
-  in
-  List.fold_left Filename.concat ""
-    [path; Util.base_path [] bname; "history_d"]
+  if Filename.is_relative path then
+    begin
+      let bname =
+        if Filename.check_suffix conf.bname ".gwb" then conf.bname else conf.bname ^ ".gwb"
+      in
+      Filename.concat (Util.base_path [] bname) path
+    end
+  else
+    path
 
 (* Le chemin du fichier historique dans le dossier history_d. *)
 let history_path conf fname =


### PR DESCRIPTION
I broke `history_d` definition in my latest PR.

This is a fix for it, but also an attempt to implement a correct behavior.

If `history_path` is provided and is an absolute path, use this path, as is.
If `history_path` is provided but is relative, concatenate it to the base path, without adding `history_d`.
If nothing is provided, use de default `/path/to/base.gwb/history_d' directory.

Related to https://github.com/geneweb/geneweb/issues/485