### PR TITLE
Correct misbehaviour of etc_file_name

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1186,8 +1186,7 @@ let etc_file_name conf fname =
         (fname ^ ".txt")
     in
     let etc_tpl_dir =
-      Filename.concat (search_in_lang_path "etc")
-        (Filename.concat dir (fname ^ ".txt"))
+      search_in_lang_path (List.fold_right Filename.concat ["etc"; dir] (fname ^ ".txt"))
     in
     if Sys.file_exists base_name_tpl_dir then base_name_tpl_dir
     else if Sys.file_exists base_tpl_dir then base_tpl_dir


### PR DESCRIPTION
The function `etc_file_name` fails with templm and v7.
`etc_file_name` calls `file_exists` which tests for file existence at several locations.
The third test performed by `file_exists` scans possible locations offered by `lang_path`.
This test is not properly constructed as it search for a folder (which may exist) and not for the file itself.

Providing the full file name to `search_in_lang_path` corrects the problem.

Side notes:
- the variables `base_name_tpl_dir`, `base_tpl_dir` and `etc_tpl_dir` are in fact files and not directories. They should be renamed without the `_dir`.
- in `base_tpl_dir`, applying `Filename.basename` to the dir parameter is unnecessary, and not consistent with other use of this parameter in `etc_tpl_dir`
- I did not perform these changes to limit the diff to the bug correction!!
