### PR TITLE
New PR for the old geneweb 6 (distrib-6-08-ocaml-4-xx)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: required
+
+language: c
+
+os:
+  - linux
+  - osx
+
+env:
+  - OCAML_VERSION=4.02 OPAM_VERSION=2.0.0
+  - OCAML_VERSION=4.05 OPAM_VERSION=2.0.0
+  - OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - os: osx
+      env: OCAML_VERSION=4.07 OPAM_VERSION=2.0.0
+
+# Needed until `opam depext geneweb` is fixed
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install protobuf ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq protobuf-compiler ; fi
+
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-ocaml.sh
+
+script:
+  - bash -ex .travis-ocaml.sh ;
+    set -ex ;
+    export OPAMYES=1 ;
+    eval $(opam config env) ;
+    opam install camlp5 ocamlfind ;
+    ./configure ;
+    make && make distrib && make clean ;
+
+after_failure:
+  - cat ~/.opam/log/*.out

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# Not building with API because piqi does not compile on windows
+
+platform:
+  - x86
+
+environment:
+  CYG_ROOT: C:/cygwin
+  CYG_BASH: '%CYG_ROOT%/bin/bash -lc'
+
+install:
+  - '%CYG_ROOT%\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P unzip -P m4 -P mingw64-x86_64-gcc-core -P mingw64-x86_64-gtk2.0'
+  - '%CYG_BASH% "curl -fsSL -o opam64.tar.xz https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam64.tar.xz"'
+  - '%CYG_BASH% "tar -xf opam64.tar.xz"'
+  - '%CYG_BASH% "opam64/install.sh"'
+  - '%CYG_BASH% "opam init -a mingw https://github.com/fdopen/opam-repository-mingw.git --comp 4.05.0+mingw64c --switch 4.05.0+mingw64c"'
+  - '%CYG_BASH% "eval `opam config env`"'
+  - '%CYG_BASH% "opam install -y depext depext-cygwinports"'
+  - 'set PATH=%PATH%;/usr/x86_64-w64-mingw32/sys-root/mingw/bin'
+  - 'set OPAMYES=1'
+  - '%CYG_BASH% "opam install camlp5 ocamlfind"'
+
+build_script:
+  - '%CYG_BASH% "cd ${APPVEYOR_BUILD_FOLDER} && ./configure && make && make distrib && make clean"'

--- a/gui/gui.ml
+++ b/gui/gui.ml
@@ -90,9 +90,9 @@ value channel_redirector channel callback = do {
     do { fun cond ->
       try
         if List.mem `IN cond then do {
-	        (* On Windows, you must use Io.read *)
-	        let len = GMain.Io.read chan ~buf ~pos:0 ~len in
-	        len >= 1 && (callback (String.sub buf 0 len))
+          (* On Windows, you must use Io.read *)
+          let len = GMain.Io.read chan ~buf ~pos:0 ~len in
+          len >= 1 && (callback (Bytes.sub buf 0 len))
         }
         else False
       with [ _ -> False ]
@@ -130,7 +130,8 @@ value exec_wait conf prog args =
     let redirect channel =
       let buffer = GText.buffer () in
       let _text = GText.view ~buffer ~editable:False ~packing:vvbox#add () in
-      channel_redirector channel (fun c -> do {buffer#insert c; True})
+      channel_redirector channel
+        (fun c -> do {buffer#insert (Bytes.to_string c); True})
     in
     ignore (redirect Unix.stderr);
     let pid = exec prog args Unix.stdout Unix.stderr in


### PR DESCRIPTION
gui/gui.ml : Fix compilation problem with OCAML >=4.06.0 (geneweb 6)
Provide basic .travis.yml and appveyor.yml files for geneweb 6  (no more red X on Github)
