### PR TITLE
Remove non-utf8-related functions.

### DIFF
--- a/contrib/gwFix/gwFixY.ml
+++ b/contrib/gwFix/gwFixY.ml
@@ -3,23 +3,6 @@
 open Def
 open Gwdb
 
-(* Copie de util.ml *)
-let gen_only_printable or_nl s =
-  let s' = Bytes.create (String.length s) in
-  for i = 0 to String.length s - 1 do
-    Bytes.set s' i
-      (if Char.code s.[i] > 127 then s.[i]
-       else
-         match s.[i] with
-           ' '..'~' | '\160'..'\255' -> s.[i]
-         | '\n' -> if or_nl then '\n' else ' '
-         | _ -> ' ')
-  done;
-  String.trim (Bytes.unsafe_to_string s')
-
-let only_printable = gen_only_printable false
-
-
 (**/**)
 
 let trace = ref false
@@ -36,7 +19,7 @@ let fix_occu_y base =
     let occu = sou base (get_occupation p) in
     let () = if Str.string_match regexp_one occu 0 then updt := true in
     let new_occu = Str.global_replace regexp_one "" occu in
-    let new_occu = only_printable new_occu in
+    let new_occu = Util.only_printable new_occu in
     let new_occu = Gwdb.insert_string base new_occu in
     let new_pevents =
       List.map
@@ -50,7 +33,7 @@ let fix_occu_y base =
            in
            let new_note = Str.global_replace regexp_two "" note in
            let new_note = Str.global_replace regexp_one "" new_note in
-           let new_note = only_printable new_note in
+           let new_note = Util.only_printable new_note in
            let new_note = Gwdb.insert_string base new_note in
            {evt with epers_note = new_note})
         (get_pevents p)
@@ -86,7 +69,7 @@ let fix_occu_y base =
            in
            let new_note = Str.global_replace regexp_two "" note in
            let new_note = Str.global_replace regexp_one "" new_note in
-           let new_note = only_printable new_note in
+           let new_note = Util.only_printable new_note in
            let new_note = Gwdb.insert_string base new_note in
            {evt with efam_note = new_note})
         (get_fevents fam)

--- a/contrib/gwFix/gwFixY.ml
+++ b/contrib/gwFix/gwFixY.ml
@@ -8,7 +8,7 @@ let gen_only_printable or_nl s =
   let s' = Bytes.create (String.length s) in
   for i = 0 to String.length s - 1 do
     Bytes.set s' i
-      (if !(Mutil.utf_8_db) && Char.code s.[i] > 127 then s.[i]
+      (if Char.code s.[i] > 127 then s.[i]
        else
          match s.[i] with
            ' '..'~' | '\160'..'\255' -> s.[i]

--- a/contrib/oneshot/gwExportAscCSV.ml
+++ b/contrib/oneshot/gwExportAscCSV.ml
@@ -10,7 +10,6 @@ let is_printable =
   | _ -> true
 
 let escape_quote s =
-  let s = if !(Mutil.utf_8_db) then s else Mutil.utf_8_of_iso_8859_1 s in
   let rec loop i len =
     if i = String.length s then Buff.get len
     else

--- a/gwb2ged/gwb2ged.ml
+++ b/gwb2ged/gwb2ged.ml
@@ -38,10 +38,9 @@ let ged_month cal m =
 let encode s =
   match !charset with
     Ansel ->
-      let s = if !(Mutil.utf_8_db) then Mutil.iso_8859_1_of_utf_8 s else s in
-      Ansel.of_iso_8859_1 s
-  | Ascii | Ansi -> if !(Mutil.utf_8_db) then Mutil.iso_8859_1_of_utf_8 s else s
-  | Utf8 -> if !(Mutil.utf_8_db) then s else Mutil.utf_8_of_iso_8859_1 s
+      Ansel.of_iso_8859_1 @@ Mutil.iso_8859_1_of_utf_8 s
+  | Ascii | Ansi -> Mutil.iso_8859_1_of_utf_8 s
+  | Utf8 -> s
 
 let max_len = 78
 

--- a/internal/date.ml
+++ b/internal/date.ml
@@ -38,7 +38,7 @@ let get_wday conf d =
 
 let death_symbol conf =
   try List.assoc "death_symbol" conf.base_env
-  with Not_found -> if !Mutil.utf_8_db then "†" else "+"
+  with Not_found -> "†"
 
 let before_date d d1 =
   if d1.year < d.year then true

--- a/internal/dutil.ml
+++ b/internal/dutil.ml
@@ -52,58 +52,15 @@ let dsk_person_misc_names base p nobtit =
 
 let check_magic ic =
   let b = really_input_string ic (String.length magic_gwb) in
-  Mutil.utf_8_db := true;
   if b <> magic_gwb then
-    if b = magic_gwb_iso_8859_1 then Mutil.utf_8_db := false
-    else if String.sub magic_gwb 0 4 = String.sub b 0 4 then
-      failwith "this is a GeneWeb base, but not compatible"
+    if b = magic_gwb_iso_8859_1
+    then failwith "this is a iso_8859_1 GeneWeb base, but you need utf-8"
+    else if String.sub magic_gwb 0 4 = String.sub b 0 4
+    then failwith "this is a GeneWeb base, but not compatible"
     else failwith "this is not a GeneWeb base, or it is a very old version"
 
-let unaccent =
-  function
-    'à' | 'á' | 'â' | 'ã' | 'ä' | 'å' | 'æ' -> 'a'
-  | 'ç' -> 'c'
-  | 'è' | 'é' | 'ê' | 'ë' -> 'e'
-  | 'ì' | 'í' | 'î' | 'ï' -> 'i'
-  | 'ð' -> 'd'
-  | 'ñ' -> 'n'
-  | 'ò' | 'ó' | 'ô' | 'õ' | 'ö' | 'ø' -> 'o'
-  | 'ù' | 'ú' | 'û' | 'ü' -> 'u'
-  | 'ý' | 'ÿ' -> 'y'
-  | 'þ' -> 'p'
-  | c -> c
-
-let compare_names_1 s1 s2 =
-  let compare_aux e1 e2 =
-    let rec loop i1 i2 =
-      if i1 = e1 && i2 = e2 then 0
-      else if i1 = e1 then -1
-      else if i2 = e2 then 1
-      else
-        let c1 = unaccent (Char.lowercase_ascii s1.[i1]) in
-        let c2 = unaccent (Char.lowercase_ascii s2.[i2]) in
-        match c1, c2 with
-          'a'..'z', 'a'..'z' ->
-            if c1 < c2 then -1
-            else if c1 > c2 then 1
-            else loop (i1 + 1) (i2 + 1)
-        | 'a'..'z', _ -> 1
-        | _, 'a'..'z' -> -1
-        | _ -> loop (i1 + 1) (i2 + 1)
-    in
-    loop
-  in
-  if s1 = s2 then 0
-  else
-    let i1 = Mutil.initial s1 in
-    let i2 = Mutil.initial s2 in
-    match compare_aux (String.length s1) (String.length s2) i1 i2 with
-      0 -> compare_aux i1 i2 0 0
-    | x -> x
-
 let compare_names base_data s1 s2 =
-  if !Mutil.utf_8_db then Mutil.compare_after_particle base_data.particles s1 s2
-  else compare_names_1 s1 s2
+  Mutil.compare_after_particle base_data.particles s1 s2
 
 let compare_istr_fun base_data is1 is2 =
   if is1 = is2 then 0

--- a/internal/gutil.ml
+++ b/internal/gutil.ml
@@ -193,6 +193,7 @@ let alphabetic_iso_8859_1 n1 n2 =
   in
   if n1 = n2 then 0 else loop (Mutil.initial n1) (Mutil.initial n2)
 
+(* ??? *)
 let alphabetic n1 n2 =
   (*
     if Mutil.utf_8_db.val then alphabetic_utf_8 n1 n2 else alphabetic_iso_8859_1 n1 n2
@@ -200,7 +201,7 @@ let alphabetic n1 n2 =
   alphabetic_iso_8859_1 n1 n2
 
 let alphabetic_order n1 n2 =
-  if !Mutil.utf_8_db then alphabetic_utf_8 n1 n2 else alphabetic_iso_8859_1 n1 n2
+  alphabetic_utf_8 n1 n2
 
 let arg_list_of_string line =
   let rec loop list i len quote =

--- a/internal/gwuLib.ml
+++ b/internal/gwuLib.ml
@@ -150,10 +150,6 @@ module Make (Select : Select) =
     let isolated = ref false
     let gen_correct_string no_num no_colon s =
       let s = String.trim s in
-      let s =
-        if !(Mutil.utf_8_db) || !raw_output then s
-        else Mutil.utf_8_of_iso_8859_1 s
-      in
       let rec loop i len =
         if i = String.length s then Buff.get len
         else if len = 0 && not (starting_char no_num s) then

--- a/internal/mutil.ml
+++ b/internal/mutil.ml
@@ -3,7 +3,6 @@
 
 let int_size = 4
 let verbose = ref true
-let utf_8_db = Name.utf_8_db
 
 let list_iter_first f = function
   | [] -> ()

--- a/internal/mutil.mli
+++ b/internal/mutil.mli
@@ -3,7 +3,6 @@
 
 val int_size : int
 val verbose : bool ref
-val utf_8_db : bool ref
 
 val list_iter_first : (bool -> 'a -> unit) -> 'a list -> unit
 val tr : char -> char -> string -> string

--- a/internal/name.ml
+++ b/internal/name.ml
@@ -1,8 +1,6 @@
 (* $Id: name.ml,v 5.12 2007-03-20 10:34:14 ddr Exp $ *)
 (* Copyright (c) 1998-2007 INRIA *)
 
-let utf_8_db = ref true
-
 (* La liste des caractères interdits *)
 let forbidden_char = [':'; '@'; '#'; '='; '$']
 
@@ -421,27 +419,20 @@ let unaccent_utf_8 lower s i =
 
 let next_chars_if_equiv s i t j =
   if i >= String.length s || j >= String.length t then None
-  else if !utf_8_db then
+  else
     let (s1, i1) = unaccent_utf_8 true s i in
     let (t1, j1) = unaccent_utf_8 true t j in
     if s1 = t1 then Some (i1, j1) else None
-  else if s.[i] = t.[j] then Some (i + 1, j + 1)
-  else if
-    unaccent_iso_8859_1 (Char.lowercase_ascii s.[i]) =
-      unaccent_iso_8859_1 (Char.lowercase_ascii t.[j])
-  then
-    Some (i + 1, j + 1)
-  else None
 
 let lower s =
   let rec copy special i len =
     if i = String.length s then Buff.get len
-    else if not !utf_8_db || Char.code s.[i] < 0x80 then
+    else if Char.code s.[i] < 0x80 then
       match s.[i] with
-        'a'..'z' | 'A'..'Z' | 'à'..'ÿ' | 'À'..'Ý' | '0'..'9' | '.' as c ->
-          let len = if special then Buff.store len ' ' else len in
-          let c = unaccent_iso_8859_1 (Char.lowercase_ascii c) in
-          copy false (i + 1) (Buff.store len c)
+      | 'a'..'z' | 'A'..'Z' | 'à'..'ÿ' | 'À'..'Ý' | '0'..'9' | '.' as c ->
+        let len = if special then Buff.store len ' ' else len in
+        let c = unaccent_iso_8859_1 (Char.lowercase_ascii c) in
+        copy false (i + 1) (Buff.store len c)
       | _ -> copy (len <> 0) (i + 1) len
     else
       let len = if special then Buff.store len ' ' else len in
@@ -550,7 +541,7 @@ let crush s =
               in
               copy (i + 1) len first_vowel
           | 's' | 'z'
-            when !utf_8_db && (i = String.length s - 1 || s.[i+1] = ' ') ->
+            when (i = String.length s - 1 || s.[i+1] = ' ') ->
               let len =
                 let rec loop i len =
                   if i > 0 && len > 0 && s.[i] = Bytes.get !(Buff.buff) len &&

--- a/internal/name.mli
+++ b/internal/name.mli
@@ -44,6 +44,4 @@ val next_chars_if_equiv : string -> int -> string -> int -> (int * int) option
 val unaccent_utf_8 : bool -> string -> int -> string * int
 val nbc : char -> int
 
-val utf_8_db : bool ref
-
 val forbidden_char : char list

--- a/internal/notes.ml
+++ b/internal/notes.ml
@@ -485,7 +485,7 @@ let begin_text_without_html_tags lim s =
       loop i size len
     else if s.[i] = '=' then loop (i + 1) size len
     else
-      let nbc = if !Mutil.utf_8_db then Name.nbc s.[i] else i + 1 in
+      let nbc = Name.nbc s.[i] in
       loop (i + nbc) (size + 1) (Buff.mstore len (String.sub s i nbc))
   in
   loop 0 0 0

--- a/internal/outbase.ml
+++ b/internal/outbase.ml
@@ -286,8 +286,7 @@ let gen_output no_patches bname base =
     if epos <> pos_out oc then count_error epos (pos_out oc)
   in
   begin try
-    output_string oc
-      (if !Mutil.utf_8_db then Dutil.magic_gwb else Dutil.magic_gwb_iso_8859_1);
+    output_string oc Dutil.magic_gwb;
     output_binary_int oc base.data.persons.len;
     output_binary_int oc base.data.families.len;
     output_binary_int oc base.data.strings.len;

--- a/internal/srcfile.ml
+++ b/internal/srcfile.ml
@@ -568,10 +568,7 @@ let print conf base fname =
 
 let print_lexicon conf _base =
   let title _ = Wserver.printf "Lexicon" in
-  let fname =
-    let f = if !(Mutil.utf_8_db) then "lex_utf8.txt" else "lexicon.txt" in
-    search_in_lang_path (Filename.concat "lang" f)
-  in
+  let fname = search_in_lang_path (Filename.concat "lang" "lex_utf8.txt") in
   Hutil.header conf title;
   begin match (try Some (Secure.open_in fname) with Sys_error _ -> None) with
     Some ic ->

--- a/internal/util.ml
+++ b/internal/util.ml
@@ -1009,10 +1009,18 @@ let start_with2 s i p =
 let get_particle base s =
   let rec loop =
     function
-      part :: parts -> if start_with2 s 0 part then part else loop parts
+    | hd :: _ when start_with2 (Name.lower s) 0 (Name.lower hd ^ " ") -> hd
+    | _ :: tl -> loop tl
     | [] -> ""
   in
-  loop (base_particles base)
+  loop (Gwdb.base_particles base)
+
+let name_key base s =
+  let part = get_particle base s in
+  if part = "" then s
+  else
+    let i = String.length part in
+    String.sub s i (String.length s - i) ^ " " ^ String.sub s 0 i
 
 let surname_begin base s =
   let part = get_particle base s in

--- a/internal/util.ml
+++ b/internal/util.ml
@@ -70,17 +70,6 @@ let amp_capitalize capitale s =
         String.sub s 2 (String.length s - 2)
     | _ -> s
 
-let rec capitale_iso_8859_1 s =
-  if String.length s = 0 then ""
-  else
-    match s.[0] with
-      'a'..'z' | '\224'..'\246' | '\248'..'\253' ->
-        String.make 1
-          (Char.chr (Char.code s.[0] - Char.code 'a' + Char.code 'A')) ^
-        String.sub s 1 (String.length s - 1)
-    | '&' -> amp_capitalize capitale_iso_8859_1 s
-    | _ -> s
-
 let rec capitale_utf_8 s =
   if String.length s = 0 then ""
   else
@@ -122,13 +111,9 @@ let rec capitale_utf_8 s =
       | _ -> s
 
 let index_of_next_char s i =
-  if !Mutil.utf_8_db then
-    min (String.length s) (i + max 1 (Name.nbc s.[i]))
-  else i + 1
+  min (String.length s) (i + max 1 (Name.nbc s.[i]))
 
-let capitale s =
-  if !Mutil.utf_8_db then capitale_utf_8 s
-  else capitale_iso_8859_1 s
+let capitale s = capitale_utf_8 s
 
 type ('a, 'b) format2 = ('a, unit, string, 'b) format4
 
@@ -2697,7 +2682,7 @@ let has_image conf base p =
 let gen_only_printable or_nl s =
   let s' =
     let conv_char i =
-      if !(Mutil.utf_8_db) && Char.code s.[i] > 127 then s.[i]
+      if Char.code s.[i] > 127 then s.[i]
       else
         match s.[i] with
           ' '..'~' | '\160'..'\255' -> s.[i]

--- a/internal/util.mli
+++ b/internal/util.mli
@@ -305,3 +305,7 @@ val array_mem_witn
 
 (* Print a date using "%4d-%02d-%02d %02d:%02d:%02d" format *)
 val fprintf_date : out_channel -> Unix.tm -> unit
+
+(* [name_key base name] is [name],
+   with particles put at the end of the string instead of the beginning *)
+val name_key : Gwdb.base -> string -> string

--- a/lib/alln.ml
+++ b/lib/alln.ml
@@ -82,15 +82,6 @@ let alphab_string base is_surname s =
     surname_end base s ^ surname_begin base s
   else s
 
-let new_name_key base s =
-  let part = Util.get_particle base s in
-  if part = "" then s
-  else
-    let i = String.length part in
-    String.sub s i (String.length s - i) ^ " " ^ String.sub s 0 i
-
-let name_key_compatible base s = new_name_key base s
-
 (* print *)
 
 let print_title conf base is_surnames ini len =
@@ -298,7 +289,7 @@ let select_names conf base is_surnames ini need_whole_list =
       let istr = spi_first iii start_k in
         let rec loop istr len list =
           let s = Mutil.nominative (sou base istr) in
-          let k = name_key_compatible base s in
+          let k = Util.name_key base s in
           if string_start_with ini k then
             let (list, len) =
               if s <> "?" then

--- a/lib/api_search.ml
+++ b/lib/api_search.ml
@@ -50,30 +50,6 @@ let kmp p s =
       if !j >= m then true else false
     end
 
-let new_name_key base s =
-  let start_with2 s i p =
-    i + String.length p <= String.length s &&
-    String.sub s i (String.length p) = p
-  in
-  let parts =
-    List.filter
-      (fun p -> start_with2 (Name.lower s) 0 (Name.lower p ^ " "))
-      (Gwdb.base_particles base)
-  in
-  let part =
-    (function
-      | [] -> ""
-      | x :: _ -> x) parts
-  in
-  let i = String.length part in
-  if part = "" || i > String.length s then s
-  else
-    String.sub s i (String.length s - i) ^ " " ^ String.sub s 0 i
-
-
-let name_key_compatible base s = new_name_key base s
-
-
 (* FIXME: DUPLICATE OF ALLN.SELECT ??? *)
 (* ************************************************************************** *)
 (*  [Fonc] get_list_of_select_start_with :
@@ -107,7 +83,7 @@ let get_list_of_select_start_with conf base ini_n ini_p need_whole_list letter =
       let istr = spi_first name letter in
         let rec loop istr list =
           let s = Mutil.nominative (sou base istr) in
-          let k = name_key_compatible base s in
+          let k = Util.name_key base s in
             (* Vérifie que le début du nom de famille de la personne correspond à celui demandé *)
             if "" = ini_n || string_start_with (Name.lower ini_n) (Name.lower k) then
               let list =
@@ -189,7 +165,7 @@ let get_list_of_select_start_with conf base ini_n ini_p need_whole_list letter =
                                                                               *)
 (* ************************************************************************** *)
 let select_start_with conf base ini_n ini_p need_whole_list =
-  let ini_n = name_key_compatible base ini_n in
+  let ini_n = Util.name_key base ini_n in
   let start =
     if ini_n <> ""
     then
@@ -212,7 +188,7 @@ let select_both_all base ini_n ini_p maiden_name =
   let find_sn p x = kmp x (sou base (get_surname p)) in
   let find_fn p x = kmp x (sou base (get_first_name p)) in
   let find_str s x = kmp x s in
-  let ini_n = name_key_compatible base ini_n in
+  let ini_n = Util.name_key base ini_n in
   let ini_n = code_varenv ini_n in
   let ini_n =
     let rec loop s acc =
@@ -302,7 +278,7 @@ let select_all base is_surnames ini =
     else kmp x (sou base (get_first_name p))
   in
   let ini =
-    if is_surnames then name_key_compatible base ini
+    if is_surnames then Util.name_key base ini
     else ini
   in
   let ini = code_varenv ini in
@@ -545,7 +521,7 @@ let select_start_with_auto_complete base mode max_res ini =
       (* majuscule *)
       let ini =
         match mode with
-        | `lastname -> name_key_compatible base ini
+        | `lastname -> Util.name_key base ini
         | `firstname -> ini
         | `place -> failwith "cannot use select_start_with_auto_complete"
         | `source -> failwith "cannot use select_start_with_auto_complete"
@@ -556,7 +532,7 @@ let select_start_with_auto_complete base mode max_res ini =
       | istr ->
           let rec loop istr =
             let s = sou base istr in
-            let k = name_key_compatible base s in
+            let k = Util.name_key base s in
             if string_start_with (Name.lower ini) (Name.lower k) then
               begin
                 string_set := StrSetAutoComplete.add s !string_set;
@@ -577,7 +553,7 @@ let select_start_with_auto_complete base mode max_res ini =
       if !nb_res < max_res then
         let ini =
           match mode with
-          | `lastname -> name_key_compatible base ini
+          | `lastname -> Util.name_key base ini
           | `firstname -> ini
           | `place -> failwith "cannot use select_start_with_auto_complete"
           | `source -> failwith "cannot use select_start_with_auto_complete"
@@ -588,7 +564,7 @@ let select_start_with_auto_complete base mode max_res ini =
         | istr ->
             let rec loop istr =
               let s = sou base istr in
-              let k = name_key_compatible base s in
+              let k = Util.name_key base s in
               if string_start_with (Name.lower ini) (Name.lower k) then
                 begin
                   string_set := StrSetAutoComplete.add s !string_set;
@@ -616,7 +592,7 @@ let select_start_with_auto_complete base mode max_res ini =
       | istr ->
           let rec loop istr list =
             let s = sou base istr in
-            let k = name_key_compatible base s in
+            let k = Util.name_key base s in
             if string_incl_start_with (Name.lower ini) (Name.lower k) then
               begin
                 string_set := StrSetAutoComplete.add (sou base istr) !string_set;
@@ -929,7 +905,7 @@ let select_both_link_person conf base ini_n ini_p =
   let find_sn p x = kmp x (sou base (get_surname p)) in
   let find_fn p x = kmp x (sou base (get_first_name p)) in
   let find_str s x = kmp x s in
-  let ini_n = name_key_compatible base ini_n in
+  let ini_n = Util.name_key base ini_n in
   let ini_n = code_varenv ini_n in
   let ini_n =
     let rec loop s acc =
@@ -1018,7 +994,7 @@ let select_both_link_person conf base ini_n ini_p =
 let select_both_link_person base ini_n ini_p max_res =
   let find_sn p x = kmp x (sou base (get_surname p)) in
   let find_fn p x = kmp x (sou base (get_first_name p)) in
-  let ini_n = name_key_compatible base ini_n in
+  let ini_n = Util.name_key base ini_n in
   let ini_n = code_varenv ini_n in
   let ini_n =
     let rec loop s acc =
@@ -1124,7 +1100,7 @@ let select_start_with_auto_complete conf base mode get_field max_res ini =
   let need_whole_list = true in
 (*
   let ini =
-    if is_surnames then name_key_compatible base ini
+    if is_surnames then Util.name_key base ini
     else ini
   in
 *)
@@ -1153,7 +1129,7 @@ let select_start_with_auto_complete conf base mode get_field max_res ini =
                   if StrSetAutoComplete.cardinal !string_set < max_res then
                     begin
                       let s = sou base istr in
-                      let k = name_key_compatible base s in
+                      let k = Util.name_key base s in
         (*              if (String.sub k 0 1) = letter then*)
                         if string_incl_start_with (Name.lower ini) (Name.lower k) then
                           begin
@@ -1222,7 +1198,7 @@ let select_start_with_auto_complete conf base mode get_field max_res ini =
                   if StrSetAutoComplete.cardinal !string_set < max_res then
                     begin
                       let s = sou base istr in
-                      let k = name_key_compatible base s in
+                      let k = Util.name_key base s in
         (*              if (String.sub k 0 1) = letter then*)
                         if string_incl_start_with (Name.lower ini) (Name.lower k) then
                           let () =

--- a/lib/api_search.ml
+++ b/lib/api_search.ml
@@ -50,9 +50,6 @@ let kmp p s =
       if !j >= m then true else false
     end
 
-let capitalize_if_not_utf8 s =
-  if !Mutil.utf_8_db then s else String.capitalize_ascii s
-
 let new_name_key base s =
   let start_with2 s i p =
     i + String.length p <= String.length s &&
@@ -74,8 +71,7 @@ let new_name_key base s =
     String.sub s i (String.length s - i) ^ " " ^ String.sub s 0 i
 
 
-let name_key_compatible base s =
-  if !Mutil.utf_8_db then new_name_key base s else Mutil.name_key s
+let name_key_compatible base s = new_name_key base s
 
 
 (* FIXME: DUPLICATE OF ALLN.SELECT ??? *)

--- a/lib/dag.ml
+++ b/lib/dag.ml
@@ -309,9 +309,7 @@ let displayed_next_char s i =
               | _ -> Some (i, j)
           in
           loop1 (i + 1)
-      | c ->
-          if !Mutil.utf_8_db then Some (i, i + max 1 (Name.nbc c))
-          else Some (i, i + 1)
+      | c -> Some (i, i + max 1 (Name.nbc c))
   in
   loop i
 

--- a/lib/forum.ml
+++ b/lib/forum.ml
@@ -204,7 +204,7 @@ let get_var ic lab s =
     String.sub s start (String.length s - start), MF.input_line ic
   else "", s
 
-let size_of_char s i = if !(Mutil.utf_8_db) then max 1 (Name.nbc s.[i]) else 1
+let size_of_char s i = max 1 (Name.nbc s.[i])
 
 let string_length s i =
   let rec loop i =

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -433,17 +433,6 @@ let treat_request conf base =
 let treat_request_on_possibly_locked_base conf bfile =
   match try Left (Gwdb.open_base bfile) with e -> Right e with
     Left base ->
-      if !(Mutil.utf_8_db) then ()
-      else
-        begin
-          Hashtbl.clear conf.lexicon;
-          let fname = Filename.concat "lang" "lexicon.txt" in
-          Mutil.input_lexicon conf.lang conf.lexicon
-            (fun () -> Secure.open_in (Util.search_in_lang_path fname));
-          conf.charset <-
-            try Hashtbl.find conf.lexicon " !charset" with
-              Not_found -> "iso-8859-1"
-        end;
       (try treat_request conf base with exc -> close_base base; raise exc);
       close_base base
   | Right e ->
@@ -501,17 +490,6 @@ let treat_request_on_base conf =
   else treat_request_on_possibly_locked_base conf bfile
 
 let treat_request_on_nobase conf =
-  if !(Mutil.utf_8_db) then ()
-  else
-    begin
-      Hashtbl.clear conf.lexicon;
-      let fname = Filename.concat "lang" "lexicon.txt" in
-      Mutil.input_lexicon conf.lang conf.lexicon
-        (fun () -> Secure.open_in (Util.search_in_lang_path fname));
-      conf.charset <-
-        try Hashtbl.find conf.lexicon " !charset" with
-          Not_found -> "iso-8859-1"
-    end;
   try family_m_nobase conf; Wserver.wflush () with exc -> raise exc
 
 

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -209,10 +209,9 @@ let print_elem conf base is_surname (p, xl) =
 let first_char s =
   (* Si la personne n'a pas de prénom/nom, on renvoie '?' *)
   if s = "" then "?"
-  else if !(Mutil.utf_8_db) then
+  else
     let len = Name.nbc s.[0] in
     if len < String.length s then String.sub s 0 len else s
-  else String.sub s (Mutil.initial s) 1
 
 let name_unaccent s =
   let rec copy i len =
@@ -327,7 +326,7 @@ let persons_of_absolute_first_name conf base x =
 
 let first_name_print conf base x =
   let (list, _) =
-    if !(Mutil.utf_8_db) && p_getenv conf.env "t" = Some "A" then
+    if p_getenv conf.env "t" = Some "A" then
       persons_of_absolute_first_name conf base x,
       (fun _ -> raise (Match_failure ("src/some.ml", 347, 51)))
     else if x = "" then
@@ -402,8 +401,7 @@ let unselected_bullets conf =
        try if k = "u" then int_of_string v :: sl else sl with Failure _ -> sl)
     [] conf.env
 
-let alphabetic1 n1 n2 =
-  if !Mutil.utf_8_db then Gutil.alphabetic_utf_8 n1 n2 else Gutil.alphabetic n1 n2
+let alphabetic1 n1 n2 = Gutil.alphabetic_utf_8 n1 n2
 
 type 'a branch_head = { bh_ancestor : 'a; bh_well_named_ancestors : 'a list }
 
@@ -790,7 +788,7 @@ module PerSet = Set.Make (struct type t = iper let compare = compare end)
 
 let surname_print conf base not_found_fun x =
   let (list, name_inj) =
-    if !(Mutil.utf_8_db) && p_getenv conf.env "t" = Some "A" then
+    if p_getenv conf.env "t" = Some "A" then
       persons_of_absolute_surname conf base x, (fun x -> x)
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 825, 29)))
@@ -860,7 +858,7 @@ let surname_print conf base not_found_fun x =
 
 let search_surname conf base x =
   let (list, name_inj) =
-    if !(Mutil.utf_8_db) && p_getenv conf.env "t" = Some "A" then
+    if p_getenv conf.env "t" = Some "A" then
       persons_of_absolute_surname conf base x, (fun x -> x)
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 896, 29)))
@@ -905,7 +903,7 @@ let search_surname conf base x =
 
 let search_surname_print conf base not_found_fun x =
   let (list, name_inj) =
-    if !(Mutil.utf_8_db) && p_getenv conf.env "t" = Some "A" then
+    if p_getenv conf.env "t" = Some "A" then
       persons_of_absolute_surname conf base x, (fun x -> x)
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 942, 29)))
@@ -970,7 +968,7 @@ let search_surname_print conf base not_found_fun x =
 
 let search_first_name conf base x =
   let (list, _) =
-    if !(Mutil.utf_8_db) && p_getenv conf.env "t" = Some "A" then
+    if p_getenv conf.env "t" = Some "A" then
       persons_of_absolute_first_name conf base x,
       (fun _ -> raise (Match_failure ("src/some.ml", 1007, 51)))
     else if x = "" then
@@ -989,7 +987,7 @@ let search_first_name conf base x =
 
 let search_first_name_print conf base x =
   let (list, _) =
-    if !(Mutil.utf_8_db) && p_getenv conf.env "t" = Some "A" then
+    if p_getenv conf.env "t" = Some "A" then
       persons_of_absolute_first_name conf base x,
       (fun _ -> raise (Match_failure ("src/some.ml", 1025, 51)))
     else if x = "" then


### PR DESCRIPTION
Because we are in 2018, and it was on the geneweb roadmap.
Fix https://github.com/geneweb/geneweb/issues/658