### PR TITLE
Rework opt=no_index and related functions (fix #1015)

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -373,15 +373,15 @@ let print_moved conf s =
       Wserver.printf "\n</dd></dt></dl>\n";
       Hutil.trailer conf
 
-let print_no_index conf base =
+let print_no_index ?(pwd=true) conf base =
   let title _ =
     Wserver.printf "%s" (Utf8.capitalize (transl conf "link to use"))
   in
-  let link = url_no_index conf base in
+  let link = url_no_index ~pwd:pwd conf base in
   Hutil.header conf title;
   Wserver.printf "<ul>\n";
   Wserver.printf "<li>" ;
-  Wserver.printf "<a href=\"http://%s\">\n" link;
+  Wserver.printf "<a href=\"%s\">\n" link;
   Wserver.printf "%s" link;
   Wserver.printf "</a>\n";
   Wserver.printf "</ul>\n";
@@ -394,7 +394,8 @@ let treat_request conf base =
     p_getenv conf.env "m"
   with
     Some s, _, _ -> print_moved conf s
-  | _, Some "no_index", _ -> print_no_index conf base
+  | _, Some "no_index", _ -> print_no_index ~pwd:true conf base
+  | _, Some "no_index_no_pwd", _ -> print_no_index ~pwd:false conf base
   | _, _, Some "IM" -> ImageDisplay.print conf base
   | _, _, Some "DOC" ->
       begin match p_getenv conf.env "s" with

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -30,9 +30,9 @@ val html : ?content_type:string -> config -> unit
 val unauthorized : config -> string -> unit
 val string_of_ctime : config -> string
 
-val commd : config -> string
+val commd : ?amp:string -> config -> string
 val commd_2 : config -> string
-val prefix_base : config -> string
+val prefix_base : ?pwd:bool -> ?amp:string -> config -> string
 val prefix_base_password : config -> string
 val prefix_base_2 : config -> string
 val prefix_base_password_2 : config -> string
@@ -119,7 +119,7 @@ val place_of_string : config -> string -> place option
 val filter_html_tags : string -> string
 val allowed_tags_file : string ref
 val body_prop : config -> string
-val url_no_index : config -> base -> string
+val url_no_index : ?pwd:bool -> config -> base -> string
 val message_to_wizard : config -> unit
 val check_xhtml : string -> string
 


### PR DESCRIPTION
Fix issue #1015.
The `print_no_index` code had `http://` hard-coded.
I suppressed it, and relied on the browser to extract http mode and server name.

Factorised `command` and `prefix_base` code.
