### PR TITLE
Search revamp

### DIFF
--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -35,6 +35,10 @@ let bench () =
         ]
     ; bench "Name.lower" Name.lower
         [ "étienne" ; "Étienne" ; "ÿvette" ; "Ÿvette" ; "Ĕtienne" ]
+    ; bench "Name.split_fname" Name.split_fname
+        [ "Jean-Baptiste Emmanuel" ; "Jean Baptiste Emmanuel" ]
+    ; bench "Name.split_sname" Name.split_sname
+        [ "Jean-Baptiste Emmanuel" ; "Jean Baptiste Emmanuel" ]
     ]
   in
   match Sys.getenv_opt "BENCH_BASE" with

--- a/bin/dico_place/marshal_dico_place.ml
+++ b/bin/dico_place/marshal_dico_place.ml
@@ -33,11 +33,11 @@ let write_dico_place_set lang =
         done
       with End_of_file -> close_in ic
     end ;
-    (List.sort Gutil.alphabetic (StrSet.elements !string_set_town),
-     List.sort Gutil.alphabetic (StrSet.elements !string_set_area_code),
-     List.sort Gutil.alphabetic (StrSet.elements !string_set_county),
-     List.sort Gutil.alphabetic (StrSet.elements !string_set_region),
-     List.sort Gutil.alphabetic (StrSet.elements !string_set_country))
+    (List.sort Utf8.compare (StrSet.elements !string_set_town),
+     List.sort Utf8.compare (StrSet.elements !string_set_area_code),
+     List.sort Utf8.compare (StrSet.elements !string_set_county),
+     List.sort Utf8.compare (StrSet.elements !string_set_region),
+     List.sort Utf8.compare (StrSet.elements !string_set_country))
   in
   let generate name data =
     let fname_set = "dico_place_" ^ name ^ "_" ^ lang ^ ".list" in

--- a/bin/gwd/requestHandler.ml
+++ b/bin/gwd/requestHandler.ml
@@ -83,7 +83,7 @@ let try_find_with_one_first_name conf base n =
     let sn = String.sub n1 (i + 1) (String.length n1 - i - 1) in
     let (list, _) =
       Some.persons_of_fsname conf base base_strings_of_surname
-        (spi_find (persons_of_surname base)) get_surname sn
+        (spi_find (persons_of_surname base)) get_surname Name.split_sname sn
     in
     List.fold_left
       (fun pl (_, _, ipl) ->

--- a/bin/gwd/requestHandler.ml
+++ b/bin/gwd/requestHandler.ml
@@ -82,7 +82,7 @@ let try_find_with_one_first_name conf base n =
     let fn = String.sub n1 0 i in
     let sn = String.sub n1 (i + 1) (String.length n1 - i - 1) in
     let (list, _) =
-      Some.persons_of_fsname conf base base_strings_of_surname
+      Some.old_persons_of_fsname conf base base_strings_of_surname
         (spi_find (persons_of_surname base)) get_surname Name.split_sname sn
     in
     List.fold_left

--- a/hd/etc/advanced.txt
+++ b/hd/etc/advanced.txt
@@ -136,9 +136,23 @@
         </div>
       </div>
       <div class="row">
+        <div class="col-3"></div>
+        <div class="form-check col-9">
+          <input class="form-check-input" type="checkbox" name="exact_first_name" value="on" checked>
+          <label class="form-check-label" for="exact_first_name">[*exact]</label>
+        </div>
+      </div>
+      <div class="row">
         <label for="surname" class="col-form-label col-3">[*surname/surnames]0</label>
         <div class="col-9">
           <input type="text" class="form-control" name="surname" id="surname" placeholder="[*surname/surnames]0">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3"></div>
+        <div class="form-check col-9">
+          <input class="form-check-input" type="checkbox" name="exact_surname" value="on">
+          <label class="form-check-label" for="exact_surname" checked>[*exact]</label>
         </div>
       </div>
       <div class="row mt-3">

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -5664,6 +5664,30 @@ sk: presne
 sl: točno
 sv: exakt
 
+    search_exact_fn
+de: genaue Suche
+en: exact search
+es: búsqueda exacta
+fi: tarkka haku
+fr: recherche exacte
+it: ricerca esatta
+nl: exact zoeken
+no: eksakt søk
+pt: pesquisa exata
+sv: exakt sökning
+
+    search_exact_sn
+de: genaue Suche
+en: exact search
+es: búsqueda exacta
+fi: tarkka haku
+fr: recherche exacte
+it: ricerca esatta
+nl: exact zoeken
+no: eksakt søk
+pt: pesquisa exata
+sv: exakt sökning
+
     excommunication
 co: scumunicazione
 de: Exkommunizierung

--- a/lib/advSearchOk.ml
+++ b/lib/advSearchOk.ml
@@ -260,13 +260,15 @@ let advanced_search conf base max_answers =
   let match_first_name p =
       fn_list = []
       || List.exists begin fun l ->
-        Gwdb.match_first_name base ~exact:(gets "exact_first_name" = "on") l p
+        Gwdb.match_first_name
+          base ~aliases:false ~exact:(gets "exact_first_name" = "on") l p
       end fn_list
   in
   let match_surname p =
     sn_list = []
     || List.exists begin fun l ->
-      Gwdb.match_surname base ~exact:(gets "exact_surname" = "on") l p
+      Gwdb.match_surname
+        base ~aliases:false ~exact:(gets "exact_surname" = "on") l p
     end sn_list
   in
   let match_married p empty_default_value =

--- a/lib/advSearchOk.ml
+++ b/lib/advSearchOk.ml
@@ -261,14 +261,14 @@ let advanced_search conf base max_answers =
       fn_list = []
       || List.exists begin fun l ->
         Gwdb.match_first_name
-          base ~aliases:false ~exact:(gets "exact_first_name" = "on") l p
+          base ~aliases:true ~exact:(gets "exact_first_name" = "on") l p
       end fn_list
   in
   let match_surname p =
     sn_list = []
     || List.exists begin fun l ->
       Gwdb.match_surname
-        base ~aliases:false ~exact:(gets "exact_surname" = "on") l p
+        base ~aliases:true ~exact:(gets "exact_surname" = "on") l p
     end sn_list
   in
   let match_married p empty_default_value =

--- a/lib/advSearchOk.ml
+++ b/lib/advSearchOk.ml
@@ -355,12 +355,12 @@ let advanced_search conf base max_answers =
       if gets "first_name" <> "" then
         Some.persons_of_fsname conf base base_strings_of_first_name
           (spi_find (persons_of_first_name base)) get_first_name
-          (gets "first_name")
+          Name.split_fname (gets "first_name")
       else
         let list =
           List.map
             (Some.persons_of_fsname conf base base_strings_of_surname
-               (spi_find (persons_of_surname base)) get_surname)
+               (spi_find (persons_of_surname base)) get_surname Name.split_sname)
             (getss "surname")
         in
         ( list |> List.map fst |> List.flatten |> List.sort_uniq compare

--- a/lib/allnDisplay.ml
+++ b/lib/allnDisplay.ml
@@ -16,7 +16,7 @@ let particle_at_the_end base is_surnames s =
   else s
 
 let compare_particle_at_the_end base is_surnames a b =
-  Gutil.alphabetic_order
+  Utf8.compare
     (particle_at_the_end base is_surnames a)
     (particle_at_the_end base is_surnames b)
 
@@ -25,7 +25,7 @@ let groupby_ini len list =
   |> Util.groupby
     ~key:(fun (k, _, _) -> ini len k)
     ~value:(fun (_, s, c) -> (s, c))
-  |> List.sort (fun (a, _) (b, _) -> Gutil.alphabetic_order a b)
+  |> List.sort (fun (a, _) (b, _) -> Utf8.compare a b)
 
 let groupby_count list =
   list
@@ -309,7 +309,7 @@ let print_alphabetic_short conf base is_surnames ini list len =
             Wserver.printf "%s" (particle_at_the_end base is_surnames s);
             if href <> "" || name <> "" then Wserver.printf "</a>";
             Wserver.printf " (%d)" cnt)
-         (List.sort (fun (a, _) (b, _) -> Gutil.alphabetic_order a b) l);
+         (List.sort (fun (a, _) (b, _) -> Utf8.compare a b) l);
        Wserver.printf "\n";
        Wserver.printf "</p>\n")
     list;

--- a/lib/allnDisplay.ml
+++ b/lib/allnDisplay.ml
@@ -309,7 +309,7 @@ let print_alphabetic_short conf base is_surnames ini list len =
             Wserver.printf "%s" (particle_at_the_end base is_surnames s);
             if href <> "" || name <> "" then Wserver.printf "</a>";
             Wserver.printf " (%d)" cnt)
-         (List.sort (fun (a, _) (b, _) -> Utf8.compare a b) l);
+         (List.sort (fun (a, _) (b, _) -> compare_particle_at_the_end base is_surnames a b) l);
        Wserver.printf "\n";
        Wserver.printf "</p>\n")
     list;

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -811,23 +811,6 @@ let print_all_families conf base =
   in
   print_result conf data
 
-module StringMap =
-  Map.Make
-    (struct
-      type t = string      let compare = Gutil.alphabetic_order      end)
-
-module IperSort =
-  Set.Make
-    (struct
-      type t = string * string       let compare (sn1, fn1) (sn2, fn2) =
-        let cmp = compare sn1 sn2 in
-        if cmp = 0 then compare fn1 fn2
-        else cmp(*
-        let cmp = Gutil.alphabetic_order sn1 sn2 in
-        if cmp = 0 then Gutil.alphabetic_order fn1 fn2
-        else cmp*)
-     end)
-
 (**/**) (* Version app *)
 
 (**/**) (* API_NOTIFICATION_BIRTHDAY *)

--- a/lib/api_saisie_autocomplete.ml
+++ b/lib/api_saisie_autocomplete.ml
@@ -53,7 +53,7 @@ let create_cache base mode cache_file =
   let cache = List.rev_map (sou base) (IstrSet.elements cache) in
   let cache =
     List.sort
-      (if mode = `place then Place.compare_places else Gutil.alphabetic_order)
+      (if mode = `place then Place.compare_places else Utf8.compare)
       cache
   in
   let oc = Secure.open_out_bin cache_file in

--- a/lib/api_saisie_read.ml
+++ b/lib/api_saisie_read.ml
@@ -2071,11 +2071,11 @@ let search_index conf base an search_order =
         | _ -> None
       end
     | Surname::le ->
-      if Some.search_surname conf base an = []
+      if fst (Some.search_surname conf base an) = []
       then loop le
       else None
     | FirstName::le ->
-      if Some.search_first_name conf base an = []
+      if fst (Some.search_first_name conf base an) = []
       then loop le
       else None
     | ApproxKey::le ->

--- a/lib/api_saisie_write.ml
+++ b/lib/api_saisie_write.ml
@@ -73,9 +73,9 @@ let print_person_search_list conf base =
         let sn1 = sou base (get_surname p1) in
         let fn2 = sou base (get_first_name p2) in
         let sn2 = sou base (get_surname p2) in
-        let cmp_sn = Gutil.alphabetic_order sn1 sn2 in
+        let cmp_sn = Utf8.compare sn1 sn2 in
         if cmp_sn = 0 then
-          let cmp_fn = Gutil.alphabetic_order fn1 fn2 in
+          let cmp_fn = Utf8.compare fn1 fn2 in
           if cmp_fn = 0 then
             (match
               (Adef.od_of_cdate (get_birth p1),
@@ -298,7 +298,7 @@ let print_config conf base =
   let transl_pevent_sec =
     List.sort
       (fun msg1 msg2 ->
-        Gutil.alphabetic_order
+        Utf8.compare
           msg1.Mwrite.Transl_pevent_name.sval
           msg2.Mwrite.Transl_pevent_name.sval)
       transl_pevent_sec
@@ -320,7 +320,7 @@ let print_config conf base =
   let transl_pevent_LDS =
     List.sort
       (fun msg1 msg2 ->
-        Gutil.alphabetic_order
+        Utf8.compare
           msg1.Mwrite.Transl_pevent_name.sval
           msg2.Mwrite.Transl_pevent_name.sval)
       transl_pevent_LDS

--- a/lib/api_search.ml
+++ b/lib/api_search.ml
@@ -314,11 +314,11 @@ let print_list conf base filters list =
         (fun p1 p2 ->
           let sn1 = Name.lower (p_surname base p1) in
           let sn2 = Name.lower (p_surname base p2) in
-          let comp = Gutil.alphabetic_order sn1 sn2 in
+          let comp = Utf8.compare sn1 sn2 in
           if comp = 0 then
             let fn1 = Name.lower (p_first_name base p1) in
             let fn2 = Name.lower (p_first_name base p2) in
-            Gutil.alphabetic_order fn1 fn2
+            Utf8.compare fn1 fn2
           else comp)
         person_l
   in
@@ -576,7 +576,7 @@ let select_start_with_auto_complete base mode max_res ini =
               | _ -> ()
           in loop istr []
     end;
-  List.sort Gutil.alphabetic_order (StrSet.elements !string_set)
+  List.sort Utf8.compare (StrSet.elements !string_set)
 
 
 let select_all_auto_complete _ base get_field max_res ini =
@@ -604,7 +604,7 @@ let select_all_auto_complete _ base get_field max_res ini =
         incr nb_res;
         end
   end () (Gwdb.persons base) ;
-  List.sort Gutil.alphabetic_order (StrSet.elements !string_set)
+  List.sort Utf8.compare (StrSet.elements !string_set)
 
 
 let load_dico_lieu conf pl_mode =
@@ -725,7 +725,7 @@ let search_auto_complete conf base mode place_mode max n =
     complete_with_dico conf nb max place_mode ini (reduce_perso list)
 
   | `source ->
-    let list = aux "src" Gutil.alphabetic_order in
+    let list = aux "src" Utf8.compare in
     let nb = ref 0 in
     let ini = Name.lower @@ Mutil.tr '_' ' ' n in
     let rec reduce acc = function

--- a/lib/descendDisplay.ml
+++ b/lib/descendDisplay.ml
@@ -76,9 +76,9 @@ let display_descendants_level conf base max_level ancestor =
   let list =
     List.sort
       (fun p1 p2 ->
-         let c = Gutil.alphabetic (p_surname base p2) (p_surname base p1) in
+         let c = Utf8.compare (p_surname base p2) (p_surname base p1) in
          if c = 0 then
-           let c = Gutil.alphabetic (p_first_name base p2) (p_first_name base p1) in
+           let c = Utf8.compare (p_first_name base p2) (p_first_name base p1) in
            if c = 0 then compare (get_occ p2) (get_occ p1) else c
          else c)
       list
@@ -462,9 +462,9 @@ let sort_and_display conf base paths precision list =
   let list =
     List.sort
       (fun p1 p2 ->
-         let c = Gutil.alphabetic (p_surname base p2) (p_surname base p1) in
+         let c = Utf8.compare (p_surname base p2) (p_surname base p1) in
          if c = 0 then
-           Gutil.alphabetic (p_first_name base p2) (p_first_name base p1)
+           Utf8.compare (p_first_name base p2) (p_first_name base p1)
          else c)
       list
   in

--- a/lib/forumDisplay.ml
+++ b/lib/forumDisplay.ml
@@ -366,6 +366,22 @@ let print conf base =
   in
   print_forum_message conf base r None
 
+let trim_trailing_spaces s =
+  let len = String.length s in
+  let len' =
+    let rec loop i =
+      if i = -1 then 0
+      else
+        match String.unsafe_get s i with
+        | ' ' | '\r' | '\n' | '\t' -> loop (i - 1)
+        | _ -> i + 1
+    in
+    loop (len - 1)
+  in
+  if len' = 0 then ""
+  else if len' = len then s
+  else String.sub s 0 len'
+
 let print_add_ok conf base =
   let mess =
     let time =
@@ -376,7 +392,7 @@ let print_add_ok conf base =
     let ident = String.trim (get conf "Ident") in
     let email = String.trim (get conf "Email") in
     let subject = String.trim (get conf "Subject") in
-    let text = Gutil.trim_trailing_spaces (get1 conf "Text") in
+    let text = trim_trailing_spaces (get1 conf "Text") in
     {m_time = time; m_date = Dtext ""; m_hour = ""; m_waiting = false;
      m_from = ""; m_ident = ident; m_wizard = ""; m_friend = "";
      m_email = email; m_access = ""; m_subject = subject; m_wiki = "";

--- a/lib/gutil.ml
+++ b/lib/gutil.ml
@@ -201,23 +201,6 @@ let alphabetic n1 n2 =
 let alphabetic_order n1 n2 =
   alphabetic_utf_8 n1 n2
 
-let arg_list_of_string line =
-  let rec loop list i len quote =
-    if i = String.length line then
-      if len = 0 then List.rev list else List.rev (Buff.get len :: list)
-    else
-      match quote, line.[i] with
-        Some c1, c2 ->
-          if c1 = c2 then loop list (i + 1) len None
-          else loop list (i + 1) (Buff.store len c2) quote
-      | None, ' ' ->
-          let list = if len = 0 then list else Buff.get len :: list in
-          loop list (i + 1) 0 quote
-      | None, ('"' | '\'' as c) -> loop list (i + 1) 0 (Some c)
-      | None, c -> loop list (i + 1) (Buff.store len c) None
-  in
-  loop [] 0 0 None
-
 let sort_person_list base pl =
   List.sort
     (fun p1 p2 ->

--- a/lib/gutil.ml
+++ b/lib/gutil.ml
@@ -125,66 +125,6 @@ let find_same_name base p =
   in
   List.sort (fun p1 p2 -> compare (get_occ p1) (get_occ p2)) pl
 
-let alphabetic_utf_8 n1 n2 =
-  let rec loop i1 i2 =
-    if i1 >= String.length n1 && i2 >= String.length n2 then i1 - i2
-    else if i1 >= String.length n1 then -1
-    else if i2 >= String.length n2 then 1
-    else
-      let (cv1, ii1) = Name.unaccent_utf_8 false n1 i1 in
-      let (cv2, ii2) = Name.unaccent_utf_8 false n2 i2 in
-      let c =
-        if cv1 = cv2 then
-          compare (String.sub n1 i1 (ii1 - i1)) (String.sub n2 i2 (ii2 - i2))
-        else compare cv1 cv2
-      in
-      if c = 0 then loop ii1 ii2 else c
-  in
-  if n1 = n2 then 0 else loop 0 0
-
-let alphabetic_value =
-  let tab = Array.make 256 0 in
-  for i = 0 to 255 do tab.(i) <- 10 * i done;
-  tab.(Char.code '\xE0')(*'à'*) <- tab.(Char.code 'a') + 1;
-  tab.(Char.code '\xE1')(*'á'*) <- tab.(Char.code 'a') + 2;
-  tab.(Char.code '\xE2')(*'â'*) <- tab.(Char.code 'a') + 3;
-  tab.(Char.code '\xE8')(*'è'*) <- tab.(Char.code 'e') + 1;
-  tab.(Char.code '\xE9')(*'é'*) <- tab.(Char.code 'e') + 2;
-  tab.(Char.code '\xEA')(*'ê'*) <- tab.(Char.code 'e') + 3;
-  tab.(Char.code '\xEB')(*'ë'*) <- tab.(Char.code 'e') + 4;
-  tab.(Char.code '\xF4')(*'ô'*) <- tab.(Char.code 'o') + 1;
-  tab.(Char.code '\xC1')(*'Á'*) <- tab.(Char.code 'A') + 2;
-  tab.(Char.code '\xC6')(*'Æ'*) <- tab.(Char.code 'A') + 5;
-  tab.(Char.code '\xC8')(*'È'*) <- tab.(Char.code 'E') + 1;
-  tab.(Char.code '\xC9')(*'É'*) <- tab.(Char.code 'E') + 2;
-  tab.(Char.code '\xD6')(*'Ö'*) <- tab.(Char.code 'O') + 4;
-  tab.(Char.code '?') <- 3000;
-  fun x -> tab.(Char.code x)
-
-let alphabetic_iso_8859_1 n1 n2 =
-  let rec loop i1 i2 =
-    if i1 = String.length n1 && i2 = String.length n2 then i1 - i2
-    else if i1 = String.length n1 then -1
-    else if i2 = String.length n2 then 1
-    else
-      let c1 = n1.[i1] in
-      let c2 = n2.[i2] in
-      if alphabetic_value c1 < alphabetic_value c2 then -1
-      else if alphabetic_value c1 > alphabetic_value c2 then 1
-      else loop (succ i1) (succ i2)
-  in
-  if n1 = n2 then 0 else loop (Mutil.initial n1) (Mutil.initial n2)
-
-(* ??? *)
-let alphabetic n1 n2 =
-  (*
-    if Mutil.utf_8_db.val then alphabetic_utf_8 n1 n2 else alphabetic_iso_8859_1 n1 n2
-  *)
-  alphabetic_iso_8859_1 n1 n2
-
-let alphabetic_order n1 n2 =
-  alphabetic_utf_8 n1 n2
-
 let sort_person_list base pl =
   List.sort
     (fun p1 p2 ->
@@ -205,13 +145,15 @@ let sort_person_list base pl =
        | _, _, Some _, _ -> -1
        | _, _, _, Death (_, _) -> -1
        | _ ->
-           let c = alphabetic (p_surname base p1) (p_surname base p2) in
-           if c = 0 then
-             let c =
-               alphabetic (p_first_name base p1) (p_first_name base p2)
-             in
-             if c = 0 then compare (get_occ p1) (get_occ p2) else c
-           else c)
+         let c =
+           Utf8.compare (p_surname base p1) (p_surname base p2)
+         in
+         if c = 0 then
+           let c =
+             Utf8.compare (p_first_name base p1) (p_first_name base p2)
+           in
+           if c = 0 then compare (get_occ p1) (get_occ p2) else c
+         else c)
     pl
 
 let find_free_occ base f s _i =

--- a/lib/gutil.ml
+++ b/lib/gutil.ml
@@ -10,11 +10,8 @@ let designation base p =
   Mutil.iso_8859_1_of_utf_8
     (first_name ^ "." ^ string_of_int (get_occ p) ^ " " ^ nom)
 
-let father = Adef.father
-let mother = Adef.mother
 let couple multi fath moth =
   if not multi then Adef.couple fath moth else Adef.multi_couple fath moth
-let parent_array = Adef.parent_array
 
 let spouse ip cpl =
   if ip = get_father cpl then get_mother cpl else get_father cpl

--- a/lib/gutil.ml
+++ b/lib/gutil.ml
@@ -125,22 +125,6 @@ let find_same_name base p =
   in
   List.sort (fun p1 p2 -> compare (get_occ p1) (get_occ p2)) pl
 
-let trim_trailing_spaces s =
-  let len = String.length s in
-  let len' =
-    let rec loop i =
-      if i = -1 then 0
-      else
-        match String.unsafe_get s i with
-        | ' ' | '\r' | '\n' | '\t' -> loop (i - 1)
-        | _ -> i + 1
-    in
-    loop (len - 1)
-  in
-  if len' = 0 then ""
-  else if len' = len then s
-  else String.sub s 0 len'
-
 let alphabetic_utf_8 n1 n2 =
   let rec loop i1 i2 =
     if i1 >= String.length n1 && i2 >= String.length n2 then i1 - i2

--- a/lib/gutil.mli
+++ b/lib/gutil.mli
@@ -15,7 +15,6 @@ val person_of_string_dot_key : base -> string -> iper option
 
 val designation : base -> person -> string
 
-val trim_trailing_spaces : string -> string
 val alphabetic_utf_8 : string -> string -> int
 val alphabetic : string -> string -> int
 val alphabetic_order : string -> string -> int

--- a/lib/gutil.mli
+++ b/lib/gutil.mli
@@ -17,9 +17,6 @@ val designation : base -> person -> string
 
 val sort_person_list : base -> person list -> person list
 
-val father : 'a gen_couple -> 'a
-val mother : 'a gen_couple -> 'a
 val couple : bool -> 'a -> 'a -> 'a gen_couple
-val parent_array : 'a gen_couple -> 'a array
 
 val find_free_occ : base -> string -> string -> int -> int

--- a/lib/gutil.mli
+++ b/lib/gutil.mli
@@ -20,8 +20,6 @@ val alphabetic_utf_8 : string -> string -> int
 val alphabetic : string -> string -> int
 val alphabetic_order : string -> string -> int
 
-val arg_list_of_string : string -> string list
-
 val sort_person_list : base -> person list -> person list
 
 val father : 'a gen_couple -> 'a

--- a/lib/gutil.mli
+++ b/lib/gutil.mli
@@ -15,10 +15,6 @@ val person_of_string_dot_key : base -> string -> iper option
 
 val designation : base -> person -> string
 
-val alphabetic_utf_8 : string -> string -> int
-val alphabetic : string -> string -> int
-val alphabetic_order : string -> string -> int
-
 val sort_person_list : base -> person list -> person list
 
 val father : 'a gen_couple -> 'a

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -437,20 +437,22 @@ let strings_of_fsname bname strings (_, person_patches) =
       in
       close_in ic_inx; ai
     in
-    let l = ref (Array.to_list r) in
-    Hashtbl.iter
-      (fun _ p ->
-         if not (List.mem p.first_name !l) then
-           begin let s1 = strings.get p.first_name in
-             let s1 = Mutil.nominative s1 in
-             if s = Name.crush_lower s1 then l := p.first_name :: !l
-           end;
-         if not (List.mem p.surname !l) then
-           let s1 = strings.get p.surname in
-           let s1 = Mutil.nominative s1 in
-           if s = Name.crush_lower s1 then l := p.surname :: !l)
-      person_patches;
-    !l
+    Hashtbl.fold begin fun _ p acc ->
+      let acc =
+        if not (List.mem p.first_name acc)
+        && strings.get p.first_name
+           |> Name.split_fname
+           |> List.exists (fun s -> i = Dutil.name_index s)
+        then p.first_name :: acc
+        else acc
+      in
+      if not (List.mem p.surname acc)
+      && strings.get p.surname
+         |> Name.split_sname
+         |> List.exists (fun s -> i = Dutil.name_index s)
+      then p.surname :: acc
+      else acc
+    end person_patches (Array.to_list r)
 (**)
 
 (* Restrict file *)

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -443,20 +443,19 @@ let strings_of_fsname bname strings (_, person_patches) =
       close_in ic_inx; ai
     in
     Hashtbl.fold begin fun _ p acc ->
-      let acc =
-        if not (List.mem p.first_name acc)
-        && strings.get p.first_name
-           |> Name.split_fname
+      let aux split acc istr =
+        if not (List.mem istr acc)
+        && strings.get istr
+           |> split
            |> List.exists (fun s -> i = Dutil.name_index s)
-        then p.first_name :: acc
+        then istr :: acc
         else acc
       in
-      if not (List.mem p.surname acc)
-      && strings.get p.surname
-         |> Name.split_sname
-         |> List.exists (fun s -> i = Dutil.name_index s)
-      then p.surname :: acc
-      else acc
+      let acc = aux Name.split_fname acc p.first_name in
+      let acc = List.fold_left (aux Name.split_fname) acc p.first_names_aliases in
+      let acc = aux Name.split_sname acc p.surname in
+      let acc = List.fold_left (aux Name.split_sname) acc p.surnames_aliases in
+      acc
     end person_patches (Array.to_list r)
 (**)
 

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -378,12 +378,10 @@ let persons_of_first_name_or_surname = function
 let persons_of_name bname patches =
   let t = ref None in
   fun s ->
-    let s = Name.crush_lower s in
-    let i = Hashtbl.hash s in
+    let i = Dutil.name_index s in
     let ai =
       let ic_inx = Secure.open_in_bin (Filename.concat bname "names.inx") in
       let ai =
-        let i = i mod Dutil.table_size in
         let fname_inx_acc = Filename.concat bname "names.acc" in
         if Sys.file_exists fname_inx_acc then
           let ic_inx_acc = Secure.open_in_bin fname_inx_acc in
@@ -412,12 +410,10 @@ let persons_of_name bname patches =
 let strings_of_fsname bname strings (_, person_patches) =
   let t = ref None in
   fun s ->
-    let s = Name.crush_lower s in
-    let i = Hashtbl.hash s in
+    let i = Dutil.name_index s in
     let r =
       let ic_inx = Secure.open_in_bin (Filename.concat bname "names.inx") in
       let ai =
-        let i = i mod Dutil.table_size in
         let fname_inx_acc = Filename.concat bname "names.acc" in
         if Sys.file_exists fname_inx_acc then
           let ic_inx_acc = Secure.open_in_bin fname_inx_acc in
@@ -948,8 +944,7 @@ let opendb bname =
   in
   let patch_name s ip =
     (* FIXME: pending patches? *)
-    let s = Name.crush_lower s in
-    let i = Hashtbl.hash s in
+    let i = Dutil.name_index s in
     try
       let ipl = Hashtbl.find patches.h_name i in
       if List.mem ip ipl then ()

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -318,9 +318,11 @@ let new_persons_of_first_name_or_surname base_data params =
         let ipera = read_loop [] len in close_in ic_dat; ipera
       with Not_found -> []
     in
+    let patched = Hashtbl.fold (fun i _ acc -> i :: acc) person_patches [] in
+    let ipera = List.filter (fun i -> not @@ List.mem i patched) ipera in
     let aux i istr1 acc =
       if istr1 = istr then if List.mem i acc then acc else i :: acc
-      else if List.mem i acc then Mutil.list_except i acc else acc
+      else acc
     in
     Hashtbl.fold begin fun i p acc ->
       List.fold_left (fun acc istr1 -> aux i istr1 acc) (aux i (name p) acc) (aliases p)

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -375,7 +375,7 @@ let new_persons_of_first_name_or_surname base_data params =
   { find ; cursor ; next }
 
 let persons_of_first_name_or_surname = function
-  | GnWb0021 -> new_persons_of_first_name_or_surname
+  | GnWb0022 | GnWb0021 -> new_persons_of_first_name_or_surname
   | GnWb0020 -> old_persons_of_first_name_or_surname
 
 (* Search index for a given name in file names.inx *)
@@ -720,7 +720,8 @@ let opendb bname =
   in
   let ic = Secure.open_in_bin (Filename.concat bname "base") in
   let version =
-    if Mutil.check_magic Dutil.magic_GnWb0021 ic then GnWb0021
+    if Mutil.check_magic Dutil.magic_GnWb0022 ic then GnWb0022
+    else if Mutil.check_magic Dutil.magic_GnWb0021 ic then GnWb0021
     else if Mutil.check_magic Dutil.magic_GnWb0020 ic then GnWb0020
     else if really_input_string ic 4 = "GnWb"
     then failwith "this is a GeneWeb base, but not compatible"
@@ -751,7 +752,11 @@ let opendb bname =
         flush stderr;
         None
   in
-  let ic2_string_start_pos = Dutil.int_size in
+  let ic2_string_start_pos =
+    match version with
+    | GnWb0022 -> Dutil.int_size
+    | GnWb0021 | GnWb0020 -> 3 * Dutil.int_size
+  in
   let ic2_string_hash_len =
     match ic2 with
       Some ic2 -> Some (input_binary_int ic2)
@@ -1122,4 +1127,4 @@ let make bname particles ((persons, families, strings, bnotes) as _arrays) : Dbd
     ; nb_of_real_persons = (fun _ -> assert false)
     }
   in
-  { data ; func ; version = GnWb0021 }
+  { data ; func ; version = GnWb0022 }

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -64,8 +64,6 @@ let move_with_backup src dst =
 
     strings.inx - index for strings, surnames, first names
        length of the strings offset array : binary_int
-       offset of surnames index           : binary_int
-       offset of first names index        : binary_int
        strings hash table index           : 2 arrays of binary_ints
          strings offset array (length = prime after 10 * strings array length)
            - associating a hash value of the string modulo length
@@ -73,20 +71,6 @@ let move_with_backup src dst =
          strings list array (length = string array length)
            - associating a string index
            - to the index of the next index holding the same hash value
-       -- the following table has been obsolete since version 4.10
-       -- it has been replaced by snames.inx/sname.dat which use
-       -- much less memory
-       surnames index                     : value
-         binary tree
-          - associating the string index of a surname
-          - to the corresponding list of persons holding this surname
-       -- the following table has been obsolete since version 4.10
-       -- it has been replaced by fnames.inx/fname.dat which use
-       -- much less memory
-       first_names index                  : value
-         binary tree
-          - associating the string index of a first name
-          - to the corresponding list of persons holding this first name
 
     snames.inx - index for surnames
        binary tree
@@ -764,7 +748,7 @@ let opendb bname =
         flush stderr;
         None
   in
-  let ic2_string_start_pos = 3 * Dutil.int_size in
+  let ic2_string_start_pos = Dutil.int_size in
   let ic2_string_hash_len =
     match ic2 with
       Some ic2 -> Some (input_binary_int ic2)

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -345,7 +345,7 @@ type base_func =
   ; nb_of_real_persons : unit -> int
   }
 
-type base_version = GnWb0020 | GnWb0021
+type base_version = GnWb0020 | GnWb0021 | GnWb0022
 
 type dsk_base = { data : base_data
                 ; func : base_func

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -72,3 +72,5 @@ module IntHT = Hashtbl.Make (struct
     let equal = (=)
     let hash x = x
   end)
+
+let name_index s = Hashtbl.hash (Name.crush_lower s) mod table_size

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -8,6 +8,7 @@ type strings_of_fsname = int array array
 
 let magic_GnWb0020 = "GnWb0020"
 let magic_GnWb0021 = "GnWb0021"
+let magic_GnWb0022 = "GnWb0022"
 let table_size = 0x3fff
 
 let poi base i = base.data.persons.get i

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -20,33 +20,29 @@ let p_first_name base p = Mutil.nominative (sou base p.first_name)
 let p_surname base p = Mutil.nominative (sou base p.surname)
 
 let husbands base p =
-  let u = uoi base p.key_index in
-  List.map
-    (fun ifam ->
-       let cpl = coi base ifam in
-       let husband = poi base (Adef.father cpl) in
-       let husband_surname = p_surname base husband in
-       let husband_surnames_aliases =
-         List.map (sou base) husband.surnames_aliases
-       in
-       husband_surname, husband_surnames_aliases)
-    (Array.to_list u.family)
+  Array.map begin fun ifam ->
+    let cpl = coi base ifam in
+    let husband = poi base (Adef.father cpl) in
+    let husband_surname = husband.surname in
+    let husband_surnames_aliases = husband.surnames_aliases in
+    husband_surname, husband_surnames_aliases
+  end (uoi base p.key_index).family
 
 let father_titles_places base p nobtit =
   match (aoi base p.key_index).parents with
-    Some ifam ->
-      let cpl = coi base ifam in
-      let fath = poi base (Adef.father cpl) in
-      List.map (fun t -> sou base t.t_place) (nobtit fath)
+  | Some ifam ->
+    let cpl = coi base ifam in
+    let fath = poi base (Adef.father cpl) in
+    (nobtit fath)
   | None -> []
 
 let dsk_person_misc_names base p nobtit =
-  let sou = sou base in
-  Futil.gen_person_misc_names (sou p.first_name) (sou p.surname)
-    (sou p.public_name) (List.map sou p.qualifiers) (List.map sou p.aliases)
-    (List.map sou p.first_names_aliases) (List.map sou p.surnames_aliases)
-    (List.map (Futil.map_title_strings sou) (nobtit p))
-    (if p.sex = Female then husbands base p else [])
+  Futil.gen_person_misc_names
+    (sou base) 0 1
+    p.first_name p.surname p.public_name p.qualifiers p.aliases
+    p.first_names_aliases p.surnames_aliases
+    (nobtit p)
+    (if p.sex = Female then husbands base p else [||])
     (father_titles_places base p nobtit)
 
 let compare_names base_data s1 s2 =

--- a/lib/gwdb-legacy/dutil.mli
+++ b/lib/gwdb-legacy/dutil.mli
@@ -31,3 +31,9 @@ module IntHT : sig
       let hash x = x
     end)
 end
+
+(** [name_index s]
+    Compute the index of crush_lowered version of s
+    in an array of size {!val:table_size}.
+*)
+val name_index : string -> int

--- a/lib/gwdb-legacy/dutil.mli
+++ b/lib/gwdb-legacy/dutil.mli
@@ -7,6 +7,7 @@ type strings_of_fsname = int array array
 
 val magic_GnWb0020 : string
 val magic_GnWb0021 : string
+val magic_GnWb0022 : string
 val table_size : int
 
 val compare_istr_fun : Dbdisk.base_data -> int -> int -> int

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -84,40 +84,13 @@ let date_of_last_change base =
   in
   s.Unix.st_mtime
 
-let husbands base (gp : (iper, iper, istr) Def.gen_person) =
-  let p = base.data.unions.get gp.Def.key_index in
-  Array.map begin fun ifam ->
-    let fam = base.data.couples.get ifam in
-    let husband = base.data.persons.get (Adef.father fam) in
-    let husband_surname = Mutil.nominative (sou base husband.surname) in
-    let husband_surnames_aliases =
-      List.map (sou base) husband.surnames_aliases
-    in
-    husband_surname, husband_surnames_aliases
-  end p.family
-
-let father_titles_places base (p : (iper, iper, istr) Def.gen_person) nobtit =
-  match (base.data.ascends.get p.Def.key_index).parents with
-  | Some ifam ->
-    let fam = base.data.couples.get ifam in
-    let fath = base.data.persons.get (Adef.father fam) in
-    List.map (fun t -> sou base t.t_place) (nobtit fath)
-  | None -> []
-
-let gen_gen_person_misc_names base (p : (iper, iper, istr) Def.gen_person) nobtit nobtit_fun =
-  let sou = sou base in
-  Futil.gen_person_misc_names (sou p.Def.first_name) (sou p.Def.surname)
-    (sou p.Def.public_name) (List.map sou p.Def.qualifiers) (List.map sou p.Def.aliases)
-    (List.map sou p.Def.first_names_aliases) (List.map sou p.Def.surnames_aliases)
-    (List.map (Futil.map_title_strings sou) nobtit)
-    (if p.Def.sex = Def.Female then Array.to_list (husbands base p) else [])
-    (father_titles_places base p nobtit_fun)
+let gen_gen_person_misc_names = Dutil.dsk_person_misc_names
 
 let patch_misc_names base ip (p : (iper, iper, istr) Def.gen_person) =
   let p = { p with Def.key_index = ip } in
   List.iter
     (fun s -> base.func.Dbdisk.patch_name s ip)
-    (gen_gen_person_misc_names base p p.Def.titles (fun p -> p.titles))
+    (gen_gen_person_misc_names base p (fun p -> p.Def.titles))
 
 let patch_person base ip (p : (iper, iper, istr) Def.gen_person) =
   base.func.Dbdisk.patch_person ip p ;

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -62,11 +62,11 @@ let make_strings_of_fsname base =
     let p = Dutil.poi base i in
     let first_name = Dutil.p_first_name base p in
     let surname = Dutil.p_surname base p in
-    if first_name <> "?" then
+    if first_name <> "?" then (* kill it? *)
       Name.split_fname_callback
         (fun i j -> add_name (String.sub first_name i j) p.first_name)
         first_name ;
-    if surname <> "?" then
+    if surname <> "?" then (* kill it? *)
       Name.split_sname_callback
         (fun i j -> add_name (String.sub surname i j) p.surname)
         surname ;
@@ -218,11 +218,12 @@ let output base =
       base.data.descends.clear_array ();
       close_out oc;
       close_out oc_acc;
-      begin let oc_inx = Secure.open_out_bin tmp_names_inx in
+      begin
+        let oc_inx = Secure.open_out_bin tmp_names_inx in
         let oc_inx_acc = Secure.open_out_bin tmp_names_acc in
         try
           trace "create name index";
-          output_binary_int oc_inx 0;
+          output_binary_int oc_inx 0; (* room for fsname index *)
           create_name_index oc_inx oc_inx_acc base;
           base.data.ascends.clear_array ();
           base.data.unions.clear_array ();
@@ -231,7 +232,7 @@ let output base =
           let surname_or_first_name_pos = pos_out oc_inx in
           trace "create strings of fsname";
           create_strings_of_fsname oc_inx oc_inx_acc base;
-          seek_out oc_inx 0;
+          seek_out oc_inx 0; (* fsname index *)
           output_binary_int oc_inx surname_or_first_name_pos;
           close_out oc_inx;
           close_out oc_inx_acc;

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -47,7 +47,8 @@ let create_name_index oc_inx oc_inx_acc base =
 
 module StringSet = Set.Make (String)
 
-module IntSet = Set.Make (Int)
+(* Int module is available for OCaml >= 4.08 *)
+module IntSet = Set.Make (struct type t = int let compare = compare end)
 
 (* For each first name/surname and aliases,
    associate it with the list of [Dutil.name_index] (run on splitted values)

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -50,19 +50,13 @@ module StringSet = Set.Make (String)
 module IntSet = Set.Make (Int)
 
 let make_strings_of_fsname base =
-  let particles =
-    List.fold_left
-      begin fun set p -> StringSet.add (Name.crush_lower p) set end
-      StringSet.empty base.data.particles
-  in
   let t = Array.make Dutil.table_size IntSet.empty in
   let add_name (key : string) (value : int) =
-    if not @@ StringSet.mem key particles then
-      let key = Dutil.name_index key in
-      let set = Array.get t key in
-      let set' = IntSet.add value set in
-      if set == set' then ()
-      else Array.set t key set'
+    let key = Dutil.name_index key in
+    let set = Array.get t key in
+    let set' = IntSet.add value set in
+    if set == set' then ()
+    else Array.set t key set'
   in
   for i = 0 to base.data.persons.len - 1 do
     let p = Dutil.poi base i in

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -74,7 +74,7 @@ let make_strings_of_fsname base =
     aux Name.split_fname_callback p.first_name ;
     List.iter (aux Name.split_fname_callback) p.first_names_aliases ;
     aux Name.split_sname_callback p.surname ;
-    List.iter (aux Name.split_fname_callback) p.surnames_aliases ;
+    List.iter (aux Name.split_sname_callback) p.surnames_aliases ;
   done ;
   Array.map begin fun set ->
     let a = Array.make (IntSet.cardinal set) 0 in

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -59,7 +59,7 @@ let make_strings_of_fsname base =
   in
   let t = Array.make Dutil.table_size IntSet.empty in
   let add_name (key : string) (value : int) =
-    (* abbrev? *)
+    (* crush_lower is crush o abrrev o lower *)
     let key = Name.crush_lower key in
     if key <> "" && not @@ StringSet.mem key particles then
       let key = Hashtbl.hash key mod Dutil.table_size in
@@ -73,9 +73,13 @@ let make_strings_of_fsname base =
     let first_name = Dutil.p_first_name base p in
     let surname = Dutil.p_surname base p in
     if first_name <> "?" then
-      List.iter (fun s -> add_name s p.first_name) @@ Name.split_fname first_name ;
+      Name.split_fname_callback
+        (fun i j -> add_name (String.sub first_name i j) p.first_name)
+        first_name ;
     if surname <> "?" then
-      List.iter (fun s -> add_name s p.surname) @@ Name.split_sname surname ;
+      Name.split_sname_callback
+        (fun i j -> add_name (String.sub surname i j) p.surname)
+        surname ;
   done ;
   Array.map begin fun set ->
     let a = Array.make (IntSet.cardinal set) 0 in

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -66,6 +66,7 @@ let make_strings_of_fsname base =
     let aux split istr =
       if istr <> 1 then begin
         let s = base.data.strings.get istr in
+        add_name s istr ;
         split (fun i j -> add_name (String.sub s i j) istr) s
       end
     in

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -20,6 +20,15 @@ let count_error computed found =
   flush stderr;
   exit 2
 
+let output_index_aux oc_inx oc_inx_acc ni =
+  let bpos = pos_out oc_inx in
+  Dutil.output_value_no_sharing oc_inx ni ;
+  let epos =
+    Iovalue.output_array_access oc_inx_acc (Array.get ni) (Array.length ni)
+      bpos
+  in
+  if epos <> pos_out oc_inx then count_error epos (pos_out oc_inx)
+
 let make_name_index base =
   let t = Array.make Dutil.table_size [] in
   for i = 0 to base.data.persons.len - 1 do
@@ -36,14 +45,7 @@ let make_name_index base =
   Array.map Array.of_list t
 
 let create_name_index oc_inx oc_inx_acc base =
-  let ni = make_name_index base in
-  let bpos = pos_out oc_inx in
-  Dutil.output_value_no_sharing oc_inx (ni : Dutil.name_index_data);
-  let epos =
-    Iovalue.output_array_access oc_inx_acc (Array.get ni) (Array.length ni)
-      bpos
-  in
-  if epos <> pos_out oc_inx then count_error epos (pos_out oc_inx)
+  output_index_aux oc_inx oc_inx_acc (make_name_index base)
 
 let add_name t key valu =
   let key = Name.crush_lower key in
@@ -67,13 +69,7 @@ let make_strings_of_fsname base =
   t
 
 let create_strings_of_fsname oc_inx oc_inx_acc base =
-  let t = make_strings_of_fsname base in
-  let bpos = pos_out oc_inx in
-  Dutil.output_value_no_sharing oc_inx (t : Dutil.strings_of_fsname);
-  let epos =
-    Iovalue.output_array_access oc_inx_acc (Array.get t) (Array.length t) bpos
-  in
-  if epos <> pos_out oc_inx then count_error epos (pos_out oc_inx)
+  output_index_aux oc_inx oc_inx_acc (make_strings_of_fsname base)
 
 let is_prime a =
   let rec loop b =

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -72,7 +72,7 @@ let make_strings_of_fsname base =
     aux Name.split_fname_callback p.first_name ;
     List.iter (aux Name.split_fname_callback) p.first_names_aliases ;
     aux Name.split_sname_callback p.surname ;
-    List.iter (aux Name.split_fname_callback) p.first_names_aliases ;
+    List.iter (aux Name.split_fname_callback) p.surnames_aliases ;
   done ;
   Array.map begin fun set ->
     let a = Array.make (IntSet.cardinal set) 0 in

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -68,7 +68,7 @@ let make_strings_of_fsname base =
     if surname <> "?" then
       begin
         add_name surname p.surname ;
-        List.iter (fun sp -> add_name sp p.surname) (Mutil.surnames_pieces surname)
+        List.iter (fun sp -> add_name sp p.surname) (Name.split_sname surname)
       end
   done ;
   Array.map Array.of_list t

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -36,9 +36,7 @@ let make_name_index base =
     if p.first_name <> 1 && p.first_name <> 1
     then begin
       List.iter (fun i -> Array.set t i @@ p.key_index :: Array.get t i) @@
-      Mutil.list_map_sort_uniq begin fun key ->
-        Hashtbl.hash (Name.crush (Name.abbrev (Name.lower key))) mod Dutil.table_size
-      end @@
+      Mutil.list_map_sort_uniq Dutil.name_index @@
       Dutil.dsk_person_misc_names base p (fun p -> p.titles)
     end
   done ;
@@ -59,10 +57,8 @@ let make_strings_of_fsname base =
   in
   let t = Array.make Dutil.table_size IntSet.empty in
   let add_name (key : string) (value : int) =
-    (* crush_lower is crush o abrrev o lower *)
-    let key = Name.crush_lower key in
-    if key <> "" && not @@ StringSet.mem key particles then
-      let key = Hashtbl.hash key mod Dutil.table_size in
+    if not @@ StringSet.mem key particles then
+      let key = Dutil.name_index key in
       let set = Array.get t key in
       let set' = IntSet.add value set in
       if set == set' then ()

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -66,10 +66,22 @@ let make_strings_of_fsname base =
       Name.split_fname_callback
         (fun i j -> add_name (String.sub first_name i j) p.first_name)
         first_name ;
+    List.iter begin fun s ->
+      let s = base.data.strings.get s in
+      Name.split_fname_callback
+        (fun i j -> add_name (String.sub s i j) p.first_name)
+        s
+    end p.first_names_aliases ;
     if surname <> "?" then (* kill it? *)
       Name.split_sname_callback
         (fun i j -> add_name (String.sub surname i j) p.surname)
         surname ;
+    List.iter begin fun s ->
+      let s = base.data.strings.get s in
+      Name.split_fname_callback
+        (fun i j -> add_name (String.sub s i j) p.surname)
+        s
+    end p.first_names_aliases ;
   done ;
   Array.map begin fun set ->
     let a = Array.make (IntSet.cardinal set) 0 in

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -189,7 +189,7 @@ let output base =
     if epos <> pos_out oc then count_error epos (pos_out oc)
   in
   begin try
-      output_string oc Dutil.magic_GnWb0021;
+      output_string oc Dutil.magic_GnWb0022;
       output_binary_int oc base.data.persons.len;
       output_binary_int oc base.data.families.len;
       output_binary_int oc base.data.strings.len;

--- a/lib/gwdb.ml
+++ b/lib/gwdb.ml
@@ -190,37 +190,30 @@ let p_surname base p = Mutil.nominative (sou base (get_surname p))
 
 let husbands base gp =
   let p = poi base gp.key_index in
-  Array.map
-    (fun ifam ->
-       let fam = foi base ifam in
-       let husband = poi base (get_father fam) in
-       let husband_surname = p_surname base husband in
-       let husband_surnames_aliases =
-         List.map (sou base) (get_surnames_aliases husband)
-       in
-       husband_surname, husband_surnames_aliases)
-    (get_family p)
+  Array.map begin fun ifam ->
+    let fam = foi base ifam in
+    let husband = poi base (get_father fam) in
+    let husband_surname = get_surname husband in
+    let husband_surnames_aliases = get_surnames_aliases husband in
+    husband_surname, husband_surnames_aliases
+  end (get_family p)
 
 let father_titles_places base p nobtit =
   match get_parents (poi base p.key_index) with
   | Some ifam ->
     let fam = foi base ifam in
     let fath = poi base (get_father fam) in
-    List.map (fun t -> sou base t.t_place) (nobtit fath)
+    (nobtit fath)
   | None -> []
 
 let gen_gen_person_misc_names base p nobtit nobtit_fun =
-  let sou = sou base in
-  Futil.gen_person_misc_names (sou p.first_name) (sou p.surname)
-    (sou p.public_name) (List.map sou p.qualifiers) (List.map sou p.aliases)
-    (List.map sou p.first_names_aliases) (List.map sou p.surnames_aliases)
-    (List.map (Futil.map_title_strings sou) nobtit)
-    (if p.sex = Female then Array.to_list (husbands base p) else [])
+  Futil.gen_person_misc_names
+    (sou base) empty_string quest_string
+    p.first_name p.surname p.public_name p.qualifiers p.aliases
+    p.first_names_aliases p.surnames_aliases
+    nobtit
+    (if p.sex = Female then husbands base p else [||])
     (father_titles_places base p nobtit_fun)
-
-let gen_person_misc_names base p nobtit =
-  gen_gen_person_misc_names base p (nobtit p)
-    (fun p -> nobtit (gen_person_of_person p))
 
 let person_misc_names base p nobtit =
   gen_gen_person_misc_names base (gen_person_of_person p) (nobtit p) nobtit

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -125,7 +125,7 @@ let notes_links_db conf base eliminate_unlinked =
     else db2
   in
   List.sort
-    (fun (s1, _) (s2, _) -> Gutil.alphabetic_order (Name.lower s1) (Name.lower s2))
+    (fun (s1, _) (s2, _) -> Utf8.compare (Name.lower s1) (Name.lower s2))
     db2
 
 let update_notes_links_db base fnotes s =

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1411,10 +1411,10 @@ let build_surnames_list conf base v p =
   List.sort
     (fun (s1, _) (s2, _) ->
        match
-         Gutil.alphabetic_order (surname_without_particle base s1) (surname_without_particle base s2)
+         Utf8.compare (surname_without_particle base s1) (surname_without_particle base s2)
        with
          0 ->
-           Gutil.alphabetic_order (surname_particle base s1)
+           Utf8.compare (surname_particle base s1)
              (surname_particle base s2)
        | x -> x)
     !list
@@ -1540,14 +1540,14 @@ let build_list_eclair conf base v p =
   List.sort
     (fun (s1, pl1, _, _, _, _) (s2, pl2, _, _, _, _) ->
        match
-         Gutil.alphabetic_order (surname_without_particle base s1) (surname_without_particle base s2)
+         Utf8.compare (surname_without_particle base s1) (surname_without_particle base s2)
        with
          0 ->
            begin match
-             Gutil.alphabetic_order (surname_particle base s1)
+             Utf8.compare (surname_particle base s1)
                (surname_particle base s2)
            with
-             0 -> Gutil.alphabetic_order pl1 pl2
+             0 -> Utf8.compare pl1 pl2
            | x -> x
            end
        | x -> x)
@@ -1639,7 +1639,7 @@ let rec compare_ls sl1 sl2 =
       (* les performances à cause du try..with.                *)
       let c =
         try Stdlib.compare (int_of_string s1) (int_of_string s2) with
-          Failure _ -> Gutil.alphabetic_order s1 s2
+          Failure _ -> Utf8.compare s1 s2
       in
       if c = 0 then compare_ls sl1 sl2 else c
   | _ :: _, [] -> 1

--- a/lib/place.ml
+++ b/lib/place.ml
@@ -63,11 +63,11 @@ let compare_places s1 s2 =
   let ss2, s2 = split_suburb s2 in
   match
     Mutil.list_compare
-      Gutil.alphabetic_order
+      Utf8.compare
       (String.split_on_char ',' s1)
       (String.split_on_char ',' s2)
   with
-  | 0 -> Gutil.alphabetic_order ss1 ss2
+  | 0 -> Utf8.compare ss1 ss2
   | x -> x
 
 (* [String.length s > 0] is always true because we already tested [is_empty_string].

--- a/lib/placeDisplay.ml
+++ b/lib/placeDisplay.ml
@@ -20,7 +20,7 @@ let print_html_places_surnames conf base (array : (string list * (string * iper 
     Wserver.printf "\">%s</a> (%d)" sn len
   in
   let print_sn_list (snl : (string * iper list) list) =
-    let snl = List.sort (fun (sn1, _) (sn2, _) -> Gutil.alphabetic_order sn1 sn2) snl in
+    let snl = List.sort (fun (sn1, _) (sn2, _) -> Utf8.compare sn1 sn2) snl in
     Wserver.printf "<li>\n";
     Mutil.list_iter_first (fun first x -> if not first then Wserver.printf ",\n" ; print_sn x) snl ;
     Wserver.printf "\n";
@@ -79,7 +79,7 @@ let print_all_places_surnames_short conf base ~add_birth ~add_baptism ~add_death
       (fun x -> x)
       max_int
   in
-  Array.sort (fun (s1, _) (s2, _) -> Gutil.alphabetic_order s1 s2) array ;
+  Array.sort (fun (s1, _) (s2, _) -> Utf8.compare s1 s2) array ;
   let title _ = Wserver.printf "%s" (Utf8.capitalize (transl conf "place")) in
   print_aux conf title begin fun () ->
     let opt = print_aux_opt ~add_birth ~add_baptism ~add_death ~add_burial ~add_marriage in
@@ -124,7 +124,7 @@ let print_all_places_surnames_long conf base ini ~add_birth ~add_baptism ~add_de
     | _, [] -> 1
     | [], _ -> -1
     | s1 :: pl11, s2 :: pl22 ->
-      match Gutil.alphabetic_order s1 s2 with
+      match Utf8.compare s1 s2 with
       | 0 -> sort_place_utf8 pl11 pl22
       | x -> x
   in

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -39,10 +39,9 @@ let try_find_with_one_first_name conf base n =
     let fn = String.sub n1 0 i in
     let sn = String.sub n1 (i + 1) (String.length n1 - i - 1) in
     let (list, _) =
-      Some.new_persons_of_fsname conf base
+      Some.new_persons_of_fsname base
         base_strings_of_surname
         (fun istr -> spi_find (Gwdb.persons_of_surname base) istr)
-        get_surname
         Name.split_sname
         sn
     in

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -53,7 +53,7 @@ let try_find_with_one_first_name conf base n =
       let sn = String.sub n1 (i + 1) (String.length n1 - i - 1) in
       let (list, _) =
         Some.persons_of_fsname conf base base_strings_of_surname
-          (spi_find (persons_of_surname base)) get_surname sn
+          (spi_find (persons_of_surname base)) get_surname Name.split_sname sn
       in
       List.fold_left
         (fun pl (_, _, ipl) ->

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -39,7 +39,7 @@ let try_find_with_one_first_name conf base n =
     let fn = String.sub n1 0 i in
     let sn = String.sub n1 (i + 1) (String.length n1 - i - 1) in
     let (list, _) =
-      Some.new_persons_of_fsname base
+      Some.persons_of_fsname base
         base_strings_of_surname
         (fun istr -> spi_find (Gwdb.persons_of_surname base) istr)
         Name.split_sname

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -52,7 +52,7 @@ let try_find_with_one_first_name conf base n =
       let fn = String.sub n1 0 i in
       let sn = String.sub n1 (i + 1) (String.length n1 - i - 1) in
       let (list, _) =
-        Some.persons_of_fsname conf base base_strings_of_surname
+        Some.old_persons_of_fsname conf base base_strings_of_surname
           (spi_find (persons_of_surname base)) get_surname Name.split_sname sn
       in
       List.fold_left

--- a/lib/searchName.mli
+++ b/lib/searchName.mli
@@ -1,13 +1,53 @@
-(* $Id: searchName.mli,v 5.2 2007-01-19 01:53:17 ddr Exp $ *)
 (* Copyright (c) 1998-2007 INRIA *)
 
 open Config
 open Gwdb
 
 val search_partial_key : config -> base -> string -> person list
-val print :
-  config -> base -> (config -> base -> string -> person list -> unit) ->
-    (config -> string -> unit) -> unit
 val search_by_sosa : config -> base -> string -> person list
 val search_by_key : config -> base -> string -> person list
 val search_approx_key : config -> base -> string -> person list
+
+type search_type =
+  | Sosa
+  | Key
+  | Surname
+  | FirstName
+  | ApproxKey
+  | PartialKey
+
+(** [search conf base specify unknown one surname firstname fn sn search_order] *)
+val search
+  : Config.config
+  -> Gwdb.base
+  -> (Config.config -> Gwdb.base -> string -> Gwdb.person list -> unit)
+  -> (Config.config -> string -> unit)
+  -> (Config.config -> Gwdb.base -> Gwdb.person -> unit)
+  -> (Config.config -> Gwdb.base -> (Config.config -> string -> unit) -> string
+      -> (string * (Mutil.StrSet.t * Gwdb.iper list)) list * (string -> string) -> unit)
+  -> (Config.config -> Gwdb.base -> string ->
+      (string * (Mutil.StrSet.t * Gwdb.iper list)) list -> unit)
+  -> string
+  -> string
+  -> search_type list
+  -> unit
+
+(** [print ~fn ~sn conf base specify unknown]
+    Uses [fn] and [sn] parameters from [conf.env] and try
+    to choose the best search function based on these inputs
+    (they may be empty).
+    [fn] is expected to be a first name.
+    [sn] can be a surname, the whole key (first name + surname), a sosa number.
+
+    A single result redirect to individual page.
+    Multiple results call the [specify] function
+    No result call the [unkown] function
+ *)
+val print
+  : config
+  -> base
+  -> (config -> base -> string -> person list -> unit)
+  -> (config -> string -> unit)
+  -> fn:string
+  -> sn:string
+  -> unit

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -279,7 +279,7 @@ let rec merge_insert acc (sstr, (strl, iperl) as x) = match acc with
 (** A person with name [n] is selected if [String.lowercase_ascii n = x].
     Until full utf8 case mapping is supported.
 *)
-let persons_of_absolute_aux strings spi get split conf base x =
+let persons_of_absolute_aux strings spi get aliases split conf base x =
   let lower = String.lowercase_ascii in
   let x = lower x in
   ( let istrs = strings base @@ List.hd @@ split x in
@@ -290,7 +290,8 @@ let persons_of_absolute_aux strings spi get split conf base x =
         let ipers =
           (* Filter out hidden persons *)
           List.fold_left begin fun ipers iper ->
-            if eq_istr (get (pget conf base iper)) istr
+            let p = pget conf base iper in
+            if eq_istr (get p) istr || List.exists (eq_istr istr) (aliases p)
             then iper :: ipers
             else ipers
           end [] ipers
@@ -305,6 +306,7 @@ let persons_of_absolute_first_name =
     base_strings_of_first_name
     persons_of_first_name
     get_first_name
+    get_first_names_aliases
     Name.split_fname
 
 let persons_of_absolute_surname =
@@ -312,6 +314,7 @@ let persons_of_absolute_surname =
     base_strings_of_surname
     persons_of_surname
     get_surname
+    get_surnames_aliases
     Name.split_sname
 
 let has_children_with_that_name conf base des name =

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -136,7 +136,7 @@ let print_alphabetic_to_branch conf x =
   Wserver.printf "</table>";
   Wserver.printf "<br%s>\n" conf.xhs
 
-let persons_of_fsname conf base base_strings_of_fsname find proj x =
+let persons_of_fsname conf base base_strings_of_fsname find proj split x =
   (* list of strings index corresponding to the crushed lower first name
      or surname "x" *)
   let istrl = base_strings_of_fsname base x in
@@ -146,8 +146,8 @@ let persons_of_fsname conf base base_strings_of_fsname find proj x =
     List.fold_right
       (fun istr l ->
          let str = Mutil.nominative (sou base istr) in
-         if Name.crush_lower str = x ||
-            List.mem x (List.map Name.crush_lower (Mutil.surnames_pieces str))
+         if Name.crush_lower str = x
+            || List.mem x (List.map Name.crush_lower @@ split str)
          then
            let iperl = find istr in
            (* maybe they are not the good ones because of changes in the
@@ -331,7 +331,8 @@ let first_name_print conf base x =
       [], (fun _ -> raise (Match_failure ("src/some.ml", 348, 29)))
     else
       persons_of_fsname conf base base_strings_of_first_name
-        (spi_find (persons_of_first_name base)) get_first_name x
+        (spi_find (persons_of_first_name base)) get_first_name
+        Name.split_fname x
   in
   let list =
     List.map
@@ -791,7 +792,9 @@ let surname_print conf base not_found_fun x =
       [], (fun _ -> raise (Match_failure ("src/some.ml", 825, 29)))
     else
       persons_of_fsname conf base base_strings_of_surname
-        (spi_find (persons_of_surname base)) get_surname x
+        (spi_find (persons_of_surname base)) get_surname
+        Name.split_sname
+        x
   in
   let list =
     List.map
@@ -861,7 +864,7 @@ let search_surname conf base x =
       [], (fun _ -> raise (Match_failure ("src/some.ml", 896, 29)))
     else
       persons_of_fsname conf base base_strings_of_surname
-        (spi_find (persons_of_surname base)) get_surname x
+        (spi_find (persons_of_surname base)) get_surname Name.split_sname x
   in
   let list =
     List.map
@@ -906,7 +909,7 @@ let search_surname_print conf base not_found_fun x =
       [], (fun _ -> raise (Match_failure ("src/some.ml", 942, 29)))
     else
       persons_of_fsname conf base base_strings_of_surname
-        (spi_find (persons_of_surname base)) get_surname x
+        (spi_find (persons_of_surname base)) get_surname Name.split_sname x
   in
   let list =
     List.map
@@ -972,7 +975,7 @@ let search_first_name conf base x =
       [], (fun _ -> raise (Match_failure ("src/some.ml", 1008, 29)))
     else
       persons_of_fsname conf base base_strings_of_first_name
-        (spi_find (persons_of_first_name base)) get_first_name x
+        (spi_find (persons_of_first_name base)) get_first_name Name.split_fname x
   in
   let list =
     List.map
@@ -991,7 +994,7 @@ let search_first_name_print conf base x =
       [], (fun _ -> raise (Match_failure ("src/some.ml", 1026, 29)))
     else
       persons_of_fsname conf base base_strings_of_first_name
-        (spi_find (persons_of_first_name base)) get_first_name x
+        (spi_find (persons_of_first_name base)) get_first_name Name.split_fname x
   in
   let list =
     List.map

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -139,11 +139,11 @@ let print_alphabetic_to_branch conf x =
 let persons_of_fsname base base_strings_of_fsname find split x =
   let list =
     let filter = Name.crush_lower in
-    let x = filter x in
+    let x' = filter x in
     List.fold_left begin fun acc istr ->
       let str = Mutil.nominative (sou base istr) in
-      if filter str = x
-      || List.mem x (List.map filter @@ split str)
+      if filter str = x'
+      || List.mem x' (List.map filter @@ split str)
       then
         let iperl = find istr in
         if iperl = [] then acc else (str, istr, iperl) :: acc
@@ -281,8 +281,8 @@ let rec merge_insert acc (sstr, (strl, iperl) as x) = match acc with
 *)
 let persons_of_absolute_aux strings spi get aliases split conf base x =
   let lower = String.lowercase_ascii in
-  let x = lower x in
   ( let istrs = strings base @@ List.hd @@ split x in
+    let x = lower x in
     List.fold_right begin fun istr l ->
       let str = sou base istr in
       if lower str = x then
@@ -576,7 +576,6 @@ let print_one_surname_by_branch conf base x xl (bhl, str) =
 
 let print_several_possible_surnames x conf base (_, homonymes) =
   let fx = x in
-  List.iter (fun sn -> print_endline @@ Printf.sprintf "%s: %s%!\n" __LOC__ sn) homonymes ;
   let x = match homonymes with x :: _ -> x | _ -> x in
   let title _ =
     Wserver.printf "%s \"%s\" : %s"

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -690,7 +690,7 @@ let search_aux persons_of_absolute strings spi split conf base x =
   sort [] list, inj
 
 let filter_hidden conf base =
-  List.filter_map begin fun i ->
+  Util.filter_map begin fun i ->
     let p = pget conf base i in
     if not (is_hide_names conf p) || authorized_age conf base p
     then Some p

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -225,7 +225,7 @@ let first_name_print_list conf base x1 xl liste =
     let l =
       List.sort
         (fun x1 x2 ->
-           match Gutil.alphabetic (p_surname base x1) (p_surname base x2) with
+           match Utf8.compare (p_surname base x1) (p_surname base x2) with
              0 ->
              begin match
                  Adef.od_of_cdate (get_birth x1),
@@ -242,7 +242,7 @@ let first_name_print_list conf base x1 xl liste =
       (fun l x ->
          let px = p_surname base x in
          match l with
-           (p, l1) :: l when Gutil.alphabetic px p = 0 -> (p, x :: l1) :: l
+           (p, l1) :: l when Utf8.compare px p = 0 -> (p, x :: l1) :: l
          | _ -> (px, [x]) :: l)
       [] l
   in
@@ -400,8 +400,6 @@ let unselected_bullets conf =
        try if k = "u" then ifam_of_string v :: sl else sl with Failure _ -> sl)
     [] conf.env
 
-let alphabetic1 n1 n2 = Gutil.alphabetic_utf_8 n1 n2
-
 type 'a branch_head = { bh_ancestor : 'a; bh_well_named_ancestors : 'a list }
 
 let print_branch conf base psn name =
@@ -547,7 +545,7 @@ let print_one_surname_by_branch conf base x xl (bhl, str) =
     | _ ->
         List.sort
           (fun p1 p2 ->
-             alphabetic1 (p_first_name base p1.bh_ancestor)
+             Utf8.compare (p_first_name base p1.bh_ancestor)
                (p_first_name base p2.bh_ancestor))
           bhl
   in
@@ -677,7 +675,7 @@ let print_family_alphabetic x conf base liste =
       List.sort
         (fun x1 x2 ->
            match
-             alphabetic1 (p_first_name base x2) (p_first_name base x1)
+             Utf8.compare (p_first_name base x2) (p_first_name base x1)
            with
              0 -> compare (get_occ x1) (get_occ x2)
            | n -> n)
@@ -687,7 +685,7 @@ let print_family_alphabetic x conf base liste =
       (fun l x ->
          let px = p_first_name base x in
          match l with
-           (p, l1) :: l when alphabetic1 px p = 0 -> (p, x :: l1) :: l
+           (p, l1) :: l when Utf8.compare px p = 0 -> (p, x :: l1) :: l
          | _ -> (px, [x]) :: l)
       [] l
   in

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -136,9 +136,7 @@ let print_alphabetic_to_branch conf x =
   Wserver.printf "</table>";
   Wserver.printf "<br%s>\n" conf.xhs
 
-let persons_of_fsname conf base base_strings_of_fsname find proj split x =
-  (* list of strings index corresponding to the crushed lower first name
-     or surname "x" *)
+let old_persons_of_fsname conf base base_strings_of_fsname find proj split x =
   let istrl = base_strings_of_fsname base x in
   (* selecting the persons who have this first name or surname *)
   let l =
@@ -147,7 +145,7 @@ let persons_of_fsname conf base base_strings_of_fsname find proj split x =
       (fun istr l ->
          let str = Mutil.nominative (sou base istr) in
          if Name.crush_lower str = x
-            || List.mem x (List.map Name.crush_lower @@ split str)
+         || List.mem x (List.map Name.crush_lower @@ split str)
          then
            let iperl = find istr in
            (* maybe they are not the good ones because of changes in the
@@ -330,7 +328,7 @@ let first_name_print conf base x =
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 348, 29)))
     else
-      persons_of_fsname conf base base_strings_of_first_name
+      old_persons_of_fsname conf base base_strings_of_first_name
         (spi_find (persons_of_first_name base)) get_first_name
         Name.split_fname x
   in
@@ -789,7 +787,7 @@ let surname_print conf base not_found_fun x =
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 825, 29)))
     else
-      persons_of_fsname conf base base_strings_of_surname
+      old_persons_of_fsname conf base base_strings_of_surname
         (spi_find (persons_of_surname base)) get_surname
         Name.split_sname
         x
@@ -861,7 +859,7 @@ let search_surname conf base x =
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 896, 29)))
     else
-      persons_of_fsname conf base base_strings_of_surname
+      old_persons_of_fsname conf base base_strings_of_surname
         (spi_find (persons_of_surname base)) get_surname Name.split_sname x
   in
   let list =
@@ -906,7 +904,7 @@ let search_surname_print conf base not_found_fun x =
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 942, 29)))
     else
-      persons_of_fsname conf base base_strings_of_surname
+      old_persons_of_fsname conf base base_strings_of_surname
         (spi_find (persons_of_surname base)) get_surname Name.split_sname x
   in
   let list =
@@ -972,7 +970,7 @@ let search_first_name conf base x =
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 1008, 29)))
     else
-      persons_of_fsname conf base base_strings_of_first_name
+      old_persons_of_fsname conf base base_strings_of_first_name
         (spi_find (persons_of_first_name base)) get_first_name Name.split_fname x
   in
   let list =
@@ -991,7 +989,7 @@ let search_first_name_print conf base x =
     else if x = "" then
       [], (fun _ -> raise (Match_failure ("src/some.ml", 1026, 29)))
     else
-      persons_of_fsname conf base base_strings_of_first_name
+      old_persons_of_fsname conf base base_strings_of_first_name
         (spi_find (persons_of_first_name base)) get_first_name Name.split_fname x
   in
   let list =

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -136,7 +136,7 @@ let print_alphabetic_to_branch conf x =
   Wserver.printf "</table>";
   Wserver.printf "<br%s>\n" conf.xhs
 
-let new_persons_of_fsname conf base base_strings_of_fsname find proj split x =
+let new_persons_of_fsname base base_strings_of_fsname find split x =
   let list =
     let filter = Name.crush_lower in
     let x = filter x in
@@ -664,13 +664,13 @@ let print_family_alphabetic x conf base liste =
         (print_elem conf base false) liste;
       Hutil.trailer conf
 
-let search_aux persons_of_absolute strings spi get split conf base x =
+let search_aux persons_of_absolute strings spi split conf base x =
   let (list, inj) =
     if p_getenv conf.env "t" = Some "A"
     then persons_of_absolute conf base x
     else if x = ""
     then ([], (fun _ -> assert false))
-    else new_persons_of_fsname conf base strings (spi_find (spi base)) get split x
+    else new_persons_of_fsname base strings (spi_find (spi base)) split x
   in
   let lower = String.lowercase_ascii in
   let list =
@@ -739,21 +739,19 @@ let print_surname conf base not_found_fun x (list, inj) =
       let strl = List.map fst list in
       print_several_possible_surnames x conf base (bhl, strl)
 
-let search_surname conf base x =
+let search_surname base x =
   search_aux
     persons_of_absolute_surname
     base_strings_of_surname
     persons_of_surname
-    get_surname
-    Name.split_sname conf base x
+    Name.split_sname base x
 
-let search_first_name conf base x =
+let search_first_name base x =
   search_aux
     persons_of_absolute_first_name
     base_strings_of_first_name
     persons_of_first_name
-    get_first_name
-    Name.split_fname conf base x
+    Name.split_fname base x
 
 let first_name_print conf base x =
   search_first_name conf base x

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -66,7 +66,7 @@ let print_branch_to_alphabetic conf x nb_branch =
   else
     begin
       Wserver.printf "<a href=\"%sm=N&o=i&v=%s\" rel=\"nofollow\">"
-        (commd conf) (code_varenv x ^ "&t=N");
+        (commd conf) (code_varenv x ^ "&t=A");
       Wserver.printf "%s"
         (transl_nth conf "display by/branch/alphabetic order" 2);
       Wserver.printf "</a>"
@@ -637,7 +637,7 @@ let print_several_possible_surnames x conf base (_, homonymes) =
   in
   let list = List.sort compare list in
   let access txt sn =
-    geneweb_link conf ("m=N&v=" ^ code_varenv sn ^ "&t=N") txt
+    geneweb_link conf ("m=N&v=" ^ code_varenv sn ^ "&t=A") txt
   in
   Util.wprint_in_columns conf (fun (ord, _, _) -> ord)
     (fun (_, txt, sn) -> Wserver.printf "%s" (access txt sn)) list;

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -136,7 +136,7 @@ let print_alphabetic_to_branch conf x =
   Wserver.printf "</table>";
   Wserver.printf "<br%s>\n" conf.xhs
 
-let new_persons_of_fsname base base_strings_of_fsname find split x =
+let persons_of_fsname base base_strings_of_fsname find split x =
   let list =
     let filter = Name.crush_lower in
     let x = filter x in
@@ -670,7 +670,7 @@ let search_aux persons_of_absolute strings spi split conf base x =
     then persons_of_absolute conf base x
     else if x = ""
     then ([], (fun _ -> assert false))
-    else new_persons_of_fsname base strings (spi_find (spi base)) split x
+    else persons_of_fsname base strings (spi_find (spi base)) split x
   in
   let lower = String.lowercase_ascii in
   let list =

--- a/lib/updateData.ml
+++ b/lib/updateData.ml
@@ -459,11 +459,11 @@ let build_list_short conf list =
     let inis = remove_dup inis in
     match inis with
     | [ ini ] -> build_ini list (String.length ini)
-    | list -> List.sort Gutil.alphabetic_order list
+    | list -> List.sort Utf8.compare list
   in
   build_ini list (String.length ini)
 
 let build_list_long conf list : (string * (istr * string) list) list =
   let ini = Opt.default "" (p_getenv conf.env "s") in
   let list = combine_by_ini ini list in
-  List.sort (fun (ini1, _) (ini2, _) -> Gutil.alphabetic_order ini1 ini2) list
+  List.sort (fun (ini1, _) (ini2, _) -> Utf8.compare ini1 ini2) list

--- a/lib/updateDataDisplay.ml
+++ b/lib/updateDataDisplay.ml
@@ -218,8 +218,8 @@ let print_foreach conf print_ast _eval_expr =
           (fun (_, s1) (_, s2) ->
              let rss1 = Place.without_suburb s1 in
              let rss2 = Place.without_suburb s2 in
-             if rss1 = rss2 then Gutil.alphabetic_order s1 s2
-             else Gutil.alphabetic_order rss1 rss2)
+             if rss1 = rss2 then Utf8.compare s1 s2
+             else Utf8.compare rss1 rss2)
           l
       | _ -> []
     in

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -125,7 +125,7 @@ and eval_simple_var conf base env (fam, cpl, des) =
         | _ -> None
       in
       eval_date_var d s
-  | "father" :: sl -> eval_key (Gutil.father cpl) sl
+  | "father" :: sl -> eval_key (Adef.father cpl) sl
   | ["fsources"] -> str_val (Util.escape_html fam.fsources)
   | ["is_first"] ->
       begin match get_env "first" env with
@@ -148,7 +148,7 @@ and eval_simple_var conf base env (fam, cpl, des) =
       let k =
         match get_env "cnt" env with
           Vint i ->
-            let arr = Gutil.parent_array cpl in
+            let arr = Adef.parent_array cpl in
             let i = i - 1 in
             if i >= 0 && i < Array.length arr then arr.(i)
             else if i >= 0 && i < 1 && Array.length arr = 0 then
@@ -618,7 +618,7 @@ let print_foreach print_ast _eval_expr =
     | ["fevent"] -> print_foreach_fevent env fcd al fam.fevents
     | ["fwitness"] -> print_foreach_fwitness env fcd al fam.fevents
     | ["witness"] -> print_foreach_witness env fcd al fam.witnesses
-    | ["parent"] -> print_foreach_parent env fcd al (Gutil.parent_array cpl)
+    | ["parent"] -> print_foreach_parent env fcd al (Adef.parent_array cpl)
     | _ -> raise Not_found
   and print_foreach_child env fcd al arr =
     for i = 0 to max 1 (Array.length arr) - 1 do

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -578,8 +578,8 @@ let check_event_witnesses conf witnesses =
   loop 0
 
 let check_parents conf cpl =
-  let (fa_fn, fa_sn, _, _, _) = Gutil.father cpl in
-  let (mo_fn, mo_sn, _, _, _) = Gutil.mother cpl in
+  let (fa_fn, fa_sn, _, _, _) = Adef.father cpl in
+  let (mo_fn, mo_sn, _, _, _) = Adef.mother cpl in
   match (fa_fn = "", fa_sn = ""), (mo_fn = "", mo_sn = "") with
     (true, true), (true, true) | (true, true), (false, false) |
     (false, false), (true, true) | (false, false), (false, false) ->
@@ -1143,14 +1143,14 @@ let is_created_or_already_there ochil_arr nchil schil =
 (* Improvement : check the name on the parents/children if they linked *)
 
 let need_check_noloop (scpl, sdes, onfs) =
-  if Array.exists is_a_link (Gutil.parent_array scpl) ||
+  if Array.exists is_a_link (Adef.parent_array scpl) ||
      Array.exists is_a_link sdes.children
   then
     match onfs with
       Some ((opar, ochil), (npar, nchil)) ->
         not
           (Mutil.array_forall2 (is_created_or_already_there opar) npar
-             (Gutil.parent_array scpl)) ||
+             (Adef.parent_array scpl)) ||
         not
           (Mutil.array_forall2 (is_created_or_already_there ochil) nchil
              sdes.children)
@@ -1310,8 +1310,8 @@ let forbidden_disconnected conf scpl sdes =
       Not_found -> false
   in
   if no_dec then
-    if get_create (Gutil.father scpl) = Update.Link ||
-       get_create (Gutil.mother scpl) = Update.Link
+    if get_create (Adef.father scpl) = Update.Link ||
+       get_create (Adef.mother scpl) = Update.Link
     then
       false
     else

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -375,3 +375,12 @@ val safe_html : string -> string
     [false] if we knwon the first name or the last name of [p].
 *)
 val is_empty_name : person -> bool
+
+(** Group persons by line. Should be used with the result of a search
+    function. *)
+val branches
+ : config
+ -> base
+ -> (string -> string)
+ -> iper list
+ -> iper list list

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -179,7 +179,7 @@ let gen_person_misc_names
     let s_surnames =
       s_surname ::
       Mutil.list_rev_map_append sou surnames_aliases
-        (Mutil.list_rev_map_append sou qualifiers @@ Mutil.surnames_pieces s_surname)
+        (Mutil.list_rev_map_append sou qualifiers @@ Name.split_sname s_surname)
     in
     let s_surnames =
       Array.fold_left begin fun s_list (husband_surname, husband_surnames_aliases) ->
@@ -189,7 +189,7 @@ let gen_person_misc_names
           let s_husband_surname = Mutil.nominative @@ sou husband_surname in
           s_husband_surname ::
           Mutil.list_rev_map_append sou husband_surnames_aliases
-            (List.rev_append (Mutil.surnames_pieces s_husband_surname) s_list)
+            (List.rev_append (Name.split_sname s_husband_surname) s_list)
       end s_surnames husbands
     in
     (* (public names) *)

--- a/lib/util/futil.mli
+++ b/lib/util/futil.mli
@@ -30,6 +30,16 @@ val eq_title_names :
 val parent : bool -> 'a array -> 'a gen_couple
 
 val gen_person_misc_names :
-  string -> string -> string -> string list -> string list -> string list ->
-    string list -> string Def.gen_title list -> (string * string list) list ->
-    string list -> string list
+  ('a -> string) ->
+  'a ->
+  'a ->
+  'a ->
+  'a ->
+  'a ->
+  'a list ->
+  'a list ->
+  'a list ->
+  'a list ->
+  'a Def.gen_title list ->
+  ('a * 'a list) array ->
+  'a Def.gen_title list -> string list

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -148,25 +148,6 @@ let input_particles fname =
     loop [] 0
   with Sys_error _ -> []
 
-let saints = ["saint"; "sainte"]
-
-let surnames_pieces surname =
-  let surname = Name.lower surname in
-  let flush i0 i1 =
-    if i1 > i0 then [String.sub surname i0 (i1 - i0)] else []
-  in
-  let rec loop i0 iw i =
-    if i = String.length surname then
-      if i0 = 0 then [] else if i > i0 + 3 then flush i0 i else []
-    else if surname.[i] = ' ' then
-      if i > iw + 3 then
-        let w = String.sub surname iw (i - iw) in
-        if List.mem w saints then loop i0 (i + 1) (i + 1)
-        else flush i0 i @ loop (i + 1) (i + 1) (i + 1)
-      else loop i0 (i + 1) (i + 1)
-    else loop i0 iw (i + 1)
-  in
-  loop 0 0 0
 
 let tr c1 c2 s =
   match String.rindex_opt s c1 with

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -511,3 +511,130 @@ let input_file_ic ic =
           loop ()
         | exception End_of_file -> Buffer.contents buffer
       in loop ()
+
+(* Copied from OCaml's List.sort_uniq and adapted to our needs
+   (commit e5ebec7 from Nov 7, 2019) *)
+let list_map_sort_uniq (fn : 'a -> 'b) l =
+  let open List in
+  let rec rev_merge l1 l2 accu =
+    match l1, l2 with
+    | [], l2 -> rev_append l2 accu
+    | l1, [] -> rev_append l1 accu
+    | h1::t1, h2::t2 ->
+      let c = compare h1 h2 in
+      if c = 0 then rev_merge t1 t2 (h1::accu)
+      else if c < 0
+      then rev_merge t1 l2 (h1::accu)
+      else rev_merge l1 t2 (h2::accu)
+  in
+  let rec rev_merge_rev l1 l2 accu =
+    match l1, l2 with
+    | [], l2 -> rev_append l2 accu
+    | l1, [] -> rev_append l1 accu
+    | h1::t1, h2::t2 ->
+      let c = compare h1 h2 in
+      if c = 0 then rev_merge_rev t1 t2 (h1::accu)
+      else if c > 0
+      then rev_merge_rev t1 l2 (h1::accu)
+      else rev_merge_rev l1 t2 (h2::accu)
+  in
+  let rec sort n l =
+    match n, l with
+    | 2, x1 :: x2 :: tl ->
+      let x1 = fn x1 in
+      let x2 = fn x2 in
+      let s =
+        let c = compare x1 x2 in
+        if c = 0 then [x1] else if c < 0 then [x1; x2] else [x2; x1]
+      in
+      (s, tl)
+    | 3, x1 :: x2 :: x3 :: tl ->
+      let x1 = fn x1 in
+      let x2 = fn x2 in
+      let x3 = fn x3 in
+      let s =
+        let c = compare x1 x2 in
+        if c = 0 then
+          let c = compare x2 x3 in
+          if c = 0 then [x2] else if c < 0 then [x2; x3] else [x3; x2]
+        else if c < 0 then
+          let c = compare x2 x3 in
+          if c = 0 then [x1; x2]
+          else if c < 0 then [x1; x2; x3]
+          else
+            let c = compare x1 x3 in
+            if c = 0 then [x1; x2]
+            else if c < 0 then [x1; x3; x2]
+            else [x3; x1; x2]
+        else
+          let c = compare x1 x3 in
+          if c = 0 then [x2; x1]
+          else if c < 0 then [x2; x1; x3]
+          else
+            let c = compare x2 x3 in
+            if c = 0 then [x2; x1]
+            else if c < 0 then [x2; x3; x1]
+            else [x3; x2; x1]
+      in
+      (s, tl)
+    | n, l ->
+      let n1 = n asr 1 in
+      let n2 = n - n1 in
+      let s1, l2 = rev_sort n1 l in
+      let s2, tl = rev_sort n2 l2 in
+      (rev_merge_rev s1 s2 [], tl)
+  and rev_sort n l =
+    match n, l with
+    | 2, x1 :: x2 :: tl ->
+      let x1 = fn x1 in
+      let x2 = fn x2 in
+      let s =
+        let c = compare x1 x2 in
+        if c = 0 then [x1] else if c > 0 then [x1; x2] else [x2; x1]
+      in
+      (s, tl)
+    | 3, x1 :: x2 :: x3 :: tl ->
+      let x1 = fn x1 in
+      let x2 = fn x2 in
+      let x3 = fn x3 in
+      let s =
+        let c = compare x1 x2 in
+        if c = 0 then
+          let c = compare x2 x3 in
+          if c = 0 then [x2] else if c > 0 then [x2; x3] else [x3; x2]
+        else if c > 0 then
+          let c = compare x2 x3 in
+          if c = 0 then [x1; x2]
+          else if c > 0 then [x1; x2; x3]
+          else
+            let c = compare x1 x3 in
+            if c = 0 then [x1; x2]
+            else if c > 0 then [x1; x3; x2]
+            else [x3; x1; x2]
+        else
+          let c = compare x1 x3 in
+          if c = 0 then [x2; x1]
+          else if c > 0 then [x2; x1; x3]
+          else
+            let c = compare x2 x3 in
+            if c = 0 then [x2; x1]
+            else if c > 0 then [x2; x3; x1]
+            else [x3; x2; x1]
+      in
+      (s, tl)
+    | n, l ->
+      let n1 = n asr 1 in
+      let n2 = n - n1 in
+      let s1, l2 = sort n1 l in
+      let s2, tl = sort n2 l2 in
+      (rev_merge s1 s2 [], tl)
+  in
+  let len = length l in
+  if len < 2 then List.map fn l else fst (sort len l)
+
+let list_rev_map_append f l1 l2 =
+  let rec aux acc = function
+    | [] -> acc
+    | hd :: tl -> aux (f hd :: acc) tl
+  in
+  aux l2 l1

--- a/lib/util/mutil.mli
+++ b/lib/util/mutil.mli
@@ -154,3 +154,8 @@ val list_except : 'a -> 'a list -> 'a list
     the result is meaningless.
 *)
 val input_file_ic : in_channel -> string
+
+val list_map_sort_uniq : ('a -> 'b) -> 'a list -> 'b list
+
+val list_rev_map_append : ('a -> 'b) -> 'a list -> 'b list -> 'b list
+

--- a/lib/util/mutil.mli
+++ b/lib/util/mutil.mli
@@ -16,7 +16,6 @@ val lock_file : string -> string
 val name_key : string -> string
 val initial : string -> int
 val input_particles : string -> string list
-val surnames_pieces : string -> string list
 
 val utf_8_of_iso_8859_1 : string -> string
 val iso_8859_1_of_utf_8 : string -> string

--- a/lib/util/name.ml
+++ b/lib/util/name.ml
@@ -179,3 +179,13 @@ let strip_lower s = strip (lower s)
 (* crush_lower *)
 
 let crush_lower s = crush (abbrev (lower s))
+
+let concat_aux fn l1 sn l2 =
+  let b = Bytes.create (l1 + l2 + 1) in
+  Bytes.blit_string fn 0 b 0 l1 ;
+  Bytes.blit_string sn 0 b (l1 + 1) l2 ;
+  Bytes.unsafe_set b l1 ' ' ;
+  Bytes.unsafe_to_string b
+
+let concat fn sn =
+  concat_aux fn (String.length fn) sn (String.length sn)

--- a/lib/util/name.ml
+++ b/lib/util/name.ml
@@ -189,3 +189,19 @@ let concat_aux fn l1 sn l2 =
 
 let concat fn sn =
   concat_aux fn (String.length fn) sn (String.length sn)
+
+(* Copy/paste from String.split_on_char adapted to our needs *)
+let split_sname s =
+  let open String in
+  let r = ref [] in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if match unsafe_get s i with ' ' | '-' -> true | _ -> false then begin
+      r := sub s (i + 1) (!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  sub s 0 !j :: !r
+
+let split_fname =
+  String.split_on_char ' '

--- a/lib/util/name.ml
+++ b/lib/util/name.ml
@@ -191,17 +191,35 @@ let concat fn sn =
   concat_aux fn (String.length fn) sn (String.length sn)
 
 (* Copy/paste from String.split_on_char adapted to our needs *)
-let split_sname s =
+let split_sname_callback fn s =
   let open String in
-  let r = ref [] in
   let j = ref (length s) in
   for i = length s - 1 downto 0 do
     if match unsafe_get s i with ' ' | '-' -> true | _ -> false then begin
-      r := sub s (i + 1) (!j - i - 1) :: !r;
+      fn (i + 1) (!j - i - 1) ;
       j := i
     end
   done;
-  sub s 0 !j :: !r
+  fn 0 !j
 
-let split_fname =
-  String.split_on_char ' '
+(* Copy/paste from String.split_on_char adapted to our needs *)
+let split_fname_callback fn s =
+  let open String in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if unsafe_get s i = ' ' then begin
+      fn (i + 1) (!j - i - 1) ;
+      j := i
+    end
+  done;
+  fn 0 !j
+
+let split_sname s =
+  let r = ref [] in
+  split_sname_callback (fun i j -> r := String.sub s i j :: !r) s ;
+  !r
+
+let split_fname s =
+  let r = ref [] in
+  split_fname_callback (fun i j -> r := String.sub s i j :: !r) s ;
+  !r

--- a/lib/util/name.mli
+++ b/lib/util/name.mli
@@ -47,3 +47,12 @@ val forbidden_char : char list
 
 (** [concat fn sn] is [fn ^ " " ^ sn] but faster. *)
 val concat : string -> string -> string
+
+(** [split_sname s] split the surname [s] in parts composing it.
+    e.g. [split_sname base "Foo-Bar"] is [[ "Foo" ; "Bar"]] *)
+val split_sname  : string -> string list
+
+(** [split_fname s] split the string [s] representing multiple first names
+    into this list of firstname.
+    e.g. [split_fname base "Foo-Bar Baz"] is [[ "Foo-Bar" ; "Baz"]] *)
+val split_fname : string -> string list

--- a/lib/util/name.mli
+++ b/lib/util/name.mli
@@ -44,3 +44,6 @@ val next_chars_if_equiv : string -> int -> string -> int -> (int * int) option
 val unaccent_utf_8 : bool -> string -> int -> string * int
 
 val forbidden_char : char list
+
+(** [concat fn sn] is [fn ^ " " ^ sn] but faster. *)
+val concat : string -> string -> string

--- a/lib/util/name.mli
+++ b/lib/util/name.mli
@@ -56,3 +56,15 @@ val split_sname  : string -> string list
     into this list of firstname.
     e.g. [split_fname base "Foo-Bar Baz"] is [[ "Foo-Bar" ; "Baz"]] *)
 val split_fname : string -> string list
+
+(** [split_sname_callback fn s]
+    Same as [split_sname], but call [fn] with substring indices instead of building
+    a list
+*)
+val split_sname_callback : (int -> int -> unit) -> string -> unit
+
+(** [split_fname_callback fn s]
+    Same as [split_fname], but call [fn] with substring indices instead of building
+    a list
+*)
+val split_fname_callback : (int -> int -> unit) -> string -> unit

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -269,7 +269,7 @@ let print_main conf base auth_file =
     if by_alphab_order then
       List.sort
         (fun (_, (_, (o1, _))) (_, (_, (o2, _))) ->
-           Gutil.alphabetic_order o1 o2)
+           Utf8.compare o1 o2)
         list
     else list
   in

--- a/test/test_place.ml
+++ b/test/test_place.ml
@@ -36,8 +36,11 @@ let suite =
       end
     ; "compare_places" >:: begin fun _ ->
         let test exp a b =
-          assert_equal ~printer:string_of_int exp (Place.compare_places a b)
-        ; assert_equal ~printer:string_of_int (-exp) (Place.compare_places b a)
+          let aux x = if x = 0 then 0 else if x < 0 then -1 else 1 in
+          assert_equal
+            ~printer:string_of_int exp (aux @@ Place.compare_places a b)
+        ; assert_equal
+            ~printer:string_of_int (-exp) (aux @@ Place.compare_places b a)
         in
         test 0 "boobar (baz)" "boobar (baz)"
       ; test (-1) "baz (boobar)" "boobar (baz)"


### PR DESCRIPTION
Les indexes doivent être régénérés pour que la nouvelle recherche fonctionne:
```
gwfixbase.exe -index /path/to/base.gwb
```

Cette refonte apporte les modifications suivantes à la recherche:
- par défaut, la recherche cherche en découpant les noms/prenoms sur les mots:
  e.g. Julien Romain Edouard SAGOT va correspondre à une recherche sur "Julien", sur "Edouard", et sur "Romain".
- La recherche avancée permet de faire une rechercher "exact": la decomposition du nom/prenom doit correspondre exactement a la decomposition recherche (pas un mot de plus, pas une mot de moins)
- La recherche sur "Julien Romain" fera ressortir "Julien Romain Edouard" pour la recherche avancée (sauf si recherche exacte est activée). Par contre en recherche simple, cela n'est pas encore effectif, et "Julien Romain" ne verra pas ressortir "Julien Romain Edouard" (ne ressort de toute façon pas dans la recherche actuelle)
- les nom/prenom aliases sont pris en compte au même titre que les nom/prenom

---

Indexes need to be regenerated in order to make this work:
```
gwfixbase.exe -index /path/to/base.gwb
```

Copy/paste from https://github.com/geneweb/geneweb/issues/904

> I will only talk about first names and surnames, but alias <del>and nicknames</del> should probably be treated the same way
>
>     When searching, first names are splitted on space
>     When searching, surnames are splitted on space and hyphen
>     Search is accent insensitive (ascii versions of the string is used, see source of "unidecode" library)
>     Search is case insensitive
>     Order of names does not matter
>     If a person match each component of the search, it is selected (if first name is "julien romain edouard" and if we search "julien edouard", it will be selected)
>     When performing "exact match" (new option) search, searching "julien romain edouard" will not match "julien romain". "julien romain" will match "julien romain" and "romain julien" but not "julien romain edouard"
> 

---

Please answer this thread if you spot a bug

---

Simple search for first name "rené"

![image](https://user-images.githubusercontent.com/1826552/84671540-cb713200-af27-11ea-8143-0b4918721d45.png)
Note: values matching exactly the search will be placed as first item, the rest is sorted alphabetically.

---

When clicking on a precise value:
![image](https://user-images.githubusercontent.com/1826552/84671710-fd829400-af27-11ea-9a4b-0cd004305a26.png)

---

Advanced search for "Julien Romain":
![image](https://user-images.githubusercontent.com/1826552/84671847-21de7080-af28-11ea-82c4-7dc441a3eba4.png)

---

Avanced search for "exactly Julien Romain":
![image](https://user-images.githubusercontent.com/1826552/84671936-3d497b80-af28-11ea-8596-a5c98b96607f.png)

---

TODO (non bloquant pour merge): Par contre en recherche simple, cela n'est pas encore effectif, et "Julien Romain" ne verra pas ressortir "Julien Romain Edouard" (ne ressort de toute façon pas dans la recherche actuelle)

---

À noter : les pages de recherche simple ainsi que la page des nom et prénoms se retrouvent aussi affectées (enrichit par les aliases). À voir si cela ne charge pas trop les listes et s'il ne faut pas améliorer cette partie