### PR TITLE
Remove Filename.basename for m=IM,v=filename

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1450,7 +1450,6 @@ let image_request conf script_name env =
         if fname.[0] = '/' then String.sub fname 1 (String.length fname - 1)
         else fname
       in
-      let fname = Filename.basename fname in
       let fname = Util.image_file_name fname in
       let _ = ImageDisplay.print_image_file conf fname in true
   | _ ->


### PR DESCRIPTION
Access to icons image files is obtained through
`href="%image_prefix;/favicon_gwd.png`
In server mode, this typically translates into `
`href="images/favicon_gwd.png"
In CGI mode, this typically translates to
`href="gwd?m=IM&v=/favicon_gwd.png"`

In the case of an icon image located in a sub-folder, as in
`href="%image_prefix;/modules/menubar_1.jpg`
The server case works properly, but the CGI case fails because a `Filename.basename` step is applied to the filename.
I suggest to remove this Filename.basename step.

In `v7_srcfile.ml`, I removed the same `Filename.basename` step in `srcfileDisplay.source_file_name`) to allow for images and documents in sub-folders.


