### PR TITLE
begin --- end arount try mkdir cnt in gwd

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1702,8 +1702,9 @@ let geneweb_server () =
             null_reopen [Unix.O_WRONLY] Unix.stderr
           end
         else exit 0;
-      try Unix.mkdir (Filename.concat !(Util.cnt_dir) "cnt") 0o777 with
+      begin try Unix.mkdir (Filename.concat !(Util.cnt_dir) "cnt") 0o777 with
         Unix.Unix_error (_, _, _) -> ()
+      end;
     end;
   Wserver.f GwdLog.syslog !selected_addr !selected_port !conn_timeout
     (if Sys.unix then !max_clients else None) connection


### PR DESCRIPTION
as suggested by @TitiFix 👍 

> Je viens de m'apercevoir qu'il y a un bug latent dans gwd (depuis très longtemps) :
> Le serveur n'est pas lancé si 
> - le s/répertoire  cnt n'existe pas dans wd 
> - et la création du répertoire est réalisée sans erreur
> Dans ce cas-là il n'y a pas de message on voit juste afficher "Type control C to stop the service". 
> En fait ce n'est pas un plantage mais une non-exécution du serveur.
> 
> Il faut écrire à la ligne 1651 de Gwd cela pour bypasser (priorité du try/with ...)
>    begin try Unix.mkdir (Filename.concat !Util.cnt_dir "cnt") 0o777 with
>      Unix.Unix_error (_, _, _) -> () 
>    end;

J'observe effectivement un plantage occasionnel au premier essai de lancement de gwd. 