### PR TITLE
Adv search

### DIFF
--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -35,6 +35,10 @@ let bench () =
         ]
     ; bench "Name.lower" Name.lower
         [ "étienne" ; "Étienne" ; "ÿvette" ; "Ÿvette" ; "Ĕtienne" ]
+    ; bench "Name.split_fname" Name.split_fname
+        [ "Jean-Baptiste Emmanuel" ; "Jean Baptiste Emmanuel" ]
+    ; bench "Name.split_sname" Name.split_sname
+        [ "Jean-Baptiste Emmanuel" ; "Jean Baptiste Emmanuel" ]
     ]
   in
   match Sys.getenv_opt "BENCH_BASE" with

--- a/hd/etc/advanced.txt
+++ b/hd/etc/advanced.txt
@@ -136,9 +136,23 @@
         </div>
       </div>
       <div class="row">
+        <div class="col-3"></div>
+        <div class="form-check col-9">
+          <input class="form-check-input" type="checkbox" name="exact_first_name" value="on" checked>
+          <label class="form-check-label" for="exact_first_name">[*exact]</label>
+        </div>
+      </div>
+      <div class="row">
         <label for="surname" class="col-form-label col-3">[*surname/surnames]0</label>
         <div class="col-9">
           <input type="text" class="form-control" name="surname" id="surname" placeholder="[*surname/surnames]0">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-3"></div>
+        <div class="form-check col-9">
+          <input class="form-check-input" type="checkbox" name="exact_surname" value="on">
+          <label class="form-check-label" for="exact_surname" checked>[*exact]</label>
         </div>
       </div>
       <div class="row mt-3">

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -5671,6 +5671,30 @@ sk: presne
 sl: točno
 sv: exakt
 
+    search_exact_fn
+de: genaue Suche
+en: exact search
+es: búsqueda exacta
+fi: tarkka haku
+fr: recherche exacte
+it: ricerca esatta
+nl: exact zoeken
+no: eksakt søk
+pt: pesquisa exata
+sv: exakt sökning
+
+    search_exact_sn
+de: genaue Suche
+en: exact search
+es: búsqueda exacta
+fi: tarkka haku
+fr: recherche exacte
+it: ricerca esatta
+nl: exact zoeken
+no: eksakt søk
+pt: pesquisa exata
+sv: exakt sökning
+
     excommunication
 co: scumunicazione
 de: Exkommunizierung

--- a/lib/advSearchOk.ml
+++ b/lib/advSearchOk.ml
@@ -382,7 +382,7 @@ let advanced_search conf base max_answers =
       in loop (pget conf base @@ get_iper sosa_ref) ([], 0)
     | None -> [], 0
   else if fn_list <> [] || sn_list <> [] then
-    let list_aux strings_of split n_list exact =
+    let list_aux strings_of persons_of split n_list exact =
       List.map begin List.map begin fun x ->
         let eq = match_name n_list exact in
         let istrs = strings_of base x in
@@ -396,7 +396,7 @@ let advanced_search conf base max_answers =
       |> List.flatten
       |> List.flatten
       |> List.sort_uniq compare
-      |> List.map (spi_find @@ Gwdb.persons_of_surname base)
+      |> List.map (spi_find @@ persons_of base)
       |> List.flatten
       |> List.sort_uniq compare
     in
@@ -405,7 +405,8 @@ let advanced_search conf base max_answers =
         ( false
         , true
         , list_aux
-            base_strings_of_surname
+            Gwdb.base_strings_of_surname
+            Gwdb.persons_of_surname
             Name.split_sname
             sn_list
             (gets "exact_surname" = "on")
@@ -414,7 +415,8 @@ let advanced_search conf base max_answers =
         ( true
         , false
         , list_aux
-            base_strings_of_first_name
+            Gwdb.base_strings_of_first_name
+            Gwdb.persons_of_first_name
             Name.split_fname
             fn_list
             (gets "exact_first_name" = "on")

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -452,10 +452,12 @@ let old_strings_of_fsname bname strings (_, person_patches) =
     in
     Hashtbl.fold begin fun _ p acc ->
       let aux split acc istr =
+        let str = strings.get istr in
         if not (List.mem istr acc)
-        && strings.get istr
-           |> split
-           |> List.exists (fun s -> i = Dutil.name_index s)
+        && match split str with
+        | [ s ] -> i = Dutil.name_index s
+        | list ->
+          List.exists (fun s -> i = Dutil.name_index s) (str :: list)
         then istr :: acc
         else acc
       in
@@ -502,7 +504,7 @@ let new_strings_of_fsname_aux offset_acc offset_inx split get bname strings (_, 
       let istr = get p in
       let str = strings.get istr in
       if not (List.mem istr acc)
-      && match split str  with
+      && match split str with
       | [ s ] -> i = Dutil.name_index s
       | list ->
         List.exists (fun s -> i = Dutil.name_index s) (str :: list)

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -386,7 +386,7 @@ let new_persons_of_first_name_or_surname base_data params =
   { find ; cursor ; next }
 
 let persons_of_first_name_or_surname = function
-  | GnWb0021 -> new_persons_of_first_name_or_surname
+  | GnWb0022 | GnWb0021 -> new_persons_of_first_name_or_surname
   | GnWb0020 -> old_persons_of_first_name_or_surname
 
 (* Search index for a given name in file names.inx *)
@@ -738,7 +738,8 @@ let opendb bname =
   in
   let ic = Secure.open_in_bin (Filename.concat bname "base") in
   let version =
-    if Mutil.check_magic Dutil.magic_GnWb0021 ic then GnWb0021
+    if Mutil.check_magic Dutil.magic_GnWb0022 ic then GnWb0022
+    else if Mutil.check_magic Dutil.magic_GnWb0021 ic then GnWb0021
     else if Mutil.check_magic Dutil.magic_GnWb0020 ic then GnWb0020
     else if really_input_string ic 4 = "GnWb"
     then failwith "this is a GeneWeb base, but not compatible"
@@ -769,7 +770,11 @@ let opendb bname =
         flush stderr;
         None
   in
-  let ic2_string_start_pos = 3 * Dutil.int_size in
+  let ic2_string_start_pos =
+    match version with
+    | GnWb0022 -> Dutil.int_size
+    | GnWb0021 | GnWb0020 -> 3 * Dutil.int_size
+  in
   let ic2_string_hash_len =
     match ic2 with
       Some ic2 -> Some (input_binary_int ic2)

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -500,10 +500,12 @@ let new_strings_of_fsname_aux offset_acc offset_inx split get bname strings (_, 
     in
     Hashtbl.fold begin fun _ p acc ->
       let istr = get p in
+      let str = strings.get istr in
       if not (List.mem istr acc)
-      && strings.get istr
-         |> split
-         |> List.exists (fun s -> i = Dutil.name_index s)
+      && match split str  with
+      | [ s ] -> i = Dutil.name_index s
+      | list ->
+        List.exists (fun s -> i = Dutil.name_index s) (str :: list)
       then istr :: acc
       else acc
     end person_patches (Array.to_list r)

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -328,7 +328,8 @@ type base_data =
 type base_func =
   { person_of_key : string -> string -> int -> int option
   ; persons_of_name : string -> int list
-  ; strings_of_fsname : string -> int list
+  ; strings_of_sname : string -> int list
+  ; strings_of_fname : string -> int list
   ; persons_of_surname : string_person_index
   ; persons_of_first_name : string_person_index
   ; patch_person : int -> dsk_person -> unit
@@ -345,7 +346,7 @@ type base_func =
   ; nb_of_real_persons : unit -> int
   }
 
-type base_version = GnWb0020 | GnWb0021 | GnWb0022
+type base_version = GnWb0020 | GnWb0021 | GnWb0022 | GnWb0023
 
 type dsk_base = { data : base_data
                 ; func : base_func

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -345,7 +345,7 @@ type base_func =
   ; nb_of_real_persons : unit -> int
   }
 
-type base_version = GnWb0020 | GnWb0021
+type base_version = GnWb0020 | GnWb0021 | GnWb0022
 
 type dsk_base = { data : base_data
                 ; func : base_func

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -8,6 +8,7 @@ type strings_of_fsname = int array array
 
 let magic_GnWb0020 = "GnWb0020"
 let magic_GnWb0021 = "GnWb0021"
+let magic_GnWb0022 = "GnWb0022"
 let table_size = 0x3fff
 
 let poi base i = base.data.persons.get i

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -9,6 +9,7 @@ type strings_of_fsname = int array array
 let magic_GnWb0020 = "GnWb0020"
 let magic_GnWb0021 = "GnWb0021"
 let magic_GnWb0022 = "GnWb0022"
+let magic_GnWb0023 = "GnWb0023"
 let table_size = 0x3fff
 
 let poi base i = base.data.persons.get i
@@ -73,3 +74,5 @@ module IntHT = Hashtbl.Make (struct
     let equal = (=)
     let hash x = x
   end)
+
+let name_index s = Hashtbl.hash (Name.crush_lower s) mod table_size

--- a/lib/gwdb-legacy/dutil.ml
+++ b/lib/gwdb-legacy/dutil.ml
@@ -21,33 +21,29 @@ let p_first_name base p = Mutil.nominative (sou base p.first_name)
 let p_surname base p = Mutil.nominative (sou base p.surname)
 
 let husbands base p =
-  let u = uoi base p.key_index in
-  List.map
-    (fun ifam ->
-       let cpl = coi base ifam in
-       let husband = poi base (Adef.father cpl) in
-       let husband_surname = p_surname base husband in
-       let husband_surnames_aliases =
-         List.map (sou base) husband.surnames_aliases
-       in
-       husband_surname, husband_surnames_aliases)
-    (Array.to_list u.family)
+  Array.map begin fun ifam ->
+    let cpl = coi base ifam in
+    let husband = poi base (Adef.father cpl) in
+    let husband_surname = husband.surname in
+    let husband_surnames_aliases = husband.surnames_aliases in
+    husband_surname, husband_surnames_aliases
+  end (uoi base p.key_index).family
 
 let father_titles_places base p nobtit =
   match (aoi base p.key_index).parents with
-    Some ifam ->
-      let cpl = coi base ifam in
-      let fath = poi base (Adef.father cpl) in
-      List.map (fun t -> sou base t.t_place) (nobtit fath)
+  | Some ifam ->
+    let cpl = coi base ifam in
+    let fath = poi base (Adef.father cpl) in
+    (nobtit fath)
   | None -> []
 
 let dsk_person_misc_names base p nobtit =
-  let sou = sou base in
-  Futil.gen_person_misc_names (sou p.first_name) (sou p.surname)
-    (sou p.public_name) (List.map sou p.qualifiers) (List.map sou p.aliases)
-    (List.map sou p.first_names_aliases) (List.map sou p.surnames_aliases)
-    (List.map (Futil.map_title_strings sou) (nobtit p))
-    (if p.sex = Female then husbands base p else [])
+  Futil.gen_person_misc_names
+    (sou base) 0 1
+    p.first_name p.surname p.public_name p.qualifiers p.aliases
+    p.first_names_aliases p.surnames_aliases
+    (nobtit p)
+    (if p.sex = Female then husbands base p else [||])
     (father_titles_places base p nobtit)
 
 let compare_names base_data s1 s2 =

--- a/lib/gwdb-legacy/dutil.mli
+++ b/lib/gwdb-legacy/dutil.mli
@@ -8,6 +8,7 @@ type strings_of_fsname = int array array
 val magic_GnWb0020 : string
 val magic_GnWb0021 : string
 val magic_GnWb0022 : string
+val magic_GnWb0023 : string
 val table_size : int
 
 val compare_istr_fun : Dbdisk.base_data -> int -> int -> int
@@ -32,3 +33,9 @@ module IntHT : sig
       let hash x = x
     end)
 end
+
+(** [name_index s]
+    Compute the index of crush_lowered version of s
+    in an array of size {!val:table_size}.
+*)
+val name_index : string -> int

--- a/lib/gwdb-legacy/dutil.mli
+++ b/lib/gwdb-legacy/dutil.mli
@@ -7,6 +7,7 @@ type strings_of_fsname = int array array
 
 val magic_GnWb0020 : string
 val magic_GnWb0021 : string
+val magic_GnWb0022 : string
 val table_size : int
 
 val compare_istr_fun : Dbdisk.base_data -> int -> int -> int

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -85,40 +85,13 @@ let date_of_last_change base =
   in
   s.Unix.st_mtime
 
-let husbands base (gp : (iper, iper, istr) Def.gen_person) =
-  let p = base.data.unions.get gp.Def.key_index in
-  Array.map begin fun ifam ->
-    let fam = base.data.couples.get ifam in
-    let husband = base.data.persons.get (Adef.father fam) in
-    let husband_surname = Mutil.nominative (sou base husband.surname) in
-    let husband_surnames_aliases =
-      List.map (sou base) husband.surnames_aliases
-    in
-    husband_surname, husband_surnames_aliases
-  end p.family
-
-let father_titles_places base (p : (iper, iper, istr) Def.gen_person) nobtit =
-  match (base.data.ascends.get p.Def.key_index).parents with
-  | Some ifam ->
-    let fam = base.data.couples.get ifam in
-    let fath = base.data.persons.get (Adef.father fam) in
-    List.map (fun t -> sou base t.t_place) (nobtit fath)
-  | None -> []
-
-let gen_gen_person_misc_names base (p : (iper, iper, istr) Def.gen_person) nobtit nobtit_fun =
-  let sou = sou base in
-  Futil.gen_person_misc_names (sou p.Def.first_name) (sou p.Def.surname)
-    (sou p.Def.public_name) (List.map sou p.Def.qualifiers) (List.map sou p.Def.aliases)
-    (List.map sou p.Def.first_names_aliases) (List.map sou p.Def.surnames_aliases)
-    (List.map (Futil.map_title_strings sou) nobtit)
-    (if p.Def.sex = Def.Female then Array.to_list (husbands base p) else [])
-    (father_titles_places base p nobtit_fun)
+let gen_gen_person_misc_names = Dutil.dsk_person_misc_names
 
 let patch_misc_names base ip (p : (iper, iper, istr) Def.gen_person) =
   let p = { p with Def.key_index = ip } in
   List.iter
     (fun s -> base.func.Dbdisk.patch_name s ip)
-    (gen_gen_person_misc_names base p p.Def.titles (fun p -> p.titles))
+    (gen_gen_person_misc_names base p (fun p -> p.Def.titles))
 
 let patch_person base ip (p : (iper, iper, istr) Def.gen_person) =
   base.func.Dbdisk.patch_person ip p ;

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -32,8 +32,6 @@ let spi_next (spi : string_person_index) istr = spi.next istr
 
 type base = dsk_base
 
-let base_strings_of_first_name_or_surname base s = base.func.strings_of_fsname s
-
 let open_base bname : base = Database.opendb bname
 
 let close_base base = base.func.cleanup ()
@@ -58,8 +56,8 @@ let persons_of_first_name base = base.func.Dbdisk.persons_of_first_name
 let persons_of_surname base = base.func.Dbdisk.persons_of_surname
 
 let base_particles base = base.data.particles
-let base_strings_of_first_name = base_strings_of_first_name_or_surname
-let base_strings_of_surname = base_strings_of_first_name_or_surname
+let base_strings_of_first_name base s = base.func.strings_of_fname s
+let base_strings_of_surname base s = base.func.strings_of_sname s
 
 let load_ascends_array base = base.data.ascends.load_array ()
 let load_unions_array base = base.data.unions.load_array ()

--- a/lib/gwdb.ml
+++ b/lib/gwdb.ml
@@ -190,37 +190,31 @@ let p_surname base p = Mutil.nominative (sou base (get_surname p))
 
 let husbands base gp =
   let p = poi base gp.key_index in
-  Array.map
-    (fun ifam ->
-       let fam = foi base ifam in
-       let husband = poi base (get_father fam) in
-       let husband_surname = p_surname base husband in
-       let husband_surnames_aliases =
-         List.map (sou base) (get_surnames_aliases husband)
-       in
-       husband_surname, husband_surnames_aliases)
-    (get_family p)
+  Array.map begin fun ifam ->
+    let fam = foi base ifam in
+    let husband = poi base (get_father fam) in
+    let husband_surname = get_surname husband in
+    let husband_surnames_aliases = get_surnames_aliases husband in
+    husband_surname, husband_surnames_aliases
+  end (get_family p)
 
 let father_titles_places base p nobtit =
   match get_parents (poi base p.key_index) with
   | Some ifam ->
     let fam = foi base ifam in
     let fath = poi base (get_father fam) in
-    List.map (fun t -> sou base t.t_place) (nobtit fath)
+    (nobtit fath)
   | None -> []
 
 let gen_gen_person_misc_names base p nobtit nobtit_fun =
-  let sou = sou base in
-  Futil.gen_person_misc_names (sou p.first_name) (sou p.surname)
-    (sou p.public_name) (List.map sou p.qualifiers) (List.map sou p.aliases)
-    (List.map sou p.first_names_aliases) (List.map sou p.surnames_aliases)
-    (List.map (Futil.map_title_strings sou) nobtit)
-    (if p.sex = Female then Array.to_list (husbands base p) else [])
+  Futil.gen_person_misc_names
+    (sou base) empty_string quest_string
+    p.first_name p.surname p.public_name p.qualifiers p.aliases
+    p.first_names_aliases p.surnames_aliases
+    nobtit
+    (if p.sex = Female then husbands base p else [||])
     (father_titles_places base p nobtit_fun)
-
-let gen_person_misc_names base p nobtit =
-  gen_gen_person_misc_names base p (nobtit p)
-    (fun p -> nobtit (gen_person_of_person p))
+  |> List.map Name.lower
 
 let person_misc_names base p nobtit =
   gen_gen_person_misc_names base (gen_person_of_person p) (nobtit p) nobtit

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -152,93 +152,87 @@ let map_couple_p multi_parents fp cpl =
 
 let map_descend_p fp des = {children = Array.map fp des.children}
 
-let gen_person_misc_names first_name surname public_name qualifiers aliases
-    first_names_aliases surnames_aliases titles husbands
-    father_titles_places =
-  let first_name = Mutil.nominative first_name in
-  let surname = Mutil.nominative surname in
-  if first_name = "?" || surname = "?" then []
+let gen_person_misc_names
+    sou empty_string quest_string
+    first_name surname public_name qualifiers
+    aliases first_names_aliases surnames_aliases
+    titles
+    husbands
+    father_titles_places
+  =
+  if first_name = quest_string || surname = quest_string then []
   else
-    let public_names =
-      let titles_names =
-        let tnl = ref [] in
-        List.iter
-          (fun t ->
-             match t.t_name with
-               Tmain | Tnone -> ()
-             | Tname x -> tnl := x :: !tnl)
-          titles;
-        !tnl
-      in
-      if public_name = "" || titles = [] then titles_names
-      else public_name :: titles_names
+    let s_first_name = Mutil.nominative @@ sou first_name in
+    let s_surname = Mutil.nominative @@ sou surname in
+    let s_titles_names =
+      List.fold_left begin fun acc t ->
+        match t.t_name with
+        | Tmain | Tnone -> acc
+        | Tname x -> sou x :: acc
+      end [] titles
     in
-    let first_names =
-      let pn =
-        if public_name <> "" && titles = [] then public_name :: public_names
-        else public_names
-      in
-      first_name :: (first_names_aliases @ pn)
+    let s_public_names =
+      if public_name = empty_string then s_titles_names
+      else sou public_name :: s_titles_names
     in
-    let surnames =
-      surname ::
-      (Mutil.surnames_pieces surname @ surnames_aliases @ qualifiers)
+    let s_first_names = s_first_name :: (* List.rev_append *) List.rev_map sou first_names_aliases (* public_names *) in
+    let s_surnames =
+      s_surname ::
+      Mutil.list_rev_map_append sou surnames_aliases
+        (Mutil.list_rev_map_append sou qualifiers @@ Mutil.surnames_pieces s_surname)
     in
-    let surnames =
-      List.fold_left
-        (fun list (husband_surname, husband_surnames_aliases) ->
-           let husband_surname = Mutil.nominative husband_surname in
-           if husband_surname = "?" then husband_surnames_aliases @ list
-           else
-             husband_surname ::
-             (Mutil.surnames_pieces husband_surname @
-              husband_surnames_aliases @ list))
-        surnames husbands
+    let s_surnames =
+      Array.fold_left begin fun s_list (husband_surname, husband_surnames_aliases) ->
+        if husband_surname = quest_string
+        then Mutil.list_rev_map_append sou husband_surnames_aliases s_list
+        else
+          let s_husband_surname = Mutil.nominative @@ sou husband_surname in
+          s_husband_surname ::
+          Mutil.list_rev_map_append sou husband_surnames_aliases
+            (List.rev_append (Mutil.surnames_pieces s_husband_surname) s_list)
+      end s_surnames husbands
     in
-    let list = public_names in
+    (* (public names) *)
+    let s_list = s_public_names in
+    (* + (first names) x (surnames) *)
+    let s_list =
+      List.fold_left begin fun list f ->
+        List.fold_left begin fun list s -> Name.concat f s :: list end list s_surnames
+      end s_list s_first_names
+    in
+    (* + (first names + (title | (public name)) ) x (titles places) *)
+    let s_list =
+      (* let first_names = first_name :: first_names_aliases in *)
+      List.fold_left begin fun list t ->
+        let s = t.t_place in
+        if s = empty_string then list
+        else
+          let s = sou s in
+          let s_first_names =
+            match t.t_name with
+            | Tname f -> sou f :: s_first_names
+            | Tmain | Tnone ->
+              if public_name = empty_string
+              then s_first_names
+              else sou public_name :: s_first_names
+          in
+          List.fold_left (fun list f -> Name.concat f s :: list) list s_first_names
+      end s_list titles
+    in
+    (* + (first names) x (father's title places) *)
     let list =
-      List.fold_left
-        (fun list f ->
-           List.fold_left (fun list s -> (f ^ " " ^ s) :: list) list surnames)
-        list first_names
-    in
-    let list =
-      let first_names = first_name :: first_names_aliases in
-      List.fold_left
-        (fun list t ->
-           let s = t.t_place in
-           if s = "" then list
-           else
-             let first_names =
-               match t.t_name with
-                 Tname f -> f :: first_names
-               | Tmain | Tnone ->
-                   let f = public_name in
-                   if f = "" then first_names else f :: first_names
-             in
-             List.fold_left (fun list f -> (f ^ " " ^ s) :: list) list
-               first_names)
-        list titles
-    in
-    let list =
-      if father_titles_places = [] then list
+      if father_titles_places = [] then s_list
       else
-        let first_names = first_name :: first_names_aliases in
-        List.fold_left
-          (fun list s ->
-             if s = "" then list
-             else
-               List.fold_left (fun list f -> (f ^ " " ^ s) :: list) list
-                 first_names)
-          list father_titles_places
+        List.fold_left begin fun list t ->
+          let s = t.t_place in
+          if s = empty_string then list
+          else
+            let s = sou s in
+            List.fold_left (fun list f -> Name.concat f s :: list) list s_first_names
+        end s_list father_titles_places
     in
-    let list = List.rev_append aliases list in
-    let fn = Name.lower (first_name ^ " " ^ surname) in
-    List.fold_left
-      (fun list s ->
-         let s = Name.lower s in
-         if s = fn || List.mem s list then list else s :: list)
-      [] list
+    let list = Mutil.list_rev_map_append sou aliases list in
+    list
 
 let rec eq_lists eq l1 l2 =
   match l1, l2 with

--- a/lib/util/futil.mli
+++ b/lib/util/futil.mli
@@ -29,7 +29,21 @@ val eq_title_names :
 
 val parent : bool -> 'a array -> 'a gen_couple
 
+(** Return a list of string corresponding to various
+    mix between all kind of names.
+    It can contain duplicates. Strings are used raw (not lowered).
+ *)
 val gen_person_misc_names :
-  string -> string -> string -> string list -> string list -> string list ->
-    string list -> string Def.gen_title list -> (string * string list) list ->
-    string list -> string list
+  ('a -> string) ->
+  'a ->
+  'a ->
+  'a ->
+  'a ->
+  'a ->
+  'a list ->
+  'a list ->
+  'a list ->
+  'a list ->
+  'a Def.gen_title list ->
+  ('a * 'a list) array ->
+  'a Def.gen_title list -> string list

--- a/lib/util/mutil.mli
+++ b/lib/util/mutil.mli
@@ -162,3 +162,7 @@ val input_file_ic : in_channel -> string
     {{:http://unicode.org/glossary/#replacement_character}the replacement character}
 *)
 val normalize_utf_8 : string -> string
+
+val list_map_sort_uniq : ('a -> 'b) -> 'a list -> 'b list
+
+val list_rev_map_append : ('a -> 'b) -> 'a list -> 'b list -> 'b list

--- a/lib/util/name.ml
+++ b/lib/util/name.ml
@@ -179,3 +179,47 @@ let strip_lower s = strip (lower s)
 (* crush_lower *)
 
 let crush_lower s = crush (abbrev (lower s))
+
+let concat_aux fn l1 sn l2 =
+  let b = Bytes.create (l1 + l2 + 1) in
+  Bytes.blit_string fn 0 b 0 l1 ;
+  Bytes.blit_string sn 0 b (l1 + 1) l2 ;
+  Bytes.unsafe_set b l1 ' ' ;
+  Bytes.unsafe_to_string b
+
+let concat fn sn =
+  concat_aux fn (String.length fn) sn (String.length sn)
+
+(* Copy/paste from String.split_on_char adapted to our needs *)
+let split_sname_callback fn s =
+  let open String in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if match unsafe_get s i with ' ' | '-' -> true | _ -> false then begin
+      fn (i + 1) (!j - i - 1) ;
+      j := i
+    end
+  done;
+  fn 0 !j
+
+(* Copy/paste from String.split_on_char adapted to our needs *)
+let split_fname_callback fn s =
+  let open String in
+  let j = ref (length s) in
+  for i = length s - 1 downto 0 do
+    if unsafe_get s i = ' ' then begin
+      fn (i + 1) (!j - i - 1) ;
+      j := i
+    end
+  done;
+  fn 0 !j
+
+let split_sname s =
+  let r = ref [] in
+  split_sname_callback (fun i j -> r := String.sub s i j :: !r) s ;
+  !r
+
+let split_fname s =
+  let r = ref [] in
+  split_fname_callback (fun i j -> r := String.sub s i j :: !r) s ;
+  !r

--- a/lib/util/name.mli
+++ b/lib/util/name.mli
@@ -44,3 +44,27 @@ val next_chars_if_equiv : string -> int -> string -> int -> (int * int) option
 val unaccent_utf_8 : bool -> string -> int -> string * int
 
 val forbidden_char : char list
+
+(** [concat fn sn] is [fn ^ " " ^ sn] but faster. *)
+val concat : string -> string -> string
+
+(** [split_sname s] split the surname [s] in parts composing it.
+    e.g. [split_sname base "Foo-Bar"] is [[ "Foo" ; "Bar"]] *)
+val split_sname  : string -> string list
+
+(** [split_fname s] split the string [s] representing multiple first names
+    into this list of firstname.
+    e.g. [split_fname base "Foo-Bar Baz"] is [[ "Foo-Bar" ; "Baz"]] *)
+val split_fname : string -> string list
+
+(** [split_sname_callback fn s]
+    Same as [split_sname], but call [fn] with substring indices instead of building
+    a list
+*)
+val split_sname_callback : (int -> int -> unit) -> string -> unit
+
+(** [split_fname_callback fn s]
+    Same as [split_fname], but call [fn] with substring indices instead of building
+    a list
+*)
+val split_fname_callback : (int -> int -> unit) -> string -> unit


### PR DESCRIPTION
After the failure of https://github.com/geneweb/geneweb/pull/964, this is a far less ambitious change.

It is really supposed to affect only advanced search.

Search on alias is not effective for now.

This is a first step toward advanced search enhancement, matching persons with the value of `first_name` and `surname` fields.

If this branch appears to stable (it should!), it will be merged and I'll work on alias as a second step of the search enhancement.

PS: GnWb0022 is a version used by 964. Since it has been deployed, even if not merged in master, this one is GnWb0023.