### PR TITLE
List other first names

### DIFF
--- a/hd/etc/buttons_fnames.txt
+++ b/hd/etc/buttons_fnames.txt
@@ -1,0 +1,40 @@
+<!-- Copyright (c) 1998-2019 INRIA -->
+%( Boutons de configurations et d'options %)
+
+<div class="d-flex">
+  <a href="%prefix_base_password;%nn;
+    %foreach;env_binding;%if;(env.val!="" and env.key!="reset" and 
+      env.key!="other" and env.key!="force_fn")%nn;
+     &%env.key=%env.val;%end;%nn;
+    %end;%nn;
+    %if;(evar.other!="on")&other=on%end;%nn;"
+    title="%if;(evar.other!="on")[*show others]%else;[*hide others]%end;">%nn;
+    %if;(evar.other!="on")<i class="fa fa-thumbs-up">%else;<i class="fa fa-thumbs-down">%end;</i>
+  </a>
+  <a class="ml-3"
+    href="%prefix_base_password;%nn;
+    %foreach;env_binding;%if;(env.val!="" and env.key!="reset" and env.key!="t")%nn;
+     &%env.key=%env.val;%end;%nn;
+    %end;%nn;
+    %if;(evar.t!="A")&t=A%end;%nn;"
+    title="%if;(evar.t!="A")[*exact match]%else;[*approxim match]%end;">%nn;
+    %if;(evar.t!="A")<i class="fa fa-equals "></i>%else;<i class="fa fa-less-than-equal"></i>%end;
+  </a>
+  <a class="ml-3"
+    href="%prefix_base_password;%nn;
+    %foreach;env_binding;%if;(env.val!="" and env.key!="reset" and env.key!="word")%nn;
+     &%env.key=%env.val;%end;%nn;
+    %end;%nn;
+    %if;(evar.word!="on")&word=on%end;%nn;"
+    title="%if;(evar.word!="on")[*word boundaries]%else;[*anywhere]%end;">%nn;
+    <i class="fa fa-crop%if;(evar.word!="on")-alt%end;"></i>
+  </a>
+  <a role="button" class="ml-auto mr-2"
+    href="%prefix_base_password;
+    %foreach;env_binding;%if;(env.val!="" and env.key!="reset")%nn;
+      &%env.key=%env.val;%end;%nn;
+    %end;&reset=on" %nn;
+    title="[*refresh fnames cache]"><i class="fa fa-sync-alt mr-2 mt-2"></i></i>
+  </a>
+</div>
+<!-- fin buttons -->

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -1,3 +1,207 @@
+    hide others
+en: hide other first mames
+fr: cacher les autres prénoms
+
+    show others
+en: show other first names
+fr: afficher les autres prénoms
+
+    exact match
+en: exact match (upper/lower and accents)
+fr: correspondance exacte (majuscules/minuscules et accents)
+
+    approxim match
+en: match with no capitale nor accents
+fr: correspondance sans capitales ni accents
+
+    refresh fnames cache
+en: refresh fnames cache
+fr: reconstruire le cache des prénoms
+
+    word boundaries
+en: match full words
+fr: correspondance de mots entiers
+
+    anywhere
+en: match anywhere
+fr: correspondance sans contrainte
+
+    reset to
+co: risturà
+en: reset to
+fr: restaurer
+
+    select p_mod
+co: selezziunà i mudulli persunalizati
+en: select personalized modules
+fr: selectionner les modules personnalisés
+
+    last sosa level not navigable
+co: l'ultimu livellu di Sosa ùn si pò micca navigà. Impiegate a lista di l'antenati.
+en: last Sosa level not navigable. Use ancestors list.
+fr: le dernier niveau des Sosa n’est pas navigable. Utilisez la liste des ancêtres.
+
+    with root, spouses and unknowns
+co: cù l'antenatu radica, i cumpagni è i scunnisciuti
+en: with root ancestor, spouses and unknowns
+fr: avec l’ancêtre racine, les conjoints et les inconnus
+
+    hide portraits
+co: piattà i ritratti
+en: hide portraits
+fr: ne pas afficher les portraits
+
+    choose a genealogy
+co: sceglie una genealugia
+en: choose a genealogy
+fr: choisir une généalogie
+
+    input database
+co: Ci vole à scrive quì u nome di a basa di dati à impiegà :
+en: Please, enter the name of the database you want to use:
+fr: Tapez à l’identique le nom de la généalogie que vous voulez utiliser :
+
+    available genealogies
+co: lista di e genealugie dispunibule (impiegà gwsetup)
+en: list of available genealogies (use gwsetup)
+fr: listes des généalogies disponibles (utilise gwsetup)
+
+    collapse implex
+co: ripiegà l'implessi
+en: collapse implex
+fr: réduire les implexes
+
+    display implex
+co: affissà l'implessi
+en: display implex
+fr: afficher les implexes
+
+    show implex
+co: identificà l'implessi
+en: show implex
+fr: identifier les implexes
+
+    ignore implex
+co: ignurà l'implessi
+en: ignore implex
+fr: ignorer les implexes
+
+    both
+co: i dui
+en: both
+fr: les deux
+
+    books
+co: dizziunarii
+en: books
+fr: dictionnaires
+oc: diccionaris
+
+    reduce/increase
+co: reduce/aumentà
+en: reduce/increase
+fr: réduire/augmenter
+
+    activate/suppress
+co: attivà/squassà
+en: activate/suppress
+fr: activer/supprimer
+
+    do not
+co: ùn micca
+en: do not
+fr: ne pas
+
+    size
+co: scala
+en: scale
+fr: echelle
+
+    couples
+co: coppii
+en: couples
+fr: couples
+
+    missing %s
+co: %s manchendu
+en: missing %s
+fr: %s manquant
+
+    one additional generation
+co: una generazione di più
+en: one additional generation
+fr: une génération en plus
+
+    compiled on %s from commit %s
+co: cumpilatu u %s à partesi di u commit %s
+en: compiled on %s from commit %s
+fr: compilé le %s à partir du commit %s
+
+    link to children
+co: lea ver di i zitelli
+en: link to children
+fr: lien vers les enfants
+
+    link back to parents
+co: lea di ritornu ver di i genitori
+en: link back to parents
+fr: lien retour vers les parents
+
+    presentation
+co: Prisentazione
+de: Präsentation
+en: Presentation
+fr: Présentation
+he: הצגה
+it: Presentazione
+pl: Prezentacja
+ru: представление
+
+    of
+co: di
+en: of
+fr: de
+
+    officer/officer/officers
+co: uffiziante/uffiziante/uffizianti
+en: officer/officer/officers
+fr: officiant/officiante/officiants
+
+    name changed. update linked pages
+co: U nome, a casata, o un occurrenza di sta persona hà cambiatu. Ci vole à rinfrescà e pagine assuciate à l'anziana chjave inghjò.
+fr: Le prénom, nom ou occurrence de cette personne a changé. Pensez à mettre à jour les pages liées à l’ancienne clé ci-dessous.
+en: The first name, name or occurrence of this person has changed. Please update the pages linked to the old key listed below.
+
+    old name
+co: vechju nome
+en: old name
+fr: ancien nom
+
+    new name
+co: novu nome
+en: new name
+fr: nouveau nom
+
+    scale
+co: anni per generazione
+en: years by generation
+fr: années par génération
+
+    multi relations graph
+co: graficu di rilazioni multiple
+en: multi relations graph
+fr: graphe de relations multiples
+
+    edit tree
+co: mudufucà u graficu
+en: edit the graph
+fr: éditer le graphe
+
+    dag on/dag off
+co: affissà un graficu orientatu aciclicu (dag)/piattà u graficu orientatu aciclicu (dag)
+en: show dag/hide dag
+fr: afficher graphe orienté acyclique (dag)/masquer graphe orienté acyclique (dag)
+
     !dates order
 af: yyyymmdd
 ar: ddmmyyyy
@@ -12164,7 +12368,7 @@ de: siehe auch
 en: see also
 es: ver también
 fi: näytä myös
-fr: à voir aussi
+fr: voir aussi
 it: vedi anche
 nl: ook te bekijken
 no: vis også

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -136,6 +136,13 @@ let print_alphabetic_to_branch conf x =
   Wserver.printf "</table>";
   Wserver.printf "<br%s>\n" conf.xhs
 
+
+let match_fnames word str x =
+  if word then
+    let rexp = Str.regexp (".*\\b" ^ x ^ "\\b.*") in
+    Str.string_match rexp str 0
+  else Mutil.contains str x
+
 let persons_of_fsname conf base base_strings_of_fsname find proj x =
   (* list of strings index corresponding to the crushed lower first name
      or surname "x" *)
@@ -220,6 +227,57 @@ let name_unaccent s =
   in
   copy 0 0
 
+type 'a env =
+    Vlist_data of (string * (string * int) list) list
+  | Vlist_ini of string list
+  | Vlist_value of (string * (string * int) list) list
+  | Venv_keys of (string * int) list
+  | Vint of int
+  | Vstring of string
+  | Vbool of bool
+  | Vother of 'a
+  | Vnone
+
+let get_vother =
+  function
+    Vother x -> Some x
+  | _ -> None
+let set_vother x = Vother x
+
+(* TODO find a way tu use get_vother, set_vother from templ.camlp5 *)
+let buttons_fnames conf =
+  Hutil.interp_no_header conf "buttons_fnames"
+    {Templ.eval_var = (fun _ -> raise Not_found);
+     Templ.eval_transl = (fun _ -> Templ.eval_transl conf);
+     Templ.eval_predefined_apply = (fun _ -> raise Not_found);
+     Templ.get_vother = get_vother; Templ.set_vother = set_vother;
+     Templ.print_foreach = (fun _ -> raise Not_found) }
+    [] ()
+
+let print_other_list conf _base list =
+  let s_title = Printf.sprintf "%s" (Utf8.capitalize (transl conf "see also")) in
+  let s_colon = Printf.sprintf "%s" (transl conf ":") in
+  Wserver.printf "<span>%s%s</span>\n" s_title s_colon;
+  Mutil.list_iter_first (fun first (fn, c) ->
+    Wserver.printf "%s<a href=\"%sm=P&v=%s&other=on\">%s</a> (%d)"
+      (if first then "" else ", ") (commd conf) (code_varenv fn) fn c)
+    list
+
+let other_fnames conf base x =
+  match Alln.select_names conf base false "" max_int with
+  | (Alln.Result list, _len) ->
+    let exact = p_getenv conf.env "t" = Some "A" in
+    let word = p_getenv conf.env "word" = Some "on" in
+    let x = if exact then x else Name.lower x in
+    List.fold_left
+      (fun l (_k, str, c) ->
+        let strl = if exact then str else Name.lower str in
+        if (match_fnames word strl x && strl <> x)
+        then (str, c) :: l else l)
+      [] list
+  | (Alln.Specify _l, _len) -> [] (* TODO is [] ok? *)
+  
+  
 let first_name_print_list conf base x1 xl liste =
   let liste =
     let l =
@@ -257,9 +315,19 @@ let first_name_print_list conf base x1 xl liste =
   in
   Hutil.header conf title;
   Hutil.print_link_to_welcome conf true;
+  buttons_fnames conf;
   (* Si on est dans un calcul de parenté, on affiche *)
   (* l'aide sur la sélection d'un individu.          *)
   Util.print_tips_relationship conf;
+  let other = p_getenv conf.env "other" = Some "on" in
+  if other then
+    let listo =
+        List.fold_left (fun l x ->
+            (other_fnames conf base x) :: l) [] (StrSet.elements xl)
+    in
+    let listo = List.flatten listo |> List.sort_uniq compare in
+    if listo <> [] then print_other_list conf base listo else ()
+  else ();
   let list =
     List.map
       (fun (sn, ipl) ->
@@ -279,6 +347,7 @@ let select_first_name conf n list =
       (transl conf "specify")
   in
   Hutil.header conf title;
+  buttons_fnames conf;
   Wserver.printf "<ul>";
   List.iter
     (fun (sstr, (strl, _)) ->
@@ -632,6 +701,7 @@ let print_several_possible_surnames x conf base (_, homonymes) =
   let access txt sn =
     geneweb_link conf ("m=N&v=" ^ code_varenv sn ^ "&t=N") txt
   in
+  buttons_fnames conf;
   Util.wprint_in_columns conf (fun (ord, _, _) -> ord)
     (fun (_, txt, sn) -> Wserver.print_string (access txt sn)) list;
   Wserver.printf "<p>\n";

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1924,10 +1924,10 @@ let hexa_string s =
   Bytes.unsafe_to_string s'
 
 let print_alphab_list crit print_elem liste =
+  Wserver.printf "<p>\n";
   let len = List.length liste in
   if len > menu_threshold then
     begin
-      Wserver.printf "<p>\n";
       begin let _ =
         List.fold_left
           (fun last e ->
@@ -1944,9 +1944,8 @@ let print_alphab_list crit print_elem liste =
       in
         ()
       end;
-      Wserver.printf "</p>\n"
     end;
-  Wserver.printf "<ul>\n";
+  Wserver.printf "</p>\n<ul>\n";
   begin let _ =
     List.fold_left
       (fun last e ->


### PR DESCRIPTION
When asking for a first name, the current solution does not list multi part first names which contain the request.
The proposed solution offers (optionnally) such a supplemental list with word and partial match options.
This list assumes that a cache file containing all first names exists. If the file does not exist, it is computed at the first request. A warning message informs the user that this operation may be somewhat lengthy.