### PR TITLE
Templ: get rid of camlp5 (used ocamllex instead).

### DIFF
--- a/hd/etc/perso_utils.txt
+++ b/hd/etc/perso_utils.txt
@@ -3,9 +3,6 @@
 %let;central_person;%first_name_key_strip;%sp;%surname_key_strip;%in;
 
 %define;ext_link(xx)
-  %if;(xx.bname_prefix != prefix and 0) %( "and 0" to suppress this style! I dont understand how bname_prefix works %)
-    style="background:linear-gradient(transparent,transparent),url(data:image/svg+xml,%%3C%%3Fxml%%20version%%3D%%221.0%%22%%20encoding%%3D%%22UTF-8%%22%%3F%%3E%%3Csvg%%20xmlns%%3D%%22http%%3A%%2F%%2Fwww.w3.org%%2F2000%%2Fsvg%%22%%20width%%3D%%2210%%22%%20height%%3D%%2210%%22%%3E%%3Cg%%20transform%%3D%%22translate%%28-826.429%%20-698.791%%29%%22%%3E%%3Crect%%20width%%3D%%225.982%%22%%20height%%3D%%225.982%%22%%20x%%3D%%22826.929%%22%%20y%%3D%%22702.309%%22%%20fill%%3D%%22%%23fff%%22%%20stroke%%3D%%22%%2306c%%22%%2F%%3E%%3Cg%%3E%%3Cpath%%20d%%3D%%22M831.194%%20698.791h5.234v5.391l-1.571%%201.545-1.31-1.31-2.725%%202.725-2.689-2.689%%202.808-2.808-1.311-1.311z%%22%%20fill%%3D%%22%%2306f%%22%%2F%%3E%%3Cpath%%20d%%3D%%22M835.424%%20699.795l.022%%204.885-1.817-1.817-2.881%%202.881-1.228-1.228%%202.881-2.881-1.851-1.851z%%22%%20fill%%3D%%22%%23fff%%22%%2F%%3E%%3C%%2Fg%%3E%%3C%%2Fg%%3E%%3C%%2Fsvg%%3E) no-repeat right; padding-right:15px;" target="_blank"
-  %end;
 %end;
 
 %( initialise le compteur à/avec la valeur passée en paramètre %)

--- a/lib/dune.in
+++ b/lib/dune.in
@@ -1,10 +1,6 @@
 (dirs :standard \ %%%DUNE_DIRS_EXCLUDE%%%)
 
-(rule
-  (target templ.ml)
-  (deps templ.camlp5.ml)
-  (action (run camlp5o pr_o.cmo pa_extend.cmo q_MLast.cmo -impl %{deps} -o %{target}))
-)
+(ocamllex (modules templ_parser))
 
 (library
  (name geneweb)

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -132,8 +132,7 @@ let gen_interp header conf fname ifun env ep =
       Some astl ->
         if header then Util.html conf;
         let full_name = Util.etc_file_name conf fname in
-        Templ.interp_ast conf ifun env ep
-          (Templ.begin_end_include conf full_name astl)
+        Templ.interp_ast conf ifun env ep [ Ainclude (full_name, astl) ]
     | None -> error_cannot_access conf fname
   with e -> Templ.template_file := v; raise e
   end;

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -125,18 +125,14 @@ let error_cannot_access conf fname =
     ~content:(Printf.sprintf "Cannot access file \"%s.txt\".\n" fname)
 
 let gen_interp header conf fname ifun env ep =
-  let v = !(Templ.template_file) in
-  Templ.template_file := fname;
-  begin try
+  Templ_parser.wrap fname begin fun () ->
     match Templ.input_templ conf fname with
-      Some astl ->
-        if header then Util.html conf;
-        let full_name = Util.etc_file_name conf fname in
-        Templ.interp_ast conf ifun env ep [ Ainclude (full_name, astl) ]
+    | Some astl ->
+      if header then Util.html conf;
+      let full_name = Util.etc_file_name conf fname in
+      Templ.interp_ast conf ifun env ep [ Ainclude (full_name, astl) ]
     | None -> error_cannot_access conf fname
-  with e -> Templ.template_file := v; raise e
-  end;
-  Templ.template_file := v
+  end
 
 let interp_no_header conf fname ifun env ep =
   gen_interp false conf fname ifun env ep

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1706,18 +1706,12 @@ let extract_var sini s =
 
 let template_file = ref "perso.txt"
 
-let warning_use_has_parents_before_parent (bp, ep) var r =
-  if Sys.unix then
-    begin
-      Printf.eprintf "*** <W> %s" !template_file;
-      Printf.eprintf ", chars %d-%d" bp ep;
-      Printf.eprintf "\
-: since v5.00, must test \"has_parents\" before using \"%s\"\n"
-        var;
-      flush stderr;
-      r
-    end
-  else r
+let warning_use_has_parents_before_parent (fname, bp, ep) var r =
+  Printf.sprintf
+    "%s %d-%d: since v5.00, must test \"has_parents\" before using \"%s\"\n"
+    fname bp ep var
+  |> !GWPARAM.syslog `LOG_WARNING ;
+  r
 
 let bool_val x = VVbool x
 let str_val x = VVstring x

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1,598 +1,27 @@
-(* $Id: templ.ml,v 5.36 2007-09-12 09:58:44 ddr Exp $ *)
-
 open Config
 open TemplAst
 
-(* Parsing *)
+let include_begin conf fname =
+  if conf.debug then Output.print_string conf ("\n<!-- begin include " ^ fname ^ " -->\n")
 
-type token =
-    BANGEQUAL
-  | COMMA
-  | DOT
-  | DIV
-  | EQUAL
-  | GREATER
-  | GREATEREQUAL
-  | LESS
-  | LESSEQUAL
-  | LPAREN
-  | MINUS
-  | PERCENT
-  | PLUS
-  | RPAREN
-  | EXP
-  | STAR
-  | IDENT of string
-  | STRING of string
-  | INT of string
-  | LEXICON of bool * string * string
-
-type loc_token =
-    Tok of loc * token
+let include_end conf fname =
+  if conf.debug then Output.print_string conf ("\n<!-- end include " ^ fname ^ " -->\n")
 
 exception Exc_located of loc * exn
 
-let raise_with_loc loc exc =
-  match exc with
-    Exc_located (_, _) -> raise exc
-  | _ -> raise (Exc_located (loc, exc))
-
-let rec get_ident len =
-  parser
-    [< ''a'..'z' | 'A'..'Z' | '0'..'9' | '_' as c;
-       a = get_ident (Buff.store len c) ?! >] ->
-      a
-  | [< >] -> Buff.get len
-
-let rec get_value len =
-  parser
-    [< '' ' | '>' | ';' | '\n' | '\r' | '\t' >] -> Buff.get len
-  | [< 'c; a = get_value (Buff.store len c) ?! >] -> a
-
-let rec get_string len =
-  parser
-    [< ''"' >] -> Buff.get len
-  | [< 'c; a = get_string (Buff.store len c) ?! >] -> a
-
-let rec get_int len =
-  parser
-    [< ''0'..'9' as c; a = get_int (Buff.store len c) ?! >] -> a
-  | [< >] -> Buff.get len
-
-let get_compound_var =
-  let rec var_kont =
-    parser
-      [< ''.'; s = get_ident 0; sl = var_kont >] -> s :: sl
-    | [< >] -> []
-  in
-  parser bp [< v = get_ident 0; vl = var_kont >] ep -> (bp, ep), v, vl
-
-let get_variable =
-  let rec var_kont =
-    parser
-      [< ''.'; s = get_ident 0; sl = var_kont >] -> s :: sl
-    | [< '';' >] -> []
-    | [< >] -> []
-  in
-  parser bp
-    [< ''%' >] ep -> (bp, ep), "%", []
-  | [< ''/' >] ep -> (bp, ep), "/", []
-  | [< ''[' >] ep -> (bp, ep), "[", []
-  | [< '']' >] ep -> (bp, ep), "]", []
-  | [< ''(' >] ep -> (bp, ep), "(", []
-  | [< '')' >] ep -> (bp, ep), ")", []
-  | [< v = get_ident 0; vl = var_kont >] ep -> (bp, ep), v, vl
-
-let rec transl_num_index =
-  parser
-    [< ''0'..'9' as c >] -> String.make 1 c ^ transl_num_index strm__
-  | [< >] -> ""
-
-let transl_index =
-  parser
-    [< ''0'..'9' as c >] -> String.make 1 c ^ transl_num_index strm__
-  | [< ''a'..'z' as c >] -> String.make 1 c
-  | [< >] -> ""
-
-let lexicon_word =
-  let upper =
-    parser
-      [< ''*' >] -> true
-    | [< >] -> false
-  in
-  let rec text lev len =
-    parser
-      [< ''['; a = text (lev + 1) (Buff.store len '[') ?! >] -> a
-    | [< '']'; s >] ->
-        if lev = 0 then Buff.get len
-        else text (lev - 1) (Buff.store len ']') s
-    | [< 'c; a = text lev (Buff.store len c) ?! >] -> a
-  in
-  parser [< upp = upper; s = text 0 0; n = transl_index >] -> upp, s, n
-
-let rec parse_comment =
-  parser
-    [< ''%'; a = parse_comment_after_percent ?! >] -> a
-  | [< '_; a = parse_comment ?! >] -> a
-and parse_comment_after_percent =
-  parser
-    [< '')'; a = parse_spaces_after_comment ?! >] -> a
-  | [< ''('; s >] -> parse_comment s; parse_comment s
-  | [< '_; a = parse_comment ?! >] -> a
-and parse_spaces_after_comment =
-  parser
-    [< '' ' | '\n' | '\t' | '\r'; a = parse_spaces_after_comment ?! >] -> a
-  | [< >] -> ()
-
-let rec get_token =
-  parser bp
-    [< '' ' | '\t' | '\n' | '\r'; a = get_token ?! >] -> a
-  | [< ''(' >] ep -> Tok ((bp, ep), LPAREN)
-  | [< '')' >] ep -> Tok ((bp, ep), RPAREN)
-  | [< '',' >] ep -> Tok ((bp, ep), COMMA)
-  | [< ''.' >] ep -> Tok ((bp, ep), DOT)
-  | [< ''=' >] ep -> Tok ((bp, ep), EQUAL)
-  | [< ''+' >] ep -> Tok ((bp, ep), PLUS)
-  | [< ''-' >] ep -> Tok ((bp, ep), MINUS)
-  | [< ''*' >] ep -> Tok ((bp, ep), STAR)
-  | [< ''^' >] ep -> Tok ((bp, ep), EXP)
-  | [< ''/' >] ep -> Tok ((bp, ep), DIV)
-  | [< ''%';
-       a =
-         parser
-           [< ''('; _ = parse_comment; a = get_token ?! >] -> a
-         | [< >] ep -> Tok ((bp, ep), PERCENT) >] ->
-      a
-  | [< ''!'; ''=' ?? "'=' expected" >] ep -> Tok ((bp, ep), BANGEQUAL)
-  | [< ''>';
-       tok =
-         parser
-           [< ''=' >] -> GREATEREQUAL
-         | [< >] -> GREATER ?! >] ep ->
-      Tok ((bp, ep), tok)
-  | [< ''<';
-       tok =
-         parser
-           [< ''=' >] -> LESSEQUAL
-         | [< >] -> LESS ?! >] ep ->
-      Tok ((bp, ep), tok)
-  | [< ''"'; s = get_string 0 >] ep -> Tok ((bp, ep), STRING s)
-  | [< ''0'..'9' as c; s = get_int (Buff.store 0 c) >] ep ->
-      Tok ((bp, ep), INT s)
-  | [< ''['; upp, s, n = lexicon_word >] ep ->
-      Tok ((bp, ep), LEXICON (upp, s, n))
-  | [< s = get_ident 0 >] ep -> Tok ((bp, ep), IDENT s)
-
-module Buff2 = Buff.Make (struct  end)
-
-let rec parse_var =
-  parser [< 'Tok (loc, IDENT id); loc, idl = ident_list loc >] -> loc, id, idl
-and ident_list (bp, _ as loc) =
-  parser
-    [< 'Tok (_, DOT);
-       loc, id =
-         (parser
-            [< 'Tok ((_, ep), IDENT id) >] -> (bp, ep), id
-          | [< 'Tok ((_, ep), INT id) >] -> (bp, ep), id
-          | [< 'Tok (loc, _) >] -> loc, "parse_error1");
-       loc, idl = ident_list loc >] ->
-      loc, id :: idl
-  | [< >] -> loc, []
-
-let rec parse_expr strm = parse_expr_if strm
-and parse_expr_if =
-  parser
-    [< 'Tok (_, IDENT "if"); e1 = parse_expr_or; 'Tok (_, IDENT "then");
-       e2 = parse_expr_or; 'Tok (_, IDENT "else"); e3 = parse_expr_or >] ->
-      Aif (e1, [e2], [e3])
-  | [< a = parse_expr_or >] -> a
-and parse_expr_or =
-  parser
-    [< e = parse_expr_and;
-       a =
-         parser
-           [< 'Tok (loc, IDENT "or") >] ->
-             Aop2 (loc, "or", e, parse_expr_or strm__)
-         | [< >] -> e >] ->
-      a
-and parse_expr_and =
-  parser
-    [< e = parse_expr_is_substr;
-       a =
-         parser
-           [< 'Tok (loc, IDENT "and") >] ->
-             Aop2 (loc, "and", e, parse_expr_and strm__)
-         | [< >] -> e >] ->
-      a
-and parse_expr_is_substr =
-  parser
-    [< e = parse_expr_in;
-       a =
-         parser
-           [< 'Tok (loc, IDENT "is_substr"); s >] ->
-             Aop2 (loc, "is_substr", e, (parse_expr_is_substr s))
-         | [< >] -> e >] ->
-      a
-and parse_expr_in =
-  parser
-    [< e = parse_expr_3;
-       a =
-         parser
-           [< 'Tok (loc, IDENT "in"); s >] ->
-             Aop2 (loc, "in", e, (parse_expr_in s))
-         | [< >] -> e >] ->
-      a
-and parse_expr_3 =
-  parser
-    [< e = parse_expr_4;
-       a =
-         parser
-           [< 'Tok (loc, EQUAL); e2 = parse_expr_4 >] ->
-             Aop2 (loc, "=", e, e2)
-         | [< 'Tok (loc, BANGEQUAL); e2 = parse_expr_4 >] ->
-             Aop2 (loc, "!=", e, e2)
-         | [< 'Tok (loc, GREATER); e2 = parse_expr_4 >] ->
-             Aop2 (loc, ">", e, e2)
-         | [< 'Tok (loc, GREATEREQUAL); e2 = parse_expr_4 >] ->
-             Aop2 (loc, ">=", e, e2)
-         | [< 'Tok (loc, LESS); e2 = parse_expr_4 >] -> Aop2 (loc, "<", e, e2)
-         | [< 'Tok (loc, LESSEQUAL); e2 = parse_expr_4 >] ->
-             Aop2 (loc, "<=", e, e2)
-         | [< >] -> e ?! >] ->
-      a
-and parse_expr_4 = parser [< e = parse_expr_5; a = parse_expr_4_kont e >] -> a
-and parse_expr_4_kont e =
-  parser
-    [< 'Tok (loc, PLUS); e2 = parse_expr_5;
-       a = parse_expr_4_kont (Aop2 (loc, "+", e, e2)) >] ->
-      a
-  | [< 'Tok (loc, MINUS); e2 = parse_expr_5;
-       a = parse_expr_4_kont (Aop2 (loc, "-", e, e2)) >] ->
-      a
-  | [< >] -> e
-and parse_expr_5 =
-  parser [< e = parse_simple_expr; a = parse_expr_5_kont e >] -> a
-and parse_expr_5_kont e =
-  parser
-    [< 'Tok (loc, STAR); e2 = parse_simple_expr;
-       a = parse_expr_5_kont (Aop2 (loc, "*", e, e2)) >] ->
-      a
-  | [< 'Tok (loc, EXP); e2 = parse_simple_expr;
-       a = parse_expr_5_kont (Aop2 (loc, "^", e, e2)) >] ->
-      a
-  | [< 'Tok (loc, DIV); e2 = parse_simple_expr;
-       a = parse_expr_5_kont (Aop2 (loc, "/", e, e2)) >] ->
-      a
-  | [< 'Tok (loc, PERCENT); e2 = parse_simple_expr;
-       a = parse_expr_5_kont (Aop2 (loc, "%", e, e2)) >] ->
-      a
-  | [< >] -> e
-and parse_simple_expr =
-  parser
-    [< 'Tok (_, LPAREN); e = parse_expr;
-       a =
-         parser
-           [< 'Tok (_, RPAREN) >] -> e
-         | [< 'Tok (loc, _) >] -> Avar (loc, "parse_error2", []) >] ->
-      a
-  | [< 'Tok (loc, IDENT "not"); e = parse_simple_expr >] ->
-      Aop1 (loc, "not", e)
-  | [< 'Tok (loc, STRING s) >] -> Atext (loc, s)
-  | [< 'Tok (loc, INT s) >] -> Aint (loc, s)
-  | [< 'Tok (loc, LEXICON (upp, s, n)) >] -> Atransl (loc, upp, s, n)
-  | [< loc, id, idl = parse_var;
-       a =
-         parser
-           [< t = parse_tuple >] -> Aapply (loc, id, t)
-         | [< >] -> Avar (loc, id, idl) >] ->
-      a
-and parse_tuple strm =
-  let rec parse_expr_list =
-    parser
-      [< x = parse_expr;
-         xl =
-           parser
-             [< 'Tok (_, COMMA); a = parse_expr_list >] -> a
-           | [< >] -> [] ?! >] ->
-        [x] :: xl
-  in
-  let parse_tuple =
-    parser
-      [< 'Tok (_, LPAREN);
-         xl =
-           (parser
-              [< a = parse_expr_list >] -> a
-            | [< >] -> []);
-         a =
-           parser
-             [< 'Tok (_, RPAREN) >] -> xl
-           | [< 'Tok (loc, _) >] -> [[Atext (loc, "parse_error4")]] >] ->
-        a
-  in
-  parse_tuple strm
-
-let parse_char_stream p strm =
-  let f _ = try Some (get_token strm) with Stream.Failure -> None in
-  p (Stream.from f)
-
-let parse_char_stream_semi p strm =
-  let opt_semi = Stream.peek strm <> Some '(' in
-  let f _ = try Some (get_token strm) with Stream.Failure -> None in
-  let r = p (Stream.from f) in
-  if opt_semi then
-    begin let (strm__ : _ Stream.t) = strm in
-      match Stream.peek strm__ with
-        Some ';' -> Stream.junk strm__; ()
-      | _ -> ()
-    end;
-  r
-
-let parse_formal_params strm =
-  let rec parse_ident_list =
-    parser
-      [< 'Tok (_, IDENT x);
-         xl =
-           parser
-             [< 'Tok (_, COMMA); a = parse_ident_list >] -> a
-           | [< >] -> [] ?! >] ->
-        x :: xl
-  in
-  let parse_tuple =
-    parser
-      [< 'Tok (_, LPAREN);
-         xl =
-           (parser
-              [< a = parse_ident_list >] -> a
-            | [< >] -> []);
-         a =
-           parser
-             [< 'Tok (_, RPAREN) >] -> xl
-           | [< >] -> ["parse_error5"] ?! >] ->
-        a
-  in
-  let f _ = try Some (get_token strm) with Stream.Failure -> None in
-  parse_tuple (Stream.from f)
-
-let strip_newlines_after_variables =
-  let rec loop =
-    function
-      Atext (loc, s) :: astl ->
-        let s =
-          let rec loop i =
-            if i = String.length s then s
-            else if s.[i] = ' ' || s.[i] = '\t' || s.[i] = '\r' then
-              loop (i + 1)
-            else if s.[i] = '\n' then
-              String.sub s (i + 1) (String.length s - i - 1)
-            else s
-          in
-          loop 0
-        in
-        Atext (loc, s) :: loop astl
-    | Aif (s, alt, ale) :: astl -> Aif (s, loop alt, loop ale) :: loop astl
-    | Aforeach (v, pl, al) :: astl -> Aforeach (v, pl, loop al) :: loop astl
-    | Adefine (f, x, al, alk) :: astl ->
-        Adefine (f, x, loop al, loop alk) :: loop astl
-    | Aapply (loc, f, all) :: astl ->
-        Aapply (loc, f, List.map loop all) :: loop astl
-    | Alet (k, v, al) :: astl -> Alet (k, loop v, loop al) :: loop astl
-    | Afor (i, min, max, al) :: astl ->
-        Afor (i, min, max, loop al) :: loop astl
-    | (Atransl (_, _, _, _) | Awid_hei _ as ast1) :: (Atext (_, _) as ast2) ::
-      astl ->
-        ast1 :: ast2 :: loop astl
-    | Ainclude (file, al) :: astl -> Ainclude (file, loop al) :: loop astl
-    | ast :: astl -> ast :: loop astl
-    | [] -> []
-  in
-  loop
-
-let included_files = ref []
-
-let begin_end_include conf fname al =
-  if conf.debug then
-    Atext ((0,0), "\n\n<!-- begin include " ^ fname ^ " -->\n")
-    :: al
-    @ [ Atext ((0,0), "<!-- end include " ^ fname ^ " -->\n") ]
-  else al
-
-let parse_templ conf strm =
-  let rec parse_astl astl bol len end_list strm =
-    match strm with parser bp
-      [< ''%' >] ->
-        let astl =
-          if len = 0 then astl
-          else Atext ((bp - len, bp), Buff2.get len) :: astl
-        in
-        begin match get_variable strm with
-          _, ("%" | "[" | "]" as c), [] ->
-            parse_astl (Atext ((bp - 1, bp), c) :: astl) false 0 end_list strm
-        | _, "(", [] ->
-            parse_comment strm; parse_astl astl false 0 end_list strm
-        | _, v, [] when List.mem v end_list -> List.rev astl, v
-        | _, "define", [] -> parse_define astl end_list strm
-        | _, "let", [] -> parse_let astl end_list strm
-        | _, "include", [] -> parse_include astl end_list strm
-        | x ->
-            let ast =
-              match x with
-                _, "if", [] -> parse_if strm
-              | _, "foreach", [] -> parse_foreach strm
-              | _, "apply", [] -> parse_apply bp strm
-              | _, "expr", [] -> parse_expr_stmt strm
-              | _, "for", [] -> parse_for strm
-              | _, "wid_hei", [] -> Awid_hei (get_value 0 strm)
-              | (_, ep), v, vl -> Avar ((bp, ep), v, vl)
-            in
-            parse_astl (ast :: astl) false 0 end_list strm
-        end
-    | [< ''[' >] ->
-        let astl =
-          if len = 0 then astl
-          else Atext ((bp - len, bp), Buff2.get len) :: astl
-        in
-        let a =
-          let (upp, s, n) = lexicon_word strm in
-          if String.length s > 1 && (s.[0] = '[' || s.[0] = '@') then
-            let (astl, _) = parse_astl [] false 0 [] (Stream.of_string s) in
-            Aconcat ((bp, Stream.count strm), astl)
-          else Atransl ((bp, Stream.count strm), upp, s, n)
-        in
-        parse_astl (a :: astl) false 0 end_list strm
-    | [< 'c >] ->
-        let empty_c = c = ' ' || c = '\t' in
-        let len = if empty_c && bol then len else Buff2.store len c in
-        let bol = empty_c && bol || c = '\n' in
-        parse_astl astl bol len end_list strm
-    | [< >] ->
-        let astl =
-          if len = 0 then astl
-          else Atext ((bp - len, bp), Buff2.get len) :: astl
-        in
-        List.rev astl, ""
-  and parse_define astl end_list strm =
-    let fxlal =
-      try
-        let f = get_ident 0 strm in
-        let xl = parse_formal_params strm in
-        let (al, _) = parse_astl [] false 0 ["end"] strm in
-        begin let rec loop () =
-          match strm with parser
-            [< ''\n' | '\r' >] -> loop ()
-          | [< >] -> ()
-        in
-          loop ()
-        end;
-        Some (f, xl, al)
-      with Stream.Failure | Stream.Error _ -> None
-    in
-    let (alk, v) = parse_astl [] false 0 end_list strm in
-    let astl =
-      match fxlal with
-        Some (f, xl, al) -> Adefine (f, xl, al, alk) :: astl
-      | None ->
-          let bp = Stream.count strm - 1 in
-          Atext ((bp, bp + 1), "define error") :: (alk @ astl)
-    in
-    List.rev astl, v
-  and parse_let astl end_list strm =
-    let (ast, tok) =
-      try
-        let k = get_ident 0 strm in
-        match strm with parser
-          [< '';' >] ->
-            let (v, _) = parse_astl [] false 0 ["in"] strm in
-            let (al, tok) = parse_astl [] false 0 end_list strm in
-            Alet (k, v, al), tok
-      with Stream.Failure | Stream.Error _ ->
-        let bp = Stream.count strm - 1 in
-        Atext ((bp, bp + 1), "let syntax error"), ""
-    in
-    List.rev (ast :: astl), tok
-  and parse_include astl end_list strm =
-    let ast =
-      try
-        let file = get_value 0 strm in
-        match List.assoc_opt file !included_files with
-        | Some ast -> Some (Ainclude (file, ast))
-        | None ->
-          match Util.open_templ_fname conf file with
-          | Some (ic, fname) ->
-            let strm2 = Stream.of_channel ic in
-            let (al, _) = parse_astl [] false 0 [] strm2 in
-            close_in ic;
-            let al = begin_end_include conf fname al in
-            let () = included_files := (file, al) :: !included_files in
-            Some (Ainclude (file, al))
-          | None -> None
-      with Stream.Failure | Stream.Error _ -> None
-    in
-    let (alk, tok) = parse_astl [] false 0 end_list strm in
-    match ast with
-      Some ast -> List.rev (ast :: astl) @ alk, tok
-    | None -> astl @ alk, tok
-  and parse_apply bp strm =
-    try
-      let f = get_ident 0 strm in
-      match strm with parser
-        [< ''%' >] ->
-          begin match get_variable strm with
-            _, "with", [] ->
-              let all =
-                let rec loop () =
-                  let (al, tok) = parse_astl [] false 0 ["and"; "end"] strm in
-                  match tok with
-                    "and" -> al :: loop ()
-                  | _ -> [al]
-                in
-                loop ()
-              in
-              Aapply ((bp, Stream.count strm), f, all)
-          | _ -> raise (Stream.Error "'with' expected")
-          end
-      | [< >] ->
-          let el = parse_char_stream parse_tuple strm in
-          Aapply ((bp, Stream.count strm), f, el)
-    with Stream.Failure | Stream.Error _ ->
-      let bp = Stream.count strm - 1 in
-      Atext ((bp, bp + 1), "apply syntax error")
-  and parse_expr_stmt strm = parse_char_stream_semi parse_simple_expr strm
-  and parse_if strm =
-    let e = parse_char_stream_semi parse_simple_expr strm in
-    let (al1, al2) =
-      let rec loop () =
-        let (al1, tok) =
-          parse_astl [] false 0 ["elseif"; "else"; "end"] strm
-        in
-        match tok with
-          "elseif" ->
-            let e2 = parse_char_stream_semi parse_simple_expr strm in
-            let (al2, al3) = loop () in al1, [Aif (e2, al2, al3)]
-        | "else" ->
-            let (al2, _) = parse_astl [] false 0 ["end"] strm in al1, al2
-        | _ -> al1, []
-      in
-      loop ()
-    in
-    Aif (e, al1, al2)
-  and parse_for strm =
-    try
-      let iterator = get_ident 0 strm in
-      match strm with parser
-        [< '';' >] ->
-          let min = parse_char_stream_semi parse_simple_expr strm in
-          let max = parse_char_stream_semi parse_simple_expr strm in
-          let (al, _) = parse_astl [] false 0 ["end"] strm in
-          Afor (iterator, min, max, al)
-    with Stream.Failure | Stream.Error _ ->
-      let bp = Stream.count strm - 1 in
-      Atext ((bp, bp + 1), "for syntax error")
-  and parse_foreach strm =
-    let (loc, v, vl) = get_compound_var strm in
-    let params =
-      if Stream.peek strm = Some '(' then parse_char_stream parse_tuple strm
-      else
-        begin
-          begin let (strm__ : _ Stream.t) = strm in
-            match Stream.peek strm__ with
-              Some ';' -> Stream.junk strm__; ()
-            | _ -> ()
-          end;
-          []
-        end
-    in
-    let (astl, _) = parse_astl [] false 0 ["end"] strm in
-    Aforeach ((loc, v, vl), params, astl)
-  in
-  let astl = fst (parse_astl [] true 0 [] strm) in
-  strip_newlines_after_variables astl
+let raise_with_loc loc = function
+  | Exc_located (_, _) as e -> raise e
+  | e -> raise (Exc_located (loc, e))
 
 let input_templ conf fname =
-  match Util.open_templ conf fname with
-    Some ic ->
-      let astl = parse_templ conf (Stream.of_channel ic) in
-      close_in ic; Some astl
+  match Util.open_templ_fname conf fname with
   | None -> None
+  | Some (ic, fname) ->
+    let lex = Lexing.from_channel ic in
+    (* Lexing.set_filename lex fname ; *)(* only for OCaml >= 4.11 *)
+    let r = Templ_parser.parse_templ conf lex in
+    close_in ic ;
+    Some r
 
 (* Common evaluation functions *)
 
@@ -611,40 +40,46 @@ let subst_text x v s =
     in
     loop 0 0 0
 
-let rec subst sf =
-  function
-    Atext (loc, s) -> Atext (loc, sf s)
+let rec subst sf = function
+  | Atext (loc, s) -> Atext (loc, sf s)
   | Avar (loc, s, sl) ->
-      let s1 = sf s in
-      let sl1 = List.map sf sl in
-      if sl = [] &&
-         (try let _ = int_of_string s1 in true with Failure _ -> false)
-      then
-        Aint (loc, s1)
-      else
-        let strm = Stream.of_string s1 in
-        let (_, s2, sl2) = get_compound_var strm in
-        if Stream.peek strm <> None then Avar (loc, s1, sl1)
-        else Avar (loc, s2, sl2 @ sl1)
+    let s1 = sf s in
+    let sl1 = List.map sf sl in
+    if sl = [] && try let _ = int_of_string s1 in true with Failure _ -> false
+    then Aint (loc, s1)
+    else begin
+      let lex = Lexing.from_string s1 in
+      match Templ_parser.compound_var lex with
+      | s2 :: sl2 ->
+        if lex.Lexing.lex_curr_p.pos_cnum = String.length s1
+        then Avar (loc, s2, sl2 @ sl1)
+        else Avar (loc, s1, sl1)
+      | _ -> assert false
+    end
   | Atransl (loc, b, s, c) -> Atransl (loc, b, sf s, c)
   | Aconcat (loc, al) -> Aconcat (loc, List.map (subst sf) al)
   | Awid_hei s -> Awid_hei (sf s)
   | Aif (e, alt, ale) -> Aif (subst sf e, substl sf alt, substl sf ale)
   | Aforeach ((loc, s, sl), pl, al) ->
-      (* Dans le cas d'une "compound variable", il faut la décomposer. *)
-      (* Ex: "ancestor.father".family  =>  ancestor.father.family      *)
-      let s1 = sf s in
-      let strm = Stream.of_string s1 in
-      let (_, s2, sl2) = get_compound_var strm in
-      let (s, sl) =
-        if Stream.peek strm <> None then s, sl else s2, sl2 @ sl
-      in
-      Aforeach
-        ((loc, sf s, List.map sf sl), List.map (substl sf) pl, substl sf al)
+    (* Dans le cas d'une "compound variable", il faut la décomposer. *)
+    (* Ex: "ancestor.father".family  =>  ancestor.father.family      *)
+    let s1 = sf s in
+    let lex = Lexing.from_string s1 in
+    begin match Templ_parser.compound_var lex with
+      | s2 :: sl2 ->
+        let (s, sl) =
+          if lex.Lexing.lex_curr_p.pos_cnum = String.length s1
+          then s2, sl2 @ sl
+          else s, sl
+        in
+        Aforeach
+          ((loc, sf s, List.map sf sl), List.map (substl sf) pl, substl sf al)
+      | _ -> assert false
+    end
   | Afor (i, min, max, al) ->
-      Afor (sf i, subst sf min, subst sf max, substl sf al)
+    Afor (sf i, subst sf min, subst sf max, substl sf al)
   | Adefine (f, xl, al, alk) ->
-      Adefine (sf f, List.map sf xl, substl sf al, substl sf alk)
+    Adefine (sf f, List.map sf xl, substl sf al, substl sf alk)
   | Aapply (loc, f, all) -> Aapply (loc, sf f, List.map (substl sf) all)
   | Alet (k, v, al) -> Alet (sf k, substl sf v, substl sf al)
   | Ainclude (file, al) -> Ainclude (sf file, substl sf al)
@@ -920,7 +355,7 @@ and eval_transl_lexicon conf upp s c =
             let k = skip_spaces_and_newlines s2 (j + 1) in
             let s3 =
               let s = String.sub s2 i (j - i) in
-              let astl = parse_templ conf (Stream.of_string s) in
+              let astl = Templ_parser.parse_templ conf (Lexing.from_string s) in
               List.fold_left (fun s a -> s ^ eval_ast conf a) "" astl
             in
             let s4 = String.sub s2 k (String.length s2 - k) in
@@ -996,7 +431,7 @@ let int_of e =
     VVstring s ->
       begin try int_of_string s with
         Failure _ ->
-          raise_with_loc (loc_of_expr e)
+          raise
             (Failure ("int value expected\nFound = " ^ s))
       end
   | VVbool _ | VVother _ ->
@@ -1007,7 +442,7 @@ let num_of e =
     VVstring s ->
       begin try Sosa.of_string s with
         Failure _ ->
-          raise_with_loc (loc_of_expr e)
+          raise
             (Failure ("num value expected\nFound = " ^ s))
       end
   | VVbool _ | VVother _ ->
@@ -1021,7 +456,7 @@ let rec eval_expr (conf, eval_var, eval_apply as ceva) =
         Not_found ->
           begin try templ_eval_var conf (s :: sl) with
             Not_found ->
-              raise_with_loc loc
+              raise
                 (Failure
                    ("unbound var \"" ^ String.concat "." (s :: sl) ^ "\""))
           end
@@ -1077,19 +512,17 @@ let rec eval_expr (conf, eval_var, eval_apply as ceva) =
 
 let line_of_loc conf fname (bp, ep) =
   match Util.open_templ conf fname with
-    Some ic ->
-      let strm = Stream.of_channel ic in
-      let rec loop lin =
-        let rec scan_line col =
-          parser cnt
-            [< 'c; s >] ->
-              if cnt < bp then
-                if c = '\n' then loop (lin + 1) else scan_line (col + 1) s
-              else let col = col - (cnt - bp) in lin, col, col + ep - bp
-        in
-        scan_line 0 strm
-      in
-      let r = try Some (loop 1) with Stream.Failure -> None in close_in ic; r
+  | Some ic ->
+    let rec line i =
+      let rec column j =
+        if j < bp
+        then match input_char ic with
+          | '\n' -> line (i + 1)
+          | _ -> column (j + 1)
+        else
+          (i, j, j + ep - bp)
+      in column 0
+    in Some (line 0)
   | None -> None
 
 let template_file = ref ""
@@ -1389,8 +822,8 @@ let rec interp_ast conf ifun env =
         match f, vl with
           "capitalize", [VVstring s] -> Utf8.capitalize_fst s
         | "interp", [VVstring s] ->
-            let astl = parse_templ conf (Stream.of_string s) in
-            String.concat "" (eval_ast_list env ep astl)
+            let astl = Templ_parser.parse_templ conf (Lexing.from_string s) in
+          String.concat "" (eval_ast_list env ep astl)
         | "language_name", [VVstring s] ->
             Translate.language_name s (Util.transl conf "!languages")
         | "nth", [VVstring s1; VVstring s2] ->
@@ -1470,8 +903,11 @@ let rec interp_ast conf ifun env =
     | Avar (_, "sq", []) :: Atext (loc, s) :: al ->
         let s = squeeze_spaces s in
         print_ast_list env ep (Atext (loc, s) :: al)
-    | Ainclude (_, astl) :: al ->
-        print_ast_list env ep astl; print_ast_list !m_env ep al
+    | Ainclude (fname, astl) :: al ->
+        include_begin conf fname ;
+        print_ast_list env ep astl;
+        include_end conf fname ;
+        print_ast_list !m_env ep al
     | [a] -> print_ast env ep a
     | a :: al -> print_ast env ep a; print_ast_list env ep al
   and print_define env ep f xl al alk =
@@ -1522,13 +958,15 @@ and print_var print_ast_list conf ifun env ep loc sl =
       | VVother f -> print_var1 f []
     with Not_found ->
       match sl with
-        ["include"; templ] ->
-          begin match Util.open_templ_fname conf templ with
-            Some (_, fname) ->
-              begin match input_templ conf templ with
-                Some astl ->
-                    let () = included_files := (templ, astl) :: !included_files in
-                    print_ast_list env ep (begin_end_include conf fname astl)
+      | [ "include" ; templ ] ->
+        begin match Util.open_templ_fname conf templ with
+          | Some (_, fname) ->
+            begin match input_templ conf templ with
+              | Some astl ->
+                let () = Templ_parser.(included_files := (templ, astl) :: !included_files) in
+                include_begin conf fname ;
+                print_ast_list env ep astl ;
+                include_end conf fname ;
               | None -> Output.printf conf " %%%s?" (String.concat "." sl)
               end
             | None -> Output.printf conf " %%%s?" (String.concat "." sl)
@@ -1556,7 +994,7 @@ and print_variable conf sl =
       with Not_found -> Output.printf conf " %%%s?" (String.concat "." sl)
 
 let copy_from_templ conf env ic =
-  let astl = parse_templ conf (Stream.of_channel ic) in
+  let astl = Templ_parser.parse_templ conf (Lexing.from_channel ic) in
   close_in ic;
   let ifun =
     {eval_var =

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -504,25 +504,9 @@ let rec eval_expr (conf, eval_var, eval_apply as ceva) =
   | Aint (_, s) -> VVstring s
   | e -> raise_with_loc (loc_of_expr e) (Failure (not_impl "eval_expr" e))
 
-let line_of_loc conf fname (bp, ep) =
-  match Util.open_templ conf fname with
-  | Some ic ->
-    begin try
-        let rec line i =
-        let rec column j =
-          if j < bp
-          then match input_char ic with
-          | '\n' -> line (i + 1)
-          | _ -> column (j + 1)
-          else
-            (i, j, j + ep - bp)
-        in column 0
-    in Some (line 0)
-      with _ -> None
-    end
-  | None -> None
+let line_of_loc = Templ_parser.line_of_loc
 
-let print_error conf (fname, bp, ep) exc =
+let print_error conf ((fname, bp, ep) as pos) exc =
   incr nb_errors;
   if !nb_errors <= 10 then
     begin
@@ -530,7 +514,7 @@ let print_error conf (fname, bp, ep) exc =
       else Printf.eprintf "File %s" fname;
       let line =
         if fname = "" then None
-        else line_of_loc conf fname (bp, ep)
+        else line_of_loc conf pos
       in
       Printf.eprintf ", ";
       begin match line with

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -24,7 +24,6 @@ val interp_ast :
 
 (**)
 
-val template_file : string ref
 val input_templ : config -> string -> ast list option
 val print_copyright : config -> unit
 val print_copyright_with_logo : config -> unit

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -7,7 +7,6 @@ type 'a vother
 type 'a env = (string * 'a) list
 
 val eval_transl : config -> bool -> string -> string -> string
-val begin_end_include : config -> string -> ast list -> ast list
 
 type ('a, 'b) interp_fun =
   { eval_var : 'a env -> 'b -> loc -> string list -> 'b expr_val;

--- a/lib/templAst.mli
+++ b/lib/templAst.mli
@@ -17,7 +17,7 @@ type ast =
   | Aop2 of loc * string * ast * ast
   | Aint of loc * string
   | Ainclude of string * ast list
-and loc = (int * int)
+and loc = (string * int * int)
 
 type 'a expr_val =
   | VVbool of bool

--- a/lib/templAst.mli
+++ b/lib/templAst.mli
@@ -19,7 +19,6 @@ type ast =
   | Ainclude of string * ast list
 and loc = (int * int)
 
-
 type 'a expr_val =
   | VVbool of bool
   | VVstring of string

--- a/lib/templ_parser.mll
+++ b/lib/templ_parser.mll
@@ -21,7 +21,9 @@ let rec dump_ast trk depth =
   let dump_ast a = if depth > 0 then dump_ast trk (depth - 1) a else "..." in
   let dump_ast_list a = if depth > 0 then dump_list dump_ast a else "..." in
   let dump_ast_list_list a = if depth > 0 then dump_list dump_ast_list a else "..." in
-  let trk s = if String.length s > trk then String.sub s 0 trk ^ "..." else s in
+  let trk s =
+    let s = Str.global_replace (Str.regexp "\n") " " s in
+    if String.length s > trk then String.sub s 0 trk ^ "..." else s in
   function
   | Atext (_, a) ->
     "(Atext " ^ trk a ^ ")"

--- a/lib/templ_parser.mll
+++ b/lib/templ_parser.mll
@@ -371,7 +371,7 @@ and parse_tuple_1 = parse
     }
 and parse_expr_list = parse
   | ws* {
-      let x = parse_expr lexbuf in
+      let x = parse_expr_3 lexbuf in
       parse_expr_list_1 x lexbuf
     }
 and parse_expr_list_1 x = parse

--- a/lib/templ_parser.mll
+++ b/lib/templ_parser.mll
@@ -73,7 +73,8 @@ let strip_newlines_after_variables =
         in
         loop 0
       in
-      TemplAst.Atext (loc, s) :: loop astl
+      if s <> "" then TemplAst.Atext (loc, s) :: loop astl
+      else loop astl
     | TemplAst.Aif (s, alt, ale) :: astl -> TemplAst.Aif (s, loop alt, loop ale) :: loop astl
     | TemplAst.Aforeach (v, pl, al) :: astl -> TemplAst.Aforeach (v, pl, loop al) :: loop astl
     | TemplAst.Adefine (f, x, al, alk) :: astl ->

--- a/lib/templ_parser.mll
+++ b/lib/templ_parser.mll
@@ -1,0 +1,620 @@
+{
+
+open Config
+open TemplAst
+
+let dump_list pp a = String.concat ";" (List.map pp a)
+let rec dump_ast trk depth =
+  let dump_ast a = if depth > 0 then dump_ast trk (depth - 1) a else "..." in
+  let dump_ast_list a = if depth > 0 then dump_list dump_ast a else "..." in
+  let dump_ast_list_list a = if depth > 0 then dump_list dump_ast_list a else "..." in
+  let trk s = if String.length s > trk then String.sub s 0 trk ^ "..." else s in
+  function
+  | Atext (_, a) ->
+    "(Atext " ^ trk a ^ ")"
+  | Avar (_, a, b) ->
+    "(Avar " ^ trk (String.concat "." (a :: b)) ^ ")"
+  | Atransl (_, a, b, c) ->
+    "(Atransl " ^ (if a then "T," else "F,") ^ trk b ^ "," ^ trk c ^ ")"
+  | Aconcat (_, a) ->
+    "(Aconcat " ^ dump_ast_list a ^ ")"
+  | Awid_hei a ->
+    "(Awid_hei " ^ trk a ^ ")"
+  | Aif (a, b, c) ->
+    "(Aif " ^ dump_ast a ^ "," ^ dump_ast_list b ^ "," ^ dump_ast_list c ^ ")"
+  | Aforeach ((_, a, b), c, d) ->
+    "(Aif " ^ trk a ^ "," ^ trk (String.concat "." b) ^ "," ^ dump_ast_list_list c ^ "," ^ dump_ast_list d ^ ")"
+  | Afor (a, b, c, d) ->
+    "(Afor " ^ trk a ^ "," ^ dump_ast b ^ "," ^ dump_ast c ^ "," ^ dump_ast_list d ^ ")"
+  | Adefine (a, b, c, d) ->
+    "(Adefine " ^ trk a ^ "," ^ String.concat "." b ^ "," ^ dump_ast_list c ^ "," ^ dump_ast_list d ^ ")"
+  | Aapply (_, a, b) ->
+    "(Aapply " ^ trk a ^ "," ^ dump_ast_list_list b ^ ")"
+  | Alet (a, b, c) ->
+    "(Alet " ^ trk a ^ "," ^ dump_ast_list b ^ "," ^ dump_ast_list c ^ ")"
+  | Aop1 (_, a, b) ->
+    "(Aop1 " ^ trk a ^ "," ^ dump_ast b ^ ")"
+  | Aop2 (_, a, b, c) ->
+    "(Aop2 " ^ trk a ^ "," ^ dump_ast b ^ "," ^ dump_ast c ^ ")"
+  | Aint (_, a) ->
+    "(Aint " ^ a ^ ")"
+  | Ainclude (a, b) ->
+    "(Ainclude " ^ trk a ^ "," ^ dump_ast_list b ^ ")"
+
+let dump_ast ?(truncate=max_int) ?(depth=max_int) a = dump_ast truncate depth a
+
+let dummy_pos = (-1, -1)
+
+let pos lex = Lexing.lexeme_start lex, Lexing.lexeme_end lex
+
+let included_files = ref []
+
+let flush ast b lexbuf =
+  let s = Buffer.contents b in
+  let ast =
+    if s = "" then ast
+    else Atext ((lexbuf.Lexing.lex_curr_pos - String.length s, lexbuf.Lexing.lex_curr_pos), s) :: ast
+  in
+  let () = Buffer.reset b in
+  ast
+
+let strip_newlines_after_variables =
+  let rec loop =
+    function
+      TemplAst.Atext (loc, s) :: astl ->
+      let s =
+        let rec loop i =
+          if i = String.length s then s
+          else if s.[i] = ' ' || s.[i] = '\t' || s.[i] = '\r' then
+            loop (i + 1)
+          else if s.[i] = '\n' then
+            String.sub s (i + 1) (String.length s - i - 1)
+          else s
+        in
+        loop 0
+      in
+      TemplAst.Atext (loc, s) :: loop astl
+    | TemplAst.Aif (s, alt, ale) :: astl -> TemplAst.Aif (s, loop alt, loop ale) :: loop astl
+    | TemplAst.Aforeach (v, pl, al) :: astl -> TemplAst.Aforeach (v, pl, loop al) :: loop astl
+    | TemplAst.Adefine (f, x, al, alk) :: astl ->
+      TemplAst.Adefine (f, x, loop al, loop alk) :: loop astl
+    | TemplAst.Aapply (loc, f, all) :: astl ->
+      TemplAst.Aapply (loc, f, List.map loop all) :: loop astl
+    | TemplAst.Alet (k, v, al) :: astl -> TemplAst.Alet (k, loop v, loop al) :: loop astl
+    | TemplAst.Afor (i, min, max, al) :: astl ->
+      TemplAst.Afor (i, min, max, loop al) :: loop astl
+    | (TemplAst.Atransl (_, _, _, _) | TemplAst.Awid_hei _ as ast1) :: (TemplAst.Atext (_, _) as ast2) ::
+      astl ->
+      ast1 :: ast2 :: loop astl
+    | TemplAst.Ainclude (file, al) :: astl -> TemplAst.Ainclude (file, loop al) :: loop astl
+    | ast :: astl -> ast :: loop astl
+    | [] -> []
+  in
+  loop
+
+}
+
+let ws = ([ ' ' '\n' '\t' '\r' ])
+
+let r_ident = ([ 'a'-'z' 'A'-'Z' '0'-'9' '_' ]+)
+
+let num = (['0'-'9']+)
+
+let var = (r_ident ('.' (r_ident|num))*)
+
+let value = ([^ ' ' '>' ';' '\n' '\r'  '\t' ]+)
+
+rule parse_ast conf b closing ast = parse
+
+  | '%' {
+      match match variable lexbuf with `variable [] -> `escaped '%' | x -> x with
+      | `escaped c -> Buffer.add_char b c ; parse_ast conf b closing ast lexbuf
+      | `comment -> parse_ast conf b closing ast lexbuf
+      | x ->
+        let pos = pos lexbuf in
+        let ast = flush ast b lexbuf in
+        match x with
+        | `variable [v] when List.mem v closing -> List.rev ast, v
+        | `variable ["nn"] -> let () = skip_ws lexbuf in parse_ast conf b closing ast lexbuf
+        | `variable ["define"] -> parse_define conf b closing ast lexbuf
+        | `variable ["let"] -> parse_let conf b closing ast lexbuf
+        | `variable ["include"] -> parse_include conf b closing ast lexbuf
+        | x ->
+          let a = match x with
+            | `variable ["if"] -> parse_if conf b lexbuf
+            | `variable ["foreach"] -> parse_foreach conf b lexbuf
+            | `variable ["apply"] -> parse_apply conf b lexbuf
+            | `variable ["expr"] -> parse_expr_stmt lexbuf
+            | `variable ["for"] -> parse_for conf b lexbuf
+            | `variable ["wid_hei"] -> Awid_hei (value lexbuf)
+            | `variable (hd :: tl) -> Avar (pos, hd, tl)
+            | _ -> assert false
+          in
+          parse_ast conf b closing (a :: ast) lexbuf
+    }
+
+  | '[' {
+      let ast = flush ast b lexbuf in
+      let a =
+        let pos = pos lexbuf in
+        let (upp, s, n) = lexicon_word lexbuf in
+        if String.length s > 1 && (s.[0] = '[' || s.[0] = '@')
+        then
+          let (ast, _) = parse_ast conf b [] [] (Lexing.from_string s) in
+          Aconcat (pos, ast)
+        else
+          Atransl (pos, upp, s, n)
+      in
+      parse_ast conf b closing (a :: ast) lexbuf
+    }
+
+  | '\n' [ ' ' '\n' '\t' '\r' ]* {
+      let () = Buffer.add_char b '\n' in
+      parse_ast conf b closing ast lexbuf
+    }
+
+  | _ as c {
+      let () = Buffer.add_char b c in
+      parse_ast conf b closing ast lexbuf
+    }
+
+  | eof {
+      List.rev (flush ast b lexbuf), ""
+    }
+
+and parse_ident_list = parse
+  | '.' ((r_ident|num) as id) {
+      id :: parse_ident_list lexbuf
+    }
+  | "" {
+      []
+    }
+
+and parse_expr = parse
+  | "" {
+      parse_expr_if lexbuf
+    }
+
+and parse_expr_if = parse
+  | ws* "if" {
+      let e1 = parse_expr_or lexbuf in
+      parse_expr_if_1 e1 lexbuf
+    }
+  | "" {
+      parse_expr_or lexbuf
+    }
+and parse_expr_if_1 e1 = parse
+  | ws* "then" {
+      let e2 = parse_expr_or lexbuf in
+      parse_expr_if_2 e1 e2 lexbuf
+    }
+and parse_expr_if_2 e1 e2 = parse
+  | ws* "else" {
+      let e3 = parse_expr_or lexbuf in
+      Aif (e1, [e2], [e3])
+    }
+
+and parse_expr_or = parse
+  | ws* {
+      let e1 = parse_expr_and lexbuf in
+      parse_expr_or_1 e1 lexbuf
+    }
+and parse_expr_or_1 e1 = parse
+  | ws* "or" {
+      let pos = pos lexbuf in
+      let e2 = parse_expr_or lexbuf in
+      Aop2 (pos, "or", e1, e2)
+    }
+  | ws* {
+      e1
+    }
+
+and parse_expr_and = parse
+  | ws* {
+      let e1 = parse_expr_is_substr lexbuf in
+      parse_expr_and_1 e1 lexbuf
+    }
+and parse_expr_and_1 e1 = parse
+  | ws* "and" {
+      let pos = pos lexbuf in
+      let e2 = parse_expr_and lexbuf in
+      Aop2 (pos, "and", e1, e2)
+    }
+  | ws* {
+      e1
+    }
+
+and parse_expr_is_substr = parse
+  | ws* {
+      let e1 = parse_expr_in lexbuf in
+      parse_expr_is_substr_1 e1 lexbuf
+    }
+and parse_expr_is_substr_1 e1 = parse
+  | ws* "is_substr" {
+      let pos = pos lexbuf in
+      let e2 = parse_expr_is_substr lexbuf in
+      Aop2 (pos, "is_substr", e1, e2)
+    }
+  | ws* {
+      e1
+    }
+
+and parse_expr_in = parse
+  | ws* {
+      let e1 = parse_expr_3 lexbuf in
+      parse_expr_in_1 e1 lexbuf
+    }
+and parse_expr_in_1 e1 = parse
+  | ws* "in" {
+      let pos = pos lexbuf in
+      let e2 = parse_expr_in lexbuf in
+      Aop2 (pos, "in", e1, e2)
+    }
+  | ws* {
+      e1
+    }
+
+and parse_expr_3 = parse
+  | ws* {
+      let e1 = parse_expr_4 lexbuf in
+      parse_expr_3_1 e1 lexbuf
+    }
+and parse_expr_3_1 e1 = parse
+  | ws* (("="|"!="|">"|">="|"<"|"<=") as op) {
+      let pos = pos lexbuf in
+      let e2 = parse_expr_4 lexbuf in
+      Aop2 (pos, op, e1, e2)
+    }
+  | ws* {
+      e1
+    }
+
+and parse_expr_4 = parse
+  | ws* {
+      let e1 = parse_expr_5 lexbuf in
+      parse_expr_4_1 e1 lexbuf
+    }
+and parse_expr_4_1 e1 = parse
+  | ws* (("+"|"-") as op) ws* {
+      let pos = pos lexbuf in
+      let e2 = parse_expr_5 lexbuf in
+      parse_expr_4_1 (Aop2 (pos, String.make 1 op, e1, e2)) lexbuf
+    }
+  | ws*  { e1 }
+
+and parse_expr_5 = parse
+  | ws* {
+      let e1 = parse_simple_expr lexbuf in
+      parse_expr_5_1 e1 lexbuf
+    }
+
+and parse_expr_5_1 e1 = parse
+  | ws* (("*"|"^"|"/"|"%") as op) {
+      let pos = pos lexbuf in
+      let e2 = parse_simple_expr lexbuf in
+      parse_expr_5_1 (Aop2 (pos, String.make 1 op, e1, e2)) lexbuf
+    }
+  | ws* {
+      e1
+    }
+
+and parse_simple_expr = parse
+  | ws* '(' {
+      let e = parse_expr lexbuf in
+      let () = discard_RPAREN lexbuf in
+      e
+    }
+  | ws* "not" {
+      let pos = pos lexbuf in
+      let e = parse_simple_expr lexbuf in
+      Aop1 (pos, "not", e)
+    }
+  | ws* '"' ([^'"']* as s) '"' {
+      Atext (pos lexbuf, s)
+    }
+  | ws* (num as s) {
+      Aint (pos lexbuf, s)
+    }
+  | ws* '[' {
+      let pos = pos lexbuf in
+      let u, w, n = lexicon_word lexbuf in
+      Atransl (pos, u, w, n)
+    }
+  | ws* (var as id) {
+      let pos = pos lexbuf in
+      let [@warning "-8"] hd :: tl = String.split_on_char '.' id in
+      try
+        let t = parse_tuple lexbuf in
+        Aapply (pos, hd, t)
+      with _ -> Avar (pos, hd, tl)
+    }
+
+and parse_simple_expr_1 = parse
+  | ws* {
+      let e = parse_expr lexbuf in
+      let () = discard_RPAREN lexbuf in
+      e
+    }
+
+and discard_RPAREN = parse
+  | ws* ')' {
+      ()
+    }
+
+and parse_tuple = parse
+  | ws* '(' {
+      parse_tuple_1 lexbuf
+    }
+and parse_tuple_1 = parse
+  | ws* ')' {
+      []
+    }
+  | ws* {
+      let r = parse_expr_list lexbuf in
+      let () = discard_RPAREN lexbuf in
+      r
+    }
+and parse_expr_list = parse
+  | ws* {
+      let x = parse_expr lexbuf in
+      parse_expr_list_1 x lexbuf
+    }
+and parse_expr_list_1 x = parse
+  | ws* ',' {
+      let tl = parse_expr_list lexbuf in
+      [x] :: tl
+    }
+  | ws* {
+      [[x]]
+    }
+
+and parse_char_stream_semi fn fn2 = parse
+  | '(' {
+      fn2 lexbuf
+    }
+  | ws* {
+      let r = fn lexbuf in
+      let () = discard_opt_semi lexbuf in
+      r
+    }
+
+and discard_opt_semi = parse
+  | ws* ';'? {
+      ()
+    }
+
+and lexicon_word = parse
+  | ('*'? as upper) {
+      let b = Buffer.create 255 in
+      let w = lexicon_word_text b 0 lexbuf in
+      let n = lexicon_index lexbuf in
+      (upper <> "", w, n)
+    }
+
+and lexicon_index = parse
+  | num as s {
+      s
+    }
+  | ['a'-'z'] as c {
+      String.make 1 c
+    }
+  | "" {
+      ""
+    }
+
+and value = parse
+  | value as v {
+      v
+    }
+
+and compound_var = parse
+  | (r_ident as i) '.' {
+      i :: compound_var lexbuf
+    }
+  | (r_ident as i) {
+      [ i ]
+    }
+
+(* '%' already consummed *)
+and variable = parse
+  | [ '%' '/' '[' ']' ] as c {
+      `escaped c
+    }
+  | '(' {
+      let () = comment lexbuf in
+      `comment
+    }
+  | (r_ident as i) {
+      `variable (i :: variable_ident lexbuf)
+    }
+  | "" {
+      `variable []
+    }
+
+and variable_ident = parse
+  | '.' (r_ident as i) {
+      i :: variable_ident lexbuf
+    }
+  | ';' {
+      []
+    }
+  | "" {
+      []
+    }
+
+and transl_index = parse
+  | num as n {
+      n
+    }
+  | ['a'-'z'] as c {
+      String.make 1 c
+    }
+  | "" {
+      ""
+    }
+
+and lexicon_word_text b n = parse
+  | '[' {
+      let () = Buffer.add_char b '[' in
+      lexicon_word_text b (n + 1) lexbuf
+    }
+  | ']' {
+      if n = 0 then
+        let r = Buffer.contents b in
+        let () = Buffer.reset b in
+        r
+      else
+        let () = Buffer.add_char b ']' in
+        lexicon_word_text b (n - 1) lexbuf
+    }
+  | _ as c {
+      let () = Buffer.add_char b c in
+      lexicon_word_text b n lexbuf
+    }
+
+(* "%(" already consummed *)
+and comment = parse
+  | "%(" {
+      let () = comment lexbuf in
+      comment lexbuf
+    }
+  | "%)" ws* {
+      ()
+    }
+  | _ {
+      comment lexbuf
+    }
+
+and skip_ws = parse
+  | ws* {
+      ()
+    }
+
+and parse_define conf b closing ast = parse
+  | ws* (r_ident as f) ws* '(' {
+      let args = parse_params lexbuf in
+      let (al, _) = parse_ast conf b ["end"] [] lexbuf in
+      let (alk, tok) = parse_ast conf b closing [] lexbuf in
+      ( List.rev (Adefine (f, args, al, alk) :: ast)
+      , tok
+      )
+    }
+and parse_params = parse
+  | ws* (r_ident as a) {
+      a :: parse_params_1 lexbuf
+    }
+  | ws* ')' ws* {
+      []
+    }
+and parse_params_1 = parse
+  | ws* ',' ws* (r_ident as a) {
+      a :: parse_params_1 lexbuf
+    }
+  | ws* ')' ws* {
+      []
+    }
+
+and parse_let conf b closing ast = parse
+  |  ws* (r_ident as k) ';' ws* {
+      let (v, _) = parse_ast conf b ["in"] [] lexbuf in
+      let (al, tok) = parse_ast conf b closing [] lexbuf in
+      ( List.rev (Alet (k, v, al) :: ast)
+      , tok
+      )
+    }
+
+and parse_include conf b closing ast = parse
+  | value as file {
+      let a =
+        match List.assoc_opt file !included_files with
+        | Some ast -> Ainclude (file, ast)
+        | None ->
+          match Util.open_templ_fname conf file with
+          | Some (ic, fname) ->
+            let lex2 = Lexing.from_channel ic in
+            let (ast, _) = parse_ast conf (Buffer.create 1024) [] [] lex2 in
+            let () = close_in ic in
+            let () = included_files := (file, ast) :: !included_files in
+            Ainclude (file, ast)
+          | None -> assert false
+      in
+      parse_ast conf b closing (a :: ast) lexbuf
+    }
+
+and parse_apply conf b = parse
+  | (r_ident as f) '%' {
+      let pos = pos lexbuf in
+      assert (`variable ["with"] = variable lexbuf) ;
+      let app =
+        let rec loop () =
+          match parse_ast conf b ["and"; "end"] [] lexbuf with
+          | a, "and" -> a :: loop ()
+          | a, _ -> [ a ]
+        in loop ()
+      in
+      Aapply (pos, f, app)
+    }
+  | (r_ident as f) {
+      let pos = pos lexbuf in
+      let app = parse_tuple lexbuf in
+      Aapply (pos, f, app)
+    }
+
+and parse_expr_stmt = parse
+  | "" {
+      parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf
+    }
+
+and parse_if conf b = parse
+  | "" {
+      let e = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
+      let (a1, a2) =
+        let rec loop () =
+          let (a1, t) = parse_ast conf b ["elseif"; "else"; "end"] [] lexbuf in
+          match t with
+          | "elseif" ->
+            let e2 = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
+            let (a2, a3) = loop () in
+            a1, [ Aif (e2, a2, a3) ]
+          | "else" ->
+            let (a2, _) = parse_ast conf b ["end"] [] lexbuf in
+            a1, a2
+          | _ -> a1, []
+        in loop ()
+      in
+      Aif (e, a1, a2)
+    }
+
+and parse_for conf b = parse
+  | (r_ident as iterator) ';' {
+      let min = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
+      let max = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
+      let (a, _) = parse_ast conf b ["end"] [] lexbuf in
+      Afor (iterator, min, max, a)
+    }
+
+and parse_foreach conf b = parse
+  | "" {
+      let pos = pos lexbuf in
+      let [@warning "-8"] hd :: tl = compound_var lexbuf in
+      let params = parse_foreach_params lexbuf in
+      let (a, _) = parse_ast conf b ["end"] [] lexbuf in
+      Aforeach ((pos, hd, tl), params, a)
+    }
+
+and parse_foreach_params = parse
+  | '(' {
+      parse_tuple_1 lexbuf
+    }
+  | ';'? {
+      []
+    }
+
+{
+
+  let parse_templ conf lexbuf =
+    parse_ast conf (Buffer.create 1024) [] [] lexbuf
+    |> fst
+    |> strip_newlines_after_variables
+
+}

--- a/lib/templ_parser.mll
+++ b/lib/templ_parser.mll
@@ -57,22 +57,21 @@ let wrap fname fn =
     raise e
 
 let line_of_loc conf (fname, bp, ep) =
-  match Util.open_templ conf fname with
+  match try Some (Secure.open_in fname) with _ -> None with
+  | None -> None
   | Some ic ->
-    begin try
-      let rec line i =
-      let rec column j =
+    try
+      let rec line i j =
+        let rec column j j0 =
           if j < bp
           then match input_char ic with
-          | '\n' -> line (i + 1)
-          | _ -> column (j + 1)
+            | '\n' -> line (i + 1) (j + 1)
+            | _ -> column (j + 1) j0
           else
-            (i, bp - j, ep - j)
-        in column 0
-    in Some (line 0)
-      with _ -> None
-    end
-  | None -> None
+            (i+1, bp - j0, ep - j0)
+        in column j j
+      in Some (line 0 0)
+    with _ -> None
 
 let dummy_pos = (-1, -1)
 

--- a/plugins/v7/dune
+++ b/plugins/v7/dune
@@ -6,10 +6,6 @@
 (library
   (name plugin_v7_lib)
   (libraries geneweb geneweb.gwd_lib geneweb.util)
-  (preprocess
-    (per_module
-      ((action (run camlp5o pr_o.cmo pa_extend.cmo q_MLast.cmo %{input-file}))
-       v7_templ)))
   (modules
     v7_cousins
     v7_descend

--- a/plugins/v7/v7_interp.ml
+++ b/plugins/v7/v7_interp.ml
@@ -17,19 +17,13 @@ let error_cannot_access conf fname =
   Hutil.trailer conf
 
 let gen_interp header conf fname ifun env ep =
-  let v = !(Templ.template_file) in
-  Templ.template_file := fname;
-  begin try
-      match Templ.input_templ conf fname with
-      | Some astl ->
-        if header then Util.html conf;
-        let full_name = Util.etc_file_name conf fname in
-        Templ.interp_ast conf ifun env ep
-          (Templ.begin_end_include conf full_name astl)
-      | None -> error_cannot_access conf fname
-    with e -> Templ.template_file := v; raise e
-  end;
-  Templ.template_file := v
+  Geneweb.Templ_parser.wrap fname begin fun () ->
+    match Templ.input_templ conf fname with
+    | Some astl ->
+      if header then Util.html conf;
+      Templ.interp_ast conf ifun env ep astl
+    | None -> error_cannot_access conf fname
+  end
 
 let templ
   : (?no_headers:bool -> string -> config -> base -> person -> unit) ref

--- a/plugins/v7/v7_perso.ml
+++ b/plugins/v7/v7_perso.ml
@@ -1323,18 +1323,12 @@ let extract_var sini s =
 
 let template_file = ref "perso.txt"
 
-let warning_use_has_parents_before_parent (_, bp, ep) var r =
-  if Sys.unix then
-    begin
-      Printf.eprintf "*** <W> %s" !template_file;
-      Printf.eprintf ", chars %d-%d" bp ep;
-      Printf.eprintf "\
-: since v5.00, must test \"has_parents\" before using \"%s\"\n"
-        var;
-      flush stderr;
-      r
-    end
-  else r
+let warning_use_has_parents_before_parent (fname, bp, ep) var r =
+  Printf.sprintf
+    "%s %d-%d: since v5.00, must test \"has_parents\" before using \"%s\"\n"
+    fname bp ep var
+  |> !Geneweb.GWPARAM.syslog `LOG_WARNING ;
+  r
 
 let obsolete_list = ref []
 

--- a/plugins/v7/v7_perso.ml
+++ b/plugins/v7/v7_perso.ml
@@ -1323,7 +1323,7 @@ let extract_var sini s =
 
 let template_file = ref "perso.txt"
 
-let warning_use_has_parents_before_parent (bp, ep) var r =
+let warning_use_has_parents_before_parent (_, bp, ep) var r =
   if Sys.unix then
     begin
       Printf.eprintf "*** <W> %s" !template_file;
@@ -1338,7 +1338,7 @@ let warning_use_has_parents_before_parent (bp, ep) var r =
 
 let obsolete_list = ref []
 
-let obsolete (bp, ep) version var new_var r =
+let obsolete (_, bp, ep) version var new_var r =
   if List.mem var !obsolete_list then r
   else if Sys.unix then
     begin


### PR DESCRIPTION
A major step in the "getting rid of camlp5" path.

This PR needs more testing <strike>and debuging</strike>.

I will update the PR with `v7` plugin update as well as soon as problems in `lib` will be fixed (with modifications backported).

<strike>perso.txt seems fine, updind.txt is a total mess.</strike>

It could be slightly faster than the camlp5 thing (well, it should run at least as fast). It is more a dumb translation.

```
7e9b01217d5cd6ff93e3f3167a086c420e771965
	minor_words : +1,766,989
	promoted_words : +322,724
	major_words : +334,546
	minor_collections : +8
	major_collections : +2
	heap_words : 0
	heap_chunks : 0
	live_words : +327,132
	live_blocks : +84,305
	free_words : -327132
	free_blocks : +181
	largest_free : -334546
	fragments : 0
	compactions : 0
	top_heap_words : 0
        stack_size : 0

7926495bce8202d2d262c89ff85cc6a3ebe9491d
	minor_words : +1,659,239
	promoted_words : +295,818
	major_words : +297,874
	minor_collections : +8
	major_collections : +2
	heap_words : 0
	heap_chunks : 0
	live_words : +295,982
	live_blocks : +75,010
	free_words : -295982
	free_blocks : +248
	largest_free : -297874
	fragments : 0
	compactions : 0
	top_heap_words : 0
	stack_size : 0
```