### PR TITLE
begin/end include adjustments for js and css

### DIFF
--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1,12 +1,6 @@
 open Config
 open TemplAst
 
-let include_begin conf fname =
-  if conf.debug then Output.print_string conf ("\n<!-- begin include " ^ fname ^ " -->\n")
-
-let include_end conf fname =
-  if conf.debug then Output.print_string conf ("\n<!-- end include " ^ fname ^ " -->\n")
-
 exception Exc_located of loc * exn
 
 let raise_with_loc loc = function
@@ -884,9 +878,9 @@ let rec interp_ast conf ifun env =
         let s = squeeze_spaces s in
         print_ast_list env ep (Atext (loc, s) :: al)
     | Ainclude (fname, astl) :: al ->
-        include_begin conf fname ;
+        Util.include_begin conf fname ;
         print_ast_list env ep astl;
-        include_end conf fname ;
+        Util.include_end conf fname ;
         print_ast_list !m_env ep al
     | [a] -> print_ast env ep a
     | a :: al -> print_ast env ep a; print_ast_list env ep al
@@ -944,9 +938,9 @@ and print_var print_ast_list conf ifun env ep loc sl =
             begin match input_templ conf templ with
               | Some astl ->
                 let () = Templ_parser.(included_files := (templ, astl) :: !included_files) in
-                include_begin conf fname ;
+                Util.include_begin conf fname ;
                 print_ast_list env ep astl ;
-                include_end conf fname ;
+                Util.include_end conf fname ;
               | None -> Output.printf conf " %%%s?" (String.concat "." sl)
               end
             | None -> Output.printf conf " %%%s?" (String.concat "." sl)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1064,6 +1064,24 @@ let bpath bname = !GWPARAM.bpath bname
 let copy_from_templ_ref = ref (fun _ _ _ -> assert false)
 let copy_from_templ conf env ic = !copy_from_templ_ref conf env ic
 
+let include_begin conf fname =
+  if conf.debug then
+    let ext = Filename.extension fname in
+    let (com_b, com_e) =
+      if (ext = ".css" || ext = ".js") then ("\n/*", "*/\n") else ("\n<!--", "-->\n")
+    in
+    let s = Printf.sprintf "begin include %s" fname in
+    Output.print_string conf (com_b ^ s ^ com_e)
+
+let include_end conf fname =
+  if conf.debug then
+    let ext = Filename.extension fname in
+    let (com_b, com_e) =
+      if (ext = ".css" || ext = ".js") then ("\n/*", "*/\n") else ("\n<!--", "-->\n")
+    in
+    let s = Printf.sprintf "end include %s" fname in
+    Output.print_string conf (com_b ^ s ^ com_e)
+
 (* ************************************************************************ *)
 (*  [Fonc] etc_file_name : config -> string -> string                       *)
 (** [Description] : Renvoie le chemin vers le fichier de template passé
@@ -1175,9 +1193,9 @@ let open_templ conf fname = Opt.map fst (open_templ_fname conf fname)
 let include_template conf env fname failure =
   match open_etc_file fname with
   | Some (ic, fname) ->
-    if conf.debug then Output.printf conf "\n<!-- begin include %s -->\n" fname;
+    include_begin conf fname;
     copy_from_templ conf env ic;
-    if conf.debug then Output.printf conf "<!-- end include %s -->\n" fname;
+    include_end conf fname;
   | None -> failure ()
 
 let image_prefix conf = conf.image_prefix

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -11,6 +11,9 @@ val bpath : string -> string
 
 val search_in_assets : string -> string
 
+val include_begin : config -> string -> unit
+val include_end : config -> string -> unit
+
 val etc_file_name : config -> string -> string
 
 val escache_value : base -> string

--- a/plugins/v7/v7_templ.ml
+++ b/plugins/v7/v7_templ.ml
@@ -2,12 +2,6 @@ open Geneweb
 open Config
 open TemplAst
 
-let include_begin conf fname =
-  if conf.debug then Output.print_string conf ("\n<!-- begin include " ^ fname ^ " -->\n")
-
-let include_end conf fname =
-  if conf.debug then Output.print_string conf ("\n<!-- end include " ^ fname ^ " -->\n")
-
 exception Exc_located of loc * exn
 
 let raise_with_loc loc = function
@@ -957,9 +951,9 @@ let rec interp_ast conf ifun env =
         let s = squeeze_spaces s in
         print_ast_list env ep (Atext (loc, s) :: al)
     | Ainclude (fname, astl) :: al ->
-        include_begin conf fname ;
+        Util.include_begin conf fname ;
         print_ast_list env ep astl;
-        include_end conf fname ;
+        Util.include_end conf fname ;
         print_ast_list !m_env ep al
     | [a] -> print_ast env ep a
     | a :: al -> print_ast env ep a; print_ast_list env ep al
@@ -1017,9 +1011,9 @@ and print_var print_ast_list conf ifun env ep loc sl =
             begin match input_templ conf templ with
               | Some astl ->
                 let () = Templ_parser.(included_files := (templ, astl) :: !included_files) in
-                include_begin conf fname ;
+                Util.include_begin conf fname ;
                 print_ast_list env ep astl ;
-                include_end conf fname ;
+                Util.include_end conf fname ;
               | None -> Output.printf conf " %%%s?" (String.concat "." sl)
               end
             | None -> Output.printf conf " %%%s?" (String.concat "." sl)


### PR DESCRIPTION
Choose right comment delimiter for .js and .css files