### PR TITLE
Correct gen_decline

### DIFF
--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -166,7 +166,7 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
             <div class="dropdown-menu">
               %if;(not browsing_with_sosa_ref or sosa_ref.index!=index)
                 <a class="dropdown-item" href="%prefix_no_iz;%(iz=%self.index;;%)pz=%first_name_key;;nz=%surname_key;;%if;(evar.oc!="" and evar.oc!=0)ocz=%occ;;%end;%access;" %laS; title="%apply;nav_with_sosa_ref(self)">%nn;
-                  <i class="far fa-dot-circle fa-fw %sexcolor; mr-1"></i> [*modify] [n° Sosa] 1%nn;
+                  <i class="far fa-dot-circle fa-fw %sexcolor; mr-1"></i> [*modify::Sosa 1]%nn;
                 </a>
               %else;
                 <a class="dropdown-item" href="%prefix_no_iz;%suffix;" title="%if;(bvar.default_sosa_ref!="")%nl;[back to default sosa reference] %bvar.default_sosa_ref;%else;[*user/password/cancel]2 [navigation] [with] %sosa_ref.first_name_key_strip; %sosa_ref.surname_key_strip;%end;">%nn;

--- a/hd/lang/lex_utf8.txt
+++ b/hd/lang/lex_utf8.txt
@@ -9317,36 +9317,6 @@ sk: zmeniť :a:
 sl: spremeni
 sv: ändra
 
-    modify %s
-af: wysig
-bg: да се променят
-br: kemmañ
-ca: modificar
-co: mudificà %s
-cs: změnit :a:
-da: ændre
-de: ändern +before
-en: edit
-eo: modifi :a:
-es: modificar
-et: muuda :g:
-fi: muokkaa
-fr: modifier %s
-he:  לשנות
-is: breyta
-it: modificare
-lv: izmainīt
-nl: wijzigen +before
-no: endre
-oc: modificar %s
-pl: zaktualizuj :a:
-pt: modificar
-ro: modifica
-ru: изменить :a:
-sk: zmeniť :a:
-sl: spremeni
-sv: ändra
-
     modify family %s event order
 co: intervertisce l’avvenimenti di a famiglia %s
 en: permute the events of family %s
@@ -9367,7 +9337,7 @@ ca: modificar imatge
 co: mudificà a fiura
 cs: změnit :a: obrázek
 da: ændre billede
-de: ändern +before Bild
+de: Bild ändern
 en: update Picture
 eo: modifi :a: bildo:a:+n
 es: modificar imagen
@@ -12882,6 +12852,36 @@ ru: Sosa
 sk: Sosa
 sl: številka Sosa
 sv: annummer
+
+    Sosa 1
+af: Sosa 1
+bg: Число на Соса 1
+br: Sosa 1
+ca: número "Sosa" 1
+co: Sosa 1
+cs: "Sosa" 1
+da: Sosa 1
+de: Ahnenkennziffer 1
+en: Sosa 1
+eo: Sosa 1
+es: Sosa 1
+et: Sosa 1
+fi: Sosa 1
+fr: Sosa 1
+he: Sosa 1
+is: Sosa 1
+it: Sosa 1
+lv: SOSA 1
+nl: Sosa 1
+no: Anenummer 1
+oc: numèro de Sosa 1
+pl: "Sosa" 1
+pt: Sosa 1
+ro: Sosa 1
+ru: Sosa 1
+sk: Sosa 1
+sl: številka Sosa 1
+sv: annummer 1
 
     sosa reference: %t
 af: Sosa verwysing: %t

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -85,19 +85,19 @@ let gen_decline_basic wt s =
     let start = String.sub wt 0 (len - 3) in
     start ^ Mutil.decline wt.[len-2] s
   else
-    match String.rindex_opt s '+' with
+    match String.rindex_opt wt '+' with
     | Some i ->
       if i > 0
-      && s.[i-1] = ' '
-      && String.length s - i = 7
-      && String.get s (i + 1) = 'b'
-      && String.get s (i + 2) = 'e'
-      && String.get s (i + 3) = 'f'
-      && String.get s (i + 4) = 'o'
-      && String.get s (i + 5) = 'r'
-      && String.get s (i + 6) = 'e'
+      && wt.[i-1] = ' '
+      && String.length wt - i = 7
+      && String.get wt (i + 1) = 'b'
+      && String.get wt (i + 2) = 'e'
+      && String.get wt (i + 3) = 'f'
+      && String.get wt (i + 4) = 'o'
+      && String.get wt (i + 5) = 'r'
+      && String.get wt (i + 6) = 'e'
       then
-        let start = String.sub s 0 (i - 1) in
+        let start = String.sub wt 0 (i - 1) in
         if s = "" then start else Mutil.decline 'n' s ^ " " ^ start
       else wt ^ Mutil.decline 'n' s1
     | None -> wt ^ Mutil.decline 'n' s1


### PR DESCRIPTION
In german, "+before" appears in the middle of some translations (pull down menu for person tools).
<img width="508" alt="Capture d’écran 2020-11-01 à 10 29 36" src="https://user-images.githubusercontent.com/5949517/97799446-ad824080-1c2e-11eb-8cfa-054cd12025bc.png">

After correction: 
<img width="482" alt="Capture d’écran 2020-11-01 à 10 39 04" src="https://user-images.githubusercontent.com/5949517/97799457-bd018980-1c2e-11eb-8bd9-01801ea62292.png">

Several problems: 
1/ bug in gen_decline_basic where search for "+before" was not performed on the right parameter string.
2/ misuse of "+before" in the middle of a translated string
3/ misuse of [*modify] without second parameter (what is modified?)

Detailed description of the [aaa::bbb] syntax is provided in the <a href="https://geneweb.tuxfamily.org/wiki/lexicon#Description_of_the_lexicon">TuxFamily documentation</a>.