### PR TITLE
Better version of a_of_b2 that tests start_with_vowel on 3rd parameter

### DIFF
--- a/hd/etc/modules/chronologie.txt
+++ b/hd/etc/modules/chronologie.txt
@@ -394,12 +394,17 @@
       %and;%apply;dprec("event_witness_relation.event.date")%nn;
       %and;%count2;
       %and;%if;(event_witness_relation.event.date!="")%event_witness_relation.event.date;%else;([missing date]0)%end;%nn;
-      %and;%apply;a_of_b%with;%apply;a_of_b%with;%event_witness_relation_kind;%and;
-        %sp;%event_witness_relation.event.name;%end;%and;
-          %apply;short_display_person("event_witness_relation.person")%sp;
-          %if;(event_witness_relation.event.spouse != "")
-            %sp;[and]%sp;%apply;short_display_person("event_witness_relation.event.spouse")%nn;
-          %end;%end;%nn;
+      %and;%nn;
+        %apply;a_of_b%with;
+          %apply;a_of_b%with;
+            %event_witness_relation_kind;
+            %and;%event_witness_relation.event.name;
+          %end;
+          %and;%apply;short_display_person("event_witness_relation.person")%sp;
+            %if;(event_witness_relation.event.spouse != "")
+              %sp;[and]%sp;%apply;short_display_person("event_witness_relation.event.spouse")%nn;
+            %end;
+        %end;%nn;
       %and;%nn;
       %and;%nn;
       %and;%nn;

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -380,10 +380,10 @@ eo: %1 de %2
 es: %1 de %2
 et: :g:%2 %1
 fi: :g:%2 %1
-fr: %1 d[e']%2
+fr: %1 d[e |’]%2
 he: %1 של %2
 is: %1 %2
-it: %1 d[i']%2
+it: %1 d[i |']%2
 lv: %1 -> %2
 nl: %1 van %2
 no: %1 til %2/%1 av %2
@@ -828,7 +828,7 @@ af: 1 %m %y/%d %m %y/%m %y/%y
 ar: 1 %m %y/%d %m %y/%m %y/%y
 bg: 1 %m %y/%d %m %y/%m %y/%y
 br: 1añ %m %y/%d %m %y/%m %y/%y
-ca: 1 d[e']%m de %y/%d d[e']%m de %y/%m de %y/%y
+ca: 1 d[e |']%m de %y/%d d[e |']%m de %y/%m de %y/%y
 co: 1<sup>u</sup> d[i']%m %y/%d d[i']%m %y/d[i']%m %y/in u %y
 cs: 1. %m %y/%d. %m %y/%m %y/%y
 da: 1. %m %y/%d. %m %y/%m %y/%y
@@ -845,7 +845,7 @@ it: 1º %m %y/%d %m %y/%m %y/%y
 lv: 1. %m %y/%y.gada %d.%m/%y %m/%y
 nl: 1 %m %y/%d %m %y/%m %y/%y
 no: 1. %m %y/%d. %m %y/%m %y/%y
-oc: 1<sup>èr</sup> d[e']%m de %y/%d d[e']%m de %y/%m de %y/%y
+oc: 1<sup>èr</sup> d[e |']%m de %y/%d d[e |']%m de %y/%m de %y/%y
 pl: 1 %m %y/%d %m %y/%m %y/%y
 pt: 1 de %m de %y/%d de %m de %y/%m %y/%y
 ro: 1 %m %y/%d. %m %y/%m %y/%y

--- a/internal/util.mli
+++ b/internal/util.mli
@@ -156,6 +156,7 @@ val transl : config -> string -> string
 val transl_nth : config -> string -> int -> string
 val transl_decline : config -> string -> string -> string
 val transl_a_of_b : config -> string -> string -> string
+val transl_a_of_b2 : config -> string -> string -> string -> string
 val transl_a_of_gr_eq_gen_lev : config -> string -> string -> string
 val ftransl : config -> ('a, 'b) format2 -> ('a, 'b) format2
 val ftransl_nth : config -> ('a, 'b) format2 -> int -> ('a, 'b) format2

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -5953,6 +5953,7 @@ let eval_predefined_apply conf env f vl =
   in
   match f, vl with
     "a_of_b", [s1; s2] -> Util.translate_eval (transl_a_of_b conf s1 s2)
+  | "a_of_b2", [s1; s2; s3] -> Util.translate_eval (transl_a_of_b2 conf s1 s2 s3)
   | "a_of_b_gr_eq_lev", [s1; s2] ->
       Util.translate_eval (transl_a_of_gr_eq_gen_lev conf s1 s2)
   | "add_in_sorted_list", sl ->


### PR DESCRIPTION
[aaa|bbb] syntax allows for more complex substitutions such as fr: [au |à l']

a_to_b2 takes 3 parameters, and the test start_with_vowel is taken on the third param. Handles correctly cases where the second parameter is decorated with html tags <em>Firstname Lastname</em>

start_with_vowel corrected to handle accented characters 