### PR TITLE
Use %m and %z to provide server name in bases list

### DIFF
--- a/setup/lang/list.htm
+++ b/setup/lang/list.htm
@@ -39,26 +39,47 @@ sv: Databaser
 
 <p />
 
+%Iz;;{
 [
 de: Um eine Datenbank abfragen zu können, muß der <a
-    href="gwsetup?lang=%l;v=gwd_info.htm">gwd-Dienst</a>  gestartet worden
+    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">gwd-Dienst</a>  gestartet worden
     sein.
-en: To consult a database, the <a href="gwsetup?lang=%l;v=gwd_info.htm">gwd
+en: To consult a database, the <a href="http://%m:%P/gwsetup?lang=%l;v=gwd_info.htm">gwd
     service</a> must have been launched.
 es: Para consultar una base de datos, es necesario que el <a
-    href="gwsetup?lang=%l;v=gwd_info.htm">servicio gwd</a> sea lanzado;.
+    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">servicio gwd</a> sea lanzado;.
 fi: Lukieksasi tietokantaa <a href="gwsetup?lang=%l;v=gwd_info.htm">gwd
     palvelun</a> täytyy olla käynnissä.
 fr: Pour consulter une base de données, il faut que le <a
-    href="gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> soit lancé.
+    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> soit lancé.
 it: Per consultare una base di dati bisogna che il <a
-    href="gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> sia lanciato.
+    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> sia lanciato.
 lv: Lai uzsâktu darbu ar datu bâzçm, jâbût palaistam <a
-    href="gwsetup?lang=%l;v=gwd_info.htm">gwd servisam</a>.
+    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">gwd servisam</a>.
 sv: För att konsultera en databas, måste <a
-    href="gwsetup?lang=%l;v=gwd_info.htm">gwd servicen</a> vara startad.
+    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">gwd servicen</a> vara startad.
 ]
-
+|
+[
+de: Um eine Datenbank abfragen zu können, muß der <a
+    href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">gwd-Dienst</a>  gestartet worden
+    sein.
+en: To consult a database, the <a href="http://%m:%P/gwsetup?lang=%l;v=gwd_info.htm">gwd
+    service</a> must have been launched.
+es: Para consultar una base de datos, es necesario que el <a
+    href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">servicio gwd</a> sea lanzado;.
+fi: Lukieksasi tietokantaa <a href="gwsetup?lang=%l;v=gwd_info.htm">gwd
+    palvelun</a> täytyy olla käynnissä.
+fr: Pour consulter une base de données, il faut que le <a
+    href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> soit lancé.
+it: Per consultare una base di dati bisogna che il <a
+    href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> sia lanciato.
+lv: Lai uzsâktu darbu ar datu bâzçm, jâbût palaistam <a
+    href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">gwd servisam</a>.
+sv: För att konsultera en databas, måste <a
+    href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">gwd servicen</a> vara startad.
+]
+}
 <p />
 
 <ul>
@@ -78,17 +99,32 @@ sv: det finns ingen databas för närvarande
 </ul>
 
 <p />
-
+%Iz;;{
 [
-de: Zurück zum <a href="gwsetup?lang=%l;v=welcome.htm">Hauptmenü</a>.
-en: Or go back to the <a href="gwsetup?lang=%l;v=welcome.htm">main menu</a>.
-es: O regrese Ud. al <a href="gwsetup?lang=%l;v=welcome.htm">menú
+de: Zurück zum <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">Hauptmenü</a>.
+en: Or go back to the <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">main menu</a>.
+es: O regrese Ud. al <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">menú
     principal</a>.
-fi: Tai mene takaisin <a href="gwsetup?lang=%l;v=welcome.htm">päävalikkoon</a>.
-fr: Ou revenez au <a href="gwsetup?lang=%l;v=welcome.htm">menu principal</a>.
-it: O tornate al <a href="gwsetup?lang=%l;v=welcome.htm">menu principale</a>.
-lv: Vai atgriezieties <a href="gwsetup?lang=%l;v=welcome.htm">galvenajâ
+fi: Tai mene takaisin <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">päävalikkoon</a>.
+fr: Ou revenez au <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">menu principal</a>.
+it: O tornate al <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">menu principale</a>.
+lv: Vai atgriezieties <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">galvenajâ
     izvçlnç</a>.
 sv: Eller gå tillbaka till <a
-    href="gwsetup?lang=%l;v=welcome.htm">huvudmenyn</a>.
+    href="http://%m/gwsetup?lang=%l;v=welcome.htm">huvudmenyn</a>.
 ]
+|
+[
+de: Zurück zum <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">Hauptmenü</a>.
+en: Or go back to the <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">main menu</a>.
+es: O regrese Ud. al <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">menú
+    principal</a>.
+fi: Tai mene takaisin <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">päävalikkoon</a>.
+fr: Ou revenez au <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">menu principal</a>.
+it: O tornate al <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">menu principale</a>.
+lv: Vai atgriezieties <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">galvenajâ
+    izvçlnç</a>.
+sv: Eller gå tillbaka till <a
+    href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">huvudmenyn</a>.
+]
+}

--- a/setup/lang/list.htm
+++ b/setup/lang/list.htm
@@ -39,27 +39,6 @@ sv: Databaser
 
 <p />
 
-%Iz;;{
-[
-de: Um eine Datenbank abfragen zu können, muß der <a
-    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">gwd-Dienst</a>  gestartet worden
-    sein.
-en: To consult a database, the <a href="http://%m:%P/gwsetup?lang=%l;v=gwd_info.htm">gwd
-    service</a> must have been launched.
-es: Para consultar una base de datos, es necesario que el <a
-    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">servicio gwd</a> sea lanzado;.
-fi: Lukieksasi tietokantaa <a href="gwsetup?lang=%l;v=gwd_info.htm">gwd
-    palvelun</a> täytyy olla käynnissä.
-fr: Pour consulter une base de données, il faut que le <a
-    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> soit lancé.
-it: Per consultare una base di dati bisogna che il <a
-    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">service gwd</a> sia lanciato.
-lv: Lai uzsâktu darbu ar datu bâzçm, jâbût palaistam <a
-    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">gwd servisam</a>.
-sv: För att konsultera en databas, måste <a
-    href="http://%m/gwsetup?lang=%l;v=gwd_info.htm">gwd servicen</a> vara startad.
-]
-|
 [
 de: Um eine Datenbank abfragen zu können, muß der <a
     href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">gwd-Dienst</a>  gestartet worden
@@ -79,7 +58,7 @@ lv: Lai uzsâktu darbu ar datu bâzçm, jâbût palaistam <a
 sv: För att konsultera en databas, måste <a
     href="http://%m:%z/gwsetup?lang=%l;v=gwd_info.htm">gwd servicen</a> vara startad.
 ]
-}
+
 <p />
 
 <ul>
@@ -99,21 +78,6 @@ sv: det finns ingen databas för närvarande
 </ul>
 
 <p />
-%Iz;;{
-[
-de: Zurück zum <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">Hauptmenü</a>.
-en: Or go back to the <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">main menu</a>.
-es: O regrese Ud. al <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">menú
-    principal</a>.
-fi: Tai mene takaisin <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">päävalikkoon</a>.
-fr: Ou revenez au <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">menu principal</a>.
-it: O tornate al <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">menu principale</a>.
-lv: Vai atgriezieties <a href="http://%m/gwsetup?lang=%l;v=welcome.htm">galvenajâ
-    izvçlnç</a>.
-sv: Eller gå tillbaka till <a
-    href="http://%m/gwsetup?lang=%l;v=welcome.htm">huvudmenyn</a>.
-]
-|
 [
 de: Zurück zum <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">Hauptmenü</a>.
 en: Or go back to the <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">main menu</a>.
@@ -127,4 +91,4 @@ lv: Vai atgriezieties <a href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">galve
 sv: Eller gå tillbaka till <a
     href="http://%m:%z/gwsetup?lang=%l;v=welcome.htm">huvudmenyn</a>.
 ]
-}
+

--- a/setup/lang/macros.htm
+++ b/setup/lang/macros.htm
@@ -5,7 +5,7 @@ gwsetup macros
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
 <body>
-<!-- 
+<!--
 insert at the bottom of setup/welcome.thm
 -->
 
@@ -71,6 +71,8 @@ assigns the current IP address to evar.anon and the content of the only.txt file
 
 <tr><td>  &#37;Ivar;value;{true part|false part} </td>
   <td> %Itest;essai;{test=essai|test!=essai} </td><td> if var=value print true part otherwise false part (not fully tested) </td></tr>
+<tr><td>  &#37;Iz;;{|:&#37;z} </td>
+  <td> %Iz;;{|:%z} </td><td> another test with a macro as parameter) </td></tr>
 
 </table>
 

--- a/setup/setup.camlp5
+++ b/setup/setup.camlp5
@@ -333,6 +333,7 @@ let macro conf =
   | 'x' -> stringify !bin_dir
   | 'w' -> slashify (Sys.getcwd ())
   | 'y' -> Filename.basename (only_file_name ())
+  | 'z' -> string_of_int !port
   | '%' -> "%"
   | 'K' -> (* print the name of -o filename, prepend bname or -o1 filename *)
     let outfile1 = strip_spaces (s_getenv conf.env "o") in
@@ -590,7 +591,7 @@ let rec copy_from_stream conf print strm =
                           print "\"";
                           if v = s then print " checked"
                       | [< >] -> print (strip_spaces v) end
-                  | None -> print "BAD MACRO 2 "
+                  | None -> print "BAD MACRO 2"
               end
           | c -> print (macro conf c)
           end


### PR DESCRIPTION
gwsetup provides two macros to obtain server name (%m) and port number (%z)
Note that the test macro (%I) cannot be used in some contexts (within strings for instance).