### PR TITLE
Indexes

### DIFF
--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -150,6 +150,7 @@ let p_NBDS = ref false
 let pevents_witnesses = ref false
 let fevents_witnesses = ref false
 let marriage_divorce = ref false
+let index = ref false
 let dry_run = ref false
 
 let speclist =
@@ -165,6 +166,7 @@ let speclist =
   ; ("-pevents-witnesses", Arg.Set pevents_witnesses, " missing doc")
   ; ("-fevents-witnesses", Arg.Set fevents_witnesses, " missing doc")
   ; ("-marriage-divorce", Arg.Set marriage_divorce, " missing doc")
+  ; ("-index", Arg.Set index, " rebuild index. It is automatically enable by any other option.")
   ]
 
 let anonfun i = bname := i
@@ -184,6 +186,7 @@ let main () =
   || !fevents_witnesses
   || !marriage_divorce
   || !p_NBDS
+  || !index
   then ()
   else begin
     f_parents := true ;

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -345,4 +345,8 @@ type base_func =
   ; nb_of_real_persons : unit -> int
   }
 
-type dsk_base = { data : base_data; func : base_func }
+type base_version = GnWb0020 | GnWb0021
+
+type dsk_base = { data : base_data
+                ; func : base_func
+                ; version : base_version }

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -71,4 +71,8 @@ let output_array_no_sharing oc arr_get arr_len =
   let pos_end = Iovalue.patch_output_value_header oc header_pos in
   seek_out oc pos_end
 
-module IntHT = Hashtbl.Make (struct include Int let hash x = x end)
+module IntHT = Hashtbl.Make (struct
+    type t = int
+    let equal = (=)
+    let hash x = x
+  end)

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -6,8 +6,8 @@ open Def
 type name_index_data = int array array
 type strings_of_fsname = int array array
 
-let magic_gwb = "GnWb0020"
-let magic_gwb_iso_8859_1 = "GnWb001y"
+let magic_GnWb0020 = "GnWb0020"
+let magic_GnWb0021 = "GnWb0021"
 let table_size = 0x3fff
 
 let poi base i = base.data.persons.get i
@@ -49,15 +49,6 @@ let dsk_person_misc_names base p nobtit =
     (if p.sex = Female then husbands base p else [])
     (father_titles_places base p nobtit)
 
-let check_magic ic =
-  let b = really_input_string ic (String.length magic_gwb) in
-  if b <> magic_gwb then
-    if b = magic_gwb_iso_8859_1
-    then failwith "this is a iso_8859_1 GeneWeb base, but you need utf-8"
-    else if String.sub magic_gwb 0 4 = String.sub b 0 4
-    then failwith "this is a GeneWeb base, but not compatible"
-    else failwith "this is not a GeneWeb base, or it is a very old version"
-
 let compare_names base_data s1 s2 =
   Mutil.compare_after_particle base_data.particles s1 s2
 
@@ -79,3 +70,5 @@ let output_array_no_sharing oc arr_get arr_len =
   for i = 0 to arr_len - 1 do Iovalue.output oc (arr_get i) done;
   let pos_end = Iovalue.patch_output_value_header oc header_pos in
   seek_out oc pos_end
+
+module IntHT = Hashtbl.Make (struct include Int let hash x = x end)

--- a/lib/gwdb-legacy/dutil.mli
+++ b/lib/gwdb-legacy/dutil.mli
@@ -5,11 +5,10 @@ open Dbdisk
 type name_index_data = int array array
 type strings_of_fsname = int array array
 
-val magic_gwb : string
-val magic_gwb_iso_8859_1 : string
+val magic_GnWb0020 : string
+val magic_GnWb0021 : string
 val table_size : int
 
-val check_magic : in_channel -> unit
 val compare_istr_fun : Dbdisk.base_data -> int -> int -> int
 val compare_names : Dbdisk.base_data -> string -> string -> int
 
@@ -24,3 +23,5 @@ val p_surname : dsk_base -> dsk_person -> string
 val output_value_no_sharing : out_channel -> _ -> unit
 val output_array_no_sharing : out_channel -> (int -> _) -> int -> unit
 val int_size : int
+
+module IntHT : sig include module type of Hashtbl.Make (struct include Int let hash x = x end) end

--- a/lib/gwdb-legacy/dutil.mli
+++ b/lib/gwdb-legacy/dutil.mli
@@ -24,4 +24,10 @@ val output_value_no_sharing : out_channel -> _ -> unit
 val output_array_no_sharing : out_channel -> (int -> _) -> int -> unit
 val int_size : int
 
-module IntHT : sig include module type of Hashtbl.Make (struct include Int let hash x = x end) end
+module IntHT : sig
+  include module type of Hashtbl.Make (struct
+      type t = int
+      let equal = (=)
+      let hash x = x
+    end)
+end

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -291,7 +291,7 @@ let make bname particles ((persons, families, strings, bnotes) as _arrays) : Dbd
     ; nb_of_real_persons = (fun _ -> assert false)
     }
   in
-  sync ~scratch:true { data ; func } ;
+  sync ~scratch:true { data ; func ; version = GnWb0021 } ;
   open_base bname
 
 let bfname base fname =

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -480,3 +480,12 @@ let rec list_replace old_v new_v = function
     if hd = old_v
     then new_v :: tl
     else hd :: list_replace old_v new_v tl
+
+let list_except x =
+  let rec loop acc = function
+    | [] -> []
+    | hd :: tl ->
+      if hd = x then List.rev_append acc tl
+      else loop (hd :: acc) tl
+  in
+  loop []

--- a/lib/util/mutil.mli
+++ b/lib/util/mutil.mli
@@ -140,3 +140,6 @@ val array_forall2 : ('a -> 'b -> bool) -> 'a array -> 'b array -> bool
     returned unchanged.
 *)
 val list_replace : 'a -> 'a -> 'a list -> 'a list
+
+(** [list_except old_v new_v list] *)
+val list_except : 'a -> 'a list -> 'a list


### PR DESCRIPTION
Copy of the commit message of 8eb8bc3 

While previous implementation used btree for storing ordered istr,
this one use plain array with binary search.

The result is an implementation performing the same
when browsing, but building the surname and first name indexes
for 2000000+ persons takes less than 8s while btree
implementation takes about 30s.