### PR TITLE
Merge Templ and V7_Templ

### DIFF
--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -9,8 +9,8 @@
     %let;l1;%apply;language(i)%in;
     %if;(lang!=l1)
       <a class="dropdown-item" id="lang_%l1;"%sp;
-        href="%prefix_no_lang;%if;(l1!=bvar.default_lang)lang=%l1;;%end;%nn;
-              %foreach;env_binding;%if;(env.key!="lang" and env.key!="p_mod" and env.key!="pz" and env.key!="nz" and env.key!="ocz")%env.key=%env.val;;%end;%end;">%nn;
+        href="%prefix_no_lang;%if;(l1!=bvar.default_lang)lang=%l1;%end;%nn;
+              %foreach;env_binding;%if;(env.key!="lang" and env.key!="p_mod" and env.key!="pz" and env.key!="nz" and env.key!="ocz")&%env.key=%env.val;%end;%end;">%nn;
        <code>%if;(l1!="pt-br")%l1;&nbsp;&nbsp;&nbsp;%else;%l1;%end;%sp;</code>%nn;
        %apply;capitalize%with;%apply;language_name(l1)%end;</a>
     %end;
@@ -34,38 +34,38 @@
           </button>
           %if;(not is_printed_by_template)
             <div class="dropdown-menu scrollable-lang short" aria-labelledby="dropdownMenu1">
-              <a class="dropdown-item" href="%prefix_no_lang;lang=af;%if;(evar.digest="")%suffix;%end;">af</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=bg;%if;(evar.digest="")%suffix;%end;">bg</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=br;%if;(evar.digest="")%suffix;%end;">br</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=ca;%if;(evar.digest="")%suffix;%end;">ca</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=co;%if;(evar.digest="")%suffix;%end;">co</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=cs;%if;(evar.digest="")%suffix;%end;">cs</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=da;%if;(evar.digest="")%suffix;%end;">da</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=de;%if;(evar.digest="")%suffix;%end;">de</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=en;%if;(evar.digest="")%suffix;%end;">en</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=eo;%if;(evar.digest="")%suffix;%end;">eo</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=es;%if;(evar.digest="")%suffix;%end;">es</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=et;%if;(evar.digest="")%suffix;%end;">et</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=fi;%if;(evar.digest="")%suffix;%end;">fi</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=fr;%if;(evar.digest="")%suffix;%end;">fr</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=he;%if;(evar.digest="")%suffix;%end;">he</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=is;%if;(evar.digest="")%suffix;%end;">is</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=it;%if;(evar.digest="")%suffix;%end;">it</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=lt;%if;(evar.digest="")%suffix;%end;">lt</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=lv;%if;(evar.digest="")%suffix;%end;">lv</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=nl;%if;(evar.digest="")%suffix;%end;">nl</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=no;%if;(evar.digest="")%suffix;%end;">no</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=oc;%if;(evar.digest="")%suffix;%end;">oc</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=pl;%if;(evar.digest="")%suffix;%end;">pl</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=pt;%if;(evar.digest="")%suffix;%end;">pt</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=pt-br;%if;(evar.digest="")%suffix;%end;">pt-br</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=ro;%if;(evar.digest="")%suffix;%end;">ro</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=ru;%if;(evar.digest="")%suffix;%end;">ru</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=sk;%if;(evar.digest="")%suffix;%end;">sk</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=sl;%if;(evar.digest="")%suffix;%end;">sl</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=sv;%if;(evar.digest="")%suffix;%end;">sv</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=tr;%if;(evar.digest="")%suffix;%end;">tr</a>
-              <a class="dropdown-item" href="%prefix_no_lang;lang=zh;%if;(evar.digest="")%suffix;%end;">zh</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=af;%if;(evar.digest="")&%suffix;%end;">af</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=bg;%if;(evar.digest="")&%suffix;%end;">bg</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=br;%if;(evar.digest="")&%suffix;%end;">br</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=ca;%if;(evar.digest="")&%suffix;%end;">ca</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=co;%if;(evar.digest="")&%suffix;%end;">co</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=cs;%if;(evar.digest="")&%suffix;%end;">cs</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=da;%if;(evar.digest="")&%suffix;%end;">da</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=de;%if;(evar.digest="")&%suffix;%end;">de</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=en;%if;(evar.digest="")&%suffix;%end;">en</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=eo;%if;(evar.digest="")&%suffix;%end;">eo</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=es;%if;(evar.digest="")&%suffix;%end;">es</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=et;%if;(evar.digest="")&%suffix;%end;">et</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=fi;%if;(evar.digest="")&%suffix;%end;">fi</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=fr;%if;(evar.digest="")&%suffix;%end;">fr</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=he;%if;(evar.digest="")&%suffix;%end;">he</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=is;%if;(evar.digest="")&%suffix;%end;">is</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=it;%if;(evar.digest="")&%suffix;%end;">it</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=lt;%if;(evar.digest="")&%suffix;%end;">lt</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=lv;%if;(evar.digest="")&%suffix;%end;">lv</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=nl;%if;(evar.digest="")&%suffix;%end;">nl</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=no;%if;(evar.digest="")&%suffix;%end;">no</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=oc;%if;(evar.digest="")&%suffix;%end;">oc</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=pl;%if;(evar.digest="")&%suffix;%end;">pl</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=pt;%if;(evar.digest="")&%suffix;%end;">pt</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=pt-br;%if;(evar.digest="")&%suffix;%end;">pt-br</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=ro;%if;(evar.digest="")&%suffix;%end;">ro</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=ru;%if;(evar.digest="")&%suffix;%end;">ru</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=sk;%if;(evar.digest="")&%suffix;%end;">sk</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=sl;%if;(evar.digest="")&%suffix;%end;">sl</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=sv;%if;(evar.digest="")&%suffix;%end;">sv</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=tr;%if;(evar.digest="")&%suffix;%end;">tr</a>
+              <a class="dropdown-item" href="%prefix_no_lang;lang=zh;%if;(evar.digest="")&%suffix;%end;">zh</a>
             </div>
           %else;
             <div class="dropdown-menu scrollable-lang" aria-labelledby="dropdownMenu1" title="lang">
@@ -77,7 +77,7 @@
       <div class="d-inline-flex flex-column justify-content-end">
         <div class="ml-auto">
           <a role="button"
-            href="%prefix_no_templ;%if(evar.templ!="templm")templ=templm;%end;%if;(evar.digest="")%suffix;%end;"
+            href="%prefix_no_templ;%if(evar.templ!="templm")templ=templm;%end;%if;(evar.digest="")&%suffix;%end;"
             title="%if(evar.templ!="templm")templm%else;default template%end;">%nn;
             <span class="fab fa-markdown" aria-hidden="true"></span>%nn;
             <span class="sr-only">switch to %if(evar.templ!="templm")templm%else;default template%end;</span>%nn;

--- a/hd/etc/cousins_tools.txt
+++ b/hd/etc/cousins_tools.txt
@@ -1,16 +1,10 @@
 <!-- $Id: cousins_tools.txt, v7.00 03/04/2018 14:04:31 $ -->
 %define;url(vvv,ttt)
-  %prefix_base_password_2;
-  %foreach;env_binding;
-    %if;(env.key="vvv")ttt
-    %elseif;(env.val!="")&%env.key;=%env.val;
-    %end;
-  %end;
-  %if;(evar.vvv="")ttt%end;
+  %urlv.vvv.ttt;
 %end;
 
 %define;url2(vvv,ttt,www,uuu)
-  %prefix_base_password_2;
+  %prefix_base_password;&
   %foreach;env_binding;
     %if;(env.key="vvv")ttt%nn;
     %elseif;(env.key="www")uuu%nn;
@@ -46,10 +40,10 @@
     <div class="d-inline-flex flex-column">
       <div class="form-inline">
         <div class="input-group">
-          <a href="%apply;url%with;v1%and;%if;(evar.v1!="" and evar.v1>=1)&v1=%expr(evar.v1-1)%end;%end;"
+          <a href="%apply;url%with;v1%and;%if;(evar.v1!="" and evar.v1>=1)%expr(evar.v1-1)%end;%end;"
             class="btn btn-sm btn-outline-secondary border-0 input-group-prepend%if;(evar.v1!="" and evar.v1<1) disabled%end;">-</a>
           <div class="align-self-center">%if;(evar.v1!="")%evar.v1;%end;</div>
-          <a href="%apply;url%with;v1%and;&v1=%expr(evar.v1+1)%end;"
+          <a href="%apply;url%with;v1%and;%expr(evar.v1+1)%end;"
             class="btn btn-sm btn-outline-secondary border-0 input-group-append%if;(evar.v1!="" and evar.v1=bvar.max_cousins_level) disabled%end;">+</a>
         </div>
       </div>
@@ -57,16 +51,16 @@
         <div class="input-group">
           <a href="%apply;url%with;v2%and;
                       %if;(evar.v2!="")
-                        %if;(evar.v2>=1)&v2=%expr(evar.v2-1)%end;
+                        %if;(evar.v2>=1)%expr(evar.v2-1)%end;
                       %else;
-                        %if;(evar.v1!="" and evar.v1>=1)&v2=%expr(evar.v1-1)%end;
+                        %if;(evar.v1!="" and evar.v1>=1)%expr(evar.v1-1)%end;
                       %end;
                     %end;"
             class="btn btn-sm btn-outline-secondary border-0 input-group-prepend%if;(evar.v2!="" and evar.v2<1) disabled%end;">-</a>
           <span class="align-self-center">%if;(evar.v2!="")%evar.v2;%else;%evar.v1;%end;</span>
           <a href="%apply;url%with;v2%and;
-                      %if;(evar.v2!="")&v2=%expr(evar.v2+1)
-                      %else;&v2=%expr(evar.v1+1)%end;
+                      %if;(evar.v2!="")%expr(evar.v2+1)
+                      %else;%expr(evar.v1+1)%end;
                     %end;"
             class="btn btn-sm btn-outline-secondary border-0 input-group-append%if;(evar.v2!="" and evar.v2=bvar.max_cousins_level) disabled%end;">+</a>
         </div>
@@ -84,7 +78,7 @@
             title="[both] +1">+</a>
     </div>
     <div class="mx-2">
-      <a href="%apply;url%with;image%and;%if;(evar.image!="off")&image=off%end;%end;"
+      <a href="%apply;url%with;image%and;%if;(evar.image!="off")off%end;%end;"
         class="btn btn-outline-secondary btn-sm border-0 px-0"
         title="%if;(evar.image!="off")[*visualize/show/hide/summary]2%else;%nn;
           [*visualize/show/hide/summary]1%end; [image/images]1">
@@ -93,7 +87,7 @@
       </a>
     </div>
     <div class="mx-2">
-      <a href="%apply;url%with;spouse%and;%if;(evar.spouse!="on")&spouse=on%end;%end;"
+      <a href="%apply;url%with;spouse%and;%if;(evar.spouse!="on")on%end;%end;"
         class="btn btn-outline-secondary btn-sm border-0 px-0"
         title="%if;(evar.spouse!="on")[*visualize/show/hide/summary]1%else;%nn;
            [*visualize/show/hide/summary]2%end; [spouse/spouses]1">

--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -8,7 +8,6 @@
 %let;laU;title="[*update] (U)" accesskey="U"%in;
 %let;laS;accesskey="S"%in;
 %let;laY;title="[*tree] (Y)" accesskey="Y"%in;
-%let;acc;%if;access_by_key;ep=%first_name_key;;en=%surname_key;;%if;(occ!= "0")eoc=%occ;;%end;%else;ei=%index;;%end;%in;
 %let;sexcolor;%if;is_male;male%elseif;is_female;female%else;neuter%end;%in;
 %define;othersexcolor(sex)
   %if;(sex=1)male%elseif;(sex=0)female%else;neuter%end;
@@ -90,8 +89,8 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
                     </div>
                     <a role="button" class="btn btn-outline-%if;(evar.wide="on")danger%else;primary%end; my-3"%sp;
                       href="%prefix_base_password;%nn;
-                            %foreach;env_binding;%if;(env.key!="wide")%env.key=%env.val;;%end;%end;%nn;
-                            %if;(evar.wide!="on")wide=on;%end;"%sp;
+                            %foreach;env_binding;%if;(env.key!="wide")&%env.key=%env.val;%end;%end;%nn;
+                            %if;(evar.wide!="on")&wide=on;%end;"%sp;
                       title="%if;(evar.wide="on")[*user/password/cancel]2 [full width/columns]0 %else;[*full width/columns]0%end;">%nn;
                       <i class="fa fa-desktop fa-fw" aria-hidden="true"></i>%nn;
                       <span class="sr-only">%if;(evar.wide="on")[*user/password/cancel]2 [full width/columns]0 %else;[*full width/columns]0%end;</span>%nn;
@@ -111,8 +110,8 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
           %if;has_sosa;
             %if;(sosa_prev.index!="")
               <li class="nav-item">
-                <a class="nav-link text-secondary" href="%prefix_base_password;%if;(bvar.access_by_key="yes")%sosa_prev.access;%else;i=%sosa_prev.index;%end;;%nn;
-                  %foreach;env_binding;%if;(env.key!="p" and env.key!="n" and env.key!="oc" and env.key!="i")%env.key=%env.val;;%end;%end;"
+                <a class="nav-link text-secondary" href="%prefix_base_password;%if;(bvar.access_by_key="yes")%sosa_prev.access;%else;i=%sosa_prev.index;%end;%nn;
+                  %foreach;env_binding;%if;(env.key!="p" and env.key!="n" and env.key!="oc" and env.key!="i")&%env.key=%env.val;%end;%end;"
                   title="[Sosa] %sosa_prev.sosa;[:] %sosa_prev;"><span class="fa fa-chevron-left" aria-hidden="true"></span><span class="sr-only">&lt;</span></a>%nn;
               </li>
             %end;
@@ -123,8 +122,8 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
                 </li>
               %end;
               <li class="nav-item">
-                <a class="nav-link text-secondary" href="%prefix_base_password;%if;(bvar.access_by_key="yes")%sosa_next.access;%else;i=%sosa_next.index;%end;;%nn;
-                  %foreach;env_binding;%if;(env.key!="p" and env.key!="n" and env.key!="oc" and env.key!="i")%env.key=%env.val;;%end;%end;"
+                <a class="nav-link text-secondary" href="%prefix_base_password;%if;(bvar.access_by_key="yes")%sosa_next.access;%else;i=%sosa_next.index;%end;%nn;
+                  %foreach;env_binding;%if;(env.key!="p" and env.key!="n" and env.key!="oc" and env.key!="i")&%env.key=%env.val;%end;%end;"
                   title="[Sosa] %sosa_next.sosa;[:] %sosa_next;"><span class="fa fa-chevron-right" aria-hidden="true"></span><span class="sr-only">></span></a>
               </li>
             %end;
@@ -132,7 +131,7 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
           %if;(not (bvar.wizard_just_friend = "yes") and wizard)
             %if;(not has_parents and first_name != "?" and surname != "?")
               <li class="nav-item">
-                <a class="nav-link %if;(evar.m="ADD_PAR" or evar.m="ADD_PAR_OK")active%end;" id="add_par" href="%prefix;m=ADD_PAR;ip=%index;" %laL;>
+                <a class="nav-link %if;(evar.m="ADD_PAR" or evar.m="ADD_PAR_OK")active%end;" id="add_par" href="%prefix;m=ADD_PAR&ip=%index;" %laL;>
                   <sup><span class="fa fa-user male" aria-hidden="true"></span></sup>%nn;
                   <sub><span class="fa fa-plus %sexcolor;" aria-hidden="true"></span></sub>%nn;
                   <sup><span class="fa fa-user female" aria-hidden="true"></span></sup>%nn;
@@ -143,14 +142,14 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
           %end;
           <li class="nav-item">
             <a class="nav-link %if;(evar.m="")active%end;" id="self"
-              href="%prefix_no_all;%if;(evar.templ!="")templ=%evar.templ;;%end;%access;%if;(evar.image="off");image=off%end;" title="%first_name;%if;(occ!=0).%occ%end; %surname;">
+              href="%prefix_no_all;%if;(evar.templ!="")templ=%evar.templ;&%end;%access;%if;(evar.image="off")&image=off%end;" title="%first_name;%if;(occ!=0).%occ%end; %surname;">
               <span class="fa fa-user-alt fa-fw %sexcolor;" aria-hidden="true"></span>
               <span class="sr-only">%first_name;%if;(occ!=0).%occ%end; %surname;</span>
             </a>
           </li>
           %if;(not (bvar.wizard_just_friend="yes") and wizard)
             <li class="nav-item">
-              <a class="nav-link %if;(evar.m="MOD_IND" or evar.m="MOD_IND_OK")active%end;" id="mod_ind" href="%prefix;m=MOD_IND;i=%index;" %laP;>%nn;
+              <a class="nav-link %if;(evar.m="MOD_IND" or evar.m="MOD_IND_OK")active%end;" id="mod_ind" href="%prefix;m=MOD_IND&i=%index;" %laP;>%nn;
                 <span class="fa fa-user-edit fa-fw %sexcolor;" aria-hidden="true"></span>%nn;
                 <span class="sr-only">[*modify::person/persons]0 (P)</span>%nn;
               </a>
@@ -164,7 +163,7 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
             </a>
             <div class="dropdown-menu">
               %if;(not browsing_with_sosa_ref or sosa_ref.index!=index)
-                <a class="dropdown-item" href="%prefix_no_iz;%(iz=%self.index;;%)pz=%first_name_key;;nz=%surname_key;;%if;(evar.oc!="" and evar.oc!=0)ocz=%occ;;%end;%access;" %laS; title="%apply;nav_with_sosa_ref(self)">%nn;
+                <a class="dropdown-item" href="%prefix_no_iz;%(iz=%self.index;;%)pz=%first_name_key;&nz=%surname_key;%if;(evar.oc!="" and evar.oc!=0)&ocz=%occ;%end;&%access;" %laS; title="%apply;nav_with_sosa_ref(self)">%nn;
                   <i class="far fa-dot-circle fa-fw %sexcolor; mr-1"></i> [*modify::Sosa 1]%nn;
                 </a>
               %else;
@@ -296,14 +295,14 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
                 <a class="dropdown-item" href="%prefix;%access;;m=A;"><span class="fa fa-cog fa-fw mr-2"></span>[*ancestors]</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" id="anc_tree" href="%prefix;%access;;m=A;t=T;v=5;marriage=on;" %laY;><span class="fa fa-sitemap fa-rotate-180 fa-fw mr-2"></span>[*ascendants tree]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=A;t=H;v=5;" title="[*horizontal tree]"><span class="fa fa-code-branch fa-rotate-90 fa-fw mr-2"></span>[*horizontal tree]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=A;t=Z;v=7;maxv=%max_anc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;age=on;occu=on;gen=on;repeat=on;ns=on;%if;(evar.image="off")image=off;%end;"><span class="fa fa-table fa-fw mr-2"></span>[*table] [ancestors]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=A;t=G;v=3;maxv=%max_anc_level;;siblings=on;alias=on;spouse=on;parents=on;rel=on;witn=on;notes=on;src=on;hide=on;"><span class="fa fa-newspaper fa-fw mr-2"></span>[*long display]</a>
-                <a class="dropdown-item" href="%prefix;i=%index;;m=A;t=F;tf1=sb;v=%max_anc_level;;maxv=%max_anc_level;;"><span class="fa fa-align-justify fa-fw mr-2"></span>[*surnames branch]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=A&t=H&v=5" title="[*horizontal tree]"><span class="fa fa-code-branch fa-rotate-90 fa-fw mr-2"></span>[*horizontal tree]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=A&t=Z&v=7&maxv=%max_anc_level;&num=on&birth=on&birth_place=on&marr=on&marr_date=on&marr_place=on&child=on&death=on&death_place=on&age=on&occu=on&gen=on&repeat=on&ns=on%if;(evar.image="off")&image=off;%end;"><span class="fa fa-table fa-fw mr-2"></span>[*table] [ancestors]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=A&t=G&v=3&maxv=%max_anc_level;&siblings=on&alias=on&spouse=on&parents=on&rel=on&witn=on&notes=on&src=on&hide=on;"><span class="fa fa-newspaper fa-fw mr-2"></span>[*long display]</a>
+                <a class="dropdown-item" href="%prefix;i=%index;&m=A&t=F&tf1=sb&v=%max_anc_level;&maxv=%max_anc_level;"><span class="fa fa-align-justify fa-fw mr-2"></span>[*surnames branch]</a>
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="%prefix;%access;;m=A;t=T;t1=CT;hi=H;v=5;scale=100;fs=17;sosa=on;" title="[*compact tree] [with] %self;"><span class="fa fa-th fa-fw mr-2"></span>[*compact tree]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=A;t=T;t1=h7;wide=on;" title="[Arbre 7 gen]"><span class="fa fa-chess-board fa-fw mr-2"></span>7 [generation/generations]1</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=A;t=T;t1=m;" title="[Arbre 9 gen]">9 [generation/generations]1</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=A&t=T&t1=CT&hi=H&v=5&scale=100&fs=17&sosa=on" title="[*compact tree] [with] %self;"><span class="fa fa-th fa-fw mr-2"></span>[*compact tree]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=A&t=T&t1=h7&wide=on" title="[Arbre 7 gen]"><span class="fa fa-chess-board fa-fw mr-2"></span>7 [generation/generations]1</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=A&t=T&t1=m" title="[Arbre 9 gen]">9 [generation/generations]1</a>
               </div>
             </li>
           %end;
@@ -311,36 +310,36 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle text-secondary %if;(evar.m="D")active%end;" data-toggle="dropdown" role="button" href="#" aria-haspopup="true" aria-expanded="false"><span class="fa fa-sitemap fa-fw" title="[*descendants]"></span></a>
               <div class="dropdown-menu">
-                <a class="dropdown-item" href="%prefix;m=D;%access;;"><span class="fa fa-cog fa-fw mr-2"></span>[*descendants]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&"><span class="fa fa-cog fa-fw mr-2"></span>[*descendants]</a>
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="%prefix;%access;;m=D;t=T;v=4;"%if;(not has_parents) %laY;%end;><span class="fa fa-sitemap fa-fw mr-2"></span>[*descendants tree]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=D;t=D;v=%max_desc_level;;"><span class="fa fa-code-branch fa-rotate-90 fa-fw mr-2"></span>[*descendant tree view]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=D;t=H;v=%max_desc_level;;num=on;birth=on;birth_place=on;marr=on;marr_date=on;marr_place=on;child=on;death=on;death_place=on;age=on;occu=on;gen=on;ns=on;%if;(evar.image="off")image=off;%end;"><span class="fa fa-table fa-fw mr-2"></span>[*table] [descendants]</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=D;t=L;v=3;maxv=%max_desc_level;;siblings=on;alias=on;spouse=on;parents=on;rel=on;witn=on;notes=on;src=on;hide=on;"><span class="fa fa-newspaper fa-fw mr-2"></span>[*long display]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&t=T&v=4;"%if;(not has_parents) %laY;%end;><span class="fa fa-sitemap fa-fw mr-2"></span>[*descendants tree]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&t=D&v=%max_desc_level;"><span class="fa fa-code-branch fa-rotate-90 fa-fw mr-2"></span>[*descendant tree view]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&t=H&v=%max_desc_level;&num=on&birth=on&birth_place=on&marr=on&marr_date=on&marr_place=on&child=on&death=on&death_place=on&age=on&occu=on&gen=on&ns=on%if;(evar.image="off")&image=off;%end;"><span class="fa fa-table fa-fw mr-2"></span>[*table] [descendants]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&t=L&v=3&maxv=%max_desc_level;&siblings=on&alias=on&spouse=on&parents=on&rel=on&witn=on&notes=on&src=on&hide=on;"><span class="fa fa-newspaper fa-fw mr-2"></span>[*long display]</a>
                 <div class="dropdown-divider"></div>
                 %(WIP%)
-                <a class="dropdown-item" href="%prefix;%access;;m=D;t=V;%if;(evar.v!="")v=%evar.v;%else;v=3%end;;spouse=on;marriage=on;"%if;(not has_parents) %laY;%end;><span class="fa fa-sitemap fa-fw mr-2"></span>[*descendants tree] (new)</a>
-                <a class="dropdown-item" href="%prefix;%access;;m=D;t=A;num=on;v=%max_desc_level;;"><span class="fa fa-code-branch fa-flip-vertical fa-fw mr-2"></span>D’Aboville</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&t=V%if;(evar.v!="")&v=%evar.v;%else;&v=3%end;&spouse=on&marriage=on"%if;(not has_parents) %laY;%end;><span class="fa fa-sitemap fa-fw mr-2"></span>[*descendants tree] (new)</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=D&t=A&num=on&v=%max_desc_level;"><span class="fa fa-code-branch fa-flip-vertical fa-fw mr-2"></span>D’Aboville</a>
               </div>
             </li>
           %end;
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle text-secondary %if;(evar.m="R" or evar.m="F" or (evar.m="C" and evar.t="AN"))active%end;" data-toggle="dropdown" role="button" href="#" aria-haspopup="true" aria-expanded="false" title="[*relationship]"><span class="fa fa-user-friends"></span></a>
             <div class="dropdown-menu">
-              <a class="dropdown-item" href="%prefix;m=R;%access;" %laR;><span class="fa fa-cog fa-fw"></span> [*relationship computing]</a>
+              <a class="dropdown-item" href="%prefix;%access;&m=R;" %laR;><span class="fa fa-cog fa-fw"></span> [*relationship computing]</a>
               <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="%prefix;%access;;m=C;v1=2;v2=2" %laR;><span class="fa fa-users-cog fa-fw"></span> [*relationship computing] [with] [close family]</a>
+              <a class="dropdown-item" href="%prefix;%access;&m=C&v1=2&v2=2" %laR;><span class="fa fa-users-cog fa-fw"></span> [*relationship computing] [with] [close family]</a>
               <div class="dropdown-divider"></div>
               <a class="dropdown-item" %nn;
-                href="%prefix;m=F;%access;;%nn;
-                  %if;(bvar.default_fnav_images="off")image=off;%end;%nn;
-                  %if;(bvar.default_fnav_semi="on")semi=on;%end;%nn;
-                  %if;(bvar.default_fnav_spouse="on")spouse=on;%end;" title="[*family/families]0">
+                href="%prefix;m=F&%access;%nn;
+                  %if;(bvar.default_fnav_images="off")&image=off;%end;%nn;
+                  %if;(bvar.default_fnav_semi="on")&semi=on;%end;%nn;
+                  %if;(bvar.default_fnav_spouse="on")&spouse=on;%end;" title="[*family/families]0">
                 <span class="fa fa-users fa-fw"></span> [*family/families]0
               </a>
               %if;(died = "" and (wizard or friend))
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="%prefix;%access;;m=C;t=AN"><span class="fa fa-birthday-cake fa-fw"></span> [*family birthday]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=C&t=AN"><span class="fa fa-birthday-cake fa-fw"></span> [*family birthday]</a>
               %end;
             </div>
           </li>

--- a/hd/etc/modules/unions.txt
+++ b/hd/etc/modules/unions.txt
@@ -148,16 +148,16 @@
     %end;
     %if;(not cancel_links)
       <span class="ml-2">%nn;
-        <a href="%prefix;%suffix;m=D;t=T;v=1;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="18" alt="tree desc." title="[*descendants tree] [to the children] ([with] [spouse/spouses]0)"/></a>
+        <a href="%prefix;%suffix;&m=D;t=T;v=1;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="18" alt="tree desc." title="[*descendants tree] [to the children] ([with] [spouse/spouses]0)"/></a>
         %if;(op_m!=1)
           %if;(max_desc_level>1)
-            <a href="%prefix;%suffix;m=D;t=T;v=2;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="20" alt="tree desc." title="[*descendants tree] [to the grandchildren]"/></a>
+            <a href="%prefix;%suffix;&m=D;t=T;v=2;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="20" alt="tree desc." title="[*descendants tree] [to the grandchildren]"/></a>
           %end;
           %if;(max_desc_level>2)
-            <a href="%prefix;%suffix;m=D;t=T;v=3;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="22" alt="tree desc." title="[*descendants tree] [to the great-grandchildren]"/></a>
+            <a href="%prefix;%suffix;&m=D;t=T;v=3;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="22" alt="tree desc." title="[*descendants tree] [to the great-grandchildren]"/></a>
           %end;
           %if;(max_desc_level>3)
-            <a href="%prefix;%suffix;m=D;t=T;v=%max_desc_level;;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="24" alt="tree desc." title="[*descendants tree] (%max_desc_level; [generation/generations]1)"/></a>
+            <a href="%prefix;%suffix;&m=D;t=T;v=%max_desc_level;;image=on"><img class="mx-1 mb-1" src="%image_prefix;/gui_create.png" height="24" alt="tree desc." title="[*descendants tree] (%max_desc_level; [generation/generations]1)"/></a>
           %end;
         %end;
       </span>

--- a/hd/etc/templm/copyr.txt
+++ b/hd/etc/templm/copyr.txt
@@ -19,8 +19,8 @@
       %nl;
       <div id="trl" style="clear:both;">
         <ul>
-          <li><a href="%prefix_no_templ;templ=;%suffix;">default</a></li>
-          <li><a href="%prefix_no_templ;templ=templm;%suffix;">templm</a></li>
+          <li><a href="%prefix_no_templ;templ=&%suffix;">default</a></li>
+          <li><a href="%prefix_no_templ;templ=templm&%suffix;">templm</a></li>
         </ul>
       </div>
     %end;
@@ -34,12 +34,12 @@
 %define;language_link()
   %for;i;1;30;
     %let;l1;%apply;lang(i)%in;
-    <a class="dropdown-item" href="%prefix_base_password;lang=%l1;;templ=%evar.templ;;%suffix;">%l1; %apply;language_name(l1)</a>
+    <a class="dropdown-item" href="%prefix_base_password;lang=%l1;&templ=%evar.templ;&%suffix;">%l1; %apply;language_name(l1)</a>
   %end;
 %end;
 
 <div id="footer">
-  <a href="%prefix_no_templ;%if(evar.templ!="templm")templ=templm;%end;%suffix;"
+  <a href="%prefix_no_templ;%if(evar.templ!="templm")templ=templm;%end;&%suffix;"
      title="Switch to %if(evar.templ!="templm")template m%else;default template%end;">GeneWeb</a>
   v. %version;%sp;
   &copy; INRIA 1998-2016 %connections;%sq;

--- a/hd/etc/templm/menu_search.txt
+++ b/hd/etc/templm/menu_search.txt
@@ -8,7 +8,7 @@
 %define;link_lang()
   %for;i;1;30;
     %let;l1;%apply;lang(i)%in;
-    <a href="%prefix_base_password;templ=%evar.templ;;lang=%l1;;%suffix;" title="%apply;language_name(l1)" 
+    <a href="%prefix_base_password;templ=%evar.templ;&lang=%l1;&%suffix;" title="%apply;language_name(l1)" 
       style="%if;((bvar.default_lang=l1 and evar.lang="") or evar.lang=l1)background-color:%if;(bvar.css=1)#666;%else;#EEE;%end;%end;">
        %if;(bvar.show_flag = "yes")<img src="%image_prefix;/flags/l-%l1;.jpg" width="20" height="11" alt="flag" id="i%tt;" style="border:0"%/> %end;
        %l1; %apply;language_name(l1)</a>
@@ -115,8 +115,8 @@
     title="[*advanced request]0%nl;%nl;[*select]%nl;%if;(evar.templ != "")%evar.templ;%else;templ%end;">%if;(bvar.hide_advanced_request != "yes")🔍%else;templ%end;</a>
     %if;(evar.digest = "")
       <span class="s_menu" id="tpl">
-        <a href="%prefix_no_all;templ=;%suffix;" %apply;bg("")>default</a>
-        %( <a href="%prefix_no_all;templ=templa;%suffix;" %apply;bg("templa")>templa</a> %)
+        <a href="%prefix_no_all;templ=&%suffix;" %apply;bg("")>default</a>
+        %( <a href="%prefix_no_all;templ=templa&%suffix;" %apply;bg("templa")>templa</a> %)
         %if;(wizard or bvar.wizard_passwd = "")
           <small><a href="%prefix;m=H;v=doc_templm">doc templm</a></small>
         %end;

--- a/hd/etc/templm/tools.txt
+++ b/hd/etc/templm/tools.txt
@@ -339,7 +339,7 @@
                     %end;
                   %end;">[*modify::tree]</a></li>
           %end;
-          <li><a href="%prefix;%suffix;notab=on" accesskey="/"
+          <li><a href="%prefix;%suffix;&notab=on" accesskey="/"
              title="[display by slices/slice width/overlap/total width]0 (/)"
              >[*display by slices/slice width/overlap/total width]0</a></li>
         </ul>

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -50,6 +50,7 @@ val string_of_ctime : config -> string
 val commd
   : ?excl:string list
   -> ?trim:bool
+  -> ?pwd:bool
   -> ?henv:bool
   -> ?senv:bool
   -> config
@@ -57,7 +58,6 @@ val commd
 
 val prefix_base : config -> Adef.escaped_string
 val prefix_base_password : config -> Adef.escaped_string
-val prefix_base_password_2 : config -> Adef.escaped_string
 
 (** [hidden_env_aux env]
     Creates a hidden HTML input for every key and value in [env].


### PR DESCRIPTION
The purpose is to remove v7_templ altogether making sure the new functions are available in all template engine contexts, thus avoiding unnecessary duplicate of modules in v7 plugin.
Modifications are add-on with the exception of apply_format which addresses an issue of missing multiple %x usage.