### PR TITLE
Missing browsing_with_sosa_ref in templ.ml

### DIFF
--- a/lib/templ.camlp5.ml
+++ b/lib/templ.camlp5.ml
@@ -951,7 +951,12 @@ let loc_of_expr =
 
 let templ_eval_var conf =
   function
-    ["cancel_links"] -> VVbool conf.cancel_links
+  | ["browsing_with_sosa_ref"] ->
+      begin match Util.p_getenv conf.env "sosa_ref" with
+        Some _ -> VVbool true
+      | _ -> VVbool false
+      end
+  | ["cancel_links"] -> VVbool conf.cancel_links
   | ["cgi"] -> VVbool !(Wserver.cgi)
   | ["false"] -> VVbool false
   | ["has_referer"] ->


### PR DESCRIPTION
This was triggering an error message: "unbound variable browsing_with_sosa_ref" while executing template dag.txt (descendant tree)