### PR TITLE
refactorize image; fix private portrait leak

### DIFF
--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -406,7 +406,7 @@ let oc' opts s =
 
 let oc_witness_kind opts wk =
   oc' opts (relation_format_of_witness_kind wk)
-  
+
 let ged_pevent opts base per_sel evt =
   let typ =
     if is_primary_pevents evt.epers_name then
@@ -570,7 +570,7 @@ let ged_psource opts base per =
     | s -> print_sour opts 1 (encode opts s)
 
 let has_image_file opts base p =
-  let s = Util.default_image_name base p in
+  let s = Image.default_portrait_filename base p in
   let f = Filename.concat opts.Gwexport.img_base_path s in
   if Sys.file_exists (f ^ ".gif") then Some (f ^ ".gif")
   else if Sys.file_exists (f ^ ".jpg") then Some (f ^ ".jpg")

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1450,7 +1450,7 @@ let image_request conf script_name env =
         if fname.[0] = '/' then String.sub fname 1 (String.length fname - 1)
         else fname
       in
-      let fname = Util.image_file_name fname in
+      let `Path fname = Image.path_of_filename fname in
       let _ = ImageDisplay.print_image_file conf fname in true
   | _ ->
       let s = script_name in
@@ -1461,7 +1461,7 @@ let image_request conf script_name env =
         (* empeche d'avoir des images qui se trouvent dans le dossier   *)
         (* image. Si on ne fait pas de basename, alors ça marche.       *)
         (* let fname = Filename.basename fname in *)
-        let fname = Util.image_file_name fname in
+        let `Path fname = Image.path_of_filename fname in
         let _ = ImageDisplay.print_image_file conf fname in true
       else false
 

--- a/lib/birthDeathDisplay.ml
+++ b/lib/birthDeathDisplay.ml
@@ -437,7 +437,7 @@ let print_population_pyramid conf base =
     Output.print_sstring conf "<td>";
     if doit then begin
       Output.print_sstring conf {|<img src="|} ;
-      Output.print_string conf (Util.image_prefix conf) ;
+      Output.print_string conf (Image.prefix conf) ;
       Output.print_sstring conf "/" ;
       Output.print_string conf iname ;
       Output.print_sstring conf {|" alt="|} ;

--- a/lib/changeChildren.ml
+++ b/lib/changeChildren.ml
@@ -33,17 +33,6 @@ let check_conflict base p key new_occ ipl =
     then raise @@ ChangeChildrenConflict (p, p1)
   end ipl
 
-let rename_image_file conf base p (nfn, nsn, noc) =
-  match auto_image_file conf base p with
-    Some old_f ->
-      let s = default_image_name_of_key nfn nsn noc in
-      let f = Filename.concat (base_path ["images"] conf.bname) s in
-      let new_f =
-        if Filename.check_suffix old_f ".gif" then f ^ ".gif" else f ^ ".jpg"
-      in
-      (try Sys.rename old_f new_f with Sys_error _ -> ())
-  | _ -> ()
-
 let change_child conf base parent_surname changed ip =
   let p = poi base ip in
   let var = "c" ^ string_of_iper (get_iper p) in
@@ -71,7 +60,7 @@ let change_child conf base parent_surname changed ip =
     let key = new_first_name ^ " " ^ new_surname in
     let ipl = Gutil.person_ht_find_all base key in
     check_conflict base p key new_occ ipl;
-    rename_image_file conf base p (new_first_name, new_surname, new_occ);
+    Image.rename_portrait conf base p (new_first_name, new_surname, new_occ);
     (* On ajoute les enfants dans le type Change_children_name       *)
     (* pour la future mise à jour de l'historique et du fichier gwf. *)
     let changed =

--- a/lib/dagDisplay.ml
+++ b/lib/dagDisplay.ml
@@ -62,8 +62,7 @@ let image_url_txt_with_size conf url_p url width height : Adef.safe_string =
 let image_txt conf base p =
   Adef.safe @@
   match p_getenv conf.env "image" with
-  | Some "off" -> ""
-  | Some _ | None ->
+  | Some "on" -> (
        match Image.get_portrait_with_size conf base p with
       | None -> ""
       | Some (`Path s, size_opt) ->
@@ -86,6 +85,8 @@ let image_txt conf base p =
         ^ {|px"><tr align="left"><td>|}
         ^ (image_url_txt conf url_p (Util.escape_html url) height |> Adef.as_string)
         ^ "</td></tr></table></center>\n"
+    )
+  | Some "off" | Some _ | None -> ""
 
 type item = Item of person * Adef.safe_string
 

--- a/lib/descendDisplay.ml
+++ b/lib/descendDisplay.ml
@@ -702,7 +702,7 @@ let print_person_table conf base p lab =
   Output.print_sstring conf "<tr>" ;
   td (fun () -> Output.print_string conf lab) ;
   td (fun () ->
-      Util.print_image_sex conf p 11 ;
+      ImageDisplay.print_placeholder_gendered_portrait conf p 11 ;
       Output.print_sstring conf " " ;
       Output.print_string conf (referenced_person_title_text conf base p) ;
       Output.print_sstring conf "&nbsp;") ;
@@ -732,7 +732,7 @@ let print_person_table conf base p lab =
     end else match alt with None -> () | Some fn -> fn ()
   in
   aux [ "marr" ] begin fun _fam spouse ->
-    Util.print_image_sex conf spouse 11;
+    ImageDisplay.print_placeholder_gendered_portrait conf spouse 11;
     Output.print_sstring conf " " ;
     Output.print_string conf (referenced_person_text conf base spouse) ;
     Output.print_sstring conf " &nbsp;"
@@ -824,7 +824,7 @@ let print_person_table conf base p lab =
         let fam = foi base (get_family u).(i) in
         Output.print_sstring conf "<tr>\n";
         aux i "marr" begin fun () ->
-          Util.print_image_sex conf spouse 11 ;
+          ImageDisplay.print_placeholder_gendered_portrait conf spouse 11 ;
           Output.print_sstring conf " " ;
           Output.print_string conf (referenced_person_text conf base spouse) ;
           Output.print_sstring conf "&nbsp;"

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -69,10 +69,10 @@ val eq_istr : istr -> istr -> bool
 
 (** [true] if families with the giving ids are equal *)
 val eq_ifam : ifam -> ifam -> bool
-  
+
 (** [true] if persons with the giving ids are equal *)
 val eq_iper : iper -> iper -> bool
-  
+
 (** [true] if string with the giving id is empty ("") *)
 val is_empty_string : istr -> bool
 

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -40,10 +40,10 @@ let header_without_http conf title =
   Output.print_sstring conf conf.charset ;
   Output.print_sstring conf "\">" ;
   Output.print_sstring conf {|<link rel="shortcut icon" href="|};
-  Output.print_string conf (Util.image_prefix conf);
+  Output.print_string conf (Image.prefix conf);
   Output.print_sstring conf {|/favicon_gwd.png">|};
   Output.print_sstring conf {|<link rel="apple-touch-icon" href="|};
-  Output.print_string conf (Util.image_prefix conf);
+  Output.print_string conf (Image.prefix conf);
   Output.print_sstring conf {|/favicon_gwd.png">|};
   Output.print_sstring conf
     {|<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">|};

--- a/lib/image.ml
+++ b/lib/image.ml
@@ -1,0 +1,268 @@
+open Config
+open Def
+open Gwdb
+
+(* TODO: use Uri/Fpath *)
+type src = [ `Url of string | `Src_with_size_info of string | `Path of string ]
+
+let prefix conf = Util.escape_html conf.image_prefix
+
+(** [default_portrait_filename_of_key fn sn occ] is the default filename of the corresponding person's portrait. WITHOUT its file extenssion.
+ e.g: default_portrait_filename_of_key "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond"
+ *)
+let default_portrait_filename_of_key first_name surname occ =
+  let space_to_unders = Mutil.tr ' ' '_' in
+  let f = space_to_unders (Name.lower first_name) in
+  let s = space_to_unders (Name.lower surname) in
+  Format.sprintf "%s.%d.%s" f occ s
+
+let default_portrait_filename base p =
+  default_portrait_filename_of_key (p_first_name base p) (p_surname base p)
+    (get_occ p)
+
+(** [full_portrait_path conf base p] is [Some path] if [p] has a portrait.
+    [path] is a the full path of the file with file extension. *)
+let full_portrait_path conf base p =
+  (* TODO why is extension not in filename..? *)
+  let s = default_portrait_filename base p in
+  let f = Filename.concat (Util.base_path [ "images" ] conf.bname) s in
+  if Sys.file_exists (f ^ ".jpg") then Some (`Path (f ^ ".jpg"))
+  else if Sys.file_exists (f ^ ".png") then Some (`Path (f ^ ".png"))
+  else if Sys.file_exists (f ^ ".gif") then Some (`Path (f ^ ".gif"))
+  else None
+
+let source_filename bname src =
+  let fname1 =
+    List.fold_right Filename.concat
+      [ Util.base_path [ "src" ] bname; "images" ]
+      src
+  in
+  let fname2 =
+    List.fold_right Filename.concat [ Secure.base_dir (); "src"; "images" ] src
+  in
+  if Sys.file_exists fname1 then fname1 else fname2
+
+let path_of_filename src =
+  let fname1 =
+    List.fold_right Filename.concat [ Secure.base_dir (); "images" ] src
+  in
+  if Sys.file_exists fname1 then `Path fname1
+  else `Path (Util.search_in_assets (Filename.concat "images" src))
+
+let png_size ic =
+  let magic = really_input_string ic 4 in
+  if magic = "\137PNG" then (
+    seek_in ic 16;
+    let wid = input_binary_int ic in
+    let hei = input_binary_int ic in
+    Ok (wid, hei))
+  else Error ()
+
+let gif_size ic =
+  let magic = really_input_string ic 4 in
+  if magic = "GIF8" then (
+    seek_in ic 6;
+    let wid =
+      let x = input_byte ic in
+      (input_byte ic * 256) + x
+    in
+    let hei =
+      let x = input_byte ic in
+      (input_byte ic * 256) + x
+    in
+    Ok (wid, hei))
+  else Error ()
+
+let jpeg_size ic =
+  let magic = really_input_string ic 10 in
+  if
+    Char.code magic.[0] = 0xff
+    && Char.code magic.[1] = 0xd8
+    &&
+    let m = String.sub magic 6 4 in
+    m = "JFIF" || m = "Exif"
+  then
+    let exif_type = String.sub magic 6 4 = "Exif" in
+    let rec loop found =
+      while Char.code (input_char ic) <> 0xFF do
+        ()
+      done;
+      let ch =
+        let rec loop ch =
+          if Char.code ch = 0xFF then loop (input_char ic) else ch
+        in
+        loop (input_char ic)
+      in
+      if Char.code ch = 0xC0 || Char.code ch = 0xC3 then
+        if exif_type && not found then loop true
+        else (
+          for i = 1 to 3 do
+            let _ = input_char ic in
+            ()
+          done;
+          let a = input_char ic in
+          let b = input_char ic in
+          let c = input_char ic in
+          let d = input_char ic in
+          let wid = (Char.code c lsl 8) lor Char.code d in
+          let hei = (Char.code a lsl 8) lor Char.code b in
+          Ok (wid, hei))
+      else
+        let a = input_char ic in
+        let b = input_char ic in
+        let len = (Char.code a lsl 8) lor Char.code b in
+        let len = if len >= 32768 then 0 else len in
+        for i = 1 to len - 2 do
+          let _ = input_char ic in
+          ()
+        done;
+        if Char.code ch <> 0xDA then loop found else Error ()
+    in
+    loop false
+  else Error ()
+
+let size_from_path fname =
+  (* TODO: size and mime type should be in db *)
+  let (`Path fname) = fname in
+  let res =
+    if fname = "" then Error ()
+    else
+      try
+        let ic = Secure.open_in_bin fname in
+        let r =
+          try
+            (* TODO: should match on mime type here *)
+            match String.lowercase_ascii @@ Filename.extension fname with
+            | ".jpeg" | ".jpg" -> jpeg_size ic
+            | ".png" -> png_size ic
+            | ".gif" -> gif_size ic
+            | _s -> Error ()
+          with End_of_file -> Error ()
+        in
+        close_in ic;
+        r
+      with Sys_error e -> Error ()
+  in
+  if Result.is_error res then
+    !GWPARAM.syslog `LOG_ERR
+      (Format.sprintf "Error reading size_from_path of %s" fname);
+  res
+
+let rename_portrait conf base p (nfn, nsn, noc) =
+  match full_portrait_path conf base p with
+  | Some (`Path old_f) -> (
+      let s = default_portrait_filename_of_key nfn nsn noc in
+      let f = Filename.concat (Util.base_path [ "images" ] conf.bname) s in
+      let new_f = f ^ Filename.extension old_f in
+      try Sys.rename old_f new_f
+      with Sys_error e ->
+        !GWPARAM.syslog `LOG_ERR
+          (Format.sprintf
+             "Error renaming portrait: old_path=%s new_path=%s : %s" old_f new_f
+             e))
+  | None -> ()
+
+let src_to_string = function `Url s | `Path s -> s
+
+let scale_to_fit ~max_w ~max_h ~w ~h =
+  let w, h =
+    if h > max_h then
+      let w = w * max_h / h in
+      let h = max_h in
+      (w, h)
+    else (w, h)
+  in
+  let w, h =
+    if w > max_w then
+      let h = h * max_w / w in
+      let w = max_w in
+      (w, h)
+    else (w, h)
+  in
+  (w, h)
+
+(** [has_access_to_portrait conf base p] is true iif we can see [p]'s portrait. *)
+let has_access_to_portrait conf base p =
+  let img = get_image p in
+  (not conf.no_image)
+  && Util.authorized_age conf base p
+  && (not (is_empty_string img))
+  && (conf.wizard || conf.friend
+     || not (Mutil.contains (sou base img) "/private/"))
+(* TODO: privacy settings should be in db not in url *)
+
+let get_portrait_path conf base p =
+  if has_access_to_portrait conf base p then full_portrait_path conf base p
+  else None
+
+(* parse a string to an `Url or a `Path *)
+let urlorpath_of_string conf s =
+  let http = "http://" in
+  let https = "https://" in
+  (* TODO OCaml 4.13: use String.starts_with *)
+  if
+    String.length s > String.length http
+    && String.sub s 0 (String.length http) = http
+    || String.length s > String.length https
+       && String.sub s 0 (String.length https) = https
+  then `Url s
+  else if Filename.is_implicit s then
+    match List.assoc_opt "images_path" conf.base_env with
+    | Some p when p <> "" -> `Path (Filename.concat p s)
+    | Some _ | None ->
+        let fname =
+          Filename.concat (Util.base_path [ "images" ] conf.bname) s
+        in
+        `Path fname
+  else `Path s
+
+let src_of_string conf s =
+  if s = "" then `Empty
+  else
+    let l = String.length s - 1 in
+    if s.[l] = ')' then `Src_with_size_info s else urlorpath_of_string conf s
+
+let parse_src_with_size_info conf s =
+  let (`Src_with_size_info s) = s in
+  let l = String.length s - 1 in
+  try
+    let pos1 = String.index s '(' in
+    let pos2 = String.index_from s pos1 'x' in
+    let w = String.sub s (pos1 + 1) (pos2 - pos1 - 1) |> int_of_string in
+    let h = String.sub s (pos2 + 1) (l - pos2 - 1) |> int_of_string in
+    let s = String.sub s 0 pos1 in
+    Ok (urlorpath_of_string conf s, (w, h))
+  with Not_found | Failure _ ->
+    !GWPARAM.syslog `LOG_ERR
+      (Format.sprintf "Error parsing portrait source with size info %s" s);
+    Error "Failed to parse url with size info"
+
+let get_portrait_with_size conf base p =
+  if has_access_to_portrait conf base p then
+    match src_of_string conf (sou base (get_image p)) with
+    | `Src_with_size_info _s as s_info -> (
+        match parse_src_with_size_info conf s_info with
+        | Error _e -> None
+        | Ok (s, size) -> Some (s, Some size))
+    | `Url _s as url -> Some (url, None)
+    | `Path _p as path -> Some (path, size_from_path path |> Result.to_option)
+    | `Empty -> (
+        match full_portrait_path conf base p with
+        | None -> None
+        | Some path -> Some (path, size_from_path path |> Result.to_option))
+  else None
+
+let get_portrait conf base p =
+  if has_access_to_portrait conf base p then
+    match src_of_string conf (sou base (get_image p)) with
+    | `Src_with_size_info _s as s_info -> (
+        match parse_src_with_size_info conf s_info with
+        | Error _e -> None
+        | Ok (s, _size) -> Some s)
+    | `Url _s as url -> Some url
+    | `Path _p as path -> Some path
+    | `Empty -> (
+        match full_portrait_path conf base p with
+        | None -> None
+        | Some path -> Some path)
+  else None

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -1,0 +1,55 @@
+open Config
+open Def
+open Gwdb
+
+val scale_to_fit : max_w:int -> max_h:int -> w:int -> h:int -> int * int
+(** [scale_to_fit ~max_w ~max_h ~w ~h] is the {(width, height)} of a proportionally scaled {(w, h)} rectangle so it can fit in a {(max_w, max_h)} rectangle *)
+
+val source_filename : string -> string -> string
+(** Returns path to the image file with the giving name in directory {i src/}. *)
+
+val prefix : config -> Adef.escaped_string
+(** Returns the image prefix (conf.image_prefix), html escaped  *)
+
+val default_portrait_filename : base -> person -> string
+(** [default_portrait_filename base p] is the default filename of [p]'s portrait. Without it's file extension.
+ e.g: default_portrait_filename_of_key "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond"
+ *)
+
+val size_from_path : [ `Path of string ] -> (int * int, unit) result
+(** [size_from_path path]
+    - Error () if failed to read or parse file
+    - Ok (width, height) of the file.
+It works by openning the file and reading magic numbers *)
+
+val path_of_filename : string -> [> `Path of string ]
+(** [path_of_filename fname] search for image {i images/fname} inside the base and assets directories.
+    Return the path to found file or [fname] if file isn't found.  *)
+
+val rename_portrait : config -> base -> person -> string * string * int -> unit
+(** Rename portrait to match updated name *)
+
+val src_to_string : [< `Path of string | `Url of string ] -> string
+(** [src_to_string src] is [src] as a string *)
+
+val get_portrait_path : config -> base -> person -> [> `Path of string ] option
+(** [get_portrait_path conf base p] is
+    - [None] if we don't have access to [p]'s portrait or it doesn't exist.
+    - [Some path] with [path] the full path with extension of [p]'s portrait.
+*)
+
+val get_portrait_with_size :
+  config ->
+  base ->
+  person ->
+  ([> `Path of string | `Url of string ] * (int * int) option) option
+(** [get_portrait_with_size conf base p] is
+    - [None] if we don't have access to [p]'s portrait or it doesn't exist.
+    - [Some (src, size_opt)] with [src] the url or path of [p]'s portrait. [size_opt] is the (width,height) of the portrait if we could recover them *)
+
+val get_portrait :
+  config -> base -> person -> [> `Path of string | `Url of string ] option
+(** [get_portrait conf base p] is
+    - [None] if we don't have access to [p]'s portrait or it doesn't exist.
+    - [Some src] with [src] the url or path of [p]'s portrait.
+*)

--- a/lib/imageDisplay.ml
+++ b/lib/imageDisplay.ml
@@ -3,6 +3,19 @@
 
 open Config
 
+let print_placeholder_gendered_portrait conf p size =
+  let open Gwdb in
+  let image, alt =
+    match get_sex p with
+    | Male -> ("male.png", "M")
+    | Female -> ("female.png", "F")
+    | Neuter -> ("sexunknown.png", "?")
+  in
+  Output.printf conf
+    {|<img src="%s/%s" alt="%s" title="sex" width="%d" height="%d">|}
+    (Image.prefix conf |> Adef.as_string)
+    image alt size size
+
 (* ************************************************************************** *)
 (*  [Fonc] content : string -> int -> string -> unit                          *)
 (** [Description] : Envoie les en-têtes de contenu et de cache pour un fichier
@@ -25,21 +38,24 @@ let content conf ct len fname =
   Output.header conf "Cache-control: private, max-age=%d" (60 * 60 * 24 * 365);
   Output.flush conf
 
-(* ************************************************************************** *)
-(*  [Fonc] print_image_type : string -> string -> bool                        *)
-(** [Description] : Affiche une image (avec ses en-têtes) en réponse HTTP en
-                    utilisant Wserver.
-    [Args] :
-      - fname : le chemin vers le fichier image
-      - ctype : le content_type MIME du fichier, par exemple "image/png",
-                "image/jpeg" ou "application/pdf"
-    [Retour] : True si le fichier image existe et qu'il a été servi en réponse
-               HTTP.
-    [Rem] : Ne pas utiliser en dehors de ce module.                           *)
-(* ************************************************************************** *)
-let print_image_type conf fname ctype =
-  match try Some (Secure.open_in_bin fname) with Sys_error _ -> None with
-    Some ic ->
+let print_image_file conf fname =
+  let res = List.find_opt
+    (fun (suff, ctype) ->
+       if Filename.check_suffix fname suff ||
+          Filename.check_suffix fname (String.uppercase_ascii suff)
+       then
+         true
+       else false)
+    [(".png", "image/png"); (".jpg", "image/jpeg");
+     (".jpeg", "image/jpeg"); (".pjpeg", "image/jpeg");
+     (".gif", "image/gif"); (".pdf", "application/pdf");
+     (".htm", "text/html"); (".html", "text/html")]
+  in
+  match res with
+  | None -> Error (Format.sprintf "Could not find mime type from extension for file: %s" fname)
+  | Some (_suff, ctype) ->
+    try
+      let ic = Secure.open_in_bin fname in
       let buf = Bytes.create 1024 in
       let len = in_channel_length ic in
       content conf ctype len fname;
@@ -51,33 +67,14 @@ let print_image_type conf fname ctype =
           Output.print_sstring conf (Bytes.sub_string buf 0 olen);
           loop (len - olen)
       in
-      loop len; close_in ic; true
-  | None -> false
+      loop len; close_in ic;
+      Ok ()
+    with Sys_error e ->
+      !GWPARAM.syslog `LOG_ERR (Format.sprintf "Error printing image file content for %s : %s" fname e);
+      Error e
 
 (* ************************************************************************** *)
-(*  [Fonc] print_image_file : string -> bool                                  *)
-(** [Description] : Affiche une image (avec ses en-têtes) en réponse HTTP en
-                    utilisant Wserver. Le type MIME de l'image est deviné à
-                    partir de l'extension contenu dans le nom du fichier.
-    [Args] :
-      - fname : le nom du fichier image
-    [Retour] : True si l'image a pu être affichée                           *)
-(* ************************************************************************** *)
-let print_image_file conf fname =
-  List.exists
-    (fun (suff, ctype) ->
-       if Filename.check_suffix fname suff ||
-          Filename.check_suffix fname (String.uppercase_ascii suff)
-       then
-         print_image_type conf fname ctype
-       else false)
-    [(".png", "image/png"); (".jpg", "image/jpeg");
-     (".jpeg", "image/jpeg"); (".pjpeg", "image/jpeg");
-     (".gif", "image/gif"); (".pdf", "application/pdf");
-     (".htm", "text/html"); (".html", "text/html")]
-
-(* ************************************************************************** *)
-(*  [Fonc] print_personal_image : Config.config -> Gwdb.base -> Gwdb.person -> unit *)
+(*  [Fonc] print_portrait : Config.config -> Gwdb.base -> Gwdb.person -> unit *)
 (** [Description] : Affiche l'image d'une personne en réponse HTTP.
     [Args] :
       - conf : configuration de la requête
@@ -86,14 +83,15 @@ let print_image_file conf fname =
     [Retour] : aucun
     [Rem] : Ne pas utiliser en dehors de ce module.                           *)
 (* ************************************************************************** *)
-let print_personal_image conf base p =
-  match Util.image_and_size conf base p (fun _ _ -> Some (1, 1)) with
-    Some (true, f, _) ->
-      if print_image_file conf f then () else Hutil.incorrect_request conf
-  | _ -> Hutil.incorrect_request conf
+let print_portrait conf base p =
+  match Image.get_portrait conf base p with
+    Some `Path path ->
+      Result.fold ~ok:ignore ~error:(fun _ -> Hutil.incorrect_request conf)
+        (print_image_file conf path)
+  | Some (`Url _) | None -> Hutil.incorrect_request conf
 
 (* ************************************************************************** *)
-(*  [Fonc] print_source_image : Config.config -> string -> unit               *)
+(*  [Fonc] print_source : Config.config -> string -> unit               *)
 (** [Description] : Affiche une image à partir de son basename uniquement en
                     la cherchant dans les dossiers d'images.
     [Args] :
@@ -102,13 +100,14 @@ let print_personal_image conf base p =
     [Retour] : aucun
     [Rem] : Ne pas utiliser en dehors de ce module.                           *)
 (* ************************************************************************** *)
-let print_source_image conf f =
+let print_source conf f =
   let fname =
     if f.[0] = '/' then String.sub f 1 (String.length f - 1) else f
   in
   if fname = Filename.basename fname then
-    let fname = Util.source_image_file_name conf.bname fname in
-    if print_image_file conf fname then () else Hutil.incorrect_request conf
+    let fname = Image.source_filename conf.bname fname in
+    Result.fold ~ok:ignore ~error:(fun _ -> Hutil.incorrect_request conf)
+      (print_image_file conf fname)
   else Hutil.incorrect_request conf
 
 (* ************************************************************************** *)
@@ -116,11 +115,11 @@ let print_source_image conf f =
 (* ************************************************************************** *)
 let print conf base =
   match Util.p_getenv conf.env "s" with
-    Some f -> print_source_image conf f
+  | Some f -> print_source conf f
   | None ->
       match Util.find_person_in_env conf base "" with
-        Some p -> print_personal_image conf base p
-      | _ -> Hutil.incorrect_request conf
+      | Some p -> print_portrait conf base p
+      | None -> Hutil.incorrect_request conf
 
 (* ************************************************************************** *)
 (*  [Fonc] print_html : config -> 'a -> unit                                  *)

--- a/lib/imageDisplay.mli
+++ b/lib/imageDisplay.mli
@@ -1,11 +1,16 @@
+open Config
+
 (** [print_image_file conf fname] send HTTP respose with content of an image file at the path [fname].
     MIME type of an image is deducted from [fname] extension. Returns [false] if image
     wasn't found or couldn't be send. *)
-val print_image_file : Config.config -> string -> bool
+val print_image_file :config -> string -> (unit, string) result
 
 (** Searhes image's filename in the environement [conf.env] and sends HTTP respose with its content on the socket. If filename isn't presented, looks up
     personal image for person's mentionned in [conf.env] *)
-val print : Config.config -> Gwdb.base -> unit
+val print : config -> Gwdb.base -> unit
 
 (** Sends HTTP respose with HTML page containg just image specified in arguments. *)
-val print_html : Config.config -> unit
+val print_html : config -> unit
+
+val print_placeholder_gendered_portrait : config -> Gwdb.person -> int -> unit
+(** prints html `<img>` tag of the default gendered portrait with square size [size] *)

--- a/lib/mergeIndDisplay.ml
+++ b/lib/mergeIndDisplay.ml
@@ -89,12 +89,15 @@ let print_differences conf base branches p1 p2 =
     (transl_nth conf "image/images" 0 |> Adef.safe)
     ("image" |> Adef.encoded)
     (fun p ->
-       let v = image_and_size conf base p (limited_image_size 75 100) in
-       match v with
-       | Some (false, link, _) ->
-         ({|<img src="|} ^<^ escape_html link ^>^ {|" style="max-width:75px;max-height:100px">|}
+       match Image.get_portrait conf base p with
+       | Some (`Url url) ->
+         ({|<img src="|} ^<^ escape_html url ^>^ {|" style="max-width:75px;max-height:100px">|}
           :> Adef.safe_string)
-       | _ -> (get_image p |> sou base |> escape_html :> Adef.safe_string)) ;
+       | Some (`Path path) ->
+           (* TODO: ?? *)
+       ((escape_html path ):> Adef.safe_string)
+       | None -> Adef.safe ""
+    );
   string_field
     (transl conf "public name" |> Adef.safe)
     ("public_name" |> Adef.encoded)

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -177,7 +177,11 @@ let reconstitute conf base p1 p2 =
        field "surname" (fun p -> p_surname base p)
          (fun x -> x = "" || x = "?");
      occ = field "number" get_occ ((=) 0);
-     image = field "image" (fun p -> sou base (get_image p)) ((=) "");
+     image = field "image" (fun p ->
+       match Image.get_portrait conf base p with
+       | Some src -> Image.src_to_string src
+       | None -> ""
+     ) ((=) "");
      public_name =
        field "public_name" (fun p -> sou base (get_public_name p)) ((=) "");
      qualifiers = list (sou base) get_qualifiers;
@@ -442,4 +446,3 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   let oocc2 = o_p2.occ in
   let pgl2 = Perso.links_to_ind conf base db (Name.lower ofn2, Name.lower osn2, oocc2) in
   print_mod_merge_ok conf base wl p pgl1 ofn1 osn1 oocc1 pgl2 ofn2 osn2 oocc2
-

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -190,11 +190,11 @@ let note conf base env str =
   wiki_aux (fun x -> x) conf base env str
 
 let person_note conf base p str =
-  let env = ['i', (fun () -> Util.default_image_name base p)] in
+  let env = ['i', (fun () -> Image.default_portrait_filename base p )] in
   note conf base env str
 
 let source_note conf base p str =
-  let env = ['i', (fun () -> Util.default_image_name base p)] in
+  let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
   wiki_aux (function [ "<p>" ; x ; "</p>" ] -> [ x ] | x -> x) conf base env str
 
 let source_note_with_env conf base env str =

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -482,7 +482,7 @@ let print_sosa conf base p link =
           )
       in
       Output.print_sstring conf {|<img src="|} ;
-      Output.print_string conf (image_prefix conf) ;
+      Output.print_string conf (Image.prefix conf) ;
       Output.print_sstring conf {|/sosa.png" alt="sosa" title="|} ;
       Output.print_string conf title ;
       Output.print_sstring conf {|"> |} ;
@@ -1579,13 +1579,13 @@ let null_val = VVstring ""
 let safe_val (x : [< `encoded | `escaped | `safe] Adef.astring) =
   VVstring ((x :> Adef.safe_string) :> string)
 
-let gen_string_of_img_sz max_wid max_hei conf base (p, p_auth) =
+let gen_string_of_img_sz max_w max_h conf base (p, p_auth) =
   if p_auth then
-    let v = image_and_size conf base p (limited_image_size max_wid max_hei) in
-    match v with
-      Some (_, _, Some (width, height)) ->
-        Format.sprintf " width=\"%d\" height=\"%d\"" width height
-    | Some (_, _, None) -> Format.sprintf " height=\"%d\"" max_hei
+    match Image.get_portrait_with_size conf base p with
+    | Some (_, Some (w,h)) ->
+        let w, h = Image.scale_to_fit ~max_w ~max_h ~w ~h in
+        Format.sprintf " width=\"%d\" height=\"%d\"" w h
+    | Some (_, None) -> Format.sprintf " height=\"%d\"" max_h
     | None -> ""
   else ""
 let string_of_image_size = gen_string_of_img_sz max_im_wid max_im_wid
@@ -3155,12 +3155,12 @@ and eval_str_event_field conf base (p, p_auth)
         |> safe_val
       else null_val
   | "note" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       sou base note
       |> get_note_source conf base env p_auth conf.no_note
       |> safe_val
   | "src" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       sou base src
       |> get_note_source conf base env p_auth false
       |> safe_val
@@ -3462,7 +3462,7 @@ and eval_bool_person_field conf base env (p, p_auth) =
       if not p_auth && is_hide_names conf p then false
       else get_first_names_aliases p <> []
   | "has_history" -> has_history conf base p p_auth
-  | "has_image" -> Util.has_image conf base p
+  | "has_image" -> Image.get_portrait conf base p |> Option.is_some
   | "has_nephews_or_nieces" -> has_nephews_or_nieces conf base p
   | "has_nobility_titles" -> p_auth && nobtit conf base p <> []
   | "has_notes" | "has_pnotes" ->
@@ -3585,24 +3585,24 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
   | "approx_death_place" ->
       if p_auth then Util.get_approx_death_date_place conf base p |> snd |> safe_val
       else null_val
-  | "auto_image_file_name" ->
-      if p_auth then match auto_image_file conf base p with
-        | Some x -> str_val x
+  | "auto_image_file_name" -> (
+      match Image.get_portrait_path conf base p with
+        | Some (`Path s) -> str_val s
         | None -> null_val
-      else null_val
+    )
   | "bname_prefix" -> Util.commd conf |> safe_val
   | "birth_place" ->
       if p_auth
       then get_birth_place p |> sou base |> Util.string_of_place conf |> safe_val
       else null_val
   | "birth_note" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_birth_note p
       |> sou base
       |> get_note_source conf base env p_auth conf.no_note
       |> safe_val
   | "birth_source" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_birth_src p
       |> sou base
       |> get_note_source conf base env p_auth false
@@ -3615,13 +3615,13 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
         |> safe_val
       else null_val
   | "baptism_note" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_baptism_note p
       |> sou base
       |> get_note_source conf base env p_auth conf.no_note
       |> safe_val
   | "baptism_source" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_baptism_src p
       |> sou base
       |> get_note_source conf base env p_auth false
@@ -3635,13 +3635,13 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
         |> safe_val
       else null_val
   | "burial_note" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_burial_note p
       |> sou base
       |> get_note_source conf base env p_auth conf.no_note
       |> safe_val
   | "burial_source" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_burial_src p
       |> sou base
       |> get_note_source conf base env p_auth false
@@ -3699,13 +3699,13 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
         |> safe_val
       else null_val
   | "death_note" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_death_note p
       |> sou base
       |> get_note_source conf base env p_auth conf.no_note
       |> safe_val
   | "death_source" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_death_src p
       |> sou base
       |> get_note_source conf base env p_auth false
@@ -3734,7 +3734,11 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
         let occ = get_occ p in
         HistoryDiff.history_file fn sn occ
         |> str_val
-  | "image" -> if not p_auth then null_val else get_image p |> sou base |> str_val
+  | "image" -> (
+      match Image.get_portrait conf base p with
+      | Some src -> Image.src_to_string src |> str_val
+      | None -> null_val
+    )
   | "image_html_url" -> string_of_image_url conf base ep true |> safe_val
   | "image_size" -> string_of_image_size conf base ep |> str_val
   | "image_medium_size" -> string_of_image_medium_size conf base ep |> str_val
@@ -3854,7 +3858,7 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
           |> str_val
       end
   | "notes" | "pnotes" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_notes p
       |> sou base
       |> get_note_source conf base env p_auth conf.no_note
@@ -3863,7 +3867,7 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
       if is_hide_names conf p && not p_auth then null_val
       else get_occ p |> string_of_int |> str_val
   | "occupation" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_occupation p
       |> sou base
       |> get_note_source conf base env p_auth false
@@ -3894,7 +3898,7 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
       | _ -> raise Not_found
     end
   | "psources" ->
-      let env = ['i', (fun () -> Util.default_image_name base p)] in
+      let env = ['i', (fun () -> Image.default_portrait_filename base p)] in
       get_psources p
       |> sou base
       |> get_note_source conf base env p_auth false
@@ -4117,11 +4121,11 @@ and string_of_died conf p p_auth =
   else Adef.safe ""
 and string_of_image_url conf base (p, p_auth) html : Adef.escaped_string =
   if p_auth then
-    match image_and_size conf base p (limited_image_size max_im_wid max_im_wid) with
-    | Some (true, fname, _) ->
+    match Image.get_portrait conf base p with
+    | Some (`Path fname) ->
       let s = Unix.stat fname in
       let b = acces conf base p in
-      let k = default_image_name base p in
+      let k = Image.default_portrait_filename base p in
       Format.sprintf "%sm=IM%s&d=%d&%s&k=/%s"
         (commd conf :> string)
         (if html then "H" else "")
@@ -4129,7 +4133,7 @@ and string_of_image_url conf base (p, p_auth) html : Adef.escaped_string =
         (b :> string)
         k
       |> Adef.escaped
-    | Some (false, link, _) -> Adef.escaped link (* FIXME *)
+    | Some (`Url url) -> Adef.escaped url (* FIXME *)
     | None -> Adef.escaped ""
   else Adef.escaped ""
 and string_of_parent_age conf base (p, p_auth) parent : Adef.safe_string =

--- a/lib/relationDisplay.ml
+++ b/lib/relationDisplay.ml
@@ -519,7 +519,7 @@ let print_solution_ancestor conf base long p1 p2 pp1 pp2 x1 x2 list =
       let dp1 = match pp1 with Some p -> p | _ -> p1 in
       let dp2 = match pp2 with Some p -> p | _ -> p2 in
       Output.print_sstring conf "<img src=\"" ;
-      Output.print_string conf (Util.image_prefix conf) ;
+      Output.print_string conf (Image.prefix conf) ;
       Output.print_sstring conf "/picto_rel_small.png\" alt=\"\">" ;
       let href =
         (commd conf)
@@ -578,7 +578,7 @@ let print_solution_not_ancestor conf base long p1 p2 sol =
       let dp1 = match pp1 with Some p -> p | _ -> p1 in
       let dp2 = match pp2 with Some p -> p | _ -> p2 in
       Output.print_sstring conf {|<img src="|} ;
-      Output.print_string conf (Util.image_prefix conf) ;
+      Output.print_string conf (Image.prefix conf) ;
       Output.print_sstring conf {|/picto_rel_small.png" alt="">|} ;
       let href =
         (commd conf)
@@ -642,7 +642,7 @@ let print_solution_not_ancestor conf base long p1 p2 sol =
 let print_solution conf base long n p1 p2 sol =
   let (pp1, pp2, (x1, x2, list), _) = sol in
   Output.print_sstring conf {|<p><img src="|} ;
-  Output.print_string conf (Util.image_prefix conf) ;
+  Output.print_string conf (Image.prefix conf) ;
   Output.print_sstring conf {|/picto_fleche_bleu.png" alt="">|} ;
   print_link_name conf base n p1 p2 sol;
   Output.print_sstring conf "</p>\n";
@@ -684,7 +684,7 @@ let print_dag_links conf base p1 p2 rl =
     let rest = ref false in
     if is_anc then begin
       Output.print_sstring conf {|<img src="|} ;
-      Output.print_string conf (Util.image_prefix conf) ;
+      Output.print_string conf (Image.prefix conf) ;
       Output.print_sstring conf {|/picto_fleche_bleu.png" alt="">|}
     end else Output.print_sstring conf "<ul>";
     M.iter begin fun ip (pp1, pp2, nn, nt, _) ->
@@ -765,7 +765,7 @@ let print_propose_upto conf base p1 p2 rl =
     in
     let (p, a) = if x1 = 0 then p2, p1 else p1, p2 in
     Output.print_sstring conf {|<p><img src="|} ;
-    Output.print_string conf (Util.image_prefix conf) ;
+    Output.print_string conf (Image.prefix conf) ;
     Output.print_sstring conf
       {|/picto_fleche_bleu.png" alt=""> <span class="smaller">|} ;
     let s = (person_title_text conf base p : Adef.safe_string :> string) in
@@ -778,7 +778,7 @@ let print_propose_upto conf base p1 p2 rl =
     |> transl_decline conf "up to"
     |> Output.print_sstring conf ;
     Output.print_sstring conf {|&nbsp;<img src="|} ;
-    Output.print_string conf (Util.image_prefix conf) ;
+    Output.print_string conf (Image.prefix conf) ;
     Output.print_sstring conf {|/picto_rel_asc.png" alt=""> <a href="|} ;
     Output.print_string conf (commd conf) ;
     Output.print_string conf (acces conf base p) ;

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -26,7 +26,7 @@ let surname_not_found conf = not_found conf (transl conf "surname not found")
 
 let print_img conf img =
   Output.print_sstring conf {|<img src="|};
-  Output.print_string conf (Util.image_prefix conf) ;
+  Output.print_string conf (Image.prefix conf) ;
   Output.print_sstring conf {|/|} ;
   Output.print_string conf img ;
   Output.print_sstring conf {|" alt="" title="">|}

--- a/lib/srcfileDisplay.ml
+++ b/lib/srcfileDisplay.ml
@@ -190,7 +190,7 @@ let macro conf base = function
             :> Adef.safe_string )
       with Not_found -> Adef.safe ""
     end
-  | 'o' -> (image_prefix conf :> Adef.safe_string)
+  | 'o' -> (Image.prefix conf :> Adef.safe_string)
   | 'q' ->
     let r = count conf in
     string_of_int_sep_aux conf (r.welcome_cnt + r.request_cnt)

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -177,8 +177,8 @@ and eval_simple_variable conf =
       let s = if conf.cgi then
         match Util.p_getenv conf.base_env "image_prefix" with
         | Some x -> x
-        | None -> Util.image_prefix conf
-      else Util.image_prefix conf
+        | None -> Image.prefix conf
+      else Image.prefix conf
       in
       s :> string
     )
@@ -669,9 +669,9 @@ let print_foreach conf ifun print_ast eval_expr env ep loc s sl el al =
       templ_print_foreach conf print_ast ifun.set_vother env ep loc s sl el al
 
 let print_wid_hei conf fname =
-  match Util.image_size (Util.image_file_name fname) with
-    Some (wid, hei) -> Output.printf conf " width=\"%d\" height=\"%d\"" wid hei
-  | None -> ()
+  match Image.size_from_path (Image.path_of_filename fname) with
+  | Ok (wid, hei) -> Output.printf conf " width=\"%d\" height=\"%d\"" wid hei
+  | Error () -> ()
 
 (** Evaluates and prints content of {i cpr} template.
     If template wasn't found prints basic copyrigth HTML structure. *)

--- a/lib/updateData.ml
+++ b/lib/updateData.ml
@@ -388,7 +388,7 @@ let update_person_list conf base new_input list nb_pers max_updates =
                   Futil.map_person_ps (fun ip -> ip)
                     (fun istr -> sou base istr) np
                 in
-                UpdateIndOk.rename_image_file conf base op sp
+                Image.rename_portrait conf base op (sp.first_name,sp.surname,sp.occ)
               end;
             patch_person base np.key_index np;
             if test_family then

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -787,17 +787,6 @@ let check_sex_married ?(prerr = default_prerr) conf base sp op =
      end (get_family op)
   then prerr conf base (Update.UERR_sex_married op)
 
-let rename_image_file conf base op sp =
-  match auto_image_file conf base op with
-    Some old_f ->
-      let s = default_image_name_of_key sp.first_name sp.surname sp.occ in
-      let f = Filename.concat (Util.base_path ["images"] conf.bname) s in
-      let new_f =
-        if Filename.check_suffix old_f ".gif" then f ^ ".gif" else f ^ ".jpg"
-      in
-      (try Sys.rename old_f new_f with Sys_error _ -> ())
-  | _ -> ()
-
 let rparents_of rparents =
   List.fold_left
     (fun ipl r ->
@@ -827,7 +816,7 @@ let effective_mod ?prerr ?skip_conflict conf base sp =
     | Some p' when p' <> pi && Some p' <> skip_conflict ->
       Update.print_create_conflict conf base (poi base p') ""
     | _ ->
-      rename_image_file conf base op sp
+      Image.rename_portrait conf base op (sp.first_name, sp.surname, sp.occ)
   end ;
   if (List.assoc_opt "nsck" conf.env :> string option) <> Some "on"
   then check_sex_married ?prerr conf base sp op ;

--- a/lib/updateIndOk.mli
+++ b/lib/updateIndOk.mli
@@ -33,10 +33,6 @@ val all_checks_person :
 val print_mod_aux :
   config -> base -> ((iper, Update.key, string) gen_person -> unit) -> unit
 
-(** Renames the image associated to a person *)
-val rename_image_file :
-  config -> base -> person -> (iper, iper, string) gen_person -> unit
-
 (** Tries to add a person to the base and displays a success HTML page if
     successful *)
 val print_add : config -> base -> unit

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -645,7 +645,7 @@ let restricted_txt = Adef.safe "....."
 let x_x_txt = Adef.safe "x x"
 
 let gen_person_text
-    ?(escape = true)  
+    ?(escape = true)
     ?(html = true)
     ?(sn = true)
     ?(chk = true)
@@ -966,7 +966,7 @@ let string_of_witness_kind conf sex witness_kind =
   | Witness ->
      transl_nth conf "witness/witness/witnesses" 0
   | Witness_CivilOfficer ->
-     let n = index_of_sex sex in     
+     let n = index_of_sex sex in
      transl_nth conf "civil registrar/civil registrar/civil registrar" n
   | Witness_GodParent ->
      let n = index_of_sex sex in
@@ -1129,8 +1129,6 @@ let include_template conf env fname failure =
     copy_from_templ conf env ic;
     include_end conf (esc fname)
   | None -> failure ()
-
-let image_prefix conf = escape_html conf.image_prefix
 
 let body_prop conf =
   try
@@ -1761,115 +1759,6 @@ let string_of_decimal_num conf f =
   in
   loop 0
 
-let personal_image_file_name bname str =
-  Filename.concat (base_path ["images"] bname) str
-
-let source_image_file_name bname str =
-  let fname1 =
-    List.fold_right Filename.concat [base_path ["src"] bname; "images"] str
-  in
-  let fname2 =
-    List.fold_right Filename.concat [Secure.base_dir (); "src"; "images"] str
-  in
-  if Sys.file_exists fname1 then fname1 else fname2
-
-let image_file_name str =
-  let fname1 =
-    List.fold_right Filename.concat [Secure.base_dir (); "images"] str
-  in
-  if Sys.file_exists fname1 then fname1
-  else search_in_assets (Filename.concat "images" str)
-
-let png_image_size ic =
-  let magic = really_input_string ic 4 in
-  if magic = "\137PNG" then
-    begin
-      seek_in ic 16;
-      let wid = input_binary_int ic in
-      let hei = input_binary_int ic in Some (wid, hei)
-    end
-  else None
-
-let gif_image_size ic =
-  let magic = really_input_string ic 4 in
-  if magic = "GIF8" then
-    begin
-      seek_in ic 6;
-      let wid = let x = input_byte ic in input_byte ic * 256 + x in
-      let hei = let x = input_byte ic in input_byte ic * 256 + x in
-      Some (wid, hei)
-    end
-  else None
-
-let jpeg_image_size ic =
-  let magic = really_input_string ic 10 in
-  if Char.code magic.[0] = 0xff && Char.code magic.[1] = 0xd8 &&
-     (let m = String.sub magic 6 4 in m = "JFIF" || m = "Exif")
-  then
-    let exif_type = String.sub magic 6 4 = "Exif" in
-    let rec loop found =
-      while Char.code (input_char ic) <> 0xFF do () done;
-      let ch =
-        let rec loop ch =
-          if Char.code ch = 0xFF then loop (input_char ic) else ch
-        in
-        loop (input_char ic)
-      in
-      if Char.code ch = 0xC0 || Char.code ch = 0xC3 then
-        if exif_type && not found then loop true
-        else
-          begin
-            for i = 1 to 3 do let _ = input_char ic in () done;
-            let a = input_char ic in
-            let b = input_char ic in
-            let c = input_char ic in
-            let d = input_char ic in
-            let wid = Char.code c lsl 8 lor Char.code d in
-            let hei = Char.code a lsl 8 lor Char.code b in Some (wid, hei)
-          end
-      else
-        let a = input_char ic in
-        let b = input_char ic in
-        let len = Char.code a lsl 8 lor Char.code b in
-        let len = if len >= 32768 then 0 else len in
-        for i = 1 to len - 2 do let _ = input_char ic in () done;
-        if Char.code ch <> 0xDA then loop found else None
-    in
-    loop false
-  else None
-
-let image_size fname =
-  try
-    let ic = Secure.open_in_bin fname in
-    let r =
-      try
-        let sz = jpeg_image_size ic in
-        let sz =
-          if sz = None then begin seek_in ic 0; png_image_size ic end
-          else sz
-        in
-        if sz = None then begin seek_in ic 0; gif_image_size ic end else sz
-      with End_of_file -> None
-    in
-    close_in ic; r
-  with Sys_error _ -> None
-
-let limited_image_size max_wid max_hei fname size =
-  match if fname = "" then size else image_size fname with
-    Some (wid, hei) ->
-      let (wid, hei) =
-        if hei > max_hei then
-          let wid = wid * max_hei / hei in let hei = max_hei in wid, hei
-        else wid, hei
-      in
-      let (wid, hei) =
-        if wid > max_wid then
-          let hei = hei * max_wid / wid in let wid = max_wid in wid, hei
-        else wid, hei
-      in
-      Some (wid, hei)
-  | None -> None
-
 let find_person_in_env_aux conf base env_i env_p env_n env_occ =
   match p_getenv conf.env env_i with
   | Some i when i <> "" ->
@@ -2038,101 +1927,6 @@ let old_sosa_of_branch conf base (ipl : (iper * sex) list) =
 let old_branch_of_sosa conf base ip sosa =
   branch_of_sosa conf base sosa (pget conf base ip)
   |> Opt.map @@ List.map (fun p -> get_iper p, get_sex p)
-
-let default_image_name_of_key fnam surn occ =
-  let aux s = Name.lower s |> Mutil.tr ' ' '_' in
-  aux fnam ^ "." ^ string_of_int occ ^ "." ^ aux surn
-
-let default_image_name base p =
-  default_image_name_of_key
-    (p_first_name base p)
-    (p_surname base p)
-    (get_occ p)
-
-let auto_image_file conf base p =
-  let s = default_image_name base p in
-  let f = Filename.concat (base_path ["images"] conf.bname) s in
-  if Sys.file_exists (f ^ ".gif") then Some (f ^ ".gif")
-  else if Sys.file_exists (f ^ ".jpg") then Some (f ^ ".jpg")
-  else if Sys.file_exists (f ^ ".png") then Some (f ^ ".png")
-  else None
-
-(* ********************************************************************** *)
-(*  [Fonc] image_and_size : config -> base -> person -> image_size        *)
-(** [Description] : Renvoie la source de l'image ainsi que sa taille.
-    [Args] :
-      - conf : configuration de la base
-      - base : base de données
-      - p    : personne
-      [Retour] :
-        - is_filename : indique si la source de l'image est un nom de
-                        fichier ou une URL.
-        - source
-        - image_size
-    [Rem] : Exporté en clair hors de ce module.                            *)
-(* *********************************************************************** *)
-let image_and_size conf base p image_size =
-  if not conf.no_image && authorized_age conf base p then
-    match sou base (get_image p) with
-      "" ->
-        begin match auto_image_file conf base p with
-          Some f -> Some (true, f, image_size f None)
-        | None -> None
-        end
-    | s ->
-        let (s, size) =
-          let l = String.length s - 1 in
-          if s.[l] = ')' then
-            try
-              let pos1 = String.index s '(' in
-              let pos2 = String.index_from s pos1 'x' in
-              let wid = String.sub s (pos1 + 1) (pos2 - pos1 - 1) in
-              let hei = String.sub s (pos2 + 1) (l - pos2 - 1) in
-              let size = Some (int_of_string wid, int_of_string hei) in
-              String.sub s 0 pos1, image_size "" size
-            with Not_found | Failure _ -> s, None
-          else s, None
-        in
-        let http = "http://" in
-        let https = "https://" in
-        if String.length s > String.length http &&
-           String.sub s 0 (String.length http) = http ||
-           String.length s > String.length https &&
-           String.sub s 0 (String.length https) = https
-        then
-          Some (false, s, size)
-        else if Filename.is_implicit s then
-          match
-            try Some (List.assoc "images_path" conf.base_env) with
-              Not_found -> None
-          with
-            Some p when p <> "" -> Some (false, p ^ s, size)
-          | _ ->
-              let fname = personal_image_file_name conf.bname s in
-              if Sys.file_exists fname then
-                Some (true, fname, image_size fname None)
-              else None
-        else None
-  else None
-
-(* ********************************************************************** *)
-(*  [Fonc] has_image : config -> base -> person -> bool                   *)
-(** [Description] : Renvoie Vrai si la personne a une photo et qu'on a les
-                    droits pour la voir, Faux sinon.
-    [Args] :
-      - conf : configuration de la base
-      - base : base de donnée
-      - p    : person
-    [Retour] : Vrai si la personne a une image, Faux sinon.
-    [Rem] : Exporté en clair hors de ce module.                           *)
-(* ********************************************************************** *)
-let has_image conf base p =
-  if not conf.no_image && authorized_age conf base p then
-    not (is_empty_string (get_image p)) &&
-    (conf.wizard || conf.friend ||
-     not (Mutil.contains (sou base (get_image p)) "/private/")) ||
-    auto_image_file conf base p <> None
-  else false
 
 let gen_only_printable or_nl s =
   let s' =
@@ -2594,25 +2388,6 @@ let print_tips_relationship conf =
     |> Adef.safe
     |> gen_print_tips conf
 
-let print_image_sex conf p size =
-  let (image, alt) =
-    match get_sex p with
-    | Male -> "male.png", "M"
-    | Female -> "female.png", "F"
-    | Neuter -> "sexunknown.png", "?"
-  in
-  Output.print_sstring conf {|<img src="|} ;
-  Output.print_string conf (image_prefix conf) ;
-  Output.print_sstring conf {|/|} ;
-  Output.print_sstring conf image ;
-  Output.print_sstring conf {|" alt="|} ;
-  Output.print_sstring conf alt ;
-  Output.print_sstring conf {|" title="sex" width="|} ;
-  Output.print_sstring conf (string_of_int size) ;
-  Output.print_sstring conf {|" heigth="|} ;
-  Output.print_sstring conf (string_of_int size) ;
-  Output.print_sstring conf {|">|}
-
 (* ********************************************************************** *)
 (*  [Fonc] display_options : config -> string                             *)
 (** [Description] : Recherche dans l'URL les options d'affichage qui sont
@@ -2883,7 +2658,7 @@ let hom_person base p1 p2 =
   let fn1, sn1 = first_name base p1, surname base p1 in
   let fn2, sn2 = first_name base p2, surname base p2 in
   fn1 = fn2 && sn1 = sn2
-  
+
 let hom_fam base f1 f2 =
   let f1, f2 = foi base f1, foi base f2 in
   let fa1, mo1 = poi base @@ get_father f1, poi base @@ get_mother f1 in

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -7,9 +7,6 @@ open Gwdb
 (** The directory where counters (e.g. number page displayed) are stored. *)
 val cnt_dir : string ref
 
-(** Returns the image prefix (conf.image_prefix)  *)
-val image_prefix : config -> Adef.escaped_string
-
 (** Alias for !GWPARAM.base_path *)
 val base_path : string list -> string -> string
 
@@ -389,42 +386,6 @@ val old_branch_of_sosa : config -> base -> iper -> Sosa.t -> (iper * sex) list o
 (** @deprecated Use [sosa_of_branch] instead *)
 val old_sosa_of_branch : config -> base -> (iper * sex) list -> Sosa.t
 
-val has_image : config -> base -> person -> bool
-
-(** [image_file_name fname] search for image {i images/fname} inside the base and assets directories.
-    Return the path to found file or [fname] if file isn't found.  *)
-val image_file_name : string -> string
-
-(** Returns path to the image file with the giving name in directory {i src/}. *)
-val source_image_file_name : string -> string -> string
-
-(** Returns width and height of an image. *)
-val image_size : string -> (int * int) option
-
-(** [limited_image_size max_wid max_hei fname defsize] returns image size of [fname]. If width and height are greater
-    then their limits [max_wid] and [max_hei] then returns reduced size with the same proportions. [defsize] is returned
-    if image filename is empty. *)
-val limited_image_size :
-  int -> int -> string -> (int * int) option -> (int * int) option
-
-(** Returns path to the personal image. In details, returns [(is_filename,source,size)] where [is_filename] tells if [source]
-    is a filename or URL and [size] is a size of image (width x height). *)
-val image_and_size :
-  config -> base -> person ->
-    (string -> (int * int) option -> (int * int) option) ->
-    (bool * string * (int * int) option) option
-
-(** Returns default image name calculated from person's first name, surname
-    and occurence number. For example : Jean Claude DUPOND 3 => jean_claude.3.dupond *)
-val default_image_name_of_key : string -> string -> int -> string
-
-(** Returns default image name calculated from person's key. *)
-val default_image_name : base -> person -> string
-
-(** Searchs personal image (portrait) inside the base directory by looking up its default name
-    and tryig to deduce its extension. Returns path to the image if found. *)
-val auto_image_file : config -> base -> person -> string option
-
 (** Trims and remplaces all non-printable characters by spaces in the given string. *)
 val only_printable : string -> string
 
@@ -485,8 +446,6 @@ val gen_print_tips : config -> Adef.safe_string -> unit
 
 (** Print a tip that tells to {i Click an individual below to calculate the family link.} *)
 val print_tips_relationship : config -> unit
-
-val print_image_sex : config -> person -> int -> unit
 
 val display_options : config -> Adef.escaped_string
 

--- a/plugins/gwxjg/gwxjg_data.ml
+++ b/plugins/gwxjg/gwxjg_data.ml
@@ -636,7 +636,8 @@ and unsafe_mk_person conf base (p : Gwdb.person) =
   in
   let first_name = Tstr (E.first_name base p) in
   let first_name_aliases = mk_str_lst base (Gwdb.get_first_names_aliases p) in
-  let image = Tstr (Gwdb.sou base @@ Gwdb.get_image p) in
+  let image = Tstr (Image.get_portrait conf base p
+    |> Option.fold ~none:"" ~some:Image.src_to_string) in
   let iper = Tstr (Gwdb.string_of_iper iper') in
   let linked_page =
     Tlazy begin lazy begin

--- a/plugins/gwxjg/gwxjg_ezgw.ml
+++ b/plugins/gwxjg/gwxjg_ezgw.ml
@@ -124,9 +124,6 @@ module Person = struct
     let sn = sou base (get_surname p) in
     let occ = get_occ p in HistoryDiff.history_file fn sn occ
 
-  let image base p =
-    sou base (get_image p)
-
   let is_accessible_by_key conf base p =
     Util.accessible_by_key
       conf base p (p_first_name base p) (p_surname base p)


### PR DESCRIPTION
This PR take useful code for portrait/images from Util into a new Image module.
Accessing portrait with this Image module enforce correct access right verification.
Notice that portrait are still accessible directly with `Gwdb.get_image`.

It fixes a bug where permission to see a portrait where not verified and unauthorized person could see a private portrait.
