### PR TITLE
Handle %s%s, %t%s, %s%t, %t%d, %s%d in translations

### DIFF
--- a/plugins/v7/v7_templ.ml
+++ b/plugins/v7/v7_templ.ml
@@ -901,18 +901,35 @@ let apply_format conf nth s1 s2 =
       match Util.check_format "%s" s1 with
         Some s3 -> Printf.sprintf (transl_nth_format s3) s2
       | None ->
-          match Util.check_format "%d" s1 with
-            Some s3 -> Printf.sprintf (transl_nth_format s3) (int_of_string s2)
-          | None ->
-              match Util.check_format "%s%s" s1 with
-                Some s3 ->
-                  let (s21, s22) =
-                    let i = String.index s2 ':' in
-                    String.sub s2 0 i,
-                    String.sub s2 (i + 1) (String.length s2 - i - 1)
-                  in
-                  Printf.sprintf (transl_nth_format s3) s21 s22
-              | None -> raise Not_found
+           match Util.check_format "%d" s1 with
+             Some s3 -> Printf.sprintf (transl_nth_format s3) (int_of_string s2)
+           | None ->
+              let (s21, s22) =
+                let i = String.index s2 ':' in
+                String.sub s2 0 i,
+                String.sub s2 (i + 1) (String.length s2 - i - 1)
+              in
+               match Util.check_format "%s%s" s1 with
+                Some s3 -> Printf.sprintf (transl_nth_format s3) s21 s22
+              | None ->
+                match Util.check_format "%t%s" s1 with
+                  Some s3 ->
+                    Printf.sprintf (transl_nth_format s3) (fun _ -> s21) s22
+                | None ->
+                  match Util.check_format "%s%t" s1 with
+                    Some s3 ->
+                      Printf.sprintf (transl_nth_format s3) s21 (fun _ -> s22)
+                  | None ->
+                    match Util.check_format "%t%d" s1 with
+                      Some s3 ->
+                        Printf.sprintf (transl_nth_format s3) (fun _ -> s21)
+                        (int_of_string s22)
+                    | None ->
+                      match Util.check_format "%s%d" s1 with
+                        Some s3 ->
+                          Printf.sprintf (transl_nth_format s3) s21
+                          (int_of_string s22)
+                      | None -> raise Not_found
 
 let rec eval_ast conf =
   function


### PR DESCRIPTION
See issue #887 and PR #888