### PR TITLE
Correct failing compare of sosa values

### DIFF
--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -363,7 +363,7 @@ let next_sosa s =
   (* La clé de la table est l'iper de la personne et on lui associe son numéro
     de sosa. On inverse pour trier sur les sosa *)
   let sosa_list = Hashtbl.fold (fun k v acc -> (v, k) :: acc) sosa_ht [] in
-  let sosa_list = List.sort (fun (s1, _) (s2, _) -> compare s1 s2) sosa_list in
+  let sosa_list = List.sort (fun (s1, _) (s2, _) -> Sosa.compare s1 s2) sosa_list in
   let rec find_n x lst = match lst with
     | [] -> (Sosa.zero, dummy_iper)
     | (so, _) :: tl ->
@@ -376,7 +376,7 @@ let next_sosa s =
 
 let prev_sosa s =
   let sosa_list = Hashtbl.fold (fun k v acc -> (v, k) :: acc) sosa_ht [] in
-  let sosa_list = List.sort (fun (s1, _) (s2, _) -> compare s1 s2) sosa_list in
+  let sosa_list = List.sort (fun (s1, _) (s2, _) -> Sosa.compare s1 s2) sosa_list in
   let sosa_list = List.rev sosa_list in
   let rec find_n x lst = match lst with
     | [] -> (Sosa.zero, dummy_iper)
@@ -3199,7 +3199,7 @@ and eval_person_field_var conf base env (p, p_auth as ep) loc =
           | Some (n, _) ->
               begin match prev_sosa n with
               | (so, ip) ->
-                if so = Sosa.zero then VVstring ""
+                if Sosa.eq so Sosa.zero then VVstring ""
                 else
                   let p = poi base ip in
                   let p_auth = authorized_age conf base p in

--- a/lib/sosa.array/sosa.ml
+++ b/lib/sosa.array/sosa.ml
@@ -163,6 +163,8 @@ let rec exp_gen x1 x2 n =
 let exp x n =
   exp_gen x x n
 
+let compare x y = if gt x y then 1 else if eq x y then 0 else -1
+
 let code_of_digit d =
   let d = to_int d in
   if d < 10 then Char.code '0' + d else Char.code 'A' + (d - 10)

--- a/lib/sosa.mli/sosa.mli
+++ b/lib/sosa.mli/sosa.mli
@@ -6,6 +6,7 @@ val zero : t
 val one : t
 val eq : t -> t -> bool
 val gt : t -> t -> bool
+val compare : t -> t -> int
 val add : t -> t -> t
 val sub : t -> t -> t
 val twice : t -> t

--- a/lib/sosa.num/sosa.ml
+++ b/lib/sosa.num/sosa.ml
@@ -17,6 +17,8 @@ let div x y = Big_int.div_big_int x (Big_int.big_int_of_int y)
 let modl x y = Big_int.mod_big_int x (Big_int.big_int_of_int y)
 let exp = Big_int.power_big_int_positive_int
 
+let compare x y = if gt x y then 1 else if eq x y then 0 else -1
+
 let inc sosa increment = Big_int.add_big_int sosa (of_int increment)
 let even =
   let two = Big_int.big_int_of_int 2 in

--- a/lib/sosa.zarith/sosa.ml
+++ b/lib/sosa.zarith/sosa.ml
@@ -17,6 +17,8 @@ let div x y = Z.div x (Z.of_int y)
 let modl x y = Z.rem x (Z.of_int y)
 let exp = Z.pow
 
+let compare = Z.compare
+
 let inc sosa increment = Z.add sosa (of_int increment)
 let even = Z.is_even
 let twice = let two = Z.succ Z.one in fun sosa -> Z.mul sosa two


### PR DESCRIPTION
Following Dominique's error report after tests with latest merge of PR #906  

The `compare` function failed when comparing sosa numbers with `--sosa-num` compile option.