### PR TITLE
Remember sexes in fam definition

### DIFF
--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -495,11 +495,6 @@ let fevent_name_unique_string gen =
 let update_family_with_fevents gen fam =
   let found_marriage = ref false in
   let found_divorce = ref false in
-  let nsck_std_fields =
-    match fam.relation with
-      NoSexesCheckNotMarried | NoSexesCheckMarried -> true
-    | _ -> false
-  in
   (* On veut cette fois ci que ce soit le dernier évènement *)
   (* qui soit mis dans les évènements principaux.           *)
   let rec loop fevents fam =
@@ -513,7 +508,7 @@ let update_family_with_fevents gen fam =
           let witnesses = Array.map fst evt.efam_witnesses in
           let fam =
             {fam with relation =
-                        if nsck_std_fields then NoSexesCheckNotMarried else Engaged;
+                      Engaged;
                       marriage = evt.efam_date; marriage_place = evt.efam_place;
                       marriage_note = evt.efam_note; marriage_src = evt.efam_src;
                       witnesses = witnesses}
@@ -523,7 +518,7 @@ let update_family_with_fevents gen fam =
         let witnesses = Array.map fst evt.efam_witnesses in
         let fam =
           {fam with relation =
-                      if nsck_std_fields then NoSexesCheckMarried else Married;
+                    Married;
                     marriage = evt.efam_date; marriage_place = evt.efam_place;
                     marriage_note = evt.efam_note; marriage_src = evt.efam_src;
                     witnesses = witnesses}
@@ -547,7 +542,7 @@ let update_family_with_fevents gen fam =
           let place = unique_string gen "" in
           let fam =
             {fam with relation =
-                        if nsck_std_fields then NoSexesCheckMarried else Married;
+                      MarriageContract;
                       marriage = date; marriage_place = place;
                       marriage_note = evt.efam_note; marriage_src = evt.efam_src;
                       witnesses = witnesses}
@@ -560,8 +555,7 @@ let update_family_with_fevents gen fam =
           let witnesses = Array.map fst evt.efam_witnesses in
           let fam =
             {fam with relation =
-                        if nsck_std_fields then NoSexesCheckNotMarried
-                        else NoMention;
+                      NoMention;
                       marriage = evt.efam_date; marriage_place = evt.efam_place;
                       marriage_note = evt.efam_note; marriage_src = evt.efam_src;
                       witnesses = witnesses}
@@ -573,8 +567,7 @@ let update_family_with_fevents gen fam =
           let witnesses = Array.map fst evt.efam_witnesses in
           let fam =
             {fam with relation =
-                        if nsck_std_fields then NoSexesCheckNotMarried
-                        else NotMarried;
+                      NotMarried;
                       marriage = evt.efam_date; marriage_place = evt.efam_place;
                       marriage_note = evt.efam_note; marriage_src = evt.efam_src;
                       witnesses = witnesses}

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -665,7 +665,7 @@ let get_mar_date str =
   | [] -> failwith str
 
 let read_line ic =
-  try let str = input_real_line ic in Some (str, fields str) with
+  try let str = input_real_line ic in incr line_cnt; Some (str, fields str) with
     End_of_file -> None
 
 let create_person () =
@@ -1102,8 +1102,9 @@ let read_family ic fname =
                 (* On récupère le nom, date, lieu, source, cause *)
                 let (name, l) = get_pevent_name str l in
                 let (date, l) = get_optional_event_date l in
+                (* TODO reason does not seem to be properly recorded for death *)
+                let (reason, l) = get_field "#r" l in
                 let (place, l) = get_field "#p" l in
-                let (cause, l) = get_field "#c" l in
                 let (src, l) = get_field "#s" l in
                 let date =
                   match date with
@@ -1116,7 +1117,7 @@ let read_family ic fname =
                 (* On récupère les notes *)
                 let (notes, line) = loop_note line ic in
                 let notes = Mutil.strip_all_trailing_spaces notes in
-                let evt = name, date, place, cause, src, notes, witn in
+                let evt = name, date, place, reason, src, notes, witn in
                 loop (evt :: pevents) line
           in
           loop [] (input_a_line ic)

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -5,6 +5,7 @@ open Def
 open Gwdb
 
 let magic_gwo = "GnWo000o"
+let gwplus1 = ref false
 
 (* Option qui force a créé les clés des individus. De fait, *)
 (* si la clé est incomplète, on l'enregistre tout de même.  *)
@@ -278,7 +279,7 @@ let get_optional_baptdate l =
 
 let get_optional_deathdate l =
   match l with
-    "?" :: l' -> Some DontKnowIfDead, l'
+  | "?" :: l' -> Some DontKnowIfDead, l'
   | "mj" :: l' -> Some DeadYoung, l'
   | "od" :: l' -> Some OfCourseDead, l'
   | x :: l' ->
@@ -617,8 +618,12 @@ let get_mar_date str =
           with _ -> (v, Male, Female), c :: l
         in
         match l with
+        | "#nm" :: c :: l when !gwplus1 && String.length c = 2 ->
+          decode_sex NotMarried c l
         | "#nm" :: l ->
           (NotMarried, Male, Female), l
+        | "#eng" ::c :: l when !gwplus1 && String.length c = 2 ->
+          decode_sex Engaged c l
         | "#eng" :: l ->
           (Engaged, Male, Female), l
         | "#noment" :: c :: l when String.length c = 2 ->
@@ -626,9 +631,9 @@ let get_mar_date str =
         | "#noment" :: l ->
           (NoMention, Male, Female), l
         | "#nsck" :: c :: l when String.length c = 2 ->
-          decode_sex NoSexesCheckNotMarried c l
+          decode_sex NotMarried c l
         | "#nsckm" :: c :: l when String.length c = 2 ->
-          decode_sex NoSexesCheckMarried c l
+          decode_sex Married c l
         | "#banns" :: c :: l when String.length c = 2 ->
           decode_sex MarriageBann c l
         | "#contract" :: c :: l when String.length c = 2 ->
@@ -639,6 +644,8 @@ let get_mar_date str =
           decode_sex Pacs c l
         | "#residence" :: c :: l when String.length c = 2 ->
           decode_sex Residence c l
+        | "#m" :: c :: l when !gwplus1 && String.length c = 2 ->
+          decode_sex Married c l
         | _ ->
           (Married, Male, Female), l
       in
@@ -894,6 +901,7 @@ let read_family ic fname =
   function
     Some (_, ["encoding:"; "utf-8"]) -> F_enc_utf_8
   | Some (_, ["gwplus"]) -> F_gw_plus
+  | Some (_, ["gwplus1"])-> begin gwplus1 := true; F_gw_plus end
   | Some (str, "fam" :: l) ->
       let (fath_key, surname, l) = parse_parent str l in
       let (relation_ss, marriage, marr_place, marr_note, marr_src, divorce,

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -618,11 +618,11 @@ let get_mar_date str =
           with _ -> (v, Male, Female), c :: l
         in
         match l with
-        | "#nm" :: c :: l when !gwplus1 && String.length c = 2 ->
+        | "#nm" :: c :: l when String.length c = 2 ->
           decode_sex NotMarried c l
         | "#nm" :: l ->
           (NotMarried, Male, Female), l
-        | "#eng" ::c :: l when !gwplus1 && String.length c = 2 ->
+        | "#eng" ::c :: l when String.length c = 2 ->
           decode_sex Engaged c l
         | "#eng" :: l ->
           (Engaged, Male, Female), l
@@ -644,7 +644,7 @@ let get_mar_date str =
           decode_sex Pacs c l
         | "#residence" :: c :: l when String.length c = 2 ->
           decode_sex Residence c l
-        | "#m" :: c :: l when !gwplus1 && String.length c = 2 ->
+        | "#m" :: c :: l when String.length c = 2 ->
           decode_sex Married c l
         | _ ->
           (Married, Male, Female), l

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -10,6 +10,8 @@ let speclist opts =
      , " export isolated persons (work only if export all database)." )
   :: ("-old_gw", Arg.Set GwuLib.old_gw
      , " do not export additional fields (for backward compatibility: < 7.00)" )
+  :: ("-gwplus", Arg.Set GwuLib.gwplus
+     , " force use of gwplus format: < 7.01)" )
   :: ( "-raw", Arg.Set GwuLib.raw_output
      , " raw output (without possible utf-8 conversion)" )
   :: ( "-sep", Arg.String (fun s -> GwuLib.separate_list := s :: !GwuLib.separate_list)

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -47,7 +47,9 @@ let main () =
     end ;
     let ofile, oc, close = opts.oc in
     if not !GwuLib.raw_output then oc "encoding: utf-8\n";
-    if !GwuLib.old_gw then oc "\n" else oc "gwplus\n\n";
+    if !GwuLib.old_gw then oc "\n" else 
+      if !GwuLib.gwplus then oc "gwplus\n\n"
+      else oc "gwplus1\n\n";
     GwuLib.prepare_free_occ base ;
     GwuLib.gwu opts !isolated base in_dir !out_dir src_oc_ht select ;
     Hashtbl.iter (fun _ (_, _, close) -> close ()) src_oc_ht ;

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -380,14 +380,18 @@ let print_infos opts base is_child csrc cbp p =
   begin match get_death p with
     | Death (dr, d) ->
       Printf.ksprintf (oc opts) " ";
-      begin match dr with
-          Killed -> Printf.ksprintf (oc opts) "k"
-        | Murdered -> Printf.ksprintf (oc opts) "m"
-        | Executed -> Printf.ksprintf (oc opts) "e"
-        | Disappeared -> Printf.ksprintf (oc opts) "s"
-        | _ -> ()
-      end;
-      if !gwplus || !old_gw then print_date opts (Adef.date_of_cdate d)
+      (* TODO must keep death ad reason is not properly handled by gwcomp *)
+      (*if !gwplus || !old_gw then *)
+      begin
+        begin match dr with
+            Killed -> Printf.ksprintf (oc opts) "k"
+          | Murdered -> Printf.ksprintf (oc opts) "m"
+          | Executed -> Printf.ksprintf (oc opts) "e"
+          | Disappeared -> Printf.ksprintf (oc opts) "s"
+          | _ -> ()
+        end;
+        print_date opts (Adef.date_of_cdate d)
+      end
     | DeadYoung -> Printf.ksprintf (oc opts) " mj"
     | DeadDontKnowWhen -> Printf.ksprintf (oc opts) " 0"
     | DontKnowIfDead ->
@@ -643,9 +647,10 @@ let print_pevent opts base gen e =
   Printf.ksprintf (oc opts) " ";
   let epers_date = Adef.od_of_cdate e.epers_date in
   print_date_option opts epers_date;
-  print_if_no_empty opts base "#p" e.epers_place;
   (* TODO *)
-  (*print_if_no_empty opts base "#c" e.epers_cause;*)
+  (*print_if_no_empty opts base "#c" e.epers_cause; ou reason!!*)
+  print_if_no_empty opts base "#r" e.epers_reason;
+  print_if_no_empty opts base "#p" e.epers_place;
   if opts.source = None then
     print_if_no_empty opts base "#s" e.epers_src;
   Printf.ksprintf (oc opts) "\n";

--- a/bin/setup/lang/gwu.htm
+++ b/bin/setup/lang/gwu.htm
@@ -151,6 +151,23 @@ sv: Välj de optioner du vill ha:
 
 <table class="setup">
 <tr align=left>
+
+<td><input type=checkbox name=isolated value="on">   </td>
+<td>[extract isolated persons]</td>
+</tr>
+</table>
+<p>
+
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=gwplus value="on">   </td>
+<td>[force use of gwplus format]</td>
+</tr>
+</table>
+<p>
+<table class="setup">
+<tr align=left>
+
 <td><input type=checkbox name=mem value="on">   </td>
 <td>[
 de: Während der Operation sparsam mit dem Speicher umgehen

--- a/bin/setup/lang/gwu.htm
+++ b/bin/setup/lang/gwu.htm
@@ -151,17 +151,16 @@ sv: Välj de optioner du vill ha:
 
 <table class="setup">
 <tr align=left>
-
-<td><input type=checkbox name=isolated value="on">   </td>
-<td>[extract isolated persons]</td>
+<td><input type=checkbox name=gwplus value="on">   </td>
+<td>[force use of gwplus format]</td>
 </tr>
 </table>
 <p>
 
 <table class="setup">
 <tr align=left>
-<td><input type=checkbox name=gwplus value="on">   </td>
-<td>[force use of gwplus format]</td>
+<td><input type=checkbox name=old_gw value="on">   </td>
+<td>[force use of old_gw format]</td>
 </tr>
 </table>
 <p>

--- a/hd/etc/templm/updfam.txt
+++ b/hd/etc/templm/updfam.txt
@@ -202,7 +202,7 @@
   <table>
     %foreach;parent;%apply;one_parent(cnt)%end;
  <tr><td colspan=4 style="border:0;text-align:left;padding:5px"><label><input type="checkbox" id="nsck" name="nsck" value="on"
-    %if;(mrel = "nsck" or mrel = "nsckm") checked="checked"%end;%/> [no sexes check]</label></td></tr>
+    %if;(same_sex) checked="checked"%end;%/> [no sexes check]</label></td></tr>
   </table>
 </fieldset>
 <fieldset>

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -555,7 +555,7 @@ $(document).ready(function(){
             %if;(bvar.multi_parents!="yes" and cnt=1)
               <div class="form-check my-2">
                 <label class="form-check-label">
-                <input type="checkbox" class="form-check-input" name="nsck" value="on"%if;(mrel="nsck" or mrel="nsckm") checked%end;%/>
+                <input type="checkbox" class="form-check-input" name="nsck" value="on"%if;(same_sex) checked%end;%/>
                   [*no sexes check]
                 </label>
               </div>

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -127,6 +127,32 @@ and eval_simple_var conf base env (fam, cpl, des) =
   | ["marriage_note"] -> str_val (Util.escape_html fam.marriage_note)
   | ["marriage_src"] -> str_val (Util.escape_html fam.marriage_src)
   | ["mrel"] -> str_val (eval_relation_kind fam.relation)
+  | ["same_sex"] ->
+      let same_sex =
+        let father = Gutil.father cpl in
+        let mother = Gutil.mother cpl in
+        let father_sex =
+          match father with
+            _, _, _, Update.Create (sex, _), _ -> sex
+          | f, s, o, Update.Link, _ ->
+              match person_of_key base f s o with
+                Some ip -> get_sex (poi base ip)
+              | _ -> Neuter
+        in
+        let mother_sex =
+          match mother with
+            _, _, _, Update.Create (sex, _), _ -> sex
+          | f, s, o, Update.Link, _ ->
+              match person_of_key base f s o with
+                Some ip -> get_sex (poi base ip)
+              | _ -> Neuter
+        in
+        begin match father_sex, mother_sex with
+          Male, Male | Female, Female -> true
+        | _ -> false
+        end
+      in
+      bool_val same_sex
   | ["nb_fevents"] -> str_val (string_of_int (List.length fam.fevents))
   | ["origin_file"] -> str_val (Util.escape_html fam.origin_file)
   | "parent" :: sl ->

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -377,17 +377,6 @@ let reconstitute_from_fevents nsck empty_string fevents =
     | Some (kind, date, place, note, src, wit) -> ((kind, date, place, note, src), wit)
   in
   (* Parents de même sexe. *)
-  let marr =
-    if nsck then
-      let (relation, date, place, note, src) = marr in
-      let relation =
-        match relation with
-        | Married -> NoSexesCheckMarried
-        | x -> x
-      in
-      relation, date, place, note, src
-    else marr
-  in
   let div = Opt.default NotDivorced !found_divorce in
   marr, div, wit
 
@@ -470,35 +459,6 @@ let reconstitute_family conf base nsck =
     marr
   in
   (* Si parents de même sex ... Pas de mode multi parent. *)
-  let relation =
-    match parents with
-      [father; mother] ->
-        let father_sex =
-          match father with
-            _, _, _, Update.Create (sex, _), _ -> sex
-          | f, s, o, Update.Link, _ ->
-              match person_of_key base f s o with
-                Some ip -> get_sex (poi base ip)
-              | _ -> Neuter
-        in
-        let mother_sex =
-          match mother with
-            _, _, _, Update.Create (sex, _), _ -> sex
-          | f, s, o, Update.Link, _ ->
-              match person_of_key base f s o with
-                Some ip -> get_sex (poi base ip)
-              | _ -> Neuter
-        in
-        begin match father_sex, mother_sex with
-          Male, Male | Female, Female ->
-            begin match relation with
-              Married -> NoSexesCheckMarried
-            | _ -> NoSexesCheckNotMarried
-            end
-        | _ -> relation
-        end
-    | _ -> relation
-  in
   let divorce = div in
   let fam =
     {marriage = marriage; marriage_place = marriage_place;

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -897,8 +897,6 @@ let effective_mod ?prerr ?skip_conflict conf base sp =
     | _ ->
       rename_image_file conf base op sp
   end ;
-  if List.assoc_opt "nsck" conf.env <> Some "on"
-  then check_sex_married ?prerr conf base sp op ;
   let created_p = ref [] in
   let np =
     Futil.map_person_ps (Update.insert_person conf base "" created_p)

--- a/plugins/export/plugin_export.ml
+++ b/plugins/export/plugin_export.ml
@@ -113,7 +113,7 @@ let export conf base =
       | `gw ->
         GwuLib.prepare_free_occ ~select:(fst select) base ;
         Output.print_string conf "encoding: utf-8\n" ;
-        Output.print_string conf "gwplus\n\n" ;
+        Output.print_string conf (if !GwuLib.gwplus then "gwplus\n\n" else "gwplus1\n\n");
         GwuLib.gwu opts isolated base "" "" (Hashtbl.create 0) select ;
     end ;
     Wserver.wflush () ;


### PR DESCRIPTION
Remember sexes in fam definition:
`fam Test1 Test20 0 + #nm mf Test Test8`
`fam Test Test7 20/10/2021 ? + #m mm Test Test10`
except in most frequent default case (#m mf) 

In addition, this PR avoids duplication of family details in the fam line.
