### PR TITLE
Fix #976, bad params in apply;link in ancsosa.txt

### DIFF
--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1208,7 +1208,7 @@
     <div class="d-flex justify-content-between">
       <div class="align-self-center mr-2">
         %apply;image_MF("ancestor")
-        %apply;link%with;%ancestor.access;%and;%ancestor;%and;%ancestor.index;%end;
+        %apply;link(ancestor.access, ancestor, ancestor.index)
         %if;(evar.title="on" and ancestor.title!=""), %ancestor.title;%end;
         %if;(ancestor.same != "" and evar.repeat = "on" and evar.num!="on")
           %apply;implex()
@@ -1236,7 +1236,7 @@
         %if;(family_cnt = 1)
           <td class="align-middle">
             %apply;image_MF("spouse")
-            %apply;link%with;%spouse.access;%and;%spouse;%and;%spouse.index;%end;
+            %apply;link(spouse.access, spouse, spouse.index)
           </td>
         %end;
       %end;
@@ -1401,7 +1401,7 @@
                        %end;"%nn;
               %end;>
               %apply;image_MF("spouse")
-              %apply;link%with;%spouse.access;%and;%spouse;%and;%spouse.index;%end;
+              %apply;link(spouse.access, spouse, spouse.index)
             </td>
           %end;
           %if;(evar.marr_date = "on")
@@ -1861,7 +1861,7 @@ TODO: obtenir les secondes valeurs valeurs jj/mm/aaaa pour les cas « ou | » 
                 <td> &nbsp; </td>
                 <td>
                   %apply;image_MF("ancestor")
-                  %apply;link%with;ancestor.access%and;ancestor%and;ancestor.index%end;
+                  %apply;link(ancestor.access, ancestor, ancestor.index)
                   %ancestor.title;
                 </td>
                 %apply;display_missing_ancestor_info("ancestor")


### PR DESCRIPTION
Corrected three other places where simpler `apply;link(aa,bb,cc) `syntax could be used rather than 
`apply;link%with;aa%and;bb%and;cc%end;`