### PR TITLE
Function %cousins.0.lev provides number of descendants at level lev

### DIFF
--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -788,7 +788,7 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
           <tr>
             <th class="text-left" scope="row" colspan="%nb_col;">
               <span class="ml-1">[*generation/generations]0 %expr(lev+1)</span>
-              <span class="float-right mr-1" title="[*nb individuals] [descendants at the generation] %expr(lev+1)">%apply;desc_count_l(lev+1)</span>%nn;            
+              <span class="float-right mr-1" title="[*nb individuals] [descendants at the generation] %expr(lev+1) (old count/new count)">%apply;desc_count_l(lev+1)</span>%nn;            
             </th
           </tr>
         %end;

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -757,9 +757,13 @@ zzz est lui même si yyy="desc", ou son conjoint si yyy="spous"
   %end;
 %end;
 
+%define;cousins_l(lll)
+  %cousins.0.lll;
+%end;
+
 %define;desc_count_l(xxx)
   %foreach;descendant_level;
-    %if;(level=xxx)%number_of_descendants_at_level;%end;
+    %if;(level=xxx)%number_of_persons_at_level;/%apply;cousins_l(xxx)%end;
   %end;
 %end;
 

--- a/lib/cousinsDisplay.ml
+++ b/lib/cousinsDisplay.ml
@@ -158,7 +158,6 @@ let rec print_descend_upto conf base max_cnt ini_p ini_br lev children =
       Wserver.printf "</ul>\n"
     end
 
-
 let print_cousins_side_of conf base max_cnt a ini_p ini_br lev1 lev2 =
   let sib = siblings conf base (get_iper a) in
   if List.exists (sibling_has_desc_lev conf base lev2) sib then
@@ -244,7 +243,7 @@ let print_cousins conf base p lev1 lev2 =
       Wserver.printf "%s" (Utf8.capitalize (Util.translate_eval s))
     else
       Wserver.printf "%s %d / %s %d" (Utf8.capitalize (transl conf "ancestors")) lev1
-        (Utf8.capitalize (transl conf "descendants")) lev2
+        (transl conf "descendants") lev2
   in
   let max_cnt =
     try int_of_string (List.assoc "max_cousins" conf.base_env) with
@@ -275,7 +274,6 @@ let print_cousins conf base p lev1 lev2 =
   Wserver.printf "</p>\n";
   Wserver.printf "</div>\n";
   Hutil.trailer conf
-
 
 let print_anniv conf base p dead_people level =
   let module S = Map.Make (struct type t = iper let compare = compare end) in
@@ -388,8 +386,6 @@ let print_anniv conf base p dead_people level =
     if dead_people then BirthdayDisplay.gen_print_menu_dead conf base f_scan mode
     else BirthdayDisplay.gen_print_menu_birth conf base f_scan mode
 
-let cousmenu_print = Perso.interp_templ "cousmenu"
-
 let print conf base p =
   let max_lev =
     try int_of_string (List.assoc "max_cousins_level" conf.base_env) with
@@ -409,4 +405,4 @@ let print conf base p =
   | (_, _, Some (("AN" | "AD") as t)) when conf.wizard || conf.friend ->
     print_anniv conf base p (t = "AD") max_lev
   | _ ->
-    cousmenu_print conf base p
+    Perso.interp_templ "cousmenu" conf base p

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -2701,23 +2701,18 @@ and eval_compound_var conf base env (a, _ as ep) loc =
           end
       | _ -> raise Not_found
       end
-  | "number_of_persons_at_level" :: sl ->
+  | "number_of_persons_at_level" :: sl | "number_of_descendants_at_level" :: sl ->
       begin match get_env "level" env with
         Vint i ->
           begin match get_env "desc_level_table" env with
             Vdesclevtab t ->
             let m = fst (Lazy.force t) in
-            let cnt0 =
+            let cnt =
               Gwdb.Collection.fold (fun cnt ip ->
-                  if Gwdb.Marker.get m ip <= i then cnt + 1 else cnt
+                  if Gwdb.Marker.get m ip = i then cnt + 1 else cnt
                 ) 0 (Gwdb.ipers base)
             in
-            let cnt1 =
-              Gwdb.Collection.fold (fun cnt ip ->
-                  if Gwdb.Marker.get m ip <= (i - 1) then cnt + 1 else cnt
-                ) 0 (Gwdb.ipers base)
-            in
-            VVstring (eval_num conf (Sosa.of_int (cnt0 - cnt1)) sl)
+            VVstring (eval_num conf (Sosa.of_int cnt) sl)
           | _ -> raise Not_found
           end
       | _ -> raise Not_found

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -738,6 +738,121 @@ let max_ancestor_level conf base ip max_lev =
   in
   loop 0 ip; !x
 
+(* count nbr of cousins. Inspired from displayCousins *)
+(* %cousins.l1.l2; will return the same count as the total computed by m=C;v1=l1;v2=l2 *)
+
+let default_max_cnt = Cousins.default_max_cnt
+
+let cnt = ref 0
+
+let rec count_descend_upto conf base max_cnt ini_p ini_br lev children =
+  if lev > 0 && !cnt < max_cnt then
+    begin
+      List.iter
+        (fun (ip, ia_asex, rev_br) ->
+           let p = pget conf base ip in
+           (* détecter l'époux de p, parent des enfants qui seront listés *)
+           (* if more than one spouse, this will be split on multiple lines *)
+           (* we ignore the case where two spouses, but only one with descendants! *)
+           let br = List.rev ((ip, get_sex p) :: rev_br) in
+           let is_valid_rel = Cousins.br_inter_is_empty ini_br br in
+           if is_valid_rel && !cnt < max_cnt && Cousins.has_desc_lev conf base lev p
+           then
+             begin
+               if lev = 1 then incr cnt;
+               (* the function children_of returns *all* the children of ip *)
+               Array.iter
+                 (fun ifam ->
+                    let children =
+                      List.map
+                        (fun ip ->
+                           (ip, ia_asex, (get_iper p, get_sex p) :: rev_br))
+                        (Cousins.children_of_fam base ifam)
+                    in
+                    count_descend_upto conf base max_cnt ini_p ini_br (lev - 1) children
+                 )
+                 (get_family p) ;
+             end)
+        children;
+    end
+
+let count_cousins_side_of conf base max_cnt a ini_p ini_br _lev1 lev2 =
+  let sib = Cousins.siblings conf base (get_iper a) in
+  if List.exists (Cousins.sibling_has_desc_lev conf base lev2) sib then
+    begin
+      let sib = List.map (fun (ip, ia_asex) -> ip, ia_asex, []) sib in
+      count_descend_upto conf base max_cnt ini_p ini_br lev2 sib;
+      true
+    end
+  else false
+
+let count_cousins_lev conf base max_cnt p lev1 lev2 =
+  let first_sosa =
+    let rec loop sosa lev =
+      if lev <= 1 then sosa else loop (Sosa.twice sosa) (lev - 1)
+    in
+    loop Sosa.one lev1
+  in
+  let last_sosa = Sosa.twice first_sosa in
+  let some =
+    let rec loop sosa some =
+      if !cnt < max_cnt && Sosa.gt last_sosa sosa then
+        let some =
+          match Util.old_branch_of_sosa conf base (get_iper p) sosa with
+            Some ((ia, _) :: _ as br) ->
+            count_cousins_side_of conf base max_cnt (pget conf base ia) p br
+              lev1 lev2 ||
+            some
+          | _ -> some
+        in
+        loop (Sosa.inc sosa 1) some
+      else some
+    in
+    loop first_sosa false
+  in
+  if some then ()
+
+let get_descendants_at_level base p lev2 =
+  match lev2 with
+  | 0 -> []
+  | n ->
+    let rec loop acc lev fam =
+      Array.fold_left
+      (fun acc ifam ->
+        let children = Array.to_list (get_children (foi base ifam)) in
+        List.fold_left
+        (fun acc ch ->
+          if lev < n then
+            loop acc (lev + 1) (get_family (poi base ch))
+          else
+            if not (List.mem ifam acc) then
+              ifam :: acc
+            else acc
+        ) acc children
+      ) acc fam
+    in
+    loop [] 1 (get_family p)
+
+let count_cousins conf base p lev1 lev2 =
+  match (lev1, lev2) with
+  | (0, 0) -> 1 (* self *)
+  | (0, lev2) -> (* descendants *)
+        let ifam_l = get_descendants_at_level base p lev2 in
+        List.fold_left (fun cnt ifam ->
+          cnt + Array.length (get_children (foi base ifam))) 0 ifam_l
+  | (_, _) ->
+        let max_cnt =
+          try int_of_string (List.assoc "max_cousins" conf.base_env) with
+            Not_found | Failure _ -> default_max_cnt
+        in
+        cnt := 0;
+        (* Construction de la table des sosa de la base *)
+        let () = build_sosa_ht conf base in
+        count_cousins_lev conf base max_cnt p lev1 lev2;
+        !cnt
+
+(* end of cousins count *)
+
 let default_max_cousin_lev = 5
 
 let max_cousin_level conf base p =
@@ -2071,6 +2186,11 @@ and eval_simple_str_var conf base env (_, p_auth) =
         Vcnt c -> string_of_int !c
       | _ -> ""
       end
+  | "desc_cnt" ->
+      begin match get_env "desc_cnt" env with
+        Vint c -> string_of_int c
+      | _ -> ""
+      end
   | "divorce_date" ->
       begin match get_env "fam" env with
         Vfam (_, fam, _, m_auth) when mode_local env ->
@@ -2455,6 +2575,13 @@ and eval_compound_var conf base env (a, _ as ep) loc =
           eval_person_field_var conf base env ep loc sl
       | _ -> raise Not_found
       end
+  | "descendant" :: sl ->
+      begin match get_env "descendant" env with
+        Vind p ->
+          let ep = p, authorized_age conf base p in
+          eval_person_field_var conf base env ep loc sl
+      | _ -> raise Not_found
+      end
   | "enclosing" :: sl ->
       let rec loop =
         function
@@ -2574,18 +2701,23 @@ and eval_compound_var conf base env (a, _ as ep) loc =
           end
       | _ -> raise Not_found
       end
-  | "number_of_descendants_at_level" :: sl ->
+  | "number_of_persons_at_level" :: sl ->
       begin match get_env "level" env with
         Vint i ->
           begin match get_env "desc_level_table" env with
             Vdesclevtab t ->
             let m = fst (Lazy.force t) in
-            let cnt =
+            let cnt0 =
               Gwdb.Collection.fold (fun cnt ip ->
                   if Gwdb.Marker.get m ip <= i then cnt + 1 else cnt
                 ) 0 (Gwdb.ipers base)
-              in
-              VVstring (eval_num conf (Sosa.of_int (cnt - 1)) sl)
+            in
+            let cnt1 =
+              Gwdb.Collection.fold (fun cnt ip ->
+                  if Gwdb.Marker.get m ip <= (i - 1) then cnt + 1 else cnt
+                ) 0 (Gwdb.ipers base)
+            in
+            VVstring (eval_num conf (Sosa.of_int (cnt0 - cnt1)) sl)
           | _ -> raise Not_found
           end
       | _ -> raise Not_found
@@ -3053,6 +3185,10 @@ and eval_person_field_var conf base env (p, p_auth as ep) loc =
           end
       | _ -> VVstring ""
       end
+  | ["cousins"; l1; l2] ->
+      let l1 = int_of_string l1 in
+      let l2 = int_of_string l2 in
+      VVstring (string_of_int (count_cousins conf base p l1 l2))
   | "cremated_date" :: sl ->
       begin match get_burial p with
         Cremated cod when p_auth ->
@@ -4806,12 +4942,14 @@ let print_foreach conf base print_ast eval_expr =
     | "cousin_level" -> print_foreach_level "max_cous_level" env al ep
     | "cremation_witness" -> print_foreach_cremation_witness env al ep
     | "death_witness" -> print_foreach_death_witness env al ep
+    | "descendant" -> print_foreach_descendant env al ep
     | "descendant_level" -> print_foreach_descendant_level env al ep
     | "event" -> print_foreach_event env al ep
     | "event_witness" -> print_foreach_event_witness env al ep
     | "event_witness_relation" ->
         print_foreach_event_witness_relation env al ep
     | "family" -> print_foreach_family env al ini_ep ep
+    | "family_at_level" -> print_foreach_family_at_level env al ini_ep ep
     | "first_name_alias" -> print_foreach_first_name_alias env al ep
     | "nobility_title" -> print_foreach_nobility_title env al ep
     | "parent" -> print_foreach_parent env al ep
@@ -5181,6 +5319,33 @@ let print_foreach conf base print_ast eval_expr =
           else loop events
     in
     loop (events_list conf base p)
+  and print_foreach_descendant env al (p, _) =
+    let lev =
+      match get_env "level" env with
+      | Vint lev -> lev
+      | _ -> 0
+    in
+    let ifam_l = get_descendants_at_level base p lev in
+    let ip_l = List.flatten (List.fold_left
+        (fun acc ifam ->
+          Array.to_list (get_children (foi base ifam)) :: acc
+        ) [] ifam_l)
+    in
+    let rec loop i ip_l =
+      match ip_l with
+      | [] -> ()
+      | ip :: ip_l ->
+          let ep = (poi base ip), true in
+          let env =
+            ("descendant", Vind (poi base ip))
+            :: ("desc_cnt", Vint i)
+            :: ("first", Vbool (i=0))
+            :: ("last", Vbool (ip_l=[] ))
+            :: env
+          in
+          List.iter (print_ast env ep) al; loop (succ i) ip_l
+    in
+    loop 0 ip_l
   and print_foreach_descendant_level env al ep =
     let max_level =
       match get_env "max_desc_level" env with
@@ -5190,7 +5355,12 @@ let print_foreach conf base print_ast eval_expr =
     let rec loop i =
       if i > max_level then ()
       else
-        let env = ("level", Vint i) :: env in
+        let env =
+          ("level", Vint i)
+          :: ("first", Vbool (i=0))
+          :: ("last", Vbool (i=max_level))
+          :: env
+        in
         List.iter (print_ast env ep) al; loop (succ i)
     in
     loop 0
@@ -5407,6 +5577,38 @@ let print_foreach conf base print_ast eval_expr =
 #else
         ()
 #endif
+  and print_foreach_family_at_level env al ini_ep (p, _) =
+    let lev =
+      match get_env "level" env with
+      | Vint lev -> lev
+      | _ -> 0
+    in
+    let ifam_l = get_descendants_at_level base p lev in
+    let rec loop prev i ifam_l =
+      match ifam_l with
+      | [] -> ()
+      | ifam :: ifam_l ->
+          let fam = foi base ifam in
+          let ifath = get_father fam in
+          let imoth = get_mother fam in
+          let ispouse = Gutil.spouse (get_iper p) fam in
+          let cpl = ifath, imoth, ispouse in
+          let m_auth =
+            authorized_age conf base (pget conf base ifath) &&
+            authorized_age conf base (pget conf base imoth)
+          in
+          let vfam = Vfam (ifam, fam, cpl, m_auth) in
+          let env = ("#loop", Vint 0) :: env in
+          let env = ("fam", vfam) :: env in
+          let env = ("family_cnt", Vint (i + 1)) :: env in
+          let env =
+            match prev with
+              Some vfam -> ("prev_fam", vfam) :: env
+            | None -> env
+          in
+          List.iter (print_ast env ini_ep) al; loop (Some vfam) (i + 1) ifam_l
+    in
+    loop None 0 ifam_l
   and print_foreach_first_name_alias env al (p, p_auth as ep) =
     if not p_auth && is_hide_names conf p then ()
     else


### PR DESCRIPTION
The current implementation of `%number_of_descendants_at_level;` is incorrect.
It does not take into account a person at level lev if present at level lev-1 (implex).
This results in a seemingly incorrect count in `destable.txt` for instance : 
<img width="946" alt="Capture d’écran 2020-06-14 à 14 34 53" src="https://user-images.githubusercontent.com/5949517/84593376-3ea57600-ae4c-11ea-9e92-e3baf264ed07.png">
In the example above, for Generation 3, the value 1 is that reported by  `%number_of_descendants_at_level;` while the value 2 is that reported by `%cousins.0.lev;`
`Test4 Gouraud` exists at generation 2 and 3.
The table itself reports `test13 Gouraud` twice as it does not try to suppress implex.

Computing `number_of_descendants_at_level` by substracting the value at level `lev-1` from the value at level `lev` is not workable given how `number_of_descendants` is reported.

The proposed solution provides a generic function `%cousins.l1.l2;` computing the number of cousins up l1 levels and down l2 levels. The result of `%cousins.0.lev;` is indeed the number of descendants at level lev. %cousins.0.0; returns 1.

This PR provides also two new functions callable within a `%foreach;descendant_level;`
`%foreach;descendant;` process each descendant at the current level
`%foreach;family_at_level;` process the descendants at the current level family by family.
The only drawback of the current implementation of `%foreach;family_at_level;` is that for level 0, it reports an empty list (which is better that reporting the family of which `self` is a member!).

These function allow template code such as:
```
%define;cousins_l(lll)
  %cousins.0.lll;
%end;

Test cousins.0.l (foreach;descendant)<br>
%foreach;descendant_level;
  Level: %level;, nb of persons: %apply;cousins_l(level)<br>
  %if;(level=0)&nbsp;&nbsp;&nbsp;&nbsp;%first_name; %surname;<br>%end;
  %foreach;descendant;
    &nbsp;&nbsp;&nbsp;&nbsp;%descendant.first_name; %descendant.surname;<br>
  %end;
%end;
<p>
Test cousins.0.l (foreach;family_at_level)<br>
%foreach;descendant_level;
  Level: %level;, nb of persons: %apply;cousins_l(level)<br>
  %if;(level=0)&nbsp;&nbsp;&nbsp;&nbsp;%first_name; %surname;<br>%end;
  %foreach;family_at_level;
    &nbsp;&nbsp;Family: %family_cnt;<br>
    %foreach;child;
      &nbsp;&nbsp;&nbsp;&nbsp;%child_cnt; %child.first_name; %child.surname;<br>
    %end;
  %end;
%end;
```
resulting in: 
```
Test cousins.0.l (foreach;descendant)
Level: 0, nb of persons: 1
    Henri Gouraud
Level: 1, nb of persons: 6
    Bénédicte Gouraud
    Christophe Gouraud
    Amélie Gouraud
    Test-Alain-2 Gouraud
    Test10 Gouraud
    test9 Gouraud
Level: 2, nb of persons: 10
    Axelle Weeger
    Solène Weeger
    O'Brien Weeger
    O’Brien Weeger
    Ariane Weeger
    Justin Test
    Etienne Fontana
    Léonie Fontana
    Test4 Gouraud
    test11 Gouraud
Level: 3, nb of persons: 2
    Test4 Gouraud
    test13 Gouraud
Test cousins.0.l (foreach;family_at_level)
Level: 0, nb of persons: 1
    Henri Gouraud
Level: 1, nb of persons: 6
  Family: 1
    1 test9 Gouraud
  Family: 2
    1 Test10 Gouraud
  Family: 3
    1 Test-Alain-2 Gouraud
  Family: 4
    1 Bénédicte Gouraud
    2 Christophe Gouraud
    3 Amélie Gouraud
Level: 2, nb of persons: 10
  Family: 1
    1 test11 Gouraud
  Family: 2
    1 Test4 Gouraud
  Family: 3
    1 Etienne Fontana
    2 Léonie Fontana
  Family: 4
    1 Justin Test
  Family: 5
    1 Axelle Weeger
    2 Solène Weeger
    3 O'Brien Weeger
    4 O’Brien Weeger
    5 Ariane Weeger
Level: 3, nb of persons: 2
  Family: 1
    1 test13 Gouraud
  Family: 2
    1 Test4 Gouraud
```