### PR TITLE
Protect bash in gwd and gwsetup with quotes (for GW6, in branch distrib-6-08-ocaml-4-xx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,12 @@ wrappers:
 	  echo -ne 'start /MIN ..\\gw\\gwsetup -lang fr -gd ..\\gw\r\n' >> $(DESTDIR)/gwsetup.bat; \
 	else \
 	  (echo '#!/bin/sh'; \
-	   echo 'cd `dirname $$0`'; \
+	   echo 'cd `dirname "$$0"`'; \
 	   echo 'mkdir -p bases'; \
 	   echo 'cd bases'; \
 	   echo 'exec ../gw/gwd -hd ../gw "$$@"') > $(DESTDIR)/gwd; \
 	  (echo '#!/bin/sh'; \
-	   echo 'cd `dirname $$0`'; \
+	   echo 'cd `dirname "$$0"`'; \
 	   echo 'mkdir -p bases'; \
 	   echo 'cd bases'; \
 	   echo 'exec ../gw/gwsetup -gd ../gw "$$@"') > $(DESTDIR)/gwsetup; \


### PR DESCRIPTION
To allow spaces in filenames

Backported from master branch : 9d893d4a0b994025681b70c3a2d5040bdc78e5f1

See also : 4c0c79a27f87e817168215c078aca27387a463fb