### PR TITLE
Rework username -> username|userkey

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -502,7 +502,7 @@ let get_actlog check_from utm from_addr base_password =
     let ic = Secure.open_in fname in
       let tmout = float_of_int !login_timeout in
       let rec loop changed r list =
-        match input_line ic with (* 1638508393 ::1/HenriP_tlrhmitst w hg *)
+        match input_line ic with
         | line ->
             let i = index line ' ' in
             let tm = float_of_string (String.sub line 0 i) in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -54,6 +54,7 @@ type config = {
   just_friend_wizard : bool;
   user : string;
   username : string;
+  userkey : string;
   auth_scheme : auth_scheme_kind;
   command : string;
   indep_command : string;
@@ -129,6 +130,7 @@ let empty =
     just_friend_wizard = false;
     user = "";
     username = "";
+    userkey = "";
     auth_scheme = NoAuth;
     command = "";
     indep_command = "";

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -45,6 +45,7 @@ type output_conf = {
 
 type env = (string * Adef.encoded_string) list
 
+(** Geneweb configuration data type *)
 type config = {
   from : string;
   api_mode : bool;
@@ -58,6 +59,7 @@ type config = {
   just_friend_wizard : bool;
   user : string;
   username : string;
+  userkey : string;
   auth_scheme : auth_scheme_kind;
   command : string;
   indep_command : string;

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -258,6 +258,7 @@ let rec eval_variable conf = function
   | [ "url_set"; evar; str ] -> url_set_aux conf [ evar ] str
   | [ "user"; "ident" ] -> conf.user
   | [ "user"; "name" ] -> conf.username
+  | [ "user"; "key" ] -> conf.userkey
   | [ s ] -> eval_simple_variable conf s
   | _ -> raise Not_found
 


### PR DESCRIPTION
1/ read user_info in .auth file even if missing : at end
2/ in .auth file, read (optional) username as username|userkey.
    provides templates with the key of the user navigating in the base (as opposed to the person being visited)

Replaces PR #1258 

Note that reading the authorization file does not happen if authentication is token based! username and userkey are lost after first navigation into the base!!
Proposal: username and userkey can be stored in actlog!
