### PR TITLE
Log m=IM content rather than request_cnt

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1277,6 +1277,12 @@ let log tm conf from gauth request script_name contents =
       Printf.fprintf oc "\n"
     end
 
+let log_im contents =
+  GwdLog.log @@ fun oc ->
+  Printf.fprintf oc "  and: ";
+  print_and_cut_if_too_big oc contents;
+  output_char oc '\n'
+
 let log_and_robot_check conf auth from request script_name contents =
   if !robot_xcl = None
   then log (Unix.time ()) conf from auth request script_name contents
@@ -1365,7 +1371,9 @@ let conf_and_connection =
           if List.mem_assoc "log_pwd" env then "..." else contents
         in
           log_and_robot_check conf auth from request script_name contents
-        end;
+        end
+      else
+        log_im contents;
       match !(Wserver.cgi), auth_err, passwd_err with
         true, true, _ ->
           if is_robot from then Robot.robot_error conf 0 0

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -496,7 +496,8 @@ let treat_request =
     let m = Opt.default "" @@ p_getenv conf.env "m" in
     if not @@ try_plugin plugins conf base m
     then begin
-        if p_getenv conf.base_env "counter" <> Some "no"
+        if Util.p_getenv conf.env "m" <> Some "IM" &&
+           p_getenv conf.base_env "counter" <> Some "no"
         then begin
           match
             if only_special_env conf.env


### PR DESCRIPTION
The current log records all requests to the GeneWeb server.
Details of the request are provided (Time, PID, User, Agent, Referer, ...)
In addition, the value of Request_cnt et Welcome_cnt is printed.

When images are requested (m=IM), details of the request are not printed, but the counts are.

```
2021-05-29 08:39:18 (71392) HenriP_rpabqrjnz?p=claire&n=gouraud
  From: localhost
  User: hg (wizard)
  Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15
  Referer: http://localhost:2317/HenriP_rpabqrjnz?p=claire&n=gouraud
  #accesses 5,557 (#welcome 5,194) since 11/05/2021
  #accesses 5,558 (#welcome 5,194) since 11/05/2021
  #accesses 5,559 (#welcome 5,194) since 11/05/2021
  #accesses 5,560 (#welcome 5,194) since 11/05/2021
  #accesses 5,561 (#welcome 5,194) since 11/05/2021

```

This PR proposes to replace the somewhat useless count report by the content of the request
```
-- m=IM&d=1606080435&p=henri&n=gouraud&k=/henri.0.gouraud Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1596751558&p=sylvie&n=sautin&k=/sylvie.0.sautin Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1308312613&p=jean&n=sautin&k=/jean.0.sautin Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1308312366&p=francoise&n=ribaucour&k=/francoise.0.ribaucour Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1327330638&p=benedicte&n=gouraud&k=/benedicte.0.gouraud Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1327331843&p=christophe&n=gouraud&k=/christophe.0.gouraud Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1327331843&p=amelie&n=gouraud&k=/amelie.0.gouraud Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1428676401&p=bernard&n=tardieu&k=/bernard.0.tardieu Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1597173815&p=marie&n=mathieu&k=/marie.0.mathieu Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1456055926&p=alain&n=michaud&k=/alain.0.michaud Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM&d=1621191442&p=pierre&n=gouraud&k=/pierre.0.gouraud Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
--- max 59 req by localhost / conn 1
2021-05-29 12:56:00 (80135) HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
  From: localhost
  User: hg (wizard)
  Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15
-- m=IM;s=famille-h-gouraud-v.jpg Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
-- m=IM;s=famille-h-gouraud.jpg Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
--- max 59 req by localhost / conn 1
2021-05-29 12:56:01 (80188) HenriP_qiaqxirbc?m=DOC;s=famille-h-gouraud.jpg
  From: localhost
  User: hg (wizard)
  Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15
  Referer: http://localhost:2317/HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
--- max 59 req by localhost / conn 1
```

Note that the `-- m=IM` requests are intermixed with other requests and that analysis of all the requests associated with one URL is not trivial! 
In the example above, the request 
```
2021-05-29 12:56:00 (80135) HenriP?p=henri&n=gouraud&oc=0&w=hg:1045
```
is the initial URL. It has no `Refrer:` field, being the first request on this test. The next URL would show this URL as its `Referer:` field.
All the other log entries in the example show `HenriP?p=henri&n=gouraud&oc=0&w=hg:1045` in their `Refer:` field, and are associated with the initial request.
Note also that the log entries do not reflect the implied assumption of "main URL request first then sub-requests for images (m=IM) and others (m=DOC)".

I even question thee fact of recording in the log file these lines and/or the request/welcome counts! How useful are they??

(Please comment if this analysis is not correct!)