### PR TITLE
Added gwgc executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lib/gwlib.ml:
 	@echo "  with Not_found -> \"$(PREFIX)\"" | sed -e 's|\\|/|g' >> $@
 	@echo " Done!"
 
-CPPO_D=$(API_D)
+CPPO_D=$(API_D) $(GWDB_D)
 
 %/dune: %/dune.in Makefile.config
 	@echo -n "Generating $@..." \

--- a/bin/dune.in
+++ b/bin/dune.in
@@ -12,6 +12,18 @@
 (dirs :standard \ dico_place)
 #endif
 
+#ifdef GENEWEB_GWDB_LEGACY
+(executable
+  (package geneweb-bin)
+  (public_name gwgc)
+  (modules gwgc)
+  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% %{input-file})))
+  (libraries unix str %%%GWDB_PKG%%% %%%SOSA_PKG%%% %%%WSERVER_PKG%%% geneweb)
+)
+#else
+(dirs :dirs \ gwgc)
+#endif
+
 (executable
   (package geneweb-bin)
   (public_name consang)
@@ -49,7 +61,7 @@
   (public_name geneweb-gwd-lib)
   (wrapped true)
   (libraries geneweb geneweb-jingoo jingoo unix str %%%GWDB_PKG%%% %%%SOSA_PKG%%% %%%WSERVER_PKG%%%)
-  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% -V OCAML:%{ocaml_version} %{input-file})))
+  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% %{input-file})))
   (modules gwDaemon jgInterp request requestHandler)
 )
 
@@ -57,7 +69,7 @@
   (package geneweb-bin)
   (public_name gwd)
   (libraries geneweb geneweb-jingoo geneweb-gwd-lib unix str %%%GWDB_PKG%%% %%%SOSA_PKG%%% %%%WSERVER_PKG%%%)
-  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% -V OCAML:%{ocaml_version} %{input-file})))
+  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% %{input-file})))
   (modules gwd)
 )
 

--- a/bin/gwgc/gwgc.ml
+++ b/bin/gwgc/gwgc.ml
@@ -1,0 +1,31 @@
+open Geneweb
+
+let dry_run = ref false
+let bname = ref ""
+
+let speclist =
+  [ ("--dry-run", Arg.Set dry_run, " do not commit changes (only print)") ]
+
+let anonfun i = bname := i
+let usage = "Usage: " ^ Sys.argv.(0) ^ " [OPTION] base"
+
+let () =
+  Arg.parse speclist anonfun usage ;
+  let bname = match !bname with "" -> Arg.usage speclist usage ; exit 1
+                              | s -> s
+  in
+  let dry_run = !dry_run in
+  Secure.set_base_dir (Filename.dirname bname);
+  Lock.control (Mutil.lock_file bname) true ~onerror:Lock.print_try_again @@
+  fun () ->
+  let base = Database.opendb bname in
+  let p, f, s = Gwdb_gc.gc ~dry_run base in
+  Printf.printf
+    "%s:\n\
+     \tnb of persons: %d\n\
+     \tnb of families: %d\n\
+     \tnb of strings: %d\n"
+    bname
+    (List.length p)
+    (List.length f)
+    (List.length s)

--- a/configure.ml
+++ b/configure.ml
@@ -61,7 +61,7 @@ let () =
   let exclude_dir s = dune_dirs_exclude := !dune_dirs_exclude ^ " " ^ s in
   let api_d, api_pkg =
     match !api with
-    | true -> "-D API", "piqirun.ext redis-sync yojson curl"
+    | true -> " -D API ", "piqirun.ext redis-sync yojson curl"
     | false -> "", ""
   in
   if !sosa = `None then begin
@@ -86,14 +86,15 @@ let () =
     | `None -> assert false
   in
   let wserver_pkg = "geneweb-wserver" in
-  let gwdb_pkg =
+  let gwdb_d, gwdb_pkg =
     match !gwdb with
     | `None
     | `Legacy ->
       exclude_dir "gwdb-legacy-x-arangodb" ;
-      "geneweb-gwdb-legacy" ;
+      (" -D GENEWEB_GWDB_LEGACY ", "geneweb-gwdb-legacy") ;
     | `LegacyArangoDB ->
-      "geneweb-gwdb-legacy-x-arangodb"
+      (" -D GENEWEB_GWDB_LEGACY -D GENEWEB_GWDB_ARANGODB "
+      , "geneweb-gwdb-legacy-x-arangodb")
   in
   let dune_profile = if !release then "release" else "dev" in
   let os_type, camlp5f, ext, rm, strip =
@@ -116,6 +117,7 @@ let () =
   var "RM" rm ;
   var "EXT" ext ;
   var "API_D" api_d ;
+  var "GWDB_D" gwdb_d ;
   var "API_PKG" api_pkg ;
   var "GWDB_PKG" gwdb_pkg ;
   var "SOSA_PKG" sosa_pkg ;

--- a/lib/gwdb-legacy-x-arangodb/dune
+++ b/lib/gwdb-legacy-x-arangodb/dune
@@ -1,4 +1,4 @@
-(copy_files %{project_root}/lib/gwdb-legacy/{btree.ml,database.ml,database.mli,dbdisk.mli,dutil.ml,dutil.mli,outbase.ml})
+(copy_files %{project_root}/lib/gwdb-legacy/{btree.ml,database.ml,database.mli,dbdisk.mli,dutil.ml,dutil.mli,gwdb_gc.ml,outbase.ml})
 (rule (copy %{project_root}/lib/gwdb-legacy/gwdb_driver.ml gwdb_driver_legacy.ml))
 
 (library
@@ -23,6 +23,7 @@
     gwdb_driver_arango
     gwdb_driver_env
     gwdb_driver_legacy
+    gwdb_gc
     http_curl
     json
     json_jsonaf

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -1075,3 +1075,65 @@ let opendb bname =
   { data = base_data
   ; func = base_func
   ; version }
+
+let record_access_of tab =
+  { Dbdisk.load_array = (fun () -> ())
+  ; get = (fun i -> tab.(i))
+  ; get_nopending = (fun i -> tab.(i))
+  ; set = (fun i v -> tab.(i) <- v)
+  ; output_array = (fun oc -> Dutil.output_value_no_sharing oc (tab : _ array))
+  ; len = Array.length tab
+  ; clear_array = fun () -> () }
+
+let make bname particles ((persons, families, strings, bnotes) as _arrays) : Dbdisk.dsk_base =
+  let bdir =
+    if Filename.check_suffix bname ".gwb" then bname
+    else bname ^ ".gwb"
+  in
+  let (persons, ascends, unions) = persons in
+  let (families, couples, descends) = families in
+  let data : Dbdisk.base_data =
+    { persons = record_access_of persons
+    ; ascends = record_access_of ascends
+    ; unions = record_access_of unions
+    ; families = record_access_of families
+    ; visible =
+       { v_write = (fun _ -> assert false)
+       ; v_get = (fun _ -> assert false)
+       }
+    ; couples = record_access_of couples
+    ; descends = record_access_of descends
+    ; strings = record_access_of strings
+    ; particles
+    ; bnotes = bnotes
+    ; bdir = bdir }
+  in
+  let func : Dbdisk.base_func =
+    { person_of_key = (fun _ -> assert false)
+    ; persons_of_name = (fun _ -> assert false)
+    ; strings_of_fsname = (fun _ -> assert false)
+    ; persons_of_surname =
+       { find = (fun _ -> assert false)
+       ; cursor = (fun _ -> assert false)
+       ; next = (fun _ -> assert false)
+       }
+    ; persons_of_first_name =
+       { find = (fun _ -> assert false)
+       ; cursor = (fun _ -> assert false)
+       ; next = (fun _ -> assert false)
+       }
+    ; patch_person = (fun _ -> assert false)
+    ; patch_ascend = (fun _ -> assert false)
+    ; patch_union = (fun _ -> assert false)
+    ; patch_family = (fun _ -> assert false)
+    ; patch_couple = (fun _ -> assert false)
+    ; patch_descend = (fun _ -> assert false)
+    ; patch_name = (fun _ -> assert false)
+    ; insert_string = (fun _ -> assert false)
+    ; commit_patches = (fun _ -> assert false)
+    ; commit_notes = (fun _ -> assert false)
+    ; cleanup = (fun _ -> ())
+    ; nb_of_real_persons = (fun _ -> assert false)
+    }
+  in
+  { data ; func ; version = GnWb0021 }

--- a/lib/gwdb-legacy/database.mli
+++ b/lib/gwdb-legacy/database.mli
@@ -2,6 +2,19 @@
 
 val opendb : string -> Dbdisk.dsk_base
 
+val make
+  : string
+  -> string list
+  -> ( ( (int, int, int) Def.gen_person array
+         * int Def.gen_ascend array
+         * int Def.gen_union array )
+       * ( (int, int, int) Def.gen_family array
+           * int Def.gen_couple array
+           * int Def.gen_descend array )
+       * string array
+       * Def.base_notes )
+  -> Dbdisk.dsk_base
+
 (* Ajout pour l'API *)
 type synchro_patch =
   { mutable synch_list : (string * int list * int list) list }

--- a/lib/gwdb-legacy/dune
+++ b/lib/gwdb-legacy/dune
@@ -15,6 +15,7 @@
     dbdisk
     dutil
     gwdb_driver
+    gwdb_gc
     outbase
   )
 )

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -227,71 +227,12 @@ let new_iper base = base.data.persons.len
 
 let new_ifam base = base.data.families.len
 
-let record_access_of tab =
-  { Dbdisk.load_array = (fun () -> ())
-  ; get = (fun i -> tab.(i))
-  ; get_nopending = (fun i -> tab.(i))
-  ; set = (fun i v -> tab.(i) <- v)
-  ; output_array = (fun oc -> Dutil.output_value_no_sharing oc (tab : _ array))
-  ; len = Array.length tab
-  ; clear_array = fun () -> () }
-
 (* FIXME: lock *)
 let sync ?scratch:_ base =
   Outbase.output base
 
-let make bname particles ((persons, families, strings, bnotes) as _arrays) : Dbdisk.dsk_base =
-  let bdir =
-    if Filename.check_suffix bname ".gwb" then bname
-    else bname ^ ".gwb"
-  in
-  let (persons, ascends, unions) = persons in
-  let (families, couples, descends) = families in
-  let data : Dbdisk.base_data =
-    { persons = record_access_of persons
-    ; ascends = record_access_of ascends
-    ; unions = record_access_of unions
-    ; families = record_access_of families
-    ; visible =
-       { v_write = (fun _ -> assert false)
-       ; v_get = (fun _ -> assert false)
-       }
-    ; couples = record_access_of couples
-    ; descends = record_access_of descends
-    ; strings = record_access_of strings
-    ; particles
-    ; bnotes = bnotes
-    ; bdir = bdir }
-  in
-  let func : Dbdisk.base_func =
-    { person_of_key = (fun _ -> assert false)
-    ; persons_of_name = (fun _ -> assert false)
-    ; strings_of_fsname = (fun _ -> assert false)
-    ; persons_of_surname =
-       { find = (fun _ -> assert false)
-       ; cursor = (fun _ -> assert false)
-       ; next = (fun _ -> assert false)
-       }
-    ; persons_of_first_name =
-       { find = (fun _ -> assert false)
-       ; cursor = (fun _ -> assert false)
-       ; next = (fun _ -> assert false)
-       }
-    ; patch_person = (fun _ -> assert false)
-    ; patch_ascend = (fun _ -> assert false)
-    ; patch_union = (fun _ -> assert false)
-    ; patch_family = (fun _ -> assert false)
-    ; patch_couple = (fun _ -> assert false)
-    ; patch_descend = (fun _ -> assert false)
-    ; patch_name = (fun _ -> assert false)
-    ; insert_string = (fun _ -> assert false)
-    ; commit_patches = (fun _ -> assert false)
-    ; commit_notes = (fun _ -> assert false)
-    ; cleanup = (fun _ -> ())
-    ; nb_of_real_persons = (fun _ -> assert false)
-    }
-  in
-  sync ~scratch:true { data ; func ; version = GnWb0021 } ;
+let make bname particles arrays : Dbdisk.dsk_base =
+  sync ~scratch:true (Database.make bname particles arrays) ;
   open_base bname
 
 let bfname base fname =

--- a/lib/gwdb-legacy/gwdb_gc.ml
+++ b/lib/gwdb-legacy/gwdb_gc.ml
@@ -1,0 +1,199 @@
+open Dbdisk
+
+(* copied from Gwdb_driver *)
+let dummy_iper = -1
+let dummy_ifam = -1
+let empty_string = 0
+let quest_string = 1
+
+let empty_person p =
+  (p.first_name = empty_string || p.first_name = quest_string)
+  && (p.surname = empty_string || p.surname = quest_string)
+  (* && p.occ = 0 *)
+  && p.image = empty_string
+  && p.first_names_aliases = []
+  && p.surnames_aliases = []
+  && p.public_name = empty_string
+  && p.qualifiers = []
+  && p.titles = []
+  && p.rparents = []
+  && p.related = []
+  && p.aliases = []
+  && p.occupation = empty_string
+  && p.sex = Neuter
+  (* && p.access = Private *)
+  && p.birth = Adef.cdate_None
+  && p.birth_place = empty_string
+  && p.birth_note = empty_string
+  && p.birth_src = empty_string
+  && p.baptism = Adef.cdate_None
+  && p.baptism_place = empty_string
+  && p.baptism_note = empty_string
+  && p.baptism_src = empty_string
+  && p.death = DontKnowIfDead
+  && p.death_place = empty_string
+  && p.death_note = empty_string
+  && p.death_src = empty_string
+  && p.burial = UnknownBurial
+  && p.burial_place = empty_string
+  && p.burial_note = empty_string
+  && p.burial_src = empty_string
+  && p.pevents = []
+  && p.notes = empty_string
+  && p.psources = empty_string
+
+let gc ?(dry_run = true) base =
+  base.data.persons.load_array () ;
+  base.data.ascends.load_array () ;
+  base.data.unions.load_array () ;
+  base.data.families.load_array () ;
+  base.data.couples.load_array () ;
+  base.data.descends.load_array () ;
+  base.data.strings.load_array () ;
+  let mp = Array.make base.data.persons.len false in
+  let mf = Array.make base.data.families.len false in
+  let ms = Array.make base.data.strings.len false in
+  let markp i = Array.set mp i true in
+  let markf i = Array.set mf i true in
+  let marks i = Array.set ms i true in
+  marks 0 ;
+  marks 1 ;
+  for i = 0 to base.data.persons.len - 1 do
+    let p = base.data.persons.get i in
+    if not (empty_person p) then begin
+      markp i ;
+      let _ = Futil.map_person_ps markp marks p in
+      let _ = Futil.map_union_f markf @@ base.data.unions.get i in
+      let _ = Futil.map_ascend_f markf @@ base.data.ascends.get i in
+      ()
+    end
+  done ;
+  for i = 0 to base.data.families.len - 1 do
+    if Array.get mf i then begin
+      let f = base.data.families.get i in
+      if f.fam_index <> dummy_ifam then begin
+        let _ = Futil.map_family_ps markp markf marks f in
+        let _ = Futil.map_couple_p false markp @@ base.data.couples.get i in
+        let _ = Futil.map_descend_p markp @@ base.data.descends.get i in
+        ()
+      end
+    end
+  done ;
+  let dst_i src m =
+    let off = ref 0 in
+    Array.init src.len begin fun i ->
+      if Array.get m i then i - !off else begin incr off ; i - !off end
+    end
+  in
+  let src_i len m =
+    let off = ref 0 in
+    let a = Array.make len (-1) in
+    let rec loop i =
+      if i = len then ()
+      else if Array.get m (i + !off) then begin
+        Array.set a i (i + !off) ;
+        loop (i + 1)
+      end
+      else begin
+        incr off ;
+        loop i
+      end
+    in
+    loop 0 ;
+    a
+  in
+  let aux arr =
+    let rec loop i (sum, acc) =
+      if i < 0 then sum, acc
+      else if Array.get arr i then begin
+        loop (pred i) (succ sum, acc)
+      end
+      else loop (pred i) (sum, i :: acc)
+    in
+    loop (Array.length arr - 1) (0, [])
+  in
+  let lenp, deletedp = aux mp in
+  let lenf, deletedf = aux mf in
+  let lens, deleteds = aux ms in
+  if dry_run then begin
+    (deletedp, deletedf, deleteds)
+  end else begin
+    let dst_ipers = dst_i base.data.persons mp in
+    let dst_ifams = dst_i base.data.families mf in
+    let dst_istrs = dst_i base.data.strings ms in
+    let dst_iper = Array.get dst_ipers in
+    let dst_ifam = Array.get dst_ifams in
+    let dst_istr = Array.get dst_istrs in
+    let src_ipers = src_i lenp mp in
+    let src_ifams = src_i lenf mf in
+    let src_istrs = src_i lens ms in
+    let src_iper = Array.get src_ipers in
+    let src_ifam = Array.get src_ifams in
+    let src_istr = Array.get src_istrs in
+    let persons =
+      Array.init lenp @@ begin fun i ->
+        { (Futil.map_person_ps dst_iper dst_istr @@
+           base.data.persons.get @@
+           src_iper i)
+          with key_index = i }
+      end
+    in
+    let ascends =
+      Array.init lenp @@ begin fun i ->
+        Futil.map_ascend_f dst_ifam @@ base.data.ascends.get @@ src_iper i
+      end
+    in
+    let unions =
+      Array.init lenp @@ begin fun i ->
+        Futil.map_union_f dst_ifam @@ base.data.unions.get @@ src_iper i
+      end
+    in
+    let families =
+      Array.init lenf @@ begin fun i ->
+        Futil.map_family_ps dst_iper (fun _ -> i) dst_istr @@ base.data.families.get @@ src_ifam i
+      end
+    in
+    let couples =
+      Array.init lenf @@ begin fun i ->
+        Futil.map_couple_p false dst_iper @@ base.data.couples.get @@ src_ifam i
+      end
+    in
+    let descends =
+      Array.init lenf @@ begin fun i ->
+        Futil.map_descend_p dst_iper @@ base.data.descends.get @@ src_ifam i
+      end
+    in
+    let strings =
+      Array.init lens begin fun i -> base.data.strings.get @@ src_istr i end
+    in
+    let bnotes = base.data.bnotes in
+    let particles = base.data.particles in
+    let bname = base.data.bdir in
+    base.data.persons.clear_array () ;
+    base.data.ascends.clear_array () ;
+    base.data.unions.clear_array () ;
+    base.data.families.clear_array () ;
+    base.data.couples.clear_array () ;
+    base.data.descends.clear_array () ;
+    base.data.strings.clear_array () ;
+    let base' =
+      Database.make bname particles
+        ((persons, ascends, unions), (families, couples, descends), strings, bnotes)
+    in
+    base'.data.persons.load_array () ;
+    base'.data.ascends.load_array () ;
+    base'.data.unions.load_array () ;
+    base'.data.families.load_array () ;
+    base'.data.couples.load_array () ;
+    base'.data.descends.load_array () ;
+    base'.data.strings.load_array () ;
+    Outbase.output base' ;
+    base'.data.persons.clear_array () ;
+    base'.data.ascends.clear_array () ;
+    base'.data.unions.clear_array () ;
+    base'.data.families.clear_array () ;
+    base'.data.couples.clear_array () ;
+    base'.data.descends.clear_array () ;
+    base'.data.strings.clear_array () ;
+    (deletedp, deletedf, deleteds)
+  end

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -122,6 +122,12 @@ let map_person_ps fp fs p =
   ; key_index = p.key_index
   }
 
+let map_ascend_f ff a =
+  begin match a.parents with
+    | Some f -> { parents = Some (ff f) ; consang = a.consang }
+    | None -> { parents = None ; consang = a.consang }
+  end
+
 let map_union_f ff u = {family = Array.map ff u.family}
 
 let map_family_ps fp ff fs fam =

--- a/lib/util/futil.mli
+++ b/lib/util/futil.mli
@@ -14,6 +14,7 @@ val map_relation_ps :
 
 val map_person_ps :
   ('b -> 'd) -> ('c -> 'e) -> ('a, 'b, 'c) gen_person -> ('a, 'd, 'e) gen_person
+val map_ascend_f : ('a -> 'b) -> 'a gen_ascend -> 'b gen_ascend
 val map_union_f : ('a -> 'b) -> 'a gen_union -> 'b gen_union
 
 val map_family_ps :


### PR DESCRIPTION
`gwgc` will clean up the base, which means: remove all the empty en isolated persons (`? ?`), remove all the deleted families, remove all the unused strings and shift/truncate the arrays to compact the base.

The few tests I did show that gwu produce the same result before the tool run on a base, and after, which is what is expected whereas searching for `?` person will not return any empty person anymore.

`update_nldb` should be run after that, but I will look into automatically running it after the indexes moved.