### PR TITLE
WIP/POC

### DIFF
--- a/lib/update.ml
+++ b/lib/update.ml
@@ -982,80 +982,40 @@ let reconstitute_date conf var =
           if txt = "" then None else Some (Dtext txt)
       | _ -> None
 
-let rec parse_int n (strm__ : _ Stream.t) =
-  match Stream.peek strm__ with
-    Some ('0'..'9' as i) ->
-      Stream.junk strm__;
-      parse_int (10 * n + Char.code i - Char.code '0') strm__
-  | _ -> n
-
-let parse_r_parent (strm__ : _ Stream.t) =
-  match Stream.peek strm__ with
-    Some 'f' -> Stream.junk strm__; 0
-  | Some 'm' -> Stream.junk strm__; 1
-  | _ -> raise Stream.Failure
+let parse_int s i =
+  let j =
+    let rec loop j =
+      if j = String.length s
+      || match String.unsafe_get s j with '0'..'9' -> false | _ -> true
+      then j
+      else loop (j + 1)
+    in
+    loop i
+  in
+  (int_of_string @@ String.sub s i (j - i), j)
 
 let text_of_var conf =
   function
-    "pa1" -> transl_nth conf "him/her" 0
+  | "pa1" -> transl_nth conf "him/her" 0
   | "pa2" -> transl_nth conf "him/her" 1
-  | var ->
-      let (strm__ : _ Stream.t) = Stream.of_string var in
-      match Stream.peek strm__ with
-        Some 'r' ->
-          Stream.junk strm__;
-          let pos =
-            try parse_int 0 strm__ with
-              Stream.Failure -> raise (Stream.Error "")
-          in
-          begin match Stream.peek strm__ with
-            Some '_' ->
-              Stream.junk strm__;
-              let pn =
-                try parse_r_parent strm__ with
-                  Stream.Failure -> raise (Stream.Error "")
-              in
-              transl_nth conf "relation/relations" 0 ^ " " ^
-              string_of_int pos ^ " - " ^ transl_nth conf "father/mother" pn
-          | _ -> raise (Stream.Error "")
-          end
-      | Some 'w' ->
-          Stream.junk strm__;
-          begin match Stream.peek strm__ with
-            Some 'i' ->
-              Stream.junk strm__;
-              begin match Stream.peek strm__ with
-                Some 't' ->
-                  Stream.junk strm__;
-                  begin match Stream.peek strm__ with
-                    Some 'n' ->
-                      Stream.junk strm__;
-                      let pos =
-                        try parse_int 0 strm__ with
-                          Stream.Failure -> raise (Stream.Error "")
-                      in
-                      transl_nth conf "witness/witnesses" 0 ^ " " ^
-                      string_of_int pos
-                  | _ -> raise (Stream.Error "")
-                  end
-              | _ -> raise (Stream.Error "")
-              end
-          | _ -> raise (Stream.Error "")
-          end
-      | Some 'c' ->
-          Stream.junk strm__;
-          begin match Stream.peek strm__ with
-            Some 'h' ->
-              Stream.junk strm__;
-              let pos =
-                try parse_int 0 strm__ with
-                  Stream.Failure -> raise (Stream.Error "")
-              in
-              Util.translate_eval (transl_nth conf "child/children" 0) ^ " " ^
-              string_of_int pos
-          | _ -> raise (Stream.Error "")
-          end
-      | _ -> var
+  | var -> match String.get var 0 with
+    | 'r' ->
+      let (pos, i) = parse_int var 1 in
+      assert (String.get var i = '_') ;
+      let pn = match String.get var (i + 1) with 'f' -> 0 | 'm' -> 1 | _ -> assert false in
+      transl_nth conf "relation/relations" 0 ^ " " ^ string_of_int pos
+      ^ " - " ^ transl_nth conf "father/mother" pn
+    | 'w' when String.length var >= 5
+            && String.unsafe_get var 1 = 'i'
+            && String.unsafe_get var 2 = 't'
+            && String.unsafe_get var 3 = 'n' ->
+      let (pos, _) = parse_int var 4 in
+      transl_nth conf "witness/witnesses" 0 ^ " " ^ string_of_int pos
+    | 'c' when String.length var >= 3 && String.unsafe_get var 1 = 'h' ->
+      let (pos, _) = parse_int var 2 in
+      Util.translate_eval (transl_nth conf "child/children" 0)
+      ^ " " ^ string_of_int pos
+    | _ -> var
 
 let print_create_conflict conf base p var =
   let err =


### PR DESCRIPTION
Some camlp5-generated parser could probably be rewritten without the need of a parser generator library easily so code would look human friendly.
Perfs could also be "better", which is not the point (and pointless), but at least they should not be worst.

In this PR, an example with the Update.text_of_var function.

For more complex parsers, we need a parser library, so either we go with menhir (which is propably a little bit too heavy for such small parsers), or some lib such as https://github.com/inhabitedtype/angstrom

PS : I did not even tried the handwritten parser yet, so it could possibly be wrong...
