### PR TITLE
witness specification allows different forms in the imported gedcom +…

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -1299,8 +1299,10 @@ let rec find_all_rela nl =
 
 let witness_kind_of_rval rval = match rval with
   | "GODP"               -> Witness_GodParent
-  | "officer"            -> Witness_CivilOfficer
+  | "officer"
+  | "Civil officer"
   | "Registry officer"   -> Witness_CivilOfficer
+  | "Religious officer"
   | "Officiating priest" -> Witness_ReligiousOfficer
   | "Informant"          -> Witness_Informant
   | "Attending"          -> Witness_Attending

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -392,10 +392,10 @@ let is_primary_pevents =
 let relation_format_of_witness_kind :
       witness_kind -> ('a, unit, string, unit) format4
   = function
-  | Witness                  -> "3 RELA witness"
+  | Witness                  -> "3 RELA Witness"
   | Witness_GodParent        -> "3 RELA GODP"
-  | Witness_CivilOfficer     -> "3 RELA officer"
-  | Witness_ReligiousOfficer -> "3 RELA Officiating priest"
+  | Witness_CivilOfficer     -> "3 RELA Civil officer"
+  | Witness_ReligiousOfficer -> "3 RELA Religious officer"
   | Witness_Informant        -> "3 RELA Informant"
   | Witness_Attending        -> "3 RELA Attending"
   | Witness_Mentioned        -> "3 RELA Mentioned"


### PR DESCRIPTION
Some changes in the gedcom export/import for witness types.

-  We still allow import of the previous allowed tags but we export with capitalized tags.
- Changed CivilOfficer and ReligiousOfficer exported tags