### PR TITLE
DateDisplay: fatorize code

### DIFF
--- a/lib/dateDisplay.ml
+++ b/lib/dateDisplay.ml
@@ -320,10 +320,10 @@ let gregorian_precision conf d =
     transl conf "between (date)" ^ " " ^ string_of_on_dmy conf d ^ " " ^
     transl_nth conf "and" 0 ^ " " ^ string_of_on_dmy conf d2
 
-let string_of_ondate_aux conf =
+let string_of_date_aux ?(dmy = string_of_dmy) ?(sep = " ") conf =
   function
     Dgreg (d, Dgregorian) ->
-      let s = string_of_on_dmy conf d in
+      let s = dmy conf d in
       if d.day > 0 && not conf.cancel_links then
         Printf.sprintf
           "<a href=\"%sm=CAL&yg=%d&mg=%d&dg=%d&tg=1\" class=\"date\">%s</a>"
@@ -342,7 +342,7 @@ let string_of_ondate_aux conf =
         else ""
       in
       let s =
-        string_of_on_dmy conf d1 ^ year_prec ^ " " ^
+        dmy conf d1 ^ year_prec ^ sep ^
         transl_nth conf "gregorian/julian/french/hebrew" 1 ^ cal_prec
       in
       if d1.day > 0 && not conf.cancel_links then
@@ -361,96 +361,26 @@ let string_of_ondate_aux conf =
         else s
       in
       begin match d.prec with
-        Sure -> s ^ " " ^ " (" ^ gregorian_precision conf d ^ ")"
+        Sure -> s ^ sep ^ " (" ^ gregorian_precision conf d ^ ")"
       | About | Before | After | Maybe | OrYear _ | YearInt _ -> s
       end
   | Dgreg (d, Dhebrew) ->
       let d1 = Calendar.hebrew_of_gregorian d in
       let s = string_of_on_hebrew_dmy conf d1 in
       begin match d.prec with
-        Sure -> s ^ " " ^ " (" ^ gregorian_precision conf d ^ ")"
+        Sure -> s ^ sep ^ " (" ^ gregorian_precision conf d ^ ")"
       | About | Before | After | Maybe | OrYear _ | YearInt _ -> s
       end
   | Dtext t -> "(" ^ string_with_macros conf [] t ^ ")"
 
 let string_of_ondate conf d =
-  Util.translate_eval (string_of_ondate_aux conf d)
+  string_of_date_aux ~dmy:string_of_on_dmy conf d
+  |> Util.translate_eval
 
 let string_of_date conf =
   function
     Dgreg (d, _) -> string_of_dmy conf d
   | Dtext t -> t
-
-let string_of_date_aux conf sep =
-  function
-    Dgreg (d, Dgregorian) ->
-      let s = string_of_dmy conf d in
-      if d.day > 0 && not conf.cancel_links then
-        Printf.sprintf
-          "<a href=\"%sm=CAL&yg=%d&mg=%d&dg=%d&tg=1\" class=\"date\">%s</a>"
-          (commd conf) d.year d.month d.day s
-      else s
-  | Dgreg (d, Djulian) ->
-      let cal_prec =
-        if d.year < 1582 then "" else " (" ^ gregorian_precision conf d ^ ")"
-      in
-      let d1 = Calendar.julian_of_gregorian d in
-      let year_prec =
-        if d1.month > 0 && d1.month < 3 ||
-           d1.month = 3 && d1.day > 0 && d1.day < 25
-        then
-          Printf.sprintf " (%d/%d)" (d1.year - 1) (d1.year mod 10)
-        else ""
-      in
-      let s =
-        string_of_dmy conf d1 ^ year_prec ^ sep ^
-        transl_nth conf "gregorian/julian/french/hebrew" 1 ^ cal_prec
-      in
-      if d1.day > 0 && not conf.cancel_links then
-        Printf.sprintf
-          "<a href=\"%sm=CAL&yj=%d&mj=%d&dj=%d&tj=1\" class=\"date\">%s</a>"
-          (commd conf) d1.year d1.month d1.day s
-      else s
-  | Dgreg (d, Dfrench) ->
-      let d1 = Calendar.french_of_gregorian d in
-      let s = string_of_on_french_dmy conf d1 in
-      let s =
-        if d1.day > 0 && not conf.cancel_links then
-          Printf.sprintf
-            "<a href=\"%sm=CAL&yf=%d&mf=%d&df=%d&tf=1\" class=\"date\">%s</a>"
-            (commd conf) d1.year d1.month d1.day s
-        else s
-      in
-      begin match d.prec with
-        Sure -> s ^ sep ^ " (" ^ gregorian_precision conf d ^ ")"
-      | About | Before | After | Maybe | OrYear _ | YearInt _ -> s
-      end
-  | Dgreg (d, Dhebrew) ->
-      let d1 = Calendar.hebrew_of_gregorian d in
-      let s = string_of_on_hebrew_dmy conf d1 in
-      begin match d.prec with
-        Sure -> s ^ sep ^ " (" ^ gregorian_precision conf d ^ ")"
-      | About | Before | After | Maybe | OrYear _ | YearInt _ -> s
-      end
-  | Dtext t -> "(" ^ string_with_macros conf [] t ^ ")"
-
-(* ********************************************************************** *)
-(*  [Fonc] string_of_date_sep : config -> Def.date -> string -> string    *)
-(** [Description] : Affiche une date et spécifie le séparateur entre la
-                    date saisie et la date grégorienne possible.
-    [Args] :
-      - conf : configuration de la base
-      - d  : Def.date
-      - sep : string
-    [Retour] : string
-    [Rem] : Exporté en clair hors de ce module.                           *)
-(* ********************************************************************** *)
-let string_of_date_sep conf sep d =
-  (* On ne veut pas les liens html dans les dates, *)
-  (* donc on met cgl à on                          *)
-  let conf = {conf with cancel_links = true} in
-  Util.translate_eval (string_of_date_aux conf sep d)
-
 
 (* ********************************************************************** *)
 (*  [Fonc] string_slash_of_date : config -> Def.date -> string            *)

--- a/lib/dateDisplay.mli
+++ b/lib/dateDisplay.mli
@@ -10,9 +10,7 @@ val get_wday : config -> date -> string
 
 val code_dmy : config -> dmy -> string
 val string_of_ondate : config -> date -> string
-val string_of_ondate_aux : config -> date -> string
 val string_of_date : config -> date -> string
-val string_of_date_sep : config -> string -> date -> string
 val string_slash_of_date : config -> date -> string
 val string_of_age : config -> dmy -> string
 val prec_year_text : config -> dmy -> string
@@ -38,3 +36,11 @@ val gregorian_precision : config -> dmy -> string
 val french_month : config -> int -> string
 val code_french_year : config -> int -> string
 val code_hebrew_date : config -> int -> int -> int -> string
+
+(** [string_of_date_aux ~dmy:string_of_dmy ~sep:" " conf d] *)
+val string_of_date_aux
+  : ?dmy:(Config.config -> Def.dmy -> string)
+  -> ?sep:string
+  -> Config.config
+  -> Def.date
+  -> string

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3327,7 +3327,12 @@ and eval_date_field_var conf d =
           end
       | _ -> VVstring ""
       end
-  | [] -> VVstring (DateDisplay.string_of_date_sep conf "&#010;  " d)
+  | [] ->
+    let s =
+      let conf = {conf with cancel_links = true} in
+      DateDisplay.string_of_date_aux conf ~sep:"&#010;  " d
+    in
+    VVstring s
   | _ -> raise Not_found
 and _eval_place_field_var conf place =
   function


### PR DESCRIPTION
Here was the diff between `string_of_ondate_aux` and `string_of_date_aux`

```diff
1c1,2
< let string_of_ondate_aux conf =
---
> 
> let string_of_date_aux conf sep =
4c5
<       let s = string_of_on_dmy conf d in
---
>       let s = string_of_dmy conf d in
23c24
<         string_of_on_dmy conf d1 ^ year_prec ^ " " ^
---
>         string_of_dmy conf d1 ^ year_prec ^ sep ^
42c43
<         Sure -> s ^ " " ^ " (" ^ gregorian_precision conf d ^ ")"
---
>         Sure -> s ^ sep ^ " (" ^ gregorian_precision conf d ^ ")"
49c50
<         Sure -> s ^ " " ^ " (" ^ gregorian_precision conf d ^ ")"
---
>         Sure -> s ^ sep ^ " (" ^ gregorian_precision conf d ^ ")"
```