### PR TITLE
Place restricted access message in lexicon.txt. Use it in request.ml

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -709,13 +709,9 @@ let treat_request =
       end conf base ;
     Output.flush conf ;
   end else
-    begin
-      let title _ = Output.print_string conf (Utf8.capitalize_fst (transl conf "error")) in
-      Hutil.rheader conf title;
-      Output.printf conf "<ul>\n<li>\n%s \"%s\" %s.</li>\n</ul>"
-        (Utf8.capitalize_fst (transl conf "base")) conf.bname
-        (Utf8.capitalize_fst (transl conf "reserved to friends or wizards"));
-      Hutil.trailer conf
+    begin match base with
+      | Some base -> SrcfileDisplay.print_start conf base
+      | None -> include_template conf [] "index" (fun () -> propose_base conf)
     end
   in
   if conf.debug then Mutil.bench (__FILE__ ^ " " ^ string_of_int __LINE__) process

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -710,8 +710,25 @@ let treat_request =
     Output.flush conf ;
   end else
     begin match base with
-      | Some base -> SrcfileDisplay.print_start conf base
-      | None -> include_template conf [] "index" (fun () -> propose_base conf)
+      | Some base ->
+          let content =
+            try (List.assoc ("visitor_access_msg_" ^ conf.lang) conf.base_env) with
+            Not_found -> Utf8.capitalize_fst
+              (transl conf "access restricted to friends and wizards")
+          in
+          let content = 
+            "<!DOCTYPE html>
+             <html lang=\"en-GB\">
+               <meta charset=\"utf-8\" />
+               <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+               <title>401 Unauthorized</title>
+               <h1>401 Unauthorized</h1>
+               <pre>" ^ content ^
+            "  </pre>
+             </html>"
+          in
+          !GWPARAM.output_error ~content conf Def.Unauthorized
+      | None -> !GWPARAM.output_error conf Def.Not_Found
     end
   in
   if conf.debug then Mutil.bench (__FILE__ ^ " " ^ string_of_int __LINE__) process

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -26,11 +26,7 @@
   %else;
     %if;(bvar.visitor_access_msg_en!="")
       %bvar.visitor_access_msg_en;
-    %else;
-      [
-en: Access restricted to friends and wizards of the database!
-fr: Accès réservé aux amis et magiciens de la base de donnée !
-      ]
+    %else;[*access restricted to friends and wizards]
     %end;
   %end;
 %end;

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -67,6 +67,11 @@ sv: af=afrikaans/bg=bulgariska/br=bretonska/ca=katalanska/co=korsikanska/cs=tjec
 tr: af=Afrikaans/bg=Bulgarca/br=Bretonca/ca=Katalanca/co=Korsikaca/cs=Çekçe/da=Danca/de=Almanca/en=İngilizce/eo=Esperanto/es=İspanyolca/et=Estonca/fi=Fince/fr=Fransızca/he=İbranice/is=İzlandaca/it=İtalyanca/lv=Letonca/nl=Hollandaca/no=Norveççe/oc=Oksitanca/pl=Lehçe/pt=Portekizce/pt-br=Brezilya Portekizcesi/ro=Romence/ru=Rusça/sk=Slovakça/sl=Slovence/sv=İsveççe/tr=Türkçe/zh=Çince
 zh: af=南非語/bg=保加利亚语/br=布列塔尼语/ca=加泰罗尼亚语/co=科西嘉岛/cs=捷克语/da=丹麦语/de=德语/en=英语/eo=世界语/es=西班牙语/et=爱沙尼亚语/fi=芬兰语/fr=法语/he=希伯来语/is=冰岛语/it=意大利语/lv=拉脱维亚语/nl=荷蘭語/no=挪威语/oc=奥克语/pl=波兰语/pt=葡萄牙語/pt-br= 巴西葡萄牙语/ro=羅馬尼亞語/ru=俄语/sk=斯洛伐克语/sl=斯洛文尼亚语/sv= 瑞典語/tr=土耳其/zh=中文
 
+    access restricted to friends and wizards
+co: l’accessu hè riservatu à l’amichi è à i maghi di a basa di dati !
+en: access restricted to friends and wizards of the database!
+fr: accès réservé aux amis et magiciens de la base de donnée !
+
     the first branch
 af: om die eerste staak te sien
 bg: за да видите първия клон

--- a/plugins/welcome/assets/etc/welcome.txt
+++ b/plugins/welcome/assets/etc/welcome.txt
@@ -26,12 +26,7 @@
   %else;
     %if;(bvar.visitor_access_msg_en!="")
       %bvar.visitor_access_msg_en;
-    %else;
-      [
-co: L’accessu hè riservatu à l’amichi è à i maghi di a basa di dati !
-en: Access restricted to friends and wizards of the database!
-fr: Accès réservé aux amis et magiciens de la base de donnée !
-      ]
+    %else;[*access restricted to friends and wizards]
     %end;
   %end;
 %end;


### PR DESCRIPTION
When access is restricted to friends and wizards, display welcome page rather than terse error message.