### PR TITLE
Few fixes

### DIFF
--- a/lib/dag.ml
+++ b/lib/dag.ml
@@ -902,10 +902,9 @@ let print_slices_menu conf hts =
   let title _ = Wserver.printf "%s" (txt 0) in
   Hutil.header conf title;
   Hutil.print_link_to_welcome conf true;
-  begin match Util.open_templ conf "buttons_rel" with
-  Some ic -> Templ.copy_from_templ conf conf.env ic;
-  | None -> Wserver.printf "buttons_rel.txt not found<br>\n";
-  end;
+  Opt.iter
+    (Templ.copy_from_templ conf conf.env)
+    (Util.open_templ conf "buttons_rel") ;
   Wserver.printf "<form method=\"get\" action=\"%s\">\n" conf.command;
   html_p conf;
   hidden_env conf;
@@ -969,10 +968,9 @@ let print_dag_page conf page_title hts next_txt =
   in
   let title _ = Wserver.printf "%s" page_title in
   Hutil.header_no_page_title conf title;
-  begin match Util.open_templ conf "buttons_rel" with
-  Some ic -> Templ.copy_from_templ conf conf.env ic;
-  | None -> Wserver.printf "buttons_rel.txt not found<br>\n";
-  end;
+  Opt.iter
+    (Templ.copy_from_templ conf conf.env)
+    (Util.open_templ conf "buttons_rel") ;
   print_html_table conf hts;
   if next_txt <> "" then
     begin

--- a/lib/gwuLib.ml
+++ b/lib/gwuLib.ml
@@ -224,7 +224,7 @@ module Make (Select : Select) =
       in
       loop [] 0 0
 
-    let has_infos_not_in_events base p =
+    let has_infos_not_dates base p =
       let has_picture_to_export =
         sou base (get_image p) <> "" && not !no_picture
       in
@@ -237,10 +237,7 @@ module Make (Select : Select) =
       get_titles p <> [] ||
       get_access p <> IfTitles ||
       sou base (get_occupation p) <> "" ||
-      sou base (get_psources p) <> ""
-
-    let has_infos_not_dates base p =
-      has_infos_not_in_events base p ||
+      sou base (get_psources p) <> "" ||
       sou base (get_birth_place p) <> "" ||
       sou base (get_birth_src p) <> "" ||
       sou base (get_baptism_place p) <> "" ||
@@ -329,10 +326,6 @@ module Make (Select : Select) =
       Printf.fprintf oc "]"
 
     let zero_birth_is_required base is_child p =
-      let has_infos_to_print =
-        if !old_gw then has_infos_not_dates base p
-        else has_infos_not_in_events base p
-      in
       if get_baptism p <> Adef.cdate_None then false
       else
         begin match get_death p with
@@ -340,7 +333,7 @@ module Make (Select : Select) =
             true
         | DontKnowIfDead
           when
-            not is_child && not has_infos_to_print &&
+            not is_child && not (has_infos_not_dates base p) &&
             p_first_name base p <> "?" && p_surname base p <> "?" ->
             true
         | _ -> false
@@ -366,29 +359,18 @@ module Make (Select : Select) =
       print_if_no_empty oc base "#occu" (get_occupation p);
       print_if_not_equal_to csrc oc base "#src" (get_psources p);
       begin match Adef.od_of_cdate (get_birth p) with
-        Some d ->
-          Printf.fprintf oc " ";
-          if !old_gw then print_date oc d
-          else Printf.fprintf oc "0(b)"
+        Some d -> Printf.fprintf oc " "; print_date oc d
       | _ when zero_birth_is_required base is_child p -> Printf.fprintf oc " 0"
       | _ -> ()
       end;
-      if !old_gw then
-        begin
-          print_if_not_equal_to cbp oc base "#bp" (get_birth_place p);
-          print_if_no_empty oc base "#bs" (get_birth_src p)
-        end;
+      print_if_not_equal_to cbp oc base "#bp" (get_birth_place p);
+      print_if_no_empty oc base "#bs" (get_birth_src p);
       begin match Adef.od_of_cdate (get_baptism p) with
-        Some d ->
-          if !old_gw then begin Printf.fprintf oc " !"; print_date oc d end
-          else if get_birth p = Adef.cdate_None then Printf.fprintf oc " !0(p)"
+        Some d -> Printf.fprintf oc " !"; print_date oc d
       | _ -> ()
       end;
-      if !old_gw then
-        begin
-          print_if_no_empty oc base "#pp" (get_baptism_place p);
-          print_if_no_empty oc base "#ps" (get_baptism_src p)
-        end;
+      print_if_no_empty oc base "#pp" (get_baptism_place p);
+      print_if_no_empty oc base "#ps" (get_baptism_src p);
       begin match get_death p with
         Death (dr, d) ->
           Printf.fprintf oc " ";
@@ -399,8 +381,7 @@ module Make (Select : Select) =
           | Disappeared -> Printf.fprintf oc "s"
           | _ -> ()
           end;
-          if !old_gw then print_date oc (Adef.date_of_cdate d)
-          else Printf.fprintf oc "0(d)"
+          print_date oc (Adef.date_of_cdate d)
       | DeadYoung -> Printf.fprintf oc " mj"
       | DeadDontKnowWhen -> Printf.fprintf oc " 0"
       | DontKnowIfDead ->
@@ -413,14 +394,11 @@ module Make (Select : Select) =
       | OfCourseDead -> Printf.fprintf oc " od"
       | NotDead -> ()
       end;
-      if !old_gw then
-        begin
-          print_if_no_empty oc base "#dp" (get_death_place p);
-          print_if_no_empty oc base "#ds" (get_death_src p);
-          print_burial oc (get_burial p);
-          print_if_no_empty oc base "#rp" (get_burial_place p);
-          print_if_no_empty oc base "#rs" (get_burial_src p)
-        end
+      print_if_no_empty oc base "#dp" (get_death_place p);
+      print_if_no_empty oc base "#ds" (get_death_src p);
+      print_burial oc (get_burial p);
+      print_if_no_empty oc base "#rp" (get_burial_place p);
+      print_if_no_empty oc base "#rs" (get_burial_src p)
 
     type gen =
       { mark : bool array;
@@ -837,8 +815,7 @@ module Make (Select : Select) =
       Printf.fprintf oc "fam ";
       print_parent oc base gen m.m_fath;
       Printf.fprintf oc " +";
-      if !old_gw then
-        print_date_option oc (Adef.od_of_cdate (get_marriage fam));
+      print_date_option oc (Adef.od_of_cdate (get_marriage fam));
       begin match get_relation fam with
         NotMarried -> Printf.fprintf oc " #nm"
       | Married -> ()
@@ -861,35 +838,32 @@ module Make (Select : Select) =
           Printf.fprintf oc " #nsckm %c%c" (c m.m_fath) (c m.m_moth)
       | NoMention -> Printf.fprintf oc " #noment"
       end;
-      if !old_gw then
-        begin
-          print_if_no_empty oc base "#mp" (get_marriage_place fam);
-          print_if_no_empty oc base "#ms" (get_marriage_src fam);
-          match get_divorce fam with
-            NotDivorced -> ()
-          | Separated -> Printf.fprintf oc " #sep"
-          | Divorced d ->
-              let d = Adef.od_of_cdate d in
-              Printf.fprintf oc " -"; print_date_option oc d
-        end;
+      print_if_no_empty oc base "#mp" (get_marriage_place fam);
+      print_if_no_empty oc base "#ms" (get_marriage_src fam);
+      begin match get_divorce fam with
+        NotDivorced -> ()
+      | Separated -> Printf.fprintf oc " #sep"
+      | Divorced d ->
+          let d = Adef.od_of_cdate d in
+          Printf.fprintf oc " -"; print_date_option oc d
+      end;
       Printf.fprintf oc " ";
       print_parent oc base gen m.m_moth;
       Printf.fprintf oc "\n";
-      if !old_gw then
-        Array.iter
-          (fun ip ->
-             if gen.per_sel ip then
-               let p = poi base ip in
-               Printf.fprintf oc "wit";
-               begin match get_sex p with
-                 Male -> Printf.fprintf oc " m"
-               | Female -> Printf.fprintf oc " f"
-               | _ -> ()
-               end;
-               Printf.fprintf oc ": ";
-               print_witness oc base gen p;
-               Printf.fprintf oc "\n")
-          (get_witnesses fam);
+      Array.iter
+        (fun ip ->
+           if gen.per_sel ip then
+             let p = poi base ip in
+             Printf.fprintf oc "wit";
+             begin match get_sex p with
+               Male -> Printf.fprintf oc " m"
+             | Female -> Printf.fprintf oc " f"
+             | _ -> ()
+             end;
+             Printf.fprintf oc ": ";
+             print_witness oc base gen p;
+             Printf.fprintf oc "\n")
+        (get_witnesses fam);
       let fsources = sou base (get_fsources fam) in
       if fsources <> ""
       then Printf.fprintf oc "src %s\n" (correct_string base (get_fsources fam));
@@ -900,9 +874,7 @@ module Make (Select : Select) =
       in
       let cbp =
         match common_children_birth_place base m.m_chil with
-          Some s ->
-            if !old_gw then Printf.fprintf oc "cbp %s\n" (s_correct_string s);
-            s
+          Some s -> Printf.fprintf oc "cbp %s\n" (s_correct_string s); s
         | _ -> ""
       in
       print_comment_for_family oc base gen fam;

--- a/lib/relation.ml
+++ b/lib/relation.ml
@@ -1342,10 +1342,9 @@ let print_main_relationship conf base long p1 p2 rel =
   in
   Hutil.header conf title;
   Hutil.print_link_to_welcome conf true;
-  begin match Util.open_templ conf "buttons_rel" with
-  Some ic -> Templ.copy_from_templ conf conf.env ic;
-  | None -> Wserver.printf "buttons_rel.txt not found<br>\n";
-  end;
+  Opt.iter
+    (Templ.copy_from_templ conf conf.env)
+    (Util.open_templ conf "buttons_rel") ;
   begin match p_getenv conf.env "spouse" with
     Some "on" -> conf.senv <- conf.senv @ ["spouse", "on"]
   | _ -> ()

--- a/lib/relationLink.ml
+++ b/lib/relationLink.ml
@@ -606,10 +606,9 @@ let print_relation_ok conf base info =
   in
   Hutil.header_no_page_title conf title;
   Hutil.print_link_to_welcome conf true;
-  begin match Util.open_templ conf "buttons_rel" with
-  Some ic -> Templ.copy_from_templ conf conf.env ic;
-  | None -> Wserver.printf "buttons_rel.txt not found<br>\n";
-  end;
+  Opt.iter
+    (Templ.copy_from_templ conf conf.env)
+    (Util.open_templ conf "buttons_rel") ;
   Wserver.printf "<p style=\"clear:both\"%s>\n" conf.xhs;
   print_relation_path conf base info;
   Hutil.trailer conf

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -84,6 +84,10 @@ let util_str_sub _ =
 let util_safe_html _ =
   assert_equal
     ~printer:(fun x -> x)
+    {|<a href="localhost:2318/foo_w?lang=fr&#38;acte=123">foo</a>|}
+    (Util.safe_html {|<a href="localhost:2318/foo_w?lang=fr&acte=123">foo</a>|}) ;
+  assert_equal
+    ~printer:(fun x -> x)
     {|<a href="localhost:2318/foo_w?lang=fr&#38;image=on">foo</a>|}
     (Util.safe_html {|<a href="localhost:2318/foo_w?lang=fr&image=on">foo</a>|})
 


### PR DESCRIPTION
f7d6b68 has been reverted because it is loosing some information in `.gw` : if a witness is "isolated" (just connected to someone else as a relation) all primary events are lost.

Note: gwu still may loose some info since this same witness is no exported except on a `wit` line (i.e. its pevents are not exported, so secondary events are lost). If this is really what happens, it is probably the case since a long time, and maybe it is how it has always been.

We may want to discuss about the `.gw` format more seriously.