### PR TITLE
Drop the -noproc option support

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1870,9 +1870,6 @@ let main () =
     ; ("-conn_tmout", Arg.Int (fun x -> conn_timeout := x), "<SEC> Connection timeout (default " ^ string_of_int !conn_timeout ^ "s; 0 means no limit)." )
     ; ("-daemon", Arg.Set daemon, " Unix daemon mode.")
 #endif
-#ifdef WINDOWS
-    ; ("-noproc", Arg.Set Wserver.noproc ," Do not launch a process at each request.")
-#endif
 #ifdef API
     ; ("-api_h", Arg.String (fun x -> selected_api_host := x), "<HOST> Host for GeneWeb API (default = " ^ !selected_api_host ^ ").")
     ; ("-api_p", Arg.Int (fun x -> selected_api_port := x), "<NUMBER> Port number for GeneWeb API (default = " ^ string_of_int !selected_api_port ^ ").")

--- a/bin/wserver/wserver.mli
+++ b/bin/wserver/wserver.mli
@@ -67,7 +67,6 @@ val stop_server : string ref
        one request is necessary to unfreeze the server to make it check
        that this file exits. Default "STOP_SERVER". Can have relative
        or absolute path. *)
-val noproc : bool ref
 val cgi : bool ref
 
 (* Example:


### PR DESCRIPTION
According to `CHANGES`:
>  - [26 Jan 01] Under Windows, added option "-noproc" asking not to run a
    new process at each request. This option was added because some users
    under Windows reported that sometimes, the service gwd blocks after some
    requests and need to be stopped and restarted. This option may resolve
    this problem (not sure).

This is likely not to be true anymore. If so, this sounds like a hack and real fix should be looked for.