### PR TITLE
Replace %bvar.static_path; by %static_path; in index.txt

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1235,7 +1235,12 @@ let make_conf from_addr request script_name env =
        if !images_url <> "" then !images_url
        else if !(Wserver.cgi) then ar.ar_command ^ "?m=IM&v="
        else "images";
-     cgi
+    static_path =
+      begin match Sys.getenv_opt "GW_STATIC_PATH" with
+      | Some x -> x
+      | None -> "../distribution/gw/etc/"
+      end
+    ; cgi
     ; output_conf
     ; forced_plugins = !forced_plugins
     ; plugins = !plugins

--- a/hd/etc/css.txt
+++ b/hd/etc/css.txt
@@ -14,11 +14,11 @@ li.female { list-style-type: circle; list-style-image: url('%image_prefix;/femal
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/all.css"
       integrity="sha384-REHJTs1r2ErKBuJB0fCK99gCYsVjwxHrSU0N7I1zl9vZbggVJXRMsv/sLlOAGb4M" crossorigin="anonymous">
   %else;
-    <link rel="stylesheet" href="%if;(cgi)%bvar.static_path;%end;css/bootstrap.min.css?version=4.4.1">
-    <link rel="stylesheet" href="%if;(cgi)%bvar.static_path;%end;css/all.min.css?version=5.12.0">
+    <link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/bootstrap.min.css?version=4.4.1">
+    <link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/all.min.css?version=5.12.0">
   %end;
 %end;
-<link rel="stylesheet" href="%if;(cgi)%bvar.static_path;%end;css/css.css">
+<link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/css.css">
 %if;(bvar.css_prop != "")
-<link rel="stylesheet" href="%if;(cgi)%bvar.static_path;%end;css/%bvar.css_prop;">
+<link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/%bvar.css_prop;">
 %end;

--- a/hd/etc/css.txt
+++ b/hd/etc/css.txt
@@ -14,11 +14,11 @@ li.female { list-style-type: circle; list-style-image: url('%image_prefix;/femal
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/all.css"
       integrity="sha384-REHJTs1r2ErKBuJB0fCK99gCYsVjwxHrSU0N7I1zl9vZbggVJXRMsv/sLlOAGb4M" crossorigin="anonymous">
   %else;
-    <link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/bootstrap.min.css?version=4.4.1">
-    <link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/all.min.css?version=5.12.0">
+    <link rel="stylesheet" href="%static_path;css/bootstrap.min.css?version=4.4.1">
+    <link rel="stylesheet" href="%static_path;css/all.min.css?version=5.12.0">
   %end;
 %end;
-<link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/css.css">
+<link rel="stylesheet" href="%static_path;css/css.css">
 %if;(bvar.css_prop != "")
-<link rel="stylesheet" href="%if;(cgi)%static_path;%end;css/%bvar.css_prop;">
+<link rel="stylesheet" href="%static_path;css/%bvar.css_prop;">
 %end;

--- a/hd/etc/index.txt
+++ b/hd/etc/index.txt
@@ -7,13 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 
-%if;(cgi)
-  <link rel="stylesheet" href="%static_path;css/bootstrap.min.css?version=4.6.1">
-  <link rel="stylesheet" href="%static_path;css/all.min.css?version=6.00.0">
-  <link rel="stylesheet" href="%static_path;css/css.css">
-%else;
-  %include;css
-%end;
+%include;css
 
 </head>
 <body%body_prop;>

--- a/hd/etc/index.txt
+++ b/hd/etc/index.txt
@@ -6,7 +6,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
-%include;css
+
+%if;(cgi)
+  <link rel="stylesheet" href="%static_path;css/bootstrap.min.css?version=4.6.1">
+  <link rel="stylesheet" href="%static_path;css/all.min.css?version=6.00.0">
+  <link rel="stylesheet" href="%static_path;css/css.css">
+%else;
+  %include;css
+%end;
+
 </head>
 <body%body_prop;>
 <div class="container text-center ">
@@ -21,8 +29,10 @@
   <button type="submit" class="btn btn-outline-secondary ml-2" value="">Ok</button>
 </form>
 
-
-<a href="http://localhost:2316/gwsetup?v=list.htm">[*available genealogies]</a>
+%( TODO find server name and port number %)
+%if;(not cgi)
+  <a href="http://localhost:2316/gwsetup?v=list.htm">[*available genealogies]</a>
+%end;
 </div>
 
 <h3 class="text-center mt-5">[*select lang]</h3>

--- a/hd/etc/js.txt
+++ b/hd/etc/js.txt
@@ -6,16 +6,16 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"
       integrity="sha384-6khuMg9gaYr5AxOqhkVIODVIvm9ynTT5J4V1cfthmT+emCG6yVmEZsRHdxlotUnm" crossorigin="anonymous"></script>
   %else;
-    <script src="%if;(cgi)%bvar.static_path;%end;js/jquery.min.js?version=3.5.0"></script>
-    <script src="%if;(cgi)%bvar.static_path;%end;js/bootstrap.bundle.min.js?version=4.4.1"></script>
+    <script src="%if;(cgi)%static_path;%end;js/jquery.min.js?version=3.5.0"></script>
+    <script src="%if;(cgi)%static_path;%end;js/bootstrap.bundle.min.js?version=4.4.1"></script>
   %end;
   %if;(evar.m!="MOD_DATA")
   <script>
     $('#load_once_p_mod').one('click', function() {
-      $.getScript('%if;(cgi)%bvar.static_path;%end;js/p_mod.js');
+      $.getScript('%if;(cgi)%static_path;%end;js/p_mod.js');
     });
     $('#load_once_copylink').one('click', function() {
-      $.getScript('%if;(cgi)%bvar.static_path;%end;js/copylink.js');
+      $.getScript('%if;(cgi)%static_path;%end;js/copylink.js');
     });
   </script>
   %end;
@@ -66,7 +66,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/autosize.js/4.0.2/autosize.min.js" 
       integrity="sha384-gqYjRLBp7SeF6PCEz2XeqqNyvtxuzI3DuEepcrNHbrO+KG3woVNa/ISn/i8gGtW8" crossorigin="anonymous"></script>
   %else;
-     <script src="%if;(cgi)%bvar.static_path;%end;js/autosize.min.js?version=4.0.2"></script>
+     <script src="%if;(cgi)%static_path;%end;js/autosize.min.js?version=4.0.2"></script>
    %end;
   <script>autosize(document.querySelectorAll('textarea'));</script>
 %end;

--- a/hd/etc/js.txt
+++ b/hd/etc/js.txt
@@ -6,16 +6,16 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"
       integrity="sha384-6khuMg9gaYr5AxOqhkVIODVIvm9ynTT5J4V1cfthmT+emCG6yVmEZsRHdxlotUnm" crossorigin="anonymous"></script>
   %else;
-    <script src="%if;(cgi)%static_path;%end;js/jquery.min.js?version=3.5.0"></script>
-    <script src="%if;(cgi)%static_path;%end;js/bootstrap.bundle.min.js?version=4.4.1"></script>
+    <script src="%static_path;js/jquery.min.js?version=3.5.0"></script>
+    <script src="%static_path;js/bootstrap.bundle.min.js?version=4.4.1"></script>
   %end;
   %if;(evar.m!="MOD_DATA")
   <script>
     $('#load_once_p_mod').one('click', function() {
-      $.getScript('%if;(cgi)%static_path;%end;js/p_mod.js');
+      $.getScript('%static_path;js/p_mod.js');
     });
     $('#load_once_copylink').one('click', function() {
-      $.getScript('%if;(cgi)%static_path;%end;js/copylink.js');
+      $.getScript('%static_path;js/copylink.js');
     });
   </script>
   %end;
@@ -66,7 +66,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/autosize.js/4.0.2/autosize.min.js" 
       integrity="sha384-gqYjRLBp7SeF6PCEz2XeqqNyvtxuzI3DuEepcrNHbrO+KG3woVNa/ISn/i8gGtW8" crossorigin="anonymous"></script>
   %else;
-     <script src="%if;(cgi)%static_path;%end;js/autosize.min.js?version=4.0.2"></script>
+     <script src="%static_path;js/autosize.min.js?version=4.0.2"></script>
    %end;
   <script>autosize(document.querySelectorAll('textarea'));</script>
 %end;

--- a/hd/etc/modules/arbre_h7.txt
+++ b/hd/etc/modules/arbre_h7.txt
@@ -1,5 +1,5 @@
   <!-- $Id: arbre_h7.txt,v 7.00 2016/05/02 23:28:26 mr Exp $ -->
-  <link type="text/css" href="%if;cgi;%bvar.static_path;%end;modules/arbre_h7%bvar.css;.css" media="all" rel="stylesheet" %/>
+  <link type="text/css" href="%if;cgi;%static_path;%end;modules/arbre_h7%bvar.css;.css" media="all" rel="stylesheet" %/>
 
   %let;l_fs;%if;(evar.fs != "")%evar.fs;%else;9%end;%in;
   %let;l_wi;%if;(evar.wi != "")%evar.wi;%else;980%end;%in;

--- a/hd/etc/modules/arbre_h7.txt
+++ b/hd/etc/modules/arbre_h7.txt
@@ -1,5 +1,5 @@
   <!-- $Id: arbre_h7.txt,v 7.00 2016/05/02 23:28:26 mr Exp $ -->
-  <link type="text/css" href="%if;cgi;%static_path;%end;modules/arbre_h7%bvar.css;.css" media="all" rel="stylesheet" %/>
+  <link type="text/css" href="%static_path;modules/arbre_h7%bvar.css;.css" media="all" rel="stylesheet" %/>
 
   %let;l_fs;%if;(evar.fs != "")%evar.fs;%else;9%end;%in;
   %let;l_wi;%if;(evar.wi != "")%evar.wi;%else;980%end;%in;

--- a/hd/etc/modules/arbre_hi.txt
+++ b/hd/etc/modules/arbre_hi.txt
@@ -43,8 +43,8 @@
   -->
 </script>
 
-<script type="text/javascript" src="%if;(cgi)%static_path;%end;js/jquery.min.js"></script>
-<script type="text/javascript" src="%if;(cgi)%static_path;%end;js/jquery.line.js"></script>
+<script type="text/javascript" src="%static_path;js/jquery.min.js"></script>
+<script type="text/javascript" src="%static_path;js/jquery.line.js"></script>
 
 %define;implexc(x0,y0,x1,y1)
   <span style="top:%top;px;left:%left;px;font-family:monospace;">x

--- a/hd/etc/modules/arbre_hi.txt
+++ b/hd/etc/modules/arbre_hi.txt
@@ -43,8 +43,8 @@
   -->
 </script>
 
-<script type="text/javascript" src="%if;(cgi)%bvar.static_path;%end;js/jquery.min.js"></script>
-<script type="text/javascript" src="%if;(cgi)%bvar.static_path;%end;js/jquery.line.js"></script>
+<script type="text/javascript" src="%if;(cgi)%static_path;%end;js/jquery.min.js"></script>
+<script type="text/javascript" src="%if;(cgi)%static_path;%end;js/jquery.line.js"></script>
 
 %define;implexc(x0,y0,x1,y1)
   <span style="top:%top;px;left:%left;px;font-family:monospace;">x

--- a/hd/etc/templm/anctree_h7.txt
+++ b/hd/etc/templm/anctree_h7.txt
@@ -1,5 +1,5 @@
   <!-- $Id: anctree_h7.txt,v 7.00 2016/05/02 23:28:26 mr Exp $ -->
-  <link type="text/css" href="%bvar.static_path;/modules/arbre_h7%bvar.css;.css" media="all" rel="stylesheet" %/>
+  <link type="text/css" href="%static_path;/modules/arbre_h7%bvar.css;.css" media="all" rel="stylesheet" %/>
 
   %let;l_fs;%if;(evar.fs != "")%evar.fs;%else;9%end;%in;
   %let;l_wi;%if;(evar.wi != "")%evar.wi;%else;980%end;%in;

--- a/hd/etc/templm/anctree_hi.txt
+++ b/hd/etc/templm/anctree_hi.txt
@@ -23,8 +23,8 @@
 </script>
 
 %if;(evar.implx = "on")
-<script type="text/javascript" src="%if;(cgi)%bvar.static_path;%end;templm/jquery.min.js"></script>
-<script type="text/javascript" src="%if;(cgi)%bvar.static_path;%end;templm/jquery.line.js"></script>
+<script type="text/javascript" src="%if;(cgi)%static_path;%end;templm/jquery.min.js"></script>
+<script type="text/javascript" src="%if;(cgi)%static_path;%end;templm/jquery.line.js"></script>
 %end;
 
 %define;implex()

--- a/hd/etc/templm/anctree_hi.txt
+++ b/hd/etc/templm/anctree_hi.txt
@@ -23,8 +23,8 @@
 </script>
 
 %if;(evar.implx = "on")
-<script type="text/javascript" src="%if;(cgi)%static_path;%end;templm/jquery.min.js"></script>
-<script type="text/javascript" src="%if;(cgi)%static_path;%end;templm/jquery.line.js"></script>
+<script type="text/javascript" src="%static_path;templm/jquery.min.js"></script>
+<script type="text/javascript" src="%static_path;templm/jquery.line.js"></script>
 %end;
 
 %define;implex()

--- a/hd/etc/templm/css.txt
+++ b/hd/etc/templm/css.txt
@@ -1,7 +1,7 @@
 <!-- $Id: templm/css.txt, v7.00 2017/11/11 hg 05:46:40 $ -->
-<link rel="stylesheet" href="%if;(cgi)%static_path;%end;templm/css%bvar.css;.css" media="all" title="css%bvar.css;"%/>
+<link rel="stylesheet" href="%static_path;templm/css%bvar.css;.css" media="all" title="css%bvar.css;"%/>
 
-<script src=%if;(cgi)%static_path;%end;templm/js.js></script>
+<script src=%static_path;templm/js.js></script>
 %if;(bvar.uppercase = "yes")
   <script>
   <!--
@@ -14,7 +14,7 @@
     %end;
   -->
   </script>
-  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase.js></script>
+  <script src=%static_path;templm/js_uppercase.js></script>
 %else;
-  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase_no.js></script>
+  <script src=%static_path;templm/js_uppercase_no.js></script>
 %end;

--- a/hd/etc/templm/css.txt
+++ b/hd/etc/templm/css.txt
@@ -1,7 +1,7 @@
 <!-- $Id: templm/css.txt, v7.00 2017/11/11 hg 05:46:40 $ -->
-<link rel="stylesheet" href="%if;(cgi)%bvar.static_path;%end;templm/css%bvar.css;.css" media="all" title="css%bvar.css;"%/>
+<link rel="stylesheet" href="%if;(cgi)%static_path;%end;templm/css%bvar.css;.css" media="all" title="css%bvar.css;"%/>
 
-<script src=%if;(cgi)%bvar.static_path;%end;templm/js.js></script>
+<script src=%if;(cgi)%static_path;%end;templm/js.js></script>
 %if;(bvar.uppercase = "yes")
   <script>
   <!--
@@ -14,7 +14,7 @@
     %end;
   -->
   </script>
-  <script src=%if;(cgi)%bvar.static_path;%end;templm/js_uppercase.js></script>
+  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase.js></script>
 %else;
-  <script src=%if;(cgi)%bvar.static_path;%end;templm/js_uppercase_no.js></script>
+  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase_no.js></script>
 %end;

--- a/hd/etc/templm/doc_templm.txt
+++ b/hd/etc/templm/doc_templm.txt
@@ -160,7 +160,7 @@
   </td>
 </tr>
 <tr>
-  <td>static_path=%bvar.static_path;</td>
+  <td>static_path=%static_path;</td>
   <td>
     En mode CGI :
     <ul>

--- a/hd/etc/templm/js_perso_accesskey.txt
+++ b/hd/etc/templm/js_perso_accesskey.txt
@@ -1,5 +1,5 @@
 <!-- $Id: js_perso_accesskey.txt,v 08/02/2016 05:44:54 A2 Exp $ -->
-<script src=%if;(cgi)%bvar.static_path;%end;templm/js_perso_accesskey.js></script>%(
+<script src=%if;(cgi)%static_path;%end;templm/js_perso_accesskey.js></script>%(
    To personalize the descriptions of shortcuts, change the character under | column
 trl       |   in accordance with the definitions of shortucts in js_perso_accesskey.js case "_"%)
 %let;laWk;W%in;%( search %)

--- a/hd/etc/templm/js_perso_accesskey.txt
+++ b/hd/etc/templm/js_perso_accesskey.txt
@@ -1,5 +1,5 @@
 <!-- $Id: js_perso_accesskey.txt,v 08/02/2016 05:44:54 A2 Exp $ -->
-<script src=%if;(cgi)%static_path;%end;templm/js_perso_accesskey.js></script>%(
+<script src=%static_path;templm/js_perso_accesskey.js></script>%(
    To personalize the descriptions of shortcuts, change the character under | column
 trl       |   in accordance with the definitions of shortucts in js_perso_accesskey.js case "_"%)
 %let;laWk;W%in;%( search %)

--- a/hd/etc/templm/js_upd.txt
+++ b/hd/etc/templm/js_upd.txt
@@ -1,10 +1,10 @@
 <!-- $Id: templm/js_upd.txt,v 7.00 2014/11/18 10:17:06 mr Exp $ --> 
-<script src="%if;(cgi)%bvar.static_path;%end;templm/js_upd.js"></script>
+<script src="%if;(cgi)%static_path;%end;templm/js_upd.js"></script>
 %if;(bvar.jquery = "no")
-  <script src="%if;(cgi)%bvar.static_path;%end;templm/js_upd_jq_no.js"></script>
+  <script src="%if;(cgi)%static_path;%end;templm/js_upd_jq_no.js"></script>
 %else;
-  <script src="%if;(cgi)%bvar.static_path;%end;templm/js_upd_jq.js"></script>
-  <script src="%if;(cgi)%bvar.static_path;%end;js/jquery.min.js"></script>
+  <script src="%if;(cgi)%static_path;%end;templm/js_upd_jq.js"></script>
+  <script src="%if;(cgi)%static_path;%end;js/jquery.min.js"></script>
 %end;
 %if;(bvar.uppercase = "yes")
   <script>
@@ -16,7 +16,7 @@
   %end;
   -->
   </script>
-  <script src=%if;(cgi)%bvar.static_path;%end;templm/js_uppercase.js></script>
+  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase.js></script>
 %else;
-  <script src=%if;(cgi)%bvar.static_path;%end;templm/js_uppercase_no.js></script>
+  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase_no.js></script>
 %end;

--- a/hd/etc/templm/js_upd.txt
+++ b/hd/etc/templm/js_upd.txt
@@ -1,10 +1,10 @@
 <!-- $Id: templm/js_upd.txt,v 7.00 2014/11/18 10:17:06 mr Exp $ --> 
-<script src="%if;(cgi)%static_path;%end;templm/js_upd.js"></script>
+<script src="%static_path;templm/js_upd.js"></script>
 %if;(bvar.jquery = "no")
-  <script src="%if;(cgi)%static_path;%end;templm/js_upd_jq_no.js"></script>
+  <script src="%static_path;templm/js_upd_jq_no.js"></script>
 %else;
-  <script src="%if;(cgi)%static_path;%end;templm/js_upd_jq.js"></script>
-  <script src="%if;(cgi)%static_path;%end;js/jquery.min.js"></script>
+  <script src="%static_path;templm/js_upd_jq.js"></script>
+  <script src="%static_path;js/jquery.min.js"></script>
 %end;
 %if;(bvar.uppercase = "yes")
   <script>
@@ -16,7 +16,7 @@
   %end;
   -->
   </script>
-  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase.js></script>
+  <script src=%static_path;templm/js_uppercase.js></script>
 %else;
-  <script src=%if;(cgi)%static_path;%end;templm/js_uppercase_no.js></script>
+  <script src=%static_path;templm/js_uppercase_no.js></script>
 %end;

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -93,7 +93,9 @@ type config =
     image_prefix : string;
     (* if true, the base name is in the b argument of the query string: ?b=BASE&...
        if false, the base name is the last element of the uri path: .../base?... *)
-    cgi : bool
+    static_path : string
+    (* in CGI mode, provides location of etc files to Apache for direct loading *)
+  ; cgi : bool
   ; forced_plugins : string list
   ; plugins : string list
  }
@@ -153,6 +155,7 @@ let empty =
   ; time = 0,0,0
   ; ctime = 0.
   ; image_prefix = ""
+  ; static_path = ""
   ; cgi = false
   ; output_conf =
       { status = ignore

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -105,7 +105,9 @@ type config =
     image_prefix : string;
     (* if true, the base name is in the b argument of the query string: ?b=BASE&...
        if false, the base name is the last element of the uri path: .../base?... *)
-    cgi : bool
+    static_path : string
+    (* in CGI mode, provides location of etc files to Apache for direct loading *)
+  ; cgi : bool
   ; forced_plugins : string list
   ; plugins : string list
 }

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -249,10 +249,11 @@ and eval_simple_variable conf =
   | "setup_link" -> if conf.setup_link then " - " ^ setup_link conf else ""
   | "sp" -> " "
   | "static_path" ->
-      begin match Util.p_getenv conf.base_env "static_path" with
-      | Some x -> x
-      | None -> conf.static_path
-      end
+      if conf.cgi then
+        match Util.p_getenv conf.base_env "static_path" with
+        | Some x -> x
+        | None -> conf.static_path
+      else ""
   | "suffix" ->
       (* On supprime de env toutes les paires qui sont dans (henv @ senv) *)
       let l =

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -248,6 +248,11 @@ and eval_simple_variable conf =
   | "right" -> conf.right
   | "setup_link" -> if conf.setup_link then " - " ^ setup_link conf else ""
   | "sp" -> " "
+  | "static_path" ->
+      begin match Util.p_getenv conf.base_env "static_path" with
+      | Some x -> x
+      | None -> conf.static_path
+      end
   | "suffix" ->
       (* On supprime de env toutes les paires qui sont dans (henv @ senv) *)
       let l =


### PR DESCRIPTION
The issue addressed here is only for CGI mode.

%bvar.static_path; is not known when no base is named.
%static_path; gets its value from `GW_STATIC_PATH` or, if absent, defaults to `../distribution/gw/etc/`

With this mechanism, it is not necessary to provide static_path values in each of the .gwf files of bases hosted in CGI mode by a server. When provided in the .gwf file, this value is preferred.

