### PR TITLE
New functions %marriage.date_s; %event.date_s; %family.date_s; correc…

### DIFF
--- a/lib/dateDisplay.mli
+++ b/lib/dateDisplay.mli
@@ -17,8 +17,15 @@ val prec_year_text : config -> dmy -> string
 val prec_text : config -> dmy -> string
 val day_text : dmy -> string
 val month_text : dmy -> string
+
+(** [year_text dmy]
+    Return the year of a date.
+    If the precision is OrYear or YearInt, returns yyy1/yyy2 or yyy1..yyy2
+ *)
 val year_text : dmy -> string
+
 val short_dates_text : config -> base -> person -> string
+val short_family_dates_text : config -> base -> family -> string
 val short_marriage_date_text : config -> base -> family -> person -> person -> string
 val print_dates : config -> base -> person -> unit
 

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3166,7 +3166,8 @@ and eval_person_field_var conf base env (p, p_auth as ep) loc =
           VVstring s
       | _ -> raise Not_found
       end
-  | "marriage_date" :: sl ->
+  | "marriage_date" :: sl
+  | "marriage" :: sl ->
       begin match get_env "fam" env with
         Vfam (_, fam, _, true) ->
           begin match Adef.od_of_cdate (get_marriage fam) with
@@ -3327,6 +3328,11 @@ and eval_date_field_var conf d =
           end
       | _ -> VVstring ""
       end
+  | ["date_s"] ->
+    begin match d with
+    | Dgreg (dmy, _) -> VVstring (DateDisplay.prec_year_text conf dmy)
+    | _ -> VVstring ""
+    end
   | [] ->
     VVstring (DateDisplay.string_of_date_aux ~link:false conf ~sep:"&#010;  " d)
   | _ -> raise Not_found
@@ -3460,6 +3466,15 @@ and eval_event_field_var conf base env (p, p_auth)
     "date" :: sl ->
       begin match p_auth, Adef.od_of_cdate date with
         true, Some d -> eval_date_field_var conf d sl
+      | _ -> VVstring ""
+      end
+  | ["date_s"] ->
+      begin match p_auth, Adef.od_of_cdate date with
+      | true, Some d ->
+        begin match d with
+        | Dgreg (dmy, _) -> VVstring (DateDisplay.prec_year_text conf dmy)
+        | _ -> VVstring ""
+        end
       | _ -> VVstring ""
       end
   | "spouse" :: sl ->
@@ -4438,6 +4453,7 @@ and eval_family_field_var conf base env
           let ep = make_ep conf base ifath in
           eval_person_field_var conf base env ep loc sl
       end
+  | ["date_s"] -> VVstring (DateDisplay.short_family_dates_text conf base fam)
   | "marriage_date" :: sl ->
       begin match Adef.od_of_cdate (get_marriage fam) with
         Some d when m_auth -> eval_date_field_var conf d sl


### PR DESCRIPTION
Marriage dates are very poorly handled in templates, in particular when multiple dates are involved (OR, INT). There is no equivalent of `%dates;` which returns a compact `year1-year2`, birth-death answer.

This PR proposes a new function comparable to %dates; which returns a set of two dates spanning marriage to divorce/separation/annulation.
This function is called with `%family.date_s; ` (and is called within a `%foreach;family; ... %end;` sequence)
The sub-function date_s is applicable to other items (`%events.date_s;`, `%divorce.date_s;`, ...) and returns a "short" version of the date (`year1..year2` rather than `between month1 day1 year1 and month2 day2 year2`)