### PR TITLE
Fix m=NG not working at all in CGI mode, and barely in server mode

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -711,7 +711,10 @@ let treat_request =
                   if sosa_acc
                   || Gutil.person_of_string_key base n <> None
                   || person_is_std_key conf base p n
-                  then person_selected_with_redirect conf base p
+                  then
+                  begin
+                    record_visited conf (get_iper p); Perso.print conf base p
+                  end
                   else specify conf base n pl
                 | pl -> specify conf base n pl
               in


### PR DESCRIPTION
The call to redirect in this context is quite mysterious!!
this PR fixes issue #1139