### PR TITLE
FIX #677

### DIFF
--- a/hd/etc/advanced.txt
+++ b/hd/etc/advanced.txt
@@ -28,25 +28,25 @@
 %define;date(xx,zz)
   %if;([ !dates order]0 = "ddmmyy" or [ !dates order]0 = "ddmmyyyy" or [ !dates order]0 = "dmyyyy")
     <label for="xxzz_dd" class="form-control-label">
-    <input type="number" class="form-control" name="xxzz_dd" id="xxzz_dd" min="1" max="12"> [year/month/day]2 </label>
+    <input type="number" class="form-control" name="xx_datezz_dd" id="xxzz_dd" min="1" max="12"> [year/month/day]2 </label>
     <label for="xxzz_mm" class="form-control-label">
-    <input type="number" class="form-control" name="xxzz_mm" id="xxzz_mm" min="1" max="31"> [year/month/day]1 </label>
+    <input type="number" class="form-control" name="xx_datezz_mm" id="xxzz_mm" min="1" max="31"> [year/month/day]1 </label>
     <label for="xxzz_yyyy" class="form-control-label">
-    <input type="text" class="form-control" name="xxzz_yyyy" id="xxzz_yyyy" size="4"> [year/month/day]0</label>
+    <input type="text" class="form-control" name="xx_datezz_yyyy" id="xxzz_yyyy" size="4"> [year/month/day]0</label>
   %elseif;([ !dates order]0 = "mmddyyyy")
     <label for="xxzz_mm" class="form-control-label">
-    <input type="number" class="form-control" name="xxzz_mm" id="xxzz_mm" min="1" max="12"> [year/month/day]1 </label>
+    <input type="number" class="form-control" name="xx_datezz_mm" id="xxzz_mm" min="1" max="12"> [year/month/day]1 </label>
     <label for="xxzz_dd" class="form-control-label">
-    <input type="number" class="form-control" name="xxzz_dd" id="xxzz_dd" min="1" max="31"> [year/month/day]2 </label>
+    <input type="number" class="form-control" name="xx_datezz_dd" id="xxzz_dd" min="1" max="31"> [year/month/day]2 </label>
     <label for="xxzz_yyyy" class="form-control-label">
-    <input type="text" class="form-control" name="xxzz_yyyy" id="xxzz_yyyy" size="4"> [year/month/day]0</label>
+    <input type="text" class="form-control" name="xx_datezz_yyyy" id="xxzz_yyyy" size="4"> [year/month/day]0</label>
   %else;
     <label for="xxzz_yyyy" class="form-control-label">
-    <input type="text" class="form-control" name="xxzz_yyyy" id="xxzz_yyyy" size="2"> [year/month/day]0 </label>
+    <input type="text" class="form-control" name="xx_datezz_yyyy" id="xxzz_yyyy" size="2"> [year/month/day]0 </label>
     <label for="xxzz_mm" class="form-control-label">
-    <input type="number" class="form-control" name="xxzz_mm" id="xxzz_mm" min="1" max="12"> [year/month/day]1 </label>
+    <input type="number" class="form-control" name="xx_datezz_mm" id="xxzz_mm" min="1" max="12"> [year/month/day]1 </label>
     <label for="xxzz_dd" class="form-control-label">
-    <input type="number" class="form-control" name="xxzz_dd" id="xxzz_dd" min="1" max="31"> [year/month/day]2</label>
+    <input type="number" class="form-control" name="xx_datezz_dd" id="xxzz_dd" min="1" max="31"> [year/month/day]2</label>
   %end;
 %end;
 


### PR DESCRIPTION
#677
Date fields were renamed (e.g.: birth1_yyyy -> birth_date1_yyyy).
It was then needed to adjust the form template.