### PR TITLE
Expand multiple %x cases in apply_format, Fix #887

### DIFF
--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -871,15 +871,32 @@ let apply_format conf nth s1 s2 =
           match Util.check_format "%d" s1 with
             Some s3 -> Printf.sprintf (transl_nth_format s3) (int_of_string s2)
           | None ->
+              let (s21, s22) =
+                let i = String.index s2 ':' in
+                String.sub s2 0 i,
+                String.sub s2 (i + 1) (String.length s2 - i - 1)
+              in
               match Util.check_format "%s%s" s1 with
-                Some s3 ->
-                  let (s21, s22) =
-                    let i = String.index s2 ':' in
-                    String.sub s2 0 i,
-                    String.sub s2 (i + 1) (String.length s2 - i - 1)
-                  in
-                  Printf.sprintf (transl_nth_format s3) s21 s22
-              | None -> raise Not_found
+                Some s3 -> Printf.sprintf (transl_nth_format s3) s21 s22
+              | None ->
+                match Util.check_format "%t%s" s1 with
+                  Some s3 ->
+                    Printf.sprintf (transl_nth_format s3) (fun _ -> s21) s22
+                | None ->
+                  match Util.check_format "%s%t" s1 with
+                    Some s3 ->
+                      Printf.sprintf (transl_nth_format s3) s21 (fun _ -> s22)
+                  | None ->
+                    match Util.check_format "%t%d" s1 with
+                      Some s3 ->
+                        Printf.sprintf (transl_nth_format s3) (fun _ -> s21)
+                        (int_of_string s22)
+                    | None ->
+                      match Util.check_format "%s%d" s1 with
+                        Some s3 ->
+                          Printf.sprintf (transl_nth_format s3) s21
+                          (int_of_string s22)
+                      | None -> raise Not_found
 
 let rec eval_ast conf =
   function


### PR DESCRIPTION
In the current master, Templ.apply_format handles only the case where two %s parameters appear.
The proposer PR, which is a proof of concept, and can certainly be recoded more elegantly and with more generality, handles also %t%s, %s%t, %s%d and %t%d