### PR TITLE
Rework test cyrillic onto master. No viet.

### DIFF
--- a/bin/fixbase/check_apostr.ml
+++ b/bin/fixbase/check_apostr.ml
@@ -1,0 +1,46 @@
+(* $Id: check_apostr.ml,v 4.4 2005-01-17 12:53:08 ddr Exp $ *)
+(* Copyright (c) 1999 INRIA *)
+
+open Geneweb
+
+let cnt = ref 0
+
+(* Scan a base to identify potential conflicts arising when:
+  - replacing ’ by ' in the lower function
+  - properly treating supplementary Latin accented characters (for vietnameese)
+  resolution typically consists in changing the occ number (+1)
+*)
+
+let scan base =
+  Printf.printf "\nChecking duplicates with apostrophe and viet accents";
+  let ht = Hashtbl.create (Gwdb.nb_of_persons base) in
+  Gwdb.Collection.iteri begin fun i p ->
+    let fn = Gwdb.sou base (Gwdb.get_first_name p) in
+    let sn = Gwdb.sou base (Gwdb.get_surname p) in
+    let oc = string_of_int (Gwdb.get_occ p) in
+    let fn1 = Name.lower ~apostr:true fn in
+    let sn1 = Name.lower ~apostr:true sn in
+    let k = fn1 ^ "." ^ oc ^ " " ^ sn1 in
+    let v = fn  ^ "." ^ oc ^ " " ^ sn in
+    if fn <> "?" && sn <> "?" then
+      begin
+        if not (Hashtbl.mem ht k) then
+          Hashtbl.add ht k v
+        else
+          begin
+          Printf.printf "\nconflit %s avec %s..." v (Hashtbl.find ht k) ;
+          incr cnt
+          end
+      end
+  end (Gwdb.persons base)
+
+let bname = ref ""
+let usage = "usage: " ^ Sys.argv.(0) ^ " <base>"
+let speclist = []
+
+let main () =
+  Arg.parse speclist (fun s -> bname := s) usage;
+  let base = Gwdb.open_base !bname in
+  scan base
+
+let _ = main ()

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -286,7 +286,15 @@ module StrSet = Set.Make (struct type t = string let compare = compare end)
 let start_with ?(wildcard = false) ini i s =
   let inilen = String.length ini in
   let strlen = String.length s in
-  if i < 0 || i > strlen then raise (Invalid_argument "start_with") ;
+  let nbs = Utf8.length s in
+  if i < 0 || i > nbs then raise (Invalid_argument "start_with") ;
+  let i =
+    let rec loop j n =
+      if j = i then n
+      else loop (j+1) (n + Unidecode.nbc s.[n])
+    in
+    loop 0 0
+  in
   let rec loop i1 i2 =
     if i1 = inilen then true
     else if i2 = strlen
@@ -301,18 +309,18 @@ let start_with ?(wildcard = false) ini i s =
   loop 0 i
 
 let contains ?(wildcard = false) str sub =
-  let strlen = String.length str in
-  let sublen = String.length sub in
+  let nbstr = Utf8.length str in
+  let nbsub = Utf8.length sub in
   if not wildcard
   then
     let rec loop i =
-      if i + sublen <= strlen
+      if i + nbsub <= nbstr
       then start_with ~wildcard sub i str || loop (i + 1)
       else false
     in loop 0
   else
     let rec loop i =
-      i <= strlen && (start_with ~wildcard sub i str || loop (i + 1))
+      i <= nbstr && (start_with ~wildcard sub i str || loop (i + 1))
     in loop 0
 
 let get_particle list s =

--- a/lib/util/name.ml
+++ b/lib/util/name.ml
@@ -30,6 +30,16 @@ let next_chars_if_equiv s i t j =
     if s1 = t1 then Some (i1, j1) else None
 
 let lower s =
+  let s = 
+    let rec loop s i =
+      if i > (String.length s - 2) then s
+      else
+        if (Char.code s.[i]) = 0xE2 && (Char.code s.[i+1]) = 0x80 && (Char.code s.[i+2]) = 0x99 then
+          loop ((String.sub s 0 (i)) ^ "'" ^
+            (String.sub s (i + 3) (String.length s - i - 3))) (i + 4)
+        else loop s (i + 1)
+    in loop s 0
+  in
   let rec copy special i len =
     if i = String.length s then Buff.get len
     else if Char.code s.[i] < 0x80 then match s.[i] with

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -3,13 +3,220 @@ open OUnit2
 open Config
 open Def
 
+let name_unaccent _ =
+  let test a b =
+    assert_equal ~printer:(fun x -> x) a (Some.name_unaccent b)
+  in
+  test "etienne" "étienne"
+; test "Etienne" "Étienne"
+; test "yvette" "ÿvette"
+; test "Yvette" "Ÿvette"
+; test "Etienne" "Ĕtienne"
+(* apostrophes *)
+; test "L'homme" "L'homme"
+; test "L'homme" "L’homme"
+; test "L'" "L’"
+(* unaccent performs cyrillic to latin translation! *)
+; test "Genri" "Генри"
+
+(* Name.lower performs lower and unaccent *)
+let name_lower _ =
+  let test a b =
+    assert_equal ~printer:(fun x -> x) a (Name.lower b)
+  in
+  test "abcdef" "ABCdEF"
+; test "abcdef" "ÂBÇdĘF"
+; test "etienne" "Ĕtienne"
+; test "andre" "André"
+; test "andrea" "Andréá"
+; test "ellenika" "ελληνικά"
+; test "ellnhiya" "ΈΛΛΝΉΊΎΆ"
+; test "yvette" "Ÿvette"
+; test "l homme" "L'homme"
+; test "l homme" "L’homme"
+; test "l" "L'" (* lower strips trailing spaces *)
+; test "l" "L’"
+(* cyrillic to latin and lower *)
+; test "genri" "Генри"
+; test "genri" "ГЕНРИ"
+(* Latin supplemental, vietnameese *)
+; test "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
+
+let capitalize str =
+  let strlen = String.length str in
+  let rec loop s i =
+    if i < strlen then
+      let char = String.sub str i (Unidecode.nbc str.[i]) in
+      loop (s ^ (Utf8.capitalize char)) (i + (Unidecode.nbc str.[i]))
+    else s
+  in
+  loop "" 0
+
+let util_capitale_full _ =
+  let test_s a b =
+    assert_equal ~printer:(fun x -> x) a (capitalize b)
+  in
+(* ASCII *)
+  test_s "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+       "abcdefghijklmnopqrstuvwxyz"
+; test_s "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+(* Latin-1 supplement. C3 80 - *)
+; test_s "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
+         "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"
+; test_s "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
+         "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
+(* Latin-1 supplement. C4 80 - *)
+; test_s "ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮIĲĴĶĹĻĽ"
+         "āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįıĳĵķĺļľ"
+; test_s "ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİĲĴĶĹĻĽ"
+         "ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİĲĴĶĹĻĽ"
+(* Latin-1 supplement. C5 80 - *)
+; test_s "ĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ"
+         "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž"
+; test_s "ĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ"
+         "ĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ"
+(* Latin-1 supplement. C5 80 - *)
+
+(* Latin-1 supplement. Greek, CE 80 - *) (* attention à la majuscule de ΰ *)
+; test_s "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΣΤΥΦΧΨΩΆΈΉΊΫ́ΪΫΌΎΏ"
+         "αβγδεζηθικλμνξοπρςστυφχψωάέήίΰϊϋόύώ"
+; test_s "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΣΤΥΦΧΨΩΆΈΉΊΫ́ΪΫΌΎΏ"
+         "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡςΣΤΥΦΧΨΩΆΈήΊΫ́ΪΫΌΎΏ"
+
+(* Latin-1 supplement. Cyrillic, - *)
+; test_s "ƂƄƇƋƑƘƠƢƤƧƪƯƵƼЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏ"
+         "ƃƅƈƌƒƙơƣƥƨƪưƶƽѐёђѓєѕіїјљњћќѝўџ"
+; test_s "ƂƄƇƋƑƘƠƢƤƧƪƯƵƼЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏ"
+         "ƂƄƇƋƑƘƠƢƤƧƪƯƵƼЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏ"
+
+; test_s
+  "ІУАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏѠѢѤѦѨѪѬѮѰѲѴѶѸѺѼѾ"
+  "іуабвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿ"
+; test_s
+  "ІУАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏѠѢѤѦѨѪѬѮѰѲѴѶѸѺѼѾ"
+  "ІУАБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯЀЁЂЃЄЅІЇЈЉЊЋЌЍЎЏѠѢѤѦѨѪѬѮѰѲѴѶѸѺѼѾ"
+
+; test_s
+  "ҀҊҌҎҐҒҔҖҘҚҜҞҠҢҤҦҨҪҬҮҰҲҴҶҸҺҼҾ"
+  "ҁҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿ"
+; test_s
+  "ҀҊҌҎҐҒҔҖҘҚҜҞҠҢҤҦҨҪҬҮҰҲҴҶҸҺҼҾ"
+  "ҀҊҌҎҐҒҔҖҘҚҜҞҠҢҤҦҨҪҬҮҰҲҴҶҸҺҼҾ"
+
+; test_s "ἈἉἊἋἌἍἎἏἘἙἚἛἜἝἨἩἪἫἬἭἮἯἸἹἺἻἼἽἾἿ"
+         "ἀἁἂἃἄἅἆἇἐἑἒἓἔἕἠἡἢἣἤἥἦἧἰἱἲἳἴἵἶἷ"
+; test_s "ἈἉἊἋἌἍἎἏἘἙἚἛἜἝἨἩἪἫἬἭἮἯἸἹἺἻἼἽἾἿ"
+         "ἈἉἊἋἌἍἎἏἘἙἚἛἜἝἨἩἪἫἬἭἮἯἸἹἺἻἼἽἾἿ"
+
+; test_s "ẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ"
+         "ạảấầẩẫậắằẳẵặẹẻẽếềểễệỉịọỏốồổỗộớờởỡợụủứừửữựỳỵỷỹ"
+; test_s "ẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ"
+         "ẠẢẤẦẨẪẬẮẰẲẴẶẸẺẼẾỀỂỄỆỈỊỌỎỐỒỔỖỘỚỜỞỠỢỤỦỨỪỬỮỰỲỴỶỸ"
+
+; test_s "ǍǏǑǓǕǗǙǛǞǠǢǤǦǨǪǬǮǱǴǸǺǼǾ"
+         "ǎǐǒǔǖǘǚǜǟǡǣǥǧǩǫǭǯǲǵǹǻǽǿ"
+; test_s "ǍǏǑǓǕǗǙǛǞǠǢǤǦǨǪǬǮǱǴǸǺǼǾ"
+         "ǍǏǑǓǕǗǙǛǞǠǢǤǦǨǪǬǮǱǴǸǺǼǾ"
+
+; test_s "ȀȂȄȆȈȊȌȎȐȒȔȖȘȚȜȞȤȦȨȪȬȮȰȲȻ"
+         "ȁȃȅȇȉȋȍȏȑȓȕȗșțȝȟȥȧȩȫȭȯȱȳȼ"
+; test_s "ȀȂȄȆȈȊȌȎȐȒȔȖȘȚȜȞȤȦȨȪȬȮȰȲȻ"
+         "ȀȂȄȆȈȊȌȎȐȒȔȖȘȚȜȞȤȦȨȪȬȮȰȲȻ"
+
+; test_s "ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾ" (* E1 B8 80 *)
+         "ḁḃḅḇḉḋḍḏḑḓḕḗḙḛḝḟḡḣḥḧḩḫḭḯḱḳḵḷḹḻḽḿ"
+; test_s "ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾ"
+         "ḀḂḄḆḈḊḌḎḐḒḔḖḘḚḜḞḠḢḤḦḨḪḬḮḰḲḴḶḸḺḼḾ"
+
+; test_s "ṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔ"
+         "ṁṃṅṇṉṋṍṏṑṓṕṗṙṛṝṟṡṣṥṧṩṫṭṯṱṳṵṷṹṻṽṿẁẃẅẇẉẋẍẏẑẓẕ"
+; test_s "ṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔ"
+         "ṀṂṄṆṈṊṌṎṐṒṔṖṘṚṜṞṠṢṤṦṨṪṬṮṰṲṴṶṸṺṼṾẀẂẄẆẈẊẌẎẐẒẔ"
+
+; test_s
+  "ӐӒӔӖӘӚӜӞӠӢӤӦӨӪӬӮӰӲӴӶӸӺӼӾԀԂԄԆԈԊԌԎԐԒ"
+  "ӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓ"
+; test_s
+  "ӁӃӅӇӉӋӍӀ"
+  "ӂӄӆӈӊӌӎӏ"
+
+; test_s
+  "ԔԖԘԚԜԞԠԢԤԦԨԪԬԮᠠᠡᠢᠣᠤᠥᠦᠨᠪᠫᠬᠭᠮᠯᠰᠱᠲᠳᠴᠵᠶᠷᠸᠹᠺᠻᠼᠽᠾᠿ"
+  "ԕԗԙԛԝԟԡԣԥԧԩԫԭԯᠠᠡᠢᠣᠤᠥᠦᠨᠪᠫᠬᠭᠮᠯᠰᠱᠲᠳᠴᠵᠶᠷᠸᠹᠺᠻᠼᠽᠾᠿ"
+; test_s
+  "ᴫℏⰊꙀꙂꙄꙆꙈꙊꙌꙎꙐꙒꙔꙖꙘꙚꙜꙞꙠꙢꙤꙦꙨꙪꙬꚀꚂꚄꚆꚈꚊꚌꚎꚐꚒꚔꚖꚘꚚ"
+  "ᴫℏⰺꙁꙃꙅꙇꙉꙋꙍꙏꙑꙓꙕꙗꙙꙛꙝꙟꙡꙣꙥꙧꙩꙫꙭꚁꚃꚅꚇꚉꚋꚍꚏꚑꚓꚕꚗꚙꚛ"
+
+let util_capitale _ =
+  let test a b =
+    assert_equal ~printer:(fun x -> x) a (Utf8.capitalize b)
+  in
+  test "Abc" "abc"
+; test "Abc" "Abc"
+; test "Étienne" "étienne"
+; test "Étienne" "Étienne"
+; test "Étienne" "Étienne"
+; test "Ńoemie" "ńoemie"
+; test "Ńoemie" "Ńoemie"
+; test "Ĕtienne" "ĕtienne"
+; test "Ĕtienne" "Ĕtienne"
+; test "Ÿvette" "ÿvette"
+; test "Ÿvette" "Ÿvette"
+(* greek *)
+; test "Δ λληνικά" "δ λληνικά"
+; test "Δ λληνικά" "Δ λληνικά"
+; test "Ελληνικά" "ελληνικά"
+; test "Ελληνικά" "Ελληνικά"
+; test "Ζ λληνικά" "ζ λληνικά"
+; test "Ζ λληνικά" "Ζ λληνικά"
+
+; test "Ϊ λληνικ" "ϊ λληνικ"
+; test "Ϊ λληνικ" "Ϊ λληνικ"
+; test "Ϋ λληνικ" "ϋ λληνικ"
+; test "Ϋ λληνικ" "Ϋ λληνικ"
+; test "Ό λληνικ" "ό λληνικ"
+; test "Ό λληνικ" "Ό λληνικ"
+; test "Ύ λληνικ" "ύ λληνικ"
+; test "Ύ λληνικ" "Ύ λληνικ"
+; test "Ώ λληνικ" "ώ λληνικ"
+; test "Ώ λληνικ" "Ώ λληνικ"
+
+; test "Έλληνικά" "έλληνικά"
+; test "Έλληνικά" "Έλληνικά"
+; test "Π λληνικ" "π λληνικ"
+; test "Π λληνικ" "Π λληνικ"
+; test "Ω λληνικ" "ω λληνικ"
+; test "Ω λληνικ" "Ω λληνικ"
+(* cyrillic *)
+; test "Генри" "генри"
+; test "Генри" "Генри"
+; test "Б енри" "б енри"
+; test "Б енри" "Б енри"
+; test "Я енри" "я енри"
+; test "Я енри" "Я енри"
+; test "Ѿ енри" "ѿ енри"
+; test "Ѿ енри" "Ѿ енри"
+; test "Ѡ енри" "ѡ енри"
+; test "Ѡ енри" "Ѡ енри"
+; test "Ҁ енри" "ҁ енри"
+; test "Ҁ енри" "Ҁ енри"
+(* Latin extended, Vietnameese *)
+; test "Nguyễn" "nguyễn"
+; test "Nguyễn" "Nguyễn"
+; test "Đình" "đình"
+; test "Đình" "Đình"
+; test "Ḕtienne" "ḕtienne"
+; test "Ḕtienne" "Ḕtienne"
+
 let mutil_contains _ =
-  let str = "foo bar" in
+  let str = "foo bar Ĕtienne Έλληνικά Генри bar" in
   let test t b1 b2 =
     assert_equal b1 (Mutil.contains ~wildcard:false str t)
   ; assert_equal b2 (Mutil.contains ~wildcard:true str t)
   in
   test "foo" true true
+; test "foo bar" true true
 ; test "baz" false false
 ; test "foo_b" false true
 ; test "foo b" true true
@@ -17,30 +224,48 @@ let mutil_contains _ =
 ; test "bar__" false true
 ; test "r" true true
 ; test "" true true
+; test "Ĕtienne" true true
+; test "Έλληνικά" true true
+; test "Генри" true true
 
+(* in this test, second argument the char number at which to start the test.*)
 let mutil_start_with _ =
   assert_raises (Invalid_argument "start_with")
     (fun () -> Mutil.start_with "foo" (-1) "foo")
 ; assert_raises (Invalid_argument "start_with")
     (fun () -> Mutil.start_with "foo" 4 "foo")
+; assert_raises (Invalid_argument "start_with")
+    (fun () -> Mutil.start_with "foo" 4 "Ĕoo")
 ; assert_bool "Mutil.start_with \"foo\" 0 \"foo\""
     (Mutil.start_with "foo" 0 "foo")
 ; assert_bool "not (Mutil.start_with \"bar\" 0 \"foo\")"
     (not @@ Mutil.start_with "bar" 0 "foo")
+; assert_bool "not (Mutil.start_with \"bar\" 3 \"foo\")"
+    (not @@ Mutil.start_with "bar" 3 "foo")
 ; assert_bool "Mutil.start_with \"\" 0 \"foo\""
     (Mutil.start_with "" 0 "foo")
+; assert_bool "Mutil.start_with \"Ĕtien\" 0 \"Ĕtienne\""
+    (Mutil.start_with "Ĕtien" 0 "Ĕtienne")
+; assert_bool "not (Mutil.start_with \"Ĕtien\" 5 \"Ĕtienne\")"
+    (not @@ Mutil.start_with "Ĕtien" 5 "Ĕtienne")
+; assert_bool "not (Mutil.start_with \"Ĕtien\" 7 \"Ĕtienne\")"
+    (not @@ Mutil.start_with "Ĕtien" 7 "Ĕtienne")
+; assert_bool "Mutil.start_with \"Ĕtien\" 1 \"aĔtienne\""
+    (Mutil.start_with "Ĕtien" 1 "aĔtienne")
+; assert_bool "Mutil.start_with \"Ĕtien\" 2 \"ĔaĔtienne\""
+    (Mutil.start_with "Ĕtien" 2 "ĔaĔtienne")
 
 let mutil_arabian_romian _ =
   let test a r =
     assert_equal a (Mutil.arabian_of_roman r) ;
     assert_equal r (Mutil.roman_of_arabian a)
   in
-  test 39 "XXXIX" ;
-  test 246 "CCXLVI" ;
-  test 421 "CDXXI" ;
-  test 160 "CLX" ;
-  test 207 "CCVII" ;
-  test 1066 "MLXVI"
+  test 39 "XXXIX"
+; test 246 "CCXLVI"
+; test 421 "CDXXI"
+; test 160 "CLX"
+; test 207 "CCVII"
+; test 1066 "MLXVI"
 
 let mutil_compare_after_particle _ =
   let particles =
@@ -55,45 +280,47 @@ let mutil_compare_after_particle _ =
       in
       assert_equal exp (cmp a b)
     in
-    test (-1) a b ;
-    test 1 b a ;
-    test 0 a a ;
-    test 0 b b
+    test (-1) a b
+  ; test 1 b a
+  ; test 0 a a
+  ; test 0 b b
   in
-  test "de la fontaine" "de musset" ;
-  test "de sade" "de sévigné" ;
-  test "de lattre de tassigny" "de montgolfier" ;
-  test "des cars" "du guesclin" ;
-  test "d'aboville" "d'artagnan" ;
-  test "descartes" "dupont"
+  (* first argument should be sorted before second *)
+  test "de la fontaine" "de musset"
+; test "de sade" "de sévigné"
+; test "de sevigne" "de sévigné"
+; test "de lattre de tassigny" "de montgolfier"
+; test "des cars" "du guesclin"
+; test "d'aboville" "d'artagnan"
+; test "descartes" "dupont"
 
 let mutil_string_of_int_sep _ =
   let test sep exp int =
     assert_equal ~printer:(fun s -> s) exp (Mutil.string_of_int_sep sep int)
   in
-  test "," "1" 1 ;
-  test "," "10" 10 ;
-  test "," "100" 100 ;
-  test "," "1,000" 1000 ;
-  test "," "10,000" 10000 ;
-  test "," "100,000" 100000 ;
-  test "," "1,000,000" 1000000
+  test "," "1" 1
+; test "," "10" 10
+; test "," "100" 100
+; test "," "1,000" 1000
+; test "," "10,000" 10000
+; test "," "100,000" 100000
+; test "," "1,000,000" 1000000
 
 let utf8_sub _ =
   let test ?pad e s i j =
     let i = Utf8.get s i in
     assert_equal e ~printer:(fun x -> x) (Utf8.sub ?pad s i j)
   in
-  test "日" "日本語" 0 1 ;
-  test "日本語" "日本語" 0 3 ;
-  test "語" "日本語" 2 1 ;
-  test "ε" "ελληνικά" 0 1 ;
-  test "ελληνικά" "ελληνικά" 0 8 ;
-  test "λ" "ελληνικά" 1 1 ;
-  test "ά" "ελληνικά" 7 1 ;
-  test "š" "švédčina" 0 1 ;
-  test "švédčina" "švédčina" 0 8 ;
-  test "a" "švédčina" 7 1
+  test "日" "日本語" 0 1
+; test "日本語" "日本語" 0 3
+; test "語" "日本語" 2 1
+; test "ε" "ελληνικά" 0 1
+; test "ελληνικά" "ελληνικά" 0 8
+; test "λ" "ελληνικά" 1 1
+; test "ά" "ελληνικά" 7 1
+; test "š" "švédčina" 0 1
+; test "švédčina" "švédčina" 0 8
+; test "a" "švédčina" 7 1
 
 let util_safe_html _ =
   assert_equal
@@ -113,8 +340,8 @@ let util_transl_a_of_b _ =
     let bbb = Util.transl_a_of_b conf s1 s2 s2_raw in
     assert_equal aaa bbb
   in
-    test "naissance de <b>Jean</b>" ("naissance", "<b>Jean</b>", "Jean")
-  ; test "naissance d'<b>André</b>" ("naissance", "<b>André</b>", "André")
+  test "naissance de <b>Jean</b>" ("naissance", "<b>Jean</b>", "Jean")
+; test "naissance d'<b>André</b>" ("naissance", "<b>André</b>", "André")
 
 let datedisplay_string_of_date _ =
   let conf = Config.empty in
@@ -125,24 +352,24 @@ let datedisplay_string_of_date _ =
   let _ = Hashtbl.add conf.lexicon "(month)"
     "ghjennaghju/ferraghju/marzu/aprile/maghju/ghjugnu/lugliu/aostu/sittembre/uttobre/nuvembre/dicembre"
   in
- let test aaa cal (d, m, y) =
+  let test aaa cal (d, m, y) =
     let date = Dgreg ({day = d; month = m; year = y; prec = Sure; delta = 0}, cal) in
     let bbb = DateDisplay.string_of_date conf date in
     let _ = if not (aaa = bbb) then Printf.eprintf "\n%s\n" bbb else () in
     assert_equal aaa bbb
   in
-    test "4 d'aostu 1974" Dgregorian (4, 8, 1974)
-  ; test "4 di sittembre 1974" Dgregorian (4, 9, 1974)
-  ; test "1<sup>u</sup> di ferraghju 1974" Dgregorian (1, 2, 1974)
-  ; test "di marzu 1974" Dgregorian (0, 3, 1974)
-  ; test "d'aprile 1974" Dgregorian (0, 4, 1974)
-  ; test "in u 1974" Dgregorian (0, 0, 1974)
-  ; let _ = Hashtbl.add conf.lexicon "(date)"
+  test "4 d'aostu 1974" Dgregorian (4, 8, 1974)
+; test "4 di sittembre 1974" Dgregorian (4, 9, 1974)
+; test "1<sup>u</sup> di ferraghju 1974" Dgregorian (1, 2, 1974)
+; test "di marzu 1974" Dgregorian (0, 3, 1974)
+; test "d'aprile 1974" Dgregorian (0, 4, 1974)
+; test "in u 1974" Dgregorian (0, 0, 1974)
+; let _ = Hashtbl.add conf.lexicon "(date)"
     "1<sup>u</sup> d[i']%m %y/%d d[i %m %y/d[i |'%m %y/in u %y"
   in
-    test "1<sup>u</sup> d[i']ferraghju 1974" Dgregorian (1, 2, 1974)
-  ; test "d[i |'marzu 1975" Dgregorian (0, 3, 1975)
-  ; test "4 d[i sittembre 1974" Dgregorian (4, 9, 1974)
+  test "1<sup>u</sup> d[i']ferraghju 1974" Dgregorian (1, 2, 1974)
+; test "d[i |'marzu 1975" Dgregorian (0, 3, 1975)
+; test "4 d[i sittembre 1974" Dgregorian (4, 9, 1974)
 
 let suite =
   [ "Mutil" >:::
@@ -159,5 +386,11 @@ let suite =
     [ "util_safe_html" >:: util_safe_html
     ; "util_transl_a_of_b" >:: util_transl_a_of_b
     ; "datedisplay_string_of_date" >:: datedisplay_string_of_date
+    ; "util_safe_html" >:: util_safe_html
+    ; "util_capitale" >:: util_capitale
+    ; "util_capitale_full" >:: util_capitale_full
+    ; "name_unaccent" >:: name_unaccent
+    ; "name_lower" >:: name_lower
     ]
   ]
+


### PR DESCRIPTION
Replaces PR #763 

apostr is kept (turns `’` into `'` before lower)
with` apostr=true`, `’`becomes a space (as does `'`)
with `apostr=false` (default) `’` becomes `'`, but too late to become a space!

Should the default value be set to `true`?

The issue of "Person already defined" triggered by the better "`Name.lower`" function is not yet addressed here.
With the current situation, `O’Brien` and `O'Brien` are still two different persons as applying lower to those two names results in `O'Brien` and `O Brien`.
but `Miên Định Nguyễn Phúc`,  `Mien Dịnh Nguyễn Phúc` or `Miên Định Nguyễn Phuc` were treated as different persons, but would  now all conflict as `mien dinh nguyen phuc`