### PR TITLE
Improved Place.normalize perfs

### DIFF
--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -1,7 +1,8 @@
 open Geneweb
 
 let bench name n fn arg =
-  ignore @@ Benchmark.latency1 ~name n (List.map fn) arg
+  if match Sys.getenv_opt "BENCH_FN" with None -> true | Some x -> x = name
+  then ignore @@ Benchmark.latency1 ~name n (List.map fn) arg
 
 let list =
   [1;2;10;100;1000;10000;100000;1000000;10000000;100000000;1000000000]

--- a/test/test_place.ml
+++ b/test/test_place.ml
@@ -8,6 +8,8 @@ let suite =
             assert_equal ~printer:(fun x -> x) exp (Place.normalize inp)
           in
           test "foo-bar, boobar (baz)" "[foo-bar] - boobar (baz)"
+        ; test "[foo-bar - boobar (baz)" "[foo-bar - boobar (baz)"
+        ; test "[foo-bar] boobar (baz)" "[foo-bar] boobar (baz)"
         end
     ]
   ]


### PR DESCRIPTION
On master:
```
Latencies for 10000000 iterations of "Place.normalize":
Place.normalize:  7.89 WALL ( 7.89 usr +  0.00 sys =  7.89 CPU) @ 1266722.32/s (n=10000000)
```

With this branch:
```
Latencies for 10000000 iterations of "Place.normalize":
Place.normalize:  0.75 WALL ( 0.75 usr +  0.00 sys =  0.75 CPU) @ 13380002.78/s (n=10000000)
```