### PR TITLE
fix corrupted image

### DIFF
--- a/plugins/v7_im/v7_im_sendImage.ml
+++ b/plugins/v7_im/v7_im_sendImage.ml
@@ -337,7 +337,7 @@ let print_send_ok conf base =
   if (digest :> string) = Mutil.decode (raw_get conf "digest")
   then
     raw_get conf "file"
-    |> Mutil.decode
+    |> Adef.as_string
     |> effective_send_ok conf base p
   else Update.error_digest conf
 


### PR DESCRIPTION
fix image corruption in v7_im

image content was passing through a `Mutil.decode`