### PR TITLE
Mutil.start_with, Util.{groupby,str_replace,str_sub}, Alln

### DIFF
--- a/contrib/lex/dune
+++ b/contrib/lex/dune
@@ -1,5 +1,5 @@
 (executable
  (name lex_utils)
- (libraries str)
+ (libraries str geneweb.internal)
 )
 

--- a/contrib/lex/lex_utils.ml
+++ b/contrib/lex/lex_utils.ml
@@ -3,15 +3,10 @@
 
 (**/**) (* Utils. *)
 
-let start_with s p =
-  String.length p <= String.length s &&
-    String.sub s 0 (String.length p) = p
-;;
-
 let skip_to_next_message ic =
   let rec loop () =
     let line = input_line ic in
-    if start_with line "    " then line else loop ()
+    if Mutil.start_with "    " 0 line then line else loop ()
   in loop ()
 ;;
 
@@ -168,7 +163,7 @@ let cut_all_msg s =
       in
       let not_msg =
         List.exists
-          (fun x -> start_with w x)
+          (fun x -> Mutil.start_with x 0 w)
           ["type="; "value="; "name="; "id="]
       in
       if not_msg then ()

--- a/contrib/oneshot/gwRemoveImgGallery.ml
+++ b/contrib/oneshot/gwRemoveImgGallery.ml
@@ -6,7 +6,7 @@ open Gwdb
 
 let image_start_with_gallery img =
   let gallery = "http://www.geneanet.org/gallery/" in
-  Mutil.start_with gallery img
+  Mutil.start_with gallery 0 img
 
 let remove_image_everybody bname trace =
   let base = Gwdb.open_base bname in

--- a/internal/mutil.ml
+++ b/internal/mutil.ml
@@ -173,7 +173,7 @@ let tr c1 c2 s =
   | Some _ ->
     String.init
       (String.length s)
-      (fun i -> if String.unsafe_get s i = c1 then c2 else s.[i])
+      (fun i -> let c = String.unsafe_get s i in if c = c1 then c2 else c)
   | None -> s
 
 let utf_8_of_iso_8859_1 str =

--- a/internal/mutil.mli
+++ b/internal/mutil.mli
@@ -30,8 +30,6 @@ val iso_8859_1_of_utf_8 : string -> string
 val roman_of_arabian : int -> string
 val arabian_of_roman : string -> int
 
-val start_with : string -> string -> bool
-
 val compare_after_particle : string list -> string -> string -> int
 
 val input_lexicon :
@@ -46,3 +44,24 @@ module StrSet : Set.S with type elt = string
     so if [fn] have side effects it may not behave as excepted.
  *)
 val array_to_list_map : ('a -> 'b) -> 'a array -> 'b list
+
+(** [start_with ?wildcard prefix off str]
+    Test if [str] starts with [prefix] (at offset [off]).
+    If [wildcard] is set to [true], occurences of ['_'] in [prefix]
+    will match both ['_'] and [' '] in [str] and trailing ['_'] of [prefix]
+    is treated as an optional ['_'] [' '].
+
+    Raise [Invalid_argument] if [off] is not a valid index in [str].
+*)
+val start_with : ?wildcard:bool -> string -> int -> string -> bool
+
+(** [contains ?wildcard str sub] Test [sub] is contained in [str].
+    See {!val:start_with} for details about [wildcard]
+    (with [sub] in the role of [prefix]).
+*)
+val contains : ?wildcard:bool -> string -> string -> bool
+
+(** [get_particle particles name]
+    Return [p] where [p] is in [particles] and is prefix of [name].
+    If no such [p] exists, empty string [""] is returned. *)
+val get_particle : string list -> string -> string

--- a/internal/templ.camlp5
+++ b/internal/templ.camlp5
@@ -32,15 +32,6 @@ type loc_token =
 
 exception Exc_located of loc * exn
 
-let is_substr substr str =
-  let str_len = String.length str in
-  let rec loop i =
-    if i = str_len then false
-    else if Mutil.start_with substr (String.sub str i (str_len - i)) then true
-    else loop (i + 1)
-  in
-  loop 0
-
 let raise_with_loc loc exc =
   match exc with
     Exc_located (_, _) -> raise exc
@@ -1049,7 +1040,7 @@ let rec eval_expr (conf, eval_var, eval_apply as ceva) =
       begin match op with
         "and" -> VVbool (if bool e1 then bool e2 else false)
       | "or" -> VVbool (if bool e1 then true else bool e2)
-      | "is_substr" -> VVbool (is_substr (string e2) (string e1))
+      | "is_substr" -> VVbool (Mutil.contains (string e1) (string e2))
       | "=" -> VVbool (eval_expr ceva e1 = eval_expr ceva e2)
       | "<" -> VVbool (int e1 < int e2)
       | ">" -> VVbool (int e1 > int e2)

--- a/internal/util.ml
+++ b/internal/util.ml
@@ -1005,39 +1005,22 @@ let old_surname_end n =
   let i = Mutil.initial n in
   if i = 0 then n else String.sub n i (String.length n - i)
 
-let start_with s i p =
-  i + String.length p <= String.length s &&
-  String.lowercase_ascii (String.sub s i (String.length p)) = p
-
-let start_with2 s i p =
-  i + String.length p <= String.length s &&
-  String.sub s i (String.length p) = p
-
-let get_particle base s =
-  let rec loop =
-    function
-    | hd :: _ when start_with2 (Name.lower s) 0 (Name.lower hd ^ " ") -> hd
-    | _ :: tl -> loop tl
-    | [] -> ""
-  in
-  loop (Gwdb.base_particles base)
-
 let name_key base s =
-  let part = get_particle base s in
+  let part = Mutil.get_particle (Gwdb.base_particles base) s in
   if part = "" then s
   else
     let i = String.length part in
     String.sub s i (String.length s - i) ^ " " ^ String.sub s 0 i
 
 let surname_begin base s =
-  let part = get_particle base s in
+  let part = Mutil.get_particle (Gwdb.base_particles base) s in
   let len = String.length part in
   if len = 0 then ""
   else if part.[len-1] = ' ' then " (" ^ String.sub part 0 (len - 1) ^ ")"
   else " (" ^ part ^ ")"
 
 let surname_end base s =
-  let part_len = String.length (get_particle base s) in
+  let part_len = String.length (Mutil.get_particle (Gwdb.base_particles base) s) in
   String.sub s part_len (String.length s - part_len)
 
 let rec skip_spaces s i =
@@ -1435,6 +1418,10 @@ let doctype conf =
        \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">"
 
 let http_string s i =
+  let start_with s i p =
+    i + String.length p <= String.length s &&
+    String.lowercase_ascii (String.sub s i (String.length p)) = p
+  in
   let http = "http://" in
   let https = "https://" in
   let (http, start_with_http) =
@@ -1619,6 +1606,10 @@ let expand_env =
     | _ -> s
 
 let string_with_macros conf env s =
+  let start_with s i p =
+    i + String.length p <= String.length s &&
+    String.lowercase_ascii (String.sub s i (String.length p)) = p
+  in
   let buff = Buffer.create 1000 in
   let rec loop tt i =
     if i < String.length s then

--- a/internal/util.mli
+++ b/internal/util.mli
@@ -294,7 +294,8 @@ val patch_cache_info : config -> string -> (string -> string) -> unit
 val real_nb_of_persons : config -> base -> int
 
 (** [array_mem_witn conf base ip array] checks if [ip] is in [array]
-    and returns corresponding [string_of_witness_kind] if so.  *)
+    and returns corresponding [string_of_witness_kind] if so.
+*)
 val array_mem_witn
  : Config.config
  -> Gwdb.base
@@ -306,18 +307,44 @@ val array_mem_witn
 val fprintf_date : out_channel -> Unix.tm -> unit
 
 (** [name_key base name] is [name],
-    with particles put at the end of the string instead of the beginning. *)
+    with particles put at the end of the string instead of the beginning.
+*)
 val name_key : Gwdb.base -> string -> string
 
 (** [nb_char_occ c s] return the number of times [c] appears in [s]. *)
 val nb_char_occ : char -> string -> int
 
 (** [filter_map fn list] is a combination of map and filter.
-    Not tail-recursive. *)
+    Not tail-recursive.
+*)
 val filter_map : ('a -> 'b option) -> 'a list -> 'b list
 
 (** [rev_iter fn list] is like [List.iter fn (List.rev list)].
-    Not tail-recursive. *)
+    Not tail-recursive.
+*)
 val rev_iter : ('a -> unit) -> 'a list -> unit
 
+(** [print_version_commit]
+    Print geneweb version and commit number on stdout and exit.
+*)
 val print_version_commit : unit -> unit
+
+(** [group_by ~key ~value list]
+    Group the elements returning the same key together.
+    Ordering of elements is unspecified.
+ *)
+val groupby : key:('a -> 'k) -> value:('a -> 'v) -> 'a list -> ('k * 'v list) list
+
+(** [str_replace ?unsafe c ~by str]
+    Return a new string which is the same as [str] with all occurences of [c]
+    replaced by [by].
+    If [str] does not contain [c]. [str] is returned intouched.
+
+    If [unsafe] is set to true, [str] is modified instead of a copy of [str].
+ *)
+val str_replace : ?unsafe:bool -> char -> by:char -> string -> string
+
+(** [str_sub ?pad s start len]
+    Return a fresh UTF8-friendly substring of [len] characters, padded if needed.
+*)
+val str_sub : ?pad:char -> string -> int -> int -> string

--- a/internal/util.mli
+++ b/internal/util.mli
@@ -136,7 +136,6 @@ val hexa_string : string -> string
 
 val surname_begin : base -> string -> string
 val surname_end : base -> string -> string
-val get_particle : base -> string -> string
 val old_surname_begin : string -> string
 val old_surname_end : string -> string
 
@@ -228,8 +227,6 @@ val has_nephews_or_nieces : config -> base -> person -> bool
 
 val browser_doesnt_have_tables : config -> bool
 
-val start_with : string -> int -> string -> bool
-
 val doctype : config -> string
 
 val begin_centered : config -> unit
@@ -296,8 +293,8 @@ val patch_cache_info : config -> string -> (string -> string) -> unit
 
 val real_nb_of_persons : config -> base -> int
 
-(* [array_mem_witn conf base ip array] checks if [ip] is in [array]
-   and returns corresponding [string_of_witness_kind] if so.  *)
+(** [array_mem_witn conf base ip array] checks if [ip] is in [array]
+    and returns corresponding [string_of_witness_kind] if so.  *)
 val array_mem_witn
  : Config.config
  -> Gwdb.base
@@ -305,22 +302,22 @@ val array_mem_witn
  -> (Def.iper * Def.witness_kind) array
  -> bool * string
 
-(* Print a date using "%4d-%02d-%02d %02d:%02d:%02d" format. *)
+(** Print a date using "%4d-%02d-%02d %02d:%02d:%02d" format. *)
 val fprintf_date : out_channel -> Unix.tm -> unit
 
-(* [name_key base name] is [name],
-   with particles put at the end of the string instead of the beginning. *)
+(** [name_key base name] is [name],
+    with particles put at the end of the string instead of the beginning. *)
 val name_key : Gwdb.base -> string -> string
 
-(* [nb_char_occ c s] return the number of times [c] appears in [s]. *)
+(** [nb_char_occ c s] return the number of times [c] appears in [s]. *)
 val nb_char_occ : char -> string -> int
 
-(* [filter_map fn list] is a combination of map and filter.
-   Not tail-recursive. *)
+(** [filter_map fn list] is a combination of map and filter.
+    Not tail-recursive. *)
 val filter_map : ('a -> 'b option) -> 'a list -> 'b list
 
-(* [rev_iter fn list] is like [List.iter fn (List.rev list)].
-   Not tail-recursive. *)
+(** [rev_iter fn list] is like [List.iter fn (List.rev list)].
+    Not tail-recursive. *)
 val rev_iter : ('a -> unit) -> 'a list -> unit
 
 val print_version_commit : unit -> unit

--- a/lib/alln.ml
+++ b/lib/alln.ml
@@ -9,23 +9,6 @@ let default_max_cnt = 2000
 
 (* tools *)
 
-let string_start_with ini s =
-  let l1 = String.length ini in
-  let l2 = String.length s in
-  let rec loop i1 i2 =
-    if i1 = l1 then true
-    else if i2 = l2
-    then
-      if String.unsafe_get ini i1 = '_'
-      then loop (i1 + 1) i2 else false
-    else if String.unsafe_get s i2 = String.unsafe_get ini i1
-         || String.unsafe_get s i2 = ' '
-            && String.unsafe_get ini i1 = '_'
-    then loop (i1 + 1) (i2 + 1)
-    else false
-  in
-  loop 0 0
-
 let combine_by_ini ini list =
   let list =
     let rec loop new_list =
@@ -290,7 +273,7 @@ let select_names conf base is_surnames ini need_whole_list =
         let rec loop istr len list =
           let s = Mutil.nominative (sou base istr) in
           let k = Util.name_key base s in
-          if string_start_with ini k then
+          if Mutil.start_with ~wildcard:true ini 0 k then
             let (list, len) =
               if s <> "?" then
                 let my_list = spi_find iii istr in

--- a/lib/gwDaemon.ml
+++ b/lib/gwDaemon.ml
@@ -733,10 +733,6 @@ let allowed_titles env =
 
 let denied_titles = allowed_denied_titles "denied_titles_file" ""
 
-let start_with s i p =
-  i + String.length p <= String.length s &&
-  String.sub s i (String.length p) = p
-
 let parse_digest s =
   let rec parse_main (strm__ : _ Stream.t) =
     match try Some (ident strm__) with Stream.Failure -> None with
@@ -855,7 +851,7 @@ let basic_authorization from_addr request base_env passwd access_type utm
     if auth = "" then ""
     else
       let s = "Basic " in
-      if start_with auth 0 s then
+      if Mutil.start_with s 0 auth then
         let i = String.length s in
         Base64.decode (String.sub auth i (String.length auth - i))
       else ""
@@ -994,7 +990,7 @@ let digest_authorization request base_env passwd utm base_file command =
      ar_friend = friend_passwd = ""; ar_uauth = ""; ar_can_stale = false}
   else if passwd = "w" || passwd = "f" then
     let auth = Wserver.extract_param "authorization: " '\r' request in
-    if start_with auth 0 "Digest " then
+    if Mutil.start_with "Digest " 0 auth then
       let meth =
         match Wserver.extract_param "GET " ' ' request with
           "" -> "POST"
@@ -1485,7 +1481,7 @@ let image_request script_name env =
       let _ = Image.print_image_file fname in true
   | _ ->
       let s = script_name in
-      if Util.start_with s 0 "images/" then
+      if Mutil.start_with "images/" 0 s then
         let i = String.length "images/" in
         let fname = String.sub s i (String.length s - i) in
         (* Je ne sais pas pourquoi on fait un basename, mais ça empeche *)

--- a/setup/setup.camlp5
+++ b/setup/setup.camlp5
@@ -1645,10 +1645,6 @@ let separate_slashed_filename s =
   in
   loop 0
 
-let start_with s x =
-  let slen = String.length s in
-  let xlen = String.length x in slen >= xlen && String.sub s 0 xlen = x
-
 let end_with s x =
   let slen = String.length s in
   let xlen = String.length x in
@@ -1768,7 +1764,9 @@ let setup_comm_ok conf =
       end
 
   | x ->
-      if start_with x "doc/" || start_with x "images/" || start_with x "css/"
+      if Mutil.start_with "doc/" 0 x
+      || Mutil.start_with "images/" 0 x
+      || Mutil.start_with "css/" 0 x
       then
         raw_file conf x
       else error conf ("bad command: \"" ^ x ^ "\"")


### PR DESCRIPTION
`start_with`, `get_particle`, and `contains` function factorized.

It also fixes `Alln.select_names` not handling utf-8 particles correctly.