### PR TITLE
Clarify on %s's side message for cousinsDisplay

### DIFF
--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -11676,6 +11676,10 @@ sl: po strani %s
 sv: från %ss släktsida
 tr: %s tarafında
 
+    on %s's siblings side
+en: on %s's siblings side
+fr: du côté des frères et soeurs de %s
+
     on (day month year)
 af: op
 ar: يوم

--- a/lib/cousinsDisplay.ml
+++ b/lib/cousinsDisplay.ml
@@ -193,7 +193,7 @@ let print_cousins_side_of conf base max_cnt a ini_p ini_br lev1 lev2 =
           : Adef.safe_string
           :> string);
       ]
-      |> cftransl conf "on %s's side"
+      |> cftransl conf "on %s's siblings side"
       |> Utf8.capitalize_fst |> Output.print_sstring conf;
       Output.print_sstring conf (Util.transl conf ":"));
     let sib = List.map (fun (ip, ia_asex) -> (ip, ia_asex, [])) sib in


### PR DESCRIPTION
Adresses issue #947

Replaces message "on %s's side" by "on %s's siblings side"