### PR TITLE
Improve homonyms list display

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -112,55 +112,14 @@ let specify conf base n pl =
   Output.print_sstring conf "<ul>\n";
   (* Construction de la table des sosa de la base *)
   let () = SosaCache.build_sosa_ht conf base in
-  List.iter begin fun (p, tl) ->
-    Output.print_sstring conf "<li>";
-    SosaCache.print_sosa conf base p true;
-    begin match tl with
-      | [] ->
-        Output.print_sstring conf " " ;
-        Output.print_string conf (referenced_person_title_text conf base p)
-      | t :: _ ->
-        Output.print_sstring conf {|<a href="|} ;
-        Output.print_string conf (commd conf) ;
-        Output.print_string conf (acces conf base p) ;
-        Output.print_sstring conf {|"> |};
-        Output.print_string conf (titled_person_text conf base p t);
-        Output.print_sstring conf "</a> ";
-        List.iter (fun t -> Output.print_string conf (one_title_text base t)) tl
-    end;
-    Output.print_string conf (DateDisplay.short_dates_text conf base p);
-    if authorized_age conf base p
-    then begin match get_first_names_aliases p with
-      | [] -> ()
-      | fnal ->
-        Output.print_sstring conf "\n<em>(" ;
-        Mutil.list_iter_first begin fun first fna ->
-          if not first then Output.print_sstring conf ", ";
-          sou base fna |> Util.escape_html |> Output.print_string conf
-        end fnal ;
-        Output.print_sstring conf ")</em>"
-    end ;
-    let spouses =
-      Array.fold_right begin fun ifam spouses ->
-        let cpl = foi base ifam in
-        let spouse = pget conf base (Gutil.spouse (get_iper p) cpl) in
-        if p_surname base spouse <> "?" then spouse :: spouses
-        else spouses
-      end (get_family p) []
-    in
-    begin match spouses with
-      | [] -> ()
-      | h :: hl ->
-        Output.print_sstring conf ", <em>&amp; " ;
-        List.fold_left
-          (fun s h -> s ^^^ ",\n" ^<^ person_title_text conf base h)
-          (person_title_text conf base h) hl
-        |> Output.print_string conf ;
-        Output.print_sstring conf "</em>"
-    end ;
-    Output.print_sstring conf "</li>"
-  end ptll;
-  Output.print_sstring conf "</ul>" ;
+  List.iter
+    (fun (p, tl) ->
+       Output.print_string conf "<li>\n";
+       SosaCache.print_sosa conf base p true;
+       Update.print_person_parents_and_spouse conf base p;
+       Output.print_string conf "</li>\n"
+    ) ptll;
+  Output.print_string conf "</ul>\n";
   Hutil.trailer conf
 
 let incorrect_request ?(comment = "") conf =

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -113,13 +113,13 @@ let specify conf base n pl =
   (* Construction de la table des sosa de la base *)
   let () = SosaCache.build_sosa_ht conf base in
   List.iter
-    (fun (p, tl) ->
-       Output.print_string conf "<li>\n";
+    (fun (p, _tl) ->
+       Output.print_sstring conf "<li>\n";
        SosaCache.print_sosa conf base p true;
-       Update.print_person_parents_and_spouse conf base p;
-       Output.print_string conf "</li>\n"
+       Update.print_person_parents_and_spouses conf base p;
+       Output.print_sstring conf "</li>\n"
     ) ptll;
-  Output.print_string conf "</ul>\n";
+  Output.print_sstring conf "</ul>\n";
   Hutil.trailer conf
 
 let incorrect_request ?(comment = "") conf =

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -9803,6 +9803,10 @@ sl: poroke/poroke
 sv: äktenskap/äktenskap
 tr: eş/eşler
 
+    marriages with
+en: relations or marriages with
+fr: relations ou marriages avec
+
     married
 af: getroud
 bg: в брак

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -172,6 +172,9 @@ let print_person_parents_and_spouses conf base p =
   Output.print_sstring conf " ";
   Output.print_string conf (escape_html @@ p_surname base p);
   Output.print_sstring conf "</a>";
+  let pub_name = sou base (get_public_name p) in
+  if pub_name <> "" then
+    Output.print_sstring conf (Printf.sprintf " (%s)" pub_name);
   Output.print_string conf (DateDisplay.short_dates_text conf base p);
   let cop = Util.child_of_parent conf base p in
   if String.length (cop :> string) > 0 then (

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -159,16 +159,17 @@ let rec infer_death conf base p =
       - p    : person
     [Retour] : unit
     [Rem] : Not visible.                                                      *)
-let print_person_parents_and_spouse conf base p =
-  Output.print_sstring conf {|<a href="|};
-  Output.print_string conf (commd conf);
-  Output.print_string conf (acces conf base p);
-  Output.print_sstring conf {|">|};
-  Output.print_string conf (escape_html @@ p_first_name base p);
-  Output.print_sstring conf ".";
-  Output.print_sstring conf (string_of_int @@ get_occ p);
-  Output.print_sstring conf " ";
-  Output.print_string conf (escape_html @@ p_surname base p);
+(* ************************************************************************** *)
+let print_person_parents_and_spouses conf base p =
+  Output.print_sstring conf {|<a href="|} ;
+  Output.print_string conf (commd conf) ;
+  Output.print_string conf (acces conf base p) ;
+  Output.print_sstring conf {|">|} ;
+  Output.print_string conf (escape_html @@ p_first_name base p) ;
+  Output.print_sstring conf "." ;
+  Output.print_sstring conf (string_of_int @@ get_occ p) ;
+  Output.print_sstring conf " " ;
+  Output.print_string conf (escape_html @@ p_surname base p) ;
   Output.print_sstring conf "</a>";
   Output.print_string conf (DateDisplay.short_dates_text conf base p);
   let cop = Util.child_of_parent conf base p in
@@ -193,7 +194,7 @@ let print_same_name conf base p =
       List.iter
         (fun p ->
           Output.print_sstring conf "<li>";
-          print_person_parents_and_spouse conf base p;
+          print_person_parents_and_spouses conf base p;
           Output.print_sstring conf "</li>")
         pl;
       Output.print_sstring conf "</ul></p>"

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -150,6 +150,8 @@ let rec infer_death conf base p =
 
 (* ************************************************************************** *)
 
+(* ************************************************************************** *)
+
 (** [Description] : Print several information to distinguish homonyms. The
       information includes name of the person, name of the parents,
       name of the spouse.
@@ -159,17 +161,16 @@ let rec infer_death conf base p =
       - p    : person
     [Retour] : unit
     [Rem] : Not visible.                                                      *)
-(* ************************************************************************** *)
 let print_person_parents_and_spouses conf base p =
-  Output.print_sstring conf {|<a href="|} ;
-  Output.print_string conf (commd conf) ;
-  Output.print_string conf (acces conf base p) ;
-  Output.print_sstring conf {|">|} ;
-  Output.print_string conf (escape_html @@ p_first_name base p) ;
-  Output.print_sstring conf "." ;
-  Output.print_sstring conf (string_of_int @@ get_occ p) ;
-  Output.print_sstring conf " " ;
-  Output.print_string conf (escape_html @@ p_surname base p) ;
+  Output.print_sstring conf {|<a href="|};
+  Output.print_string conf (commd conf);
+  Output.print_string conf (acces conf base p);
+  Output.print_sstring conf {|">|};
+  Output.print_string conf (escape_html @@ p_first_name base p);
+  Output.print_sstring conf ".";
+  Output.print_sstring conf (string_of_int @@ get_occ p);
+  Output.print_sstring conf " ";
+  Output.print_string conf (escape_html @@ p_surname base p);
   Output.print_sstring conf "</a>";
   Output.print_string conf (DateDisplay.short_dates_text conf base p);
   let cop = Util.child_of_parent conf base p in

--- a/lib/update.mli
+++ b/lib/update.mli
@@ -42,7 +42,7 @@ val infer_death_from_parents : config -> base -> family -> death
 (** [infer_death_from_parents conf base fam] infer death status for a new children in this family *)
 
 val print_same_name : config -> base -> person -> unit
-val print_person_parents_and_spouse : config -> base -> person -> unit
+val print_person_parents_and_spouses : config -> base -> person -> unit
 
 val insert_person :
   config ->

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1663,10 +1663,9 @@ let husband_wife conf base p all =
         let conjoint = pget conf base conjoint in
         if not @@ is_empty_name conjoint then
           Printf.sprintf (relation_txt conf (get_sex p) fam) (fun () -> "")
-             |> translate_eval
-             |> Adef.safe
+          |> translate_eval |> Adef.safe
         else Adef.safe ""
-      else (transl conf "marriages with") |> Adef.safe
+      else transl conf "marriages with" |> Adef.safe
     else Adef.safe ""
   in
   let res =
@@ -1675,12 +1674,14 @@ let husband_wife conf base p all =
         let fam = foi base (get_family p).(i) in
         let conjoint = Gutil.spouse (get_iper p) fam in
         let conjoint = pget conf base conjoint in
-        if not @@ is_empty_name conjoint
-        then
+        if not @@ is_empty_name conjoint then
           let res =
             res
-            ^>^ translate_eval (" " ^<^ gen_person_text conf base conjoint ^^^ relation_date conf fam
-                                :> string)
+            ^>^ translate_eval
+                  (" "
+                   ^<^ gen_person_text conf base conjoint
+                   ^^^ relation_date conf fam
+                    :> string)
             ^ ","
           in
           if all then loop (i + 1) res else res
@@ -1691,8 +1692,8 @@ let husband_wife conf base p all =
   in
   let res = (res :> string) in
   let res =
-    if String.length res > 1
-    then (String.sub res 0 (String.length res - 1)) else res
+    if String.length res > 1 then String.sub res 0 (String.length res - 1)
+    else res
   in
   Adef.safe res
 


### PR DESCRIPTION
In Request.specify, use the code of Update.print_person_parents_and_spouses to display list of persons.
In Util.husband_wife, detect multiple unions and adjust union kind to the situation.
Use plural in Update.print_person_parents_and_spouses!

Supersedes PR #1057
