### PR TITLE
Base title is now shown as label in Notes button (fix #701)

### DIFF
--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -130,7 +130,8 @@ fr: Les <strong>droits des magiciens</strong> sont actuellement <strong>suspendu
                 <a class="btn btn-outline-primary" href="%prefix;m=MOD_NOTES">[*add base notes]</a>
               %end;
               %if;base.has_notes;
-                <a class="btn btn-outline-primary" href="%prefix;m=NOTES"><i class="far fa-file-alt fa-fw" aria-hidden="true"></i> [*base notes]</a>%base.title;
+                <a class="btn btn-outline-primary" href="%prefix;m=NOTES">
+                	%if(base.title!="")%base.title;%else;<i class="far fa-file-alt fa-fw" aria-hidden="true"></i>[*base notes]</a>
               %end;
               %if;has_misc_notes;
                 <a class="btn btn-outline-primary" href="%prefix;m=MISC_NOTES">[*base index notes]</a>

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -5,7 +5,7 @@ open Gwdb
 open NotesLinks
 
 val file_path : config -> base -> string -> string
-val read_notes : base -> string -> (string * string) list * string
+val read_notes : bool -> base -> string -> (string * string) list * string
 
 val print : config -> base -> unit
 val print_mod : config -> base -> unit
@@ -17,3 +17,5 @@ val print_misc_notes_search : config -> base -> unit
 val print_linked_list : config -> base -> page list -> unit
 
 val merge_possible_aliases : config -> notes_links_db -> notes_links_db
+
+val skip_notes_first_line : string -> string * string

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1552,7 +1552,7 @@ let linked_page_text conf base p s key str (pg, (_, il)) =
       List.fold_right
         (fun text str ->
            try
-             let (nenv, _) = Notes.read_notes base pg in
+             let (nenv, _) = Notes.read_notes false base pg in
              let v =
                let v = List.assoc s nenv in
                if v = "" then raise Not_found
@@ -3175,7 +3175,7 @@ and eval_person_field_var conf base env (p, p_auth as ep) loc =
                  match pg with
                    NotesLinks.PgMisc pg ->
                      if List.mem_assoc key il then
-                       let (nenv, _) = Notes.read_notes base pg in
+                       let (nenv, _) = Notes.read_notes false base pg in
                        List.mem_assoc s nenv
                      else false
                  | _ -> false)

--- a/lib/srcfile.ml
+++ b/lib/srcfile.ml
@@ -193,13 +193,9 @@ let macro conf base =
       string_of_num (transl conf "(thousand separator)")
         (Sosa.of_int (nb_of_persons base))
   | 'N' ->
-      let s = base_notes_read_first_line base "" in
-      let len = String.length s in
-      if len > 9 && String.sub s 0 5 = "<!-- " &&
-         String.sub s (len - 4) 4 = " -->"
-      then
-        " : " ^ String.sub s 5 (String.length s - 9)
-      else ""
+      let s = base_notes_read base "" in
+      let (s, _) = Notes.skip_notes_first_line s in
+      s
   | 'o' -> image_prefix conf
   | 'q' ->
       let r = count conf in
@@ -483,15 +479,8 @@ let eval_var conf base env () _loc =
         (string_of_num (Util.transl conf "(thousand separator)")
            (Sosa.of_int (Util.real_nb_of_persons conf base)))
   | ["base"; "title"] ->
-      let s = base_notes_read_first_line base "" in
-      let len = String.length s in
-      let s =
-        if len > 9 && String.sub s 0 5 = "<!-- " &&
-           String.sub s (len - 4) 4 = " -->"
-        then
-          " : " ^ String.sub s 5 (String.length s - 9)
-        else ""
-      in
+      let s = base_notes_read base "" in
+      let (s, _) = Notes.skip_notes_first_line s in
       VVstring s
   | ["browsing_with_sosa_ref"] ->
       begin match get_env "sosa_ref" env with

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -577,6 +577,7 @@ let html_with_summary_of_tlsw conf wi edit_opt s =
     let s2 = string_of_modify_link conf 0 (s = "") edit_opt in s2 ^ s
   else s
 
+(* FIXME should not skip over <!-- xxx -> as first line!! *)
 let rev_extract_sub_part s v =
   let (lines, _) = lines_list_of_string s in
   let rec loop lines lev cnt =


### PR DESCRIPTION
- srcfile.ml, notes.ml and wiki.ml were not coherent relative to
%base.title; (feature was mostly unused)
- if first line of Notes begins with `<!--` then it is shown as
%base.title; (untill matching `-->`)
- title can be multiline and include html tags, but no comment (`-->`)