### PR TITLE
Probable correction in gen_decline_basic for spanish

### DIFF
--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -2357,7 +2357,7 @@ da: og
 de: und
 en: and
 eo: kaj
-es: y/e 
+es: y/e
 et: ja
 fi: ja
 fr: et

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -189,7 +189,7 @@ let gen_decline_basic wt s =
     if String.rindex_opt wt '/' <> None then
         (* special case for Spanish *)
         if String.length s > 0 && start_with_hi_i s then
-          nth_field wt 1 ^ Mutil.decline 'n' s
+          nth_field wt 1 ^ Mutil.decline 'n' s1
         else nth_field wt 0 ^ Mutil.decline 'n' s1
     else wt ^ Mutil.decline 'n' s1
   else if len >= 3 && wt.[len-3] = ':' && wt.[len-1] = ':' then


### PR DESCRIPTION
I found no cases where `gen_decline_basic wt s` was called with `transl conf [and]` as parameter.
This the code for spanish (/ present in lexicon wt string and s starts with hi or i) in `gen_decline_basic` has probably never been used.
I built a test case where it was called, and verified that the `start_with_hi_i` rule is applied.
Without the correction in lex_utf8, there are two spaces if start_with_hi_i is true, and only one in the other case.
One can suppress the extra space after y/e in lex_utf8 with the proposed correction in `gen_decline_basic`.