### PR TITLE
Check of secure should stop only when all prefixes have failed

### DIFF
--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -50,8 +50,8 @@ let check fname =
     let rec loop = function
       | d :: dl ->
         begin match suffix d df with
-          | Some bf -> not (List.mem Filename.parent_dir_name bf)
-          | None -> loop dl
+          | Some bf when not (List.mem Filename.parent_dir_name bf) -> true
+          | _ -> loop dl
         end
       | [] ->
         if Filename.is_relative fname


### PR DESCRIPTION
The module `Secure` serves as a checker for correct file access. Among other things, it allows to search in specific "valid" directories that are passed in some options. The `check` function tests all paths and, if it finds a prefix that matches a valid directory, it tests that the file belong to the said directory.
However, it stops after finding one prefix, while it should check all the valid directories.

This caused a bug with the scripts in `distribution/`, which are fixed with this PR.