### PR TITLE
Fixes issue #813 : bad behaviour for notes modification in history 

### DIFF
--- a/lib/history.ml
+++ b/lib/history.ml
@@ -333,6 +333,7 @@ let rev_input_line ic pos (rbuff, rpos) =
       else
         match rev_input_char ic (rbuff, rpos) pos with
           '\n' -> buff_get_rev len, pos
+        | '\r' -> buff_get_rev len, (pos - 1)
         | c -> loop (Buff.store len c) (pos - 1)
     in
     loop 0 (pos - 1)


### PR DESCRIPTION
Fixes #813 : Was not behaving correctly in Windows environment
It appears that int_of_string or string_of_int for a single digit may be failing.

Replacing `HI_notes of string * int` by `HI_notes of string * string` suppresses the problem (which needs to be scrutinized more thoroughly).

HI_notes is local to history.ml.