### PR TITLE
correct fr: -> co: in setup/lang/welcome.htm

### DIFF
--- a/bin/setup/lang/welcome.htm
+++ b/bin/setup/lang/welcome.htm
@@ -276,7 +276,7 @@ sv: <a href="gwsetup?lang=%l;v=update_nldb.htm">Uppdatera länksida / släktkrö
 ] (update_nldb)
 
 <li>[
-fr: <a href="gwsetup?lang=%l;v=connex.htm">Calcula i cumpunenti cunnessi</a>
+co: <a href="gwsetup?lang=%l;v=connex.htm">Calcula i cumpunenti cunnessi</a>
 en: <a href="gwsetup?lang=%l;v=connex.htm">Compute connected componants</a>
 fr: <a href="gwsetup?lang=%l;v=connex.htm">Calcule les composantes connexes</a>
 ] (connex)


### PR DESCRIPTION
Corsican message was incorrectly labeled "fr:"