### PR TITLE
Add m=DOC to plugins_v7

### DIFF
--- a/lib/srcfileDisplay.mli
+++ b/lib/srcfileDisplay.mli
@@ -4,6 +4,8 @@
 open Gwdb
 open Config
 
+type src_mode = Lang | Source
+
 val print : config -> base -> string -> unit
 val print_source : config -> base -> string -> unit
 val print_start : config -> base -> unit
@@ -12,3 +14,5 @@ val incr_request_counter : config -> (int * int * string) option
 
 val adm_file : string -> string
 val source_file_name : config -> string -> string
+
+val copy_from_stream : config -> base -> char Stream.t -> src_mode -> unit

--- a/plugins/v7/dune
+++ b/plugins/v7/dune
@@ -18,6 +18,7 @@
     v7_place
     v7_some
     v7_sosa
+    v7_srcfile
     v7_templ
   )
   (wrapped true)

--- a/plugins/v7/plugin_v7.ml
+++ b/plugins/v7/plugin_v7.ml
@@ -51,6 +51,22 @@ let ps =
     true
   end
 
+let doc =
+  w_base begin fun conf base ->
+    let _ = Printf.eprintf "m=DOC\n" in
+    match Util.p_getenv conf.env "s" with
+    | Some f ->
+        begin
+          let _ = Printf.eprintf "m=DOC;f=%s\n" f in
+          if Filename.check_suffix f ".txt" then
+            let f = Filename.chop_suffix f ".txt" in
+            V7_srcfile.new_print_source conf base f
+          else V7_srcfile.new_print_source_image conf f;
+          true
+        end
+    | None -> false
+  end
+
 let ns = "v7"
 
 let _ =
@@ -63,4 +79,5 @@ let _ =
     ; "L", aux l
     ; "P", aux p
     ; "PS", aux ps
+    ; "DOC", aux doc
     ]

--- a/plugins/v7/v7_srcfile.ml
+++ b/plugins/v7/v7_srcfile.ml
@@ -1,0 +1,56 @@
+open Geneweb.Config
+open Geneweb.Gwdb
+open Geneweb.Util
+open Geneweb.Hutil
+open Geneweb.Cousins
+open Geneweb.ImageDisplay
+open Geneweb.SrcfileDisplay
+open Geneweb.Output
+open Def
+
+module Util = Geneweb.Util
+module Hutil = Geneweb.Hutil
+module ImageDisplay = Geneweb.ImageDisplay
+module SrcfileDisplay = Geneweb.SrcfileDisplay
+module Output = Geneweb.Output
+
+(* removed Filename.basename from those two functions *)
+
+let new_source_file_name conf fname =
+  let bname = conf.bname in
+  let lang = conf.lang in
+  let fname1 =
+    List.fold_right Filename.concat [Util.base_path ["src"] bname; lang]
+      (fname ^ ".txt")
+  in
+  if Sys.file_exists fname1 then fname1
+  else
+    Filename.concat (Util.base_path ["src"] bname)
+      (fname ^ ".txt")
+
+let new_print_source_image conf f =
+  let fname =
+    if f.[0] = '/' then String.sub f 1 (String.length f - 1) else f
+  in
+    let fname = Util.source_image_file_name conf.bname fname in
+    if ImageDisplay.print_image_file conf fname then () else Hutil.incorrect_request conf
+
+let new_print_source conf base fname =
+  let channel =
+    try Some (Secure.open_in (new_source_file_name conf fname)) with
+      Sys_error _ -> None
+  in
+  match channel with
+    Some ic ->
+      let title _ = Output.print_string conf fname in
+      Hutil.header_without_page_title conf title;
+      SrcfileDisplay.copy_from_stream conf base
+        (Stream.of_channel ic) SrcfileDisplay.Source;
+      Hutil.gen_trailer true conf
+  | _ ->
+      let title _ = Output.printf conf "Error" in
+      Hutil.header conf title;
+      Output.printf conf "<ul><li>Cannot access file \"%s.txt\"</ul>" fname;
+      Hutil.gen_trailer true conf;
+      raise Exit
+


### PR DESCRIPTION
m=DOC reads .pdf and .html files (and .txt files) in the same fashion m=SRC.
Allows sub-folders m=DOC;s=folder/filename.txt
