### PR TITLE
Print trace of full template file path

### DIFF
--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -380,7 +380,7 @@ let strip_newlines_after_variables =
 
 let included_files = ref []
 
-let rec parse_templ conf strm =
+let parse_templ conf strm =
   let rec parse_astl astl bol len end_list strm =
     match strm with parser bp
       [< ''%' >] ->
@@ -485,18 +485,13 @@ let rec parse_templ conf strm =
                 let () = included_files := file :: !included_files in
                 let strm2 = Stream.of_channel ic in
                 let (al, _) = parse_astl [] false 0 [] strm2 in
-                let trace =
-                	match Util.p_getenv conf.base_env "trace_templ" with
-                	| Some "on" -> true
-                	| _ -> false
-                in
                 let al =
-                	if trace then
-		        		let include_fname = "<!-- file included from " ^ fname ^ " -->\n" in
-		        		let astl_fname = parse_templ conf (Stream.of_string include_fname) in
-		        		List.append astl_fname al
-		        	else al
-		        in
+                  if Util.p_getenv conf.base_env "trace_templ" = Some "on" then
+                    Atext ((0,0), "<!-- begin include from " ^ fname ^ " -->\n")
+                    :: al
+                    @ [ Atext ((0,0), "<!-- end include from " ^ fname ^ " -->\n") ]
+                  else al
+                in
                 close_in ic; Some (Ainclude (file, al))
             | None -> None
           in

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -380,7 +380,7 @@ let strip_newlines_after_variables =
 
 let included_files = ref []
 
-let parse_templ conf strm =
+let rec parse_templ conf strm =
   let rec parse_astl astl bol len end_list strm =
     match strm with parser bp
       [< ''%' >] ->
@@ -480,11 +480,23 @@ let parse_templ conf strm =
         (* Protection pour ne pas inclure plusieurs fois un même template ? *)
         if not (List.mem file !included_files) then
           let al =
-            match Util.open_templ conf file with
-              Some ic ->
+            match Util.open_templ_fname conf file with
+              Some (ic, fname) ->
                 let () = included_files := file :: !included_files in
                 let strm2 = Stream.of_channel ic in
                 let (al, _) = parse_astl [] false 0 [] strm2 in
+                let trace =
+                	match Util.p_getenv conf.base_env "trace_templ" with
+                	| Some "on" -> true
+                	| _ -> false
+                in
+                let al =
+                	if trace then
+		        		let include_fname = "<!-- file included from " ^ fname ^ " -->\n" in
+		        		let astl_fname = parse_templ conf (Stream.of_string include_fname) in
+		        		List.append astl_fname al
+		        	else al
+		        in
                 close_in ic; Some (Ainclude (file, al))
             | None -> None
           in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1334,16 +1334,6 @@ let open_hed_trl conf fname =
   try Some (Secure.open_in (etc_file_name conf fname)) with
     Sys_error _ -> None
 
-let open_templ conf fname =
-  try Some (Secure.open_in (etc_file_name conf fname)) with
-    Sys_error _ ->
-      if true then
-        let std_fname =
-          search_in_lang_path (Filename.concat "etc" (fname ^ ".txt"))
-        in
-        try Some (Secure.open_in std_fname) with Sys_error _ -> None
-      else None
-
 let open_templ_fname conf fname =
   try
     let fname = etc_file_name conf fname in
@@ -1354,8 +1344,9 @@ let open_templ_fname conf fname =
       in
       try Some (Secure.open_in std_fname, std_fname) with Sys_error _ -> None
 
-let image_prefix conf = conf.image_prefix
+let open_templ conf fname = Opt.map fst (open_templ_fname conf fname)
 
+let image_prefix conf = conf.image_prefix
 
 (*
    On cherche le fichier dans cet ordre :

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1344,6 +1344,16 @@ let open_templ conf fname =
         try Some (Secure.open_in std_fname) with Sys_error _ -> None
       else None
 
+let open_templ_fname conf fname =
+  try
+    let fname = etc_file_name conf fname in
+    Some (Secure.open_in fname, fname) with
+    Sys_error _ ->
+      let std_fname =
+        search_in_lang_path (Filename.concat "etc" (fname ^ ".txt"))
+      in
+      try Some (Secure.open_in std_fname, std_fname) with Sys_error _ -> None
+
 let image_prefix conf = conf.image_prefix
 
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -116,6 +116,7 @@ val index_of_next_char : string -> int -> int
 val open_etc_file : string -> in_channel option
 val open_hed_trl : config -> string -> in_channel option
 val open_templ : config -> string -> in_channel option
+val open_templ_fname : config -> string -> (in_channel * string) option
 val string_with_macros :
   config -> (char * (unit -> string)) list -> string -> string
 val string_of_place : config -> string -> string


### PR DESCRIPTION
If bvar.trace_templ=on (.gwf) then print a html comment showing where the template file is coming from.
Usefull when developping private templates that supersede those sitting in gw/etc