### PR TITLE
rename distribution/gwd to distribution.gwd.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,8 @@ distrib: build
 	  cp etc/gwsetup $(DISTRIB_DIR)/gwsetup.command; \
 	  cp etc/macOS/geneweb.command $(DISTRIB_DIR); \
 	else \
-	  cp etc/gwd $(DISTRIB_DIR); \
-	  cp etc/gwsetup $(DISTRIB_DIR); \
+	  cp etc/gwd $(DISTRIB_DIR)/gwd.sh; \
+	  cp etc/gwsetup $(DISTRIB_DIR)/gwsetup.sh; \
 	fi
 	mkdir $(DISTRIB_DIR)/gw
 	cp etc/a.gwf $(DISTRIB_DIR)/gw/.


### PR DESCRIPTION
See the end of the discussion in issue #1251.
Using the same name for the executable file (`distribution/gw/gwd`) and the launch shell script (`distribution/gwd`) is a bad idea