### PR TITLE
Templates: removed template loop protection /!\ + added included file name as HTML comment 

### DIFF
--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -122,14 +122,6 @@ let log_passwd_failed ar oc tm from request base_file =
   Printf.fprintf oc "  Agent: %s\n" user_agent;
   if referer <> "" then Printf.fprintf oc "  Referer: %s\n" referer
 
-let include_template ?(trace = true) conf env fname failure =
-  match Util.open_etc_file fname with
-  | Some (ic, fname) ->
-    if trace then Wserver.printf "<!-- begin include %s -->\n" fname;
-    Templ.copy_from_templ conf env ic;
-    if trace then Wserver.printf "<!-- end include %s -->\n" fname;
-  | None -> failure ()
-
 let copy_file fname =
   match Util.open_etc_file fname with
     Some (ic, _fname) ->

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -122,9 +122,11 @@ let log_passwd_failed ar oc tm from request base_file =
   Printf.fprintf oc "  Agent: %s\n" user_agent;
   if referer <> "" then Printf.fprintf oc "  Referer: %s\n" referer
 
-let copy_file fname =
+let copy_file ?(trace = true) fname =
   match Util.open_etc_file fname with
-    Some (ic, _fname) ->
+    Some (ic, fname) ->
+      if trace = true then
+        Wserver.printf "<!-- begin copy from %s -->\n" fname;
       begin try
         while true do let c = input_char ic in Wserver.printf "%c" c done
       with _ -> ()
@@ -141,7 +143,7 @@ let robots_txt () =
   Log.with_log (fun oc -> Printf.fprintf oc "Robot request\n");
   Wserver.http Wserver.OK;
   Wserver.header "Content-type: text/plain";
-  if copy_file "robots" then ()
+  if copy_file ~trace:false "robots" then ()
   else
     begin Wserver.printf "User-Agent: *\n"; Wserver.printf "Disallow: /\n" end
 

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -32,6 +32,7 @@ let daemon = ref false
 let login_timeout = ref 1800
 let conn_timeout = ref 120
 let trace_failed_passwd = ref false
+let trace_templates = ref false
 let use_auth_digest_scheme = ref false
 let no_host_address = ref false
 let lexicon_list = ref []
@@ -1124,10 +1125,6 @@ let make_conf from_addr request script_name env =
       if x = "" then !default_lang else x
     with Not_found -> !default_lang
   in
-  let trace_templ =
-    try List.assoc "trace_templ" base_env = "yes"
-    with Not_found -> false
-  in
   let lexicon = input_lexicon (if lang = "" then default_lang else lang) in
   List.iter
     (fun fname ->
@@ -1172,7 +1169,7 @@ let make_conf from_addr request script_name env =
      manitou = manitou;
      supervisor = supervisor; wizard = ar.ar_wizard && not wizard_just_friend;
      is_printed_by_template = true;
-     trace_templ = trace_templ;
+     trace_templ = !trace_templates;
      friend = ar.ar_friend || wizard_just_friend && ar.ar_wizard;
      just_friend_wizard = ar.ar_wizard && wizard_just_friend;
      user = ar.ar_user; username = ar.ar_name; auth_scheme = ar.ar_scheme;
@@ -1871,6 +1868,9 @@ let main ~speclist () =
     ("-trace_failed_passwd", Arg.Set trace_failed_passwd,
      "\n       \
       Print the failed passwords in log (except if option -digest is set) ") ::
+    ("-trace_templ", Arg.Set trace_templates,
+     "\n       \
+      Print the full path to template files as html comment ") ::
     ("-nolock", Arg.Set Lock.no_lock_flag,
      "\n       Do not lock files before writing.") ::
     (if Sys.unix then

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -124,12 +124,14 @@ let log_passwd_failed ar oc tm from request base_file =
 
 let copy_file fname =
   match Util.open_etc_file fname with
-    Some ic ->
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
       begin try
         while true do let c = input_char ic in Wserver.printf "%c" c done
       with _ -> ()
       end;
       close_in ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
       true
   | None -> false
 
@@ -288,7 +290,10 @@ let print_renamed conf new_n =
   in
   let env = ["old", conf.bname; "new", new_n; "link", link] in
   match Util.open_etc_file "renamed" with
-    Some ic -> Util.html conf; Templ.copy_from_templ conf env ic
+    Some (ic, fname) -> Util.html conf;
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf env ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None ->
       let title _ = Wserver.printf "%s -&gt; %s" conf.bname new_n in
       Hutil.header conf title;
@@ -314,9 +319,12 @@ let print_redirected conf from request new_addr =
   let env = ["link", link] in
   log_redirect from request req;
   match Util.open_etc_file "redirect" with
-    Some ic ->
+    Some (ic, fname) ->
       let conf = {conf with is_printed_by_template = false} in
-      Util.html conf; Templ.copy_from_templ conf env ic
+      Util.html conf;
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf env ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None ->
       let title _ = Wserver.printf "Address changed" in
       Hutil.header conf title;
@@ -339,7 +347,10 @@ let propose_base conf =
 
 let general_welcome conf =
   match Util.open_etc_file "index" with
-    Some ic -> Util.html conf; Templ.copy_from_templ conf [] ic
+    Some (ic, fname) -> Util.html conf;
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf [] ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None -> propose_base conf
 
 let nonce_private_key =

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -318,7 +318,7 @@ let print_redirected conf from request new_addr =
       Hutil.header conf title;
       Wserver.printf "Use the following address:\n<p>\n";
       Wserver.printf "<ul><li><a href=\"%s\">%s</a></li></ul>" link link ;
-      Hutil.trailer conf
+      Hutil.trailer conf)
 
 let propose_base conf =
   let title _ = Wserver.printf "Base" in
@@ -343,7 +343,7 @@ let general_welcome conf =
       Wserver.printf "<input name=\"b\" size=\"40\"> =&gt;\n";
       Wserver.printf
         "<button type=\"submit\" class=\"btn btn-secondary btn-lg\">\n";
-      Wserver.printf "%s" (capitale (transl_nth conf "validate/delete" 0));
+      Wserver.printf "%s" (Utf8.capitalize (transl_nth conf "validate/delete" 0));
       Wserver.printf "</button>\n";
       Wserver.printf "</li></ul>";
       Hutil.trailer conf)

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -1135,6 +1135,10 @@ let make_conf from_addr request script_name env =
       if x = "" then !default_lang else x
     with Not_found -> !default_lang
   in
+  let trace_templ =
+    try List.assoc "trace_templ" base_env = "yes"
+    with Not_found -> false
+  in
   let lexicon = input_lexicon (if lang = "" then default_lang else lang) in
   List.iter
     (fun fname ->
@@ -1179,6 +1183,7 @@ let make_conf from_addr request script_name env =
      manitou = manitou;
      supervisor = supervisor; wizard = ar.ar_wizard && not wizard_just_friend;
      is_printed_by_template = true;
+     trace_templ = trace_templ;
      friend = ar.ar_friend || wizard_just_friend && ar.ar_wizard;
      just_friend_wizard = ar.ar_wizard && wizard_just_friend;
      user = ar.ar_user; username = ar.ar_name; auth_scheme = ar.ar_scheme;

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -124,14 +124,12 @@ let log_passwd_failed ar oc tm from request base_file =
 
 let copy_file fname =
   match Util.open_etc_file fname with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+    Some (ic, _fname) ->
       begin try
         while true do let c = input_char ic in Wserver.printf "%c" c done
       with _ -> ()
       end;
       close_in ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
       true
   | None -> false
 

--- a/bin/gwd/gwDaemon.ml
+++ b/bin/gwd/gwDaemon.ml
@@ -335,18 +335,7 @@ let propose_base conf =
 
 let general_welcome conf =
   include_template conf [] "index"
-    (fun () ->
-      let title _ = Wserver.printf "Base" in
-      Hutil.header conf title;
-      Wserver.printf "<ul><li>";
-      Wserver.printf "<form method=\"get\" action=\"%s\">\n" conf.indep_command;
-      Wserver.printf "<input name=\"b\" size=\"40\"> =&gt;\n";
-      Wserver.printf
-        "<button type=\"submit\" class=\"btn btn-secondary btn-lg\">\n";
-      Wserver.printf "%s" (Utf8.capitalize (transl_nth conf "validate/delete" 0));
-      Wserver.printf "</button>\n";
-      Wserver.printf "</li></ul>";
-      Hutil.trailer conf)
+    (fun () -> propose_base conf)
 
 let nonce_private_key =
   Lazy.from_fun

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -357,15 +357,8 @@ let log_count r =
   | None -> ()
 
 let print_moved conf s =
-  match Util.open_etc_file "moved" with
-    Some (ic, fname) ->
-      let env = ["bname", conf.bname] in
-      let conf = {conf with is_printed_by_template = false} in
-      Util.html conf;
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Templ.copy_from_templ conf env ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None ->
+  Util.include_template conf ["bname", conf.bname] "moved"
+    (fun () ->
       let title _ = Wserver.printf "%s -&gt; %s" conf.bname s in
       Hutil.header_no_page_title conf title;
       Wserver.printf "The database %s has moved to:\n<dl><dt><dd>\n"
@@ -374,7 +367,7 @@ let print_moved conf s =
       Wserver.print_string s;
       Wserver.printf "</a>";
       Wserver.printf "\n</dd></dt></dl>\n";
-      Hutil.trailer conf
+      Hutil.trailer conf)
 
 let print_no_index conf base =
   let title _ =

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -358,10 +358,13 @@ let log_count r =
 
 let print_moved conf s =
   match Util.open_etc_file "moved" with
-    Some ic ->
+    Some (ic, fname) ->
       let env = ["bname", conf.bname] in
       let conf = {conf with is_printed_by_template = false} in
-      Util.html conf; Templ.copy_from_templ conf env ic
+      Util.html conf;
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf env ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None ->
       let title _ = Wserver.printf "%s -&gt; %s" conf.bname s in
       Hutil.header_no_page_title conf title;

--- a/hd/etc/perso.txt
+++ b/hd/etc/perso.txt
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="%lang;">
-%trace.begin_head;
 <head>
   <!-- $Id: perso.txt,v7.00 01/03/2018 11:44:53 $ -->
   <!-- Copyright (c) 1998-2017 INRIA -->
@@ -18,22 +17,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
-%trace.begin_css;
   %include;css
-%trace.begin_hed;
   %include;hed
 </head>
-%trace.end_head;
 <body%body_prop;>
 %message_to_wizard;
 <a href="#content" class="sr-only sr-only-focusable">Skip navigation menu</a>
 <div class="container%if;(evar.wide="on")-fluid%end;">
-%trace.begin_perso_utils;
 %include;perso_utils
-%trace.begin_menubar;
 %include;menubar
 <div id="content" tabindex="-1">
-%trace.menubar_finished;
 
 %define;init_nb_asc(tplnum)
   %let;templ;%bvar.perso_module_tplnum;%in
@@ -86,13 +79,10 @@
   %init_cache.nb_asc.from_gen_desc.nb_desc;
 %end;
 
-%trace.begin_perso;
-
 %(note that p_mod= (b)%bvar.p_mod; or (e)%evar.p_mod;%)
 %if;(evar.p_mod="zz" or (bvar.p_mod="zz" and evar.p_mod="") or
     (bvar.p_mod="" and evar.p_mod=""))
-  %trace.statique;
-  Statique
+  %(Statique%)
   %apply;init_cache(3, 2, 2)
   %if;(has_parents and (father.has_parents or mother.has_parents))
      <div class="collapse" id="collapseExample1">
@@ -118,16 +108,13 @@
     </div>
   </div>
 %else;
-  %trace.dynamic;
-  Dynamic
+  %(Dynamic %)
   %apply;init_cache(3, 2, 2)
   <div class="mt-2">
-    %trace.begin_for;
     %for;i;0;p_mod_nbr;
       %let;mmi;%apply;mm(i)%in;
       %let;ooi;%apply;oo(i)%in;
       %if;(mmi!="" and ooi!=0)
-        %trace.get_mod;
         %apply;get_mod(mmi, ooi)
       %end
     %end;

--- a/hd/etc/perso.txt
+++ b/hd/etc/perso.txt
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <html lang="%lang;">
+%clean_tpl_list;
+%trace.begin_head;
 <head>
   <!-- $Id: perso.txt,v7.00 01/03/2018 11:44:53 $ -->
   <!-- Copyright (c) 1998-2017 INRIA -->
@@ -17,16 +19,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
+%trace.begin_css;
   %include;css
+%trace.begin_hed;
   %include;hed
 </head>
+%trace.end_head;
 <body%body_prop;>
 %message_to_wizard;
 <a href="#content" class="sr-only sr-only-focusable">Skip navigation menu</a>
 <div class="container%if;(evar.wide="on")-fluid%end;">
+%trace.begin_perso_utils;
 %include;perso_utils
+%trace.begin_menubar;
 %include;menubar
 <div id="content" tabindex="-1">
+%trace.menubar_finished;
 
 %define;init_nb_asc(tplnum)
   %let;templ;%bvar.perso_module_tplnum;%in
@@ -79,10 +87,13 @@
   %init_cache.nb_asc.from_gen_desc.nb_desc;
 %end;
 
+%trace.begin_perso;
+
 %(note that p_mod= (b)%bvar.p_mod; or (e)%evar.p_mod;%)
 %if;(evar.p_mod="zz" or (bvar.p_mod="zz" and evar.p_mod="") or
     (bvar.p_mod="" and evar.p_mod=""))
-  %(Statique%)
+  %trace.statique;
+  Statique
   %apply;init_cache(3, 2, 2)
   %if;(has_parents and (father.has_parents or mother.has_parents))
      <div class="collapse" id="collapseExample1">
@@ -108,13 +119,16 @@
     </div>
   </div>
 %else;
-  %(Dynamic %)
+  %trace.dynamic;
+  Dynamic
   %apply;init_cache(3, 2, 2)
   <div class="mt-2">
+    %trace.begin_for;
     %for;i;0;p_mod_nbr;
       %let;mmi;%apply;mm(i)%in;
       %let;ooi;%apply;oo(i)%in;
       %if;(mmi!="" and ooi!=0)
+        %trace.get_mod;
         %apply;get_mod(mmi, ooi)
       %end
     %end;

--- a/hd/etc/perso.txt
+++ b/hd/etc/perso.txt
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="%lang;">
-%clean_tpl_list;
 %trace.begin_head;
 <head>
   <!-- $Id: perso.txt,v7.00 01/03/2018 11:44:53 $ -->

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -34,6 +34,7 @@ type config =
     supervisor : bool;
     wizard : bool;
     is_printed_by_template : bool;
+    trace_templ : bool;
     friend : bool;
     just_friend_wizard : bool;
     user : string;

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -106,6 +106,7 @@ let empty =
   ; api_port = 0
 #endif
   ; is_printed_by_template = false
+  ; trace_templ = false
   ; friend = false
   ; just_friend_wizard = false
   ; user = ""

--- a/lib/cousinsDisplay.ml
+++ b/lib/cousinsDisplay.ml
@@ -213,9 +213,8 @@ let print_cousins_lev conf base max_cnt p lev1 lev2 =
   if lev1 > 1 then Wserver.printf "</ul>\n"
 
 let include_templ conf name =
-  match Util.open_hed_trl conf name with
-  | Some ic -> Templ.copy_from_templ conf [] ic (* no env -> problem!! *)
-  | None -> (Wserver.printf "Failed to open: %s.txt" name)
+  Util.include_template conf [] name
+    (fun () -> (Wserver.printf "Failed to open: %s.txt" name))
 
 (* HTML main *)
 

--- a/lib/dagDisplay.ml
+++ b/lib/dagDisplay.ml
@@ -762,9 +762,7 @@ let print_slices_menu conf hts =
   let title _ = Wserver.print_string (txt 0) in
   Hutil.header conf title;
   Hutil.print_link_to_welcome conf true;
-  Opt.iter
-    (Templ.copy_from_templ conf conf.env)
-    (Util.open_templ conf "buttons_rel") ;
+  Util.include_template conf conf.env "buttons_rel" (fun () -> ());
   Wserver.printf "<form method=\"get\" action=\"%s\">\n" conf.command;
   Wserver.printf "<p>" ;
   hidden_env conf;
@@ -828,9 +826,7 @@ let print_dag_page conf page_title hts next_txt =
   in
   let title _ = Wserver.print_string page_title in
   Hutil.header_no_page_title conf title;
-  Opt.iter
-    (Templ.copy_from_templ conf conf.env)
-    (Util.open_templ conf "buttons_rel") ;
+  Util.include_template conf conf.env "buttons_rel" (fun () -> ());
   print_html_table conf hts;
   if next_txt <> "" then
     begin

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -148,7 +148,10 @@ let gen_interp header conf fname ifun env ep =
   begin try
     match Templ.input_templ conf fname with
       Some astl ->
-        if header then Util.html conf; Templ.interp_ast conf ifun env ep astl
+        if header then Util.html conf;
+        let full_name = Util.etc_file_name conf fname in
+        Templ.interp_ast conf ifun env ep
+          (Templ.begin_end_include conf full_name astl "interp")
     | None -> error_cannot_access conf fname
   with e -> Templ.template_file := v; raise e
   end;

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -145,7 +145,7 @@ let gen_interp header conf fname ifun env ep =
         if header then Util.html conf;
         let full_name = Util.etc_file_name conf fname in
         Templ.interp_ast conf ifun env ep
-          (Templ.begin_end_include conf full_name astl "interp")
+          (Templ.begin_end_include conf full_name astl)
     | None -> error_cannot_access conf fname
   with e -> Templ.template_file := v; raise e
   end;

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -56,10 +56,7 @@ let header_without_http conf title =
     (Util.image_prefix conf);
   Wserver.printf "  <meta name=\"viewport\" content=\"width=device-width, \
                     initial-scale=1, shrink-to-fit=no\">\n";
-  begin match Util.open_templ conf "css" with
-    Some ic -> Templ.copy_from_templ conf [] ic
-  | None -> ()
-  end;
+  Util.include_template conf [] "css" (fun () -> ());
   Templ.include_hed_trl conf "hed";
   Wserver.printf "\n</head>\n";
   let s =
@@ -113,10 +110,7 @@ let gen_trailer with_logo conf =
   Templ.include_hed_trl conf "trl";
   if with_logo then Templ.print_copyright_with_logo conf
   else Templ.print_copyright conf;
-  begin match Util.open_templ conf "js" with
-    Some ic -> Templ.copy_from_templ conf [] ic
-  | None -> ()
-  end;
+  Util.include_template conf [] "js" (fun () -> ());
   Wserver.printf "</body>\n</html>\n"
 
 let trailer = gen_trailer true

--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -70,13 +70,7 @@ let print_whole_notes conf base fnotes title s ho =
       Wserver.printf "<h1 class=\"my-3\">%s</h1>\n" title
     end;
   Wserver.printf "</div>\n";
-  begin match Util.open_etc_file "summary" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Templ.copy_from_templ conf [] ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None -> ()
-  end;
+  Util.include_template conf [] "summary" (fun () -> ());
   let file_path = file_path conf base in
   let s = string_with_macros conf [] s in
   let edit_opt = Some (conf.wizard, "NOTES", fnotes) in
@@ -107,13 +101,7 @@ let print_notes_part conf base fnotes title s cnt0 =
   Hutil.header_no_page_title conf
     (fun _ -> Wserver.print_string (if title = "" then fnotes else title));
   Hutil.print_link_to_welcome conf true;
-  begin match Util.open_etc_file "summary" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Templ.copy_from_templ conf [] ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None -> ()
-  end;
+  Util.include_template conf [] "summary" (fun () -> ());
   if cnt0 = 0 && title <> "" then
     begin
       Wserver.printf "<br%s>\n" conf.xhs;
@@ -130,7 +118,6 @@ let print_notes_part conf base fnotes title s cnt0 =
      Wiki.wi_always_show_link = conf.wizard || conf.friend}
   in
   Wiki.print_sub_part conf wi conf.wizard mode fnotes cnt0 lines; Hutil.trailer conf
-
 
 let print_linked_list conf base pgl =
   Wserver.printf "<ul>\n";

--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -71,7 +71,10 @@ let print_whole_notes conf base fnotes title s ho =
     end;
   Wserver.printf "</div>\n";
   begin match Util.open_etc_file "summary" with
-    Some ic -> Templ.copy_from_templ conf [] ic
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf [] ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None -> ()
   end;
   let file_path = file_path conf base in
@@ -105,7 +108,10 @@ let print_notes_part conf base fnotes title s cnt0 =
     (fun _ -> Wserver.print_string (if title = "" then fnotes else title));
   Hutil.print_link_to_welcome conf true;
   begin match Util.open_etc_file "summary" with
-    Some ic -> Templ.copy_from_templ conf [] ic
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf [] ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None -> ()
   end;
   if cnt0 = 0 && title <> "" then

--- a/lib/relationDisplay.ml
+++ b/lib/relationDisplay.ml
@@ -866,9 +866,7 @@ let print_main_relationship conf base long p1 p2 rel =
   in
   Hutil.header conf title;
   Hutil.print_link_to_welcome conf true;
-  Opt.iter
-    (Templ.copy_from_templ conf conf.env)
-    (Util.open_templ conf "buttons_rel") ;
+  Util.include_template conf conf.env "buttons_rel" (fun () -> ());
   begin match p_getenv conf.env "spouse" with
     Some "on" -> conf.senv <- conf.senv @ ["spouse", "on"]
   | _ -> ()

--- a/lib/relationLink.ml
+++ b/lib/relationLink.ml
@@ -606,9 +606,7 @@ let print_relation_ok conf base info =
   in
   Hutil.header_no_page_title conf title;
   Hutil.print_link_to_welcome conf true;
-  Opt.iter
-    (Templ.copy_from_templ conf conf.env)
-    (Util.open_templ conf "buttons_rel") ;
+  Util.include_template conf conf.env "buttons_rel" (fun () -> ());
   Wserver.printf "<p style=\"clear:both\"%s>\n" conf.xhs;
   print_relation_path conf base info;
   Hutil.trailer conf

--- a/lib/robot.ml
+++ b/lib/robot.ml
@@ -2,7 +2,6 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
 open Config
-open Util
 
 let magic_robot = "GWRB0007"
 
@@ -29,19 +28,14 @@ let robot_error conf cnt sec =
   Wserver.http Wserver.Forbidden;
   Wserver.header "Content-type: text/html; charset=iso-8859-1";
   let env = ["cnt", string_of_int cnt; "sec", string_of_int sec] in
-  begin match open_etc_file "robot" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Templ.copy_from_templ conf env ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None ->
+  Util.include_template conf env "robot"
+    (fun () ->
       let title _ = Wserver.printf "Access refused" in
       Wserver.printf "<head><title>";
       title true;
       Wserver.printf "</title>\n<body>\n<h1>";
       title false;
-      Wserver.printf "</body>\n"
-  end;
+      Wserver.printf "</body>\n");
   raise Exit
 
 let purge_who tm xcl sec =

--- a/lib/robot.ml
+++ b/lib/robot.ml
@@ -30,7 +30,10 @@ let robot_error conf cnt sec =
   Wserver.header "Content-type: text/html; charset=iso-8859-1";
   let env = ["cnt", string_of_int cnt; "sec", string_of_int sec] in
   begin match open_etc_file "robot" with
-    Some ic -> Templ.copy_from_templ conf env ic
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf env ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None ->
       let title _ = Wserver.printf "Access refused" in
       Wserver.printf "<head><title>";

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -380,9 +380,9 @@ let strip_newlines_after_variables =
 
 let included_files = ref []
 
-let begin_end_include conf fname al where =
+let begin_end_include conf fname al =
   if conf.trace_templ then
-    Atext ((0,0), "\n<!-- begin include (" ^ where ^ ") " ^ fname ^ " -->\n")
+    Atext ((0,0), "\n\n<!-- begin include " ^ fname ^ " -->\n")
     :: al
     @ [ Atext ((0,0), "<!-- end include " ^ fname ^ " -->\n") ]
   else al
@@ -492,7 +492,7 @@ let parse_templ conf strm =
                 let strm2 = Stream.of_channel ic in
                 let (al, _) = parse_astl [] false 0 [] strm2 in
                 close_in ic;
-                let al = begin_end_include conf fname al "parse" in
+                let al = begin_end_include conf fname al in
                 let () = included_files := (file, al) :: !included_files in
                 Some (Ainclude (file, al))
             | None -> None
@@ -1521,7 +1521,7 @@ and print_var print_ast_list conf ifun env ep loc sl =
               begin match input_templ conf templ with
                 Some astl ->
                     let () = included_files := (templ, astl) :: !included_files in
-                    print_ast_list env ep (begin_end_include conf fname astl "print")
+                    print_ast_list env ep (begin_end_include conf fname astl)
               | None -> Wserver.printf " %%%s?" (String.concat "." sl)
               end
             | None -> Wserver.printf " %%%s?" (String.concat "." sl)

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -1305,24 +1305,16 @@ let print_wid_hei fname =
     Some (wid, hei) -> Wserver.printf " width=\"%d\" height=\"%d\"" wid hei
   | None -> ()
 
-let copy_from_templ_fwd =
-  ref (fun _ -> raise (Match_failure ("templ.ml", 1296, 33)))
-let copy_from_templ conf env ic = !copy_from_templ_fwd conf env ic
-
 let print_copyright conf =
-  match Util.open_etc_file "copyr" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      copy_from_templ conf [] ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None ->
+  Util.include_template conf [] "copyr"
+    (fun () ->
       Wserver.printf "<hr style=\"margin:0\"%s>\n" conf.xhs;
       Wserver.printf "<div style=\"font-size: 80%%\">\n";
       Wserver.printf "<em>";
       Wserver.printf "Copyright (c) 1998-2007 INRIA - GeneWeb %s" Version.txt;
       Wserver.printf "</em>";
       Wserver.printf "</div>\n";
-      Wserver.printf "<br%s>\n" conf.xhs
+      Wserver.printf "<br%s>\n" conf.xhs)
 
 let print_copyright_with_logo conf =
   let conf =
@@ -1334,9 +1326,7 @@ let print_copyright_with_logo conf =
   print_copyright conf
 
 let include_hed_trl conf name =
-  match Util.open_hed_trl conf name with
-    Some ic -> copy_from_templ conf [] ic
-  | None -> ()
+  Util.include_template conf [] name  (fun () -> ())
 
 let rec interp_ast conf ifun env =
   let m_env = ref env in
@@ -1578,4 +1568,4 @@ let copy_from_templ conf env ic =
   end;
   template_file := v
 
-let _ = copy_from_templ_fwd := copy_from_templ
+let _ = Util.copy_from_templ_ref := copy_from_templ

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -485,9 +485,6 @@ let parse_templ conf strm =
       try
         let file = get_value 0 strm in
         (* Protection pour ne pas inclure plusieurs fois un même template ? *)
-        let _ = Printf.eprintf "parse_include: %s\n" file in
-        let _ = List.iter (fun (f, _) -> Printf.eprintf "included files: %s\n" f) !included_files in
-        let _ = flush stderr in
         if not (List.mem_assoc file !included_files) then
           let al =
             match Util.open_templ_fname conf file with
@@ -701,7 +698,6 @@ let rec eval_variable conf =
       | None -> ""
       end
   | "time" :: sl -> eval_time_var conf sl
-  | ["trace"; message] -> Printf.eprintf "Trace: %s\n" message;flush stderr; ""
   | ["user"; "ident"] -> conf.user
   | ["user"; "name"] -> conf.username
   | [s] -> eval_simple_variable conf s
@@ -741,7 +737,6 @@ and eval_simple_variable conf =
           else ""
       | None -> ""
       end
-  | "clean_tpl_list" -> included_files := []; ""
   | "doctype" -> Util.doctype conf ^ "\n"
   | "doctype_transitional" ->
       let doctype =
@@ -1528,7 +1523,6 @@ and print_var print_ast_list conf ifun env ep loc sl =
     with Not_found ->
       match sl with
         ["include"; templ] ->
-          let _ = Printf.eprintf " print_var [include; %s]\n" templ in
           begin match Util.open_templ_fname conf templ with
             Some (_, fname) ->
               begin match input_templ conf templ with

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -381,7 +381,7 @@ let strip_newlines_after_variables =
 let included_files = ref []
 
 let begin_end_include conf fname al where =
-  if conf.trace_templ then 
+  if conf.trace_templ then
     Atext ((0,0), "\n<!-- begin include (" ^ where ^ ") " ^ fname ^ " -->\n")
     :: al
     @ [ Atext ((0,0), "<!-- end include " ^ fname ^ " -->\n") ]

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -381,8 +381,8 @@ let strip_newlines_after_variables =
 let included_files = ref []
 
 let begin_end_include conf fname al where =
-  if Util.p_getenv conf.base_env "trace_templ" = Some "on" then
-    Atext ((0,0), "<!-- begin include (" ^ where ^ ") " ^ fname ^ " -->\n")
+  if conf.trace_templ then 
+    Atext ((0,0), "\n<!-- begin include (" ^ where ^ ") " ^ fname ^ " -->\n")
     :: al
     @ [ Atext ((0,0), "<!-- end include " ^ fname ^ " -->\n") ]
   else al

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -382,9 +382,9 @@ let included_files = ref []
 
 let begin_end_include conf fname al where =
   if Util.p_getenv conf.base_env "trace_templ" = Some "on" then
-    Atext ((0,0), "<!-- begin include (" ^ where ^ ") from: " ^ fname ^ " -->\n")
+    Atext ((0,0), "<!-- begin include (" ^ where ^ ") " ^ fname ^ " -->\n")
     :: al
-    @ [ Atext ((0,0), "<!-- end include from " ^ fname ^ " -->\n") ]
+    @ [ Atext ((0,0), "<!-- end include " ^ fname ^ " -->\n") ]
   else al
 
 let parse_templ conf strm =
@@ -484,7 +484,7 @@ let parse_templ conf strm =
     let ast =
       try
         let file = get_value 0 strm in
-        (* Protection pour ne pas inclure plusieurs fois un même template ? *)
+        (* Protection pour ne pas "parser" plusieurs fois le même template ? *)
         if not (List.mem_assoc file !included_files) then
           let al =
             match Util.open_templ_fname conf file with

--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -1311,7 +1311,10 @@ let copy_from_templ conf env ic = !copy_from_templ_fwd conf env ic
 
 let print_copyright conf =
   match Util.open_etc_file "copyr" with
-    Some ic -> copy_from_templ conf [] ic
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      copy_from_templ conf [] ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None ->
       Wserver.printf "<hr style=\"margin:0\"%s>\n" conf.xhs;
       Wserver.printf "<div style=\"font-size: 80%%\">\n";

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -7,7 +7,7 @@ type 'a vother
 type 'a env = (string * 'a) list
 
 val eval_transl : config -> bool -> string -> string -> string
-val begin_end_include : config -> string -> ast list -> string -> ast list
+val begin_end_include : config -> string -> ast list -> ast list
 
 type ('a, 'b) interp_fun =
   { eval_var : 'a env -> 'b -> loc -> string list -> 'b expr_val;

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -7,7 +7,6 @@ type 'a vother
 type 'a env = (string * 'a) list
 
 val eval_transl : config -> bool -> string -> string -> string
-val copy_from_templ : config -> (string * string) list -> in_channel -> unit
 val begin_end_include : config -> string -> ast list -> string -> ast list
 
 type ('a, 'b) interp_fun =

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -8,6 +8,7 @@ type 'a env = (string * 'a) list
 
 val eval_transl : config -> bool -> string -> string -> string
 val copy_from_templ : config -> (string * string) list -> in_channel -> unit
+val begin_end_include : config -> string -> ast list -> string -> ast list
 
 type ('a, 'b) interp_fun =
   { eval_var : 'a env -> 'b -> loc -> string list -> 'b expr_val;

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1158,6 +1158,9 @@ let base_path pref bname =
     else bfile
   else bfile
 
+let copy_from_templ_ref = ref (fun _ _ _ -> assert false)
+let copy_from_templ conf env ic = !copy_from_templ_ref conf env ic
+
 (* ************************************************************************ *)
 (*  [Fonc] etc_file_name : config -> string -> string                       *)
 (** [Description] : Renvoie le chemin vers le fichier de template passé
@@ -1259,6 +1262,14 @@ let open_templ_fname conf fname =
       try Some (Secure.open_in std_fname, std_fname) with Sys_error _ -> None
 
 let open_templ conf fname = Opt.map fst (open_templ_fname conf fname)
+
+let include_template ?(trace = true) conf env fname failure =
+  match open_etc_file fname with
+  | Some (ic, fname) ->
+    if trace then Wserver.printf "<!-- begin include %s -->\n" fname;
+    copy_from_templ conf env ic;
+    if trace then Wserver.printf "<!-- end include %s -->\n" fname;
+  | None -> failure ()
 
 let image_prefix conf = conf.image_prefix
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1263,12 +1263,12 @@ let open_templ_fname conf fname =
 
 let open_templ conf fname = Opt.map fst (open_templ_fname conf fname)
 
-let include_template ?(trace = true) conf env fname failure =
+let include_template conf env fname failure =
   match open_etc_file fname with
   | Some (ic, fname) ->
-    if trace then Wserver.printf "<!-- begin include %s -->\n" fname;
+    if conf.trace_templ then Wserver.printf "\n<!-- begin include %s -->\n" fname;
     copy_from_templ conf env ic;
-    if trace then Wserver.printf "<!-- end include %s -->\n" fname;
+    if conf.trace_templ then Wserver.printf "<!-- end include %s -->\n" fname;
   | None -> failure ()
 
 let image_prefix conf = conf.image_prefix

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1241,8 +1241,8 @@ let open_etc_file fname =
     search_in_lang_path
       (Filename.concat "etc" (Filename.basename fname ^ ".txt"))
   in
-  try Some (Secure.open_in fname1) with
-    Sys_error _ -> try Some (Secure.open_in fname2) with Sys_error _ -> None
+  try Some (Secure.open_in fname1, fname1) with
+    Sys_error _ -> try Some (Secure.open_in fname2, fname2) with Sys_error _ -> None
 
 let open_hed_trl conf fname =
   try Some (Secure.open_in (etc_file_name conf fname)) with

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -108,7 +108,7 @@ val p_getenv : (string * string) list -> string -> string option
 val p_getint : (string * string) list -> string -> int option
 val create_env : string -> (string * string) list
 
-val open_etc_file : string -> in_channel option
+val open_etc_file : string -> (in_channel * string) option
 val open_hed_trl : config -> string -> in_channel option
 val open_templ : config -> string -> in_channel option
 val open_templ_fname : config -> string -> (in_channel * string) option

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -381,3 +381,17 @@ val string_with_macros
     [false] if we knwon the first name or the last name of [p].
 *)
 val is_empty_name : person -> bool
+
+(**/**)
+val init_cache_info : string -> Gwdb.base -> unit
+
+(**/**)
+(* [copy_from_templ_ref] is for internal usage only. Use copy_from_templ *)
+val copy_from_templ_ref :
+  (config -> (string * string) list -> in_channel -> unit) ref
+
+(**/**)
+val copy_from_templ : config -> (string * string) list -> in_channel -> unit
+
+val include_template : ?trace:bool -> config -> (string * string) list -> string ->
+  (unit -> unit) -> unit

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -393,5 +393,5 @@ val copy_from_templ_ref :
 (**/**)
 val copy_from_templ : config -> (string * string) list -> in_channel -> unit
 
-val include_template : ?trace:bool -> config -> (string * string) list -> string ->
+val include_template : config -> (string * string) list -> string ->
   (unit -> unit) -> unit

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -383,9 +383,6 @@ val string_with_macros
 val is_empty_name : person -> bool
 
 (**/**)
-val init_cache_info : string -> Gwdb.base -> unit
-
-(**/**)
 (* [copy_from_templ_ref] is for internal usage only. Use copy_from_templ *)
 val copy_from_templ_ref :
   (config -> (string * string) list -> in_channel -> unit) ref

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -695,15 +695,8 @@ let print_mod_view_page conf can_edit mode fname title env s =
         conf.xhs
     end;
   Wserver.printf "<div class=\"row ml-3\">\n";
-  begin match Util.open_etc_file "toolbar" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Wserver.printf "<div class=\"d-inline col-9 py-1\">\n";
-      Templ.copy_from_templ conf ["name", "notes"] ic;
-      Wserver.printf "</div>\n";
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None -> ()
-  end;
+  Util.include_template conf ["name", "notes"] "toolbar"
+    (fun () -> ());
   Wserver.printf "<textarea name=\"notes\" id=\"notes_comments\"";
   Wserver.printf " class=\"col-9 form-control\" rows=\"25\" cols=\"110\"%s>"
     (if can_edit then "" else " readonly=\"readonly\"");
@@ -719,15 +712,8 @@ let print_mod_view_page conf can_edit mode fname title env s =
         Wserver.printf "</button>\n"
       end
     end;
-  begin match Util.open_etc_file "accent" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Wserver.printf "<div class=\"col my-1 mr-2 text-monospace\">\n";
-      Templ.copy_from_templ conf ["name", "notes"] ic;
-      Wserver.printf "</div>\n";
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None -> ()
-  end;
+  Util.include_template conf ["name", "notes"] "accent"
+    (fun () -> ());
   Wserver.printf "</div>\n";
   Wserver.printf "</form>\n";
   Hutil.trailer conf

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -696,10 +696,12 @@ let print_mod_view_page conf can_edit mode fname title env s =
     end;
   Wserver.printf "<div class=\"row ml-3\">\n";
   begin match Util.open_etc_file "toolbar" with
-    Some ic ->
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
       Wserver.printf "<div class=\"d-inline col-9 py-1\">\n";
       Templ.copy_from_templ conf ["name", "notes"] ic;
       Wserver.printf "</div>\n";
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None -> ()
   end;
   Wserver.printf "<textarea name=\"notes\" id=\"notes_comments\"";
@@ -718,10 +720,12 @@ let print_mod_view_page conf can_edit mode fname title env s =
       end
     end;
   begin match Util.open_etc_file "accent" with
-    Some ic ->
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
       Wserver.printf "<div class=\"col my-1 mr-2 text-monospace\">\n";
       Templ.copy_from_templ conf ["name", "notes"] ic;
       Wserver.printf "</div>\n";
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None -> ()
   end;
   Wserver.printf "</div>\n";

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -339,7 +339,10 @@ let print_whole_wiznote conf base auth_file wz wfile (s, date) ho =
   title false;
   Wserver.printf "</h1>\n";
   begin match Util.open_etc_file "summary" with
-    Some ic -> Templ.copy_from_templ conf [] ic
+    Some (ic, fname) ->
+      Wserver.printf "<!-- begin copy from %s -->\n" fname;
+      Templ.copy_from_templ conf [] ic;
+      Wserver.printf "<!-- end copy from %s -->\n" fname;
   | None -> ()
   end;
   Wserver.printf "<table border=\"0\" width=\"100%%\">\n";

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -338,13 +338,8 @@ let print_whole_wiznote conf base auth_file wz wfile (s, date) ho =
   Wserver.printf "<h1>";
   title false;
   Wserver.printf "</h1>\n";
-  begin match Util.open_etc_file "summary" with
-    Some (ic, fname) ->
-      Wserver.printf "<!-- begin copy from %s -->\n" fname;
-      Templ.copy_from_templ conf [] ic;
-      Wserver.printf "<!-- end copy from %s -->\n" fname;
-  | None -> ()
-  end;
+  Util.include_template conf [] "summary"
+    (fun () -> ());
   Wserver.printf "<table border=\"0\" width=\"100%%\">\n";
   Wserver.printf "<tr>\n";
   Wserver.printf "<td>\n";


### PR DESCRIPTION
The previous PR providing begin/end comments bracketing included files was missing two sources for template files 
- the top level template file
- files not detected by pass one parsing

This PR covers all three cases, and specifies which kind ("interp" for top level, "parse" for parsing "print" for include without parsing)

Additionnaly, this PR proposes to keep the result of the parsing along with the included file name, and provide it to the following step rather than returning nil. The effect of this modification is that files included within an included file are now correctly treated (the problem was shown with the data_3col module). This is a fix to #798
