### PR TITLE
Keep oc= in url_no_index, ignore empty values. Fix #926

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1354,7 +1354,7 @@ let url_no_index conf base =
       function
         [] -> []
       | ("opt", "no_index") :: l -> loop l
-      | (("dsrc" | "escache" | "oc" | "templ"), _) :: l -> loop l
+      | (("dsrc" | "escache" | "templ"), _) :: l -> loop l
       | ("i", v) :: l -> new_env "i" v (fun x -> x) l
       | ("ei", v) :: l -> new_env "ei" v (fun x -> "e" ^ x) l
       | (k, v) :: l when String.length k = 2 && k.[0] = 'i' ->
@@ -1391,7 +1391,9 @@ let url_no_index conf base =
   let suff =
     List.fold_right
       (fun (x, v) s ->
-         let sep = if s = "" then "" else "&" in x ^ "=" ^ v ^ sep ^ s)
+        if v != "" then
+          let sep = if s = "" then "" else "&" in x ^ "=" ^ v ^ sep ^ s
+        else s )
       (("lang", conf.lang) :: env) ""
   in
   if conf.b_arg_for_basename then addr ^ "?b=" ^ conf.bname ^ "&" ^ suff


### PR DESCRIPTION
url_no_index works properly only if the url identifies the person with i=index
When the person is identified with p=fn;n=sn;oc=oc, url_no_index drops the oc!

In addition, ignore empty values in rebuilding url.