### PR TITLE
Unused variable wait

### DIFF
--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -659,7 +659,11 @@ let list_rev_map_append f l1 l2 =
 
    i.e. Do not close channels before releasing the lock.
 *)
+#ifndef WINDOWS 
 let read_or_create ?(wait = true) ?magic fname read write =
+#else
+let read_or_create ?wait:(_ = true) ?magic fname read write =
+#endif
   assert (Secure.check fname) ;
   let fd = Unix.openfile fname [ Unix.O_RDWR ; Unix.O_CREAT ] 0o666 in
   let ic = Unix.in_channel_of_descr fd in


### PR DESCRIPTION
The code given by Sagotch looks good: I have no more error building on Windows without `--release` option.