### PR TITLE
Raise error st gwd start time if tag file is missing

### DIFF
--- a/etc/macOS/geneweb.command
+++ b/etc/macOS/geneweb.command
@@ -55,11 +55,11 @@ else
   echo "Starting gwd..."
 fi
 "$DIR/gw/gwd" -hd "$DIR/gw" > gwd.log 2>&1 &
-sleep 1
+sleep 2
 gwd_pid=`ps -ef|grep '/gwd'|grep -v grep|awk '{print $2}'`
 if test "$gwd_pid" = ""; then
   if test "$LANG" = "fr"; then echo Echec gwd; else echo Failed gwd; fi
-  cat
+  cat gwd.log
   exit 1
 fi
 


### PR DESCRIPTION
Self explanatory.
In my personnal gwd launch file, I had to add a `sleep 2;` command to see the full content of the log file!!
The various `flush stderr;` do not seem to be sufficient!
Any idea??
