### PR TITLE
Fix typos for Corsican and Turkish languages

### DIFF
--- a/bin/setup/lang/gwd.htm
+++ b/bin/setup/lang/gwd.htm
@@ -56,7 +56,7 @@ refore like a "default default" language.
 <option value="br"%Edefault_lang=br;>%Lbr;
 <option value="ca"%Edefault_lang=ca;>%Lca;
 <option value="cs"%Edefault_lang=cs;>%Lcs;
-<option value="co"%Edefault_lang=cs;>%Lco;
+<option value="co"%Edefault_lang=co;>%Lco;
 <option value="da"%Edefault_lang=da;>%Lda;
 <option value="de"%Edefault_lang=de;>%Lde;
 <option value="en"%Edefault_lang=en;>%Len;
@@ -78,7 +78,7 @@ refore like a "default default" language.
 <option value="ru"%Edefault_lang=ru;>%Lru;
 <option value="sl"%Edefault_lang=sl;>%Lsl;
 <option value="sv"%Edefault_lang=sv;>%Lsv;
-<option value="tr"%Edefault_lang=sv;>%Ltr;
+<option value="tr"%Edefault_lang=tr;>%Ltr;
 <option value="zh"%Edefault_lang=zh;>%Lzh;
 </select>
 </td>

--- a/bin/setup/lang/gwf_1.htm
+++ b/bin/setup/lang/gwf_1.htm
@@ -243,7 +243,7 @@ value="bgcolor=#CC0000 text=#FFFFFF link=#FFFF00 vlink=#00FFFF">
 <option value="bg"%Edefault_lang=bg;>%Lbg;
 <option value="br"%Edefault_lang=br;>%Lbr;
 <option value="ca"%Edefault_lang=ca;>%Lca;
-<option value="co"%Edefault_lang=ca;>%Lco;
+<option value="co"%Edefault_lang=co;>%Lco;
 <option value="cs"%Edefault_lang=cs;>%Lcs;
 <option value="da"%Edefault_lang=da;>%Lda;
 <option value="de"%Edefault_lang=de;>%Lde;
@@ -266,7 +266,7 @@ value="bgcolor=#CC0000 text=#FFFFFF link=#FFFF00 vlink=#00FFFF">
 <option value="ru"%Edefault_lang=ru;>%Lru;
 <option value="sl"%Edefault_lang=sl;>%Lsl;
 <option value="sv"%Edefault_lang=sv;>%Lsv;
-<option value="tr"%Edefault_lang=sv;>%Ltr;
+<option value="tr"%Edefault_lang=tr;>%Ltr;
 <option value="zh"%Edefault_lang=zh;>%Lzh;
 </select>
 </td>


### PR DESCRIPTION
Hello,

This will fix typos for Corsican and Turkish languages in `gwd.htm` and `gwf_1.htm`.

Cheers,
Patriccollu.