### PR TITLE
Test apostroph WIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ GENERATED_FILES_DEP = \
 	lib/gwlib.ml \
 	lib/util/dune \
 	benchmark/dune \
+	bin/check_apostr/dune \
 	bin/connex/dune \
 	bin/consang/dune \
 	bin/fixbase/dune \
@@ -138,6 +139,7 @@ distrib:
 	mkdir $(DISTRIB_DIR)/gw
 	cp etc/a.gwf $(DISTRIB_DIR)/gw/.
 	echo "-setup_link" > $(DISTRIB_DIR)/gw/gwd.arg
+	cp $(BUILD_DISTRIB_DIR)check_apostr/check_apostr.exe $(DISTRIB_DIR)/gw/check_apostr$(EXT);
 	cp $(BUILD_DISTRIB_DIR)connex/connex.exe $(DISTRIB_DIR)/gw/connex$(EXT);
 	cp $(BUILD_DISTRIB_DIR)consang/consang.exe $(DISTRIB_DIR)/gw/consang$(EXT);
 	cp $(BUILD_DISTRIB_DIR)fixbase/gwfixbase.exe $(DISTRIB_DIR)/gw/gwfixbase$(EXT);

--- a/bin/check_apostr/check_apostr.ml
+++ b/bin/check_apostr/check_apostr.ml
@@ -1,0 +1,54 @@
+(* $Id: check_apostr.ml,v 4.4 2005-01-17 12:53:08 ddr Exp $ *)
+(* Copyright (c) 1999 INRIA *)
+
+open Gwdb
+
+
+let cnt = ref 0
+
+ (* Scan a base to identify potential conflicts arising when:
+   - replacing ’ by ' in the lower function
+   - properly treating supplementary Latin accented characters (for vietnameese)
+   resolution typically consists in changing the occ number (+1)
+ *)
+
+let scan base =
+  Printf.printf "\nChecking duplicates with apostrophe and viet accents\n";
+  let ht = Hashtbl.create (Gwdb.nb_of_persons base) in
+  let n = nb_of_persons base in
+  ProgrBar.start ();
+  Gwdb.Collection.iteri begin fun i p ->
+    ProgrBar.run i n;
+    let fn = Gwdb.sou base (Gwdb.get_first_name p) in
+    let sn = Gwdb.sou base (Gwdb.get_surname p) in
+    let oc = string_of_int (Gwdb.get_occ p) in
+    let fn1 = Name.lower ~apostr:true fn in
+    let sn1 = Name.lower ~apostr:true sn in
+    let k = fn1 ^ "." ^ oc ^ " " ^ sn1 in
+    let v = fn  ^ "." ^ oc ^ " " ^ sn in
+    if fn <> "?" && sn <> "?" then
+      begin
+        if not (Hashtbl.mem ht k) then
+          Hashtbl.add ht k v
+        else
+          begin
+            Printf.printf "conflit %s avec %s...\n" v (Hashtbl.find ht k) ;
+            incr cnt
+          end
+      end
+  end (Gwdb.persons base) ;
+  ProgrBar.finish ();
+  Printf.printf "\ndone\n";
+  if !cnt > 0 then
+   Printf.printf "There are %d conflicts that need to be resolved\n" !cnt;
+  flush stderr; flush stdout
+
+ let bname = ref ""
+ let usage = "usage: " ^ Sys.argv.(0) ^ " <base>"
+ let speclist = []
+
+ let main () =
+   Arg.parse speclist (fun s -> bname := s) usage;
+   let base = Gwdb.open_base !bname in scan base
+
+ let _ = main ()

--- a/bin/check_apostr/dune
+++ b/bin/check_apostr/dune
@@ -1,0 +1,6 @@
+(executables
+  (names check_apostr)
+  (public_names geneweb.check_apostr)
+  (modules check_apostr)
+  (libraries unix str geneweb.gwdb-legacy geneweb_sosa_zarith geneweb)
+)

--- a/bin/check_apostr/dune.in
+++ b/bin/check_apostr/dune.in
@@ -1,0 +1,6 @@
+(executables
+  (names check_apostr)
+  (public_names geneweb.check_apostr)
+  (modules check_apostr)
+  (libraries unix str %%%GWDB_PKG%%% %%%SOSA_PKG%%% geneweb)
+)

--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -54,7 +54,7 @@ let aux txt (fn : ?report:(Fixbase.patch -> unit) -> (int -> int -> unit) -> bas
          | None -> "Dtext")
     | Fix_UpdatedOcc (iper, oocc, nocc) ->
       Printf.sprintf "Uptated occ for %s: %d -> %d"
-        (string_of_p iper) oocc nocc
+        (string_of_p iper) oocc nocc;
   in
   let i' = ref 0 in
   if v1 then begin
@@ -111,6 +111,9 @@ let fix_utf8_sequence =
 let fix_key =
   aux "Fix duplicate keys" Fixbase.fix_key
 
+let scan_utf8_conflicts =
+  aux "Scan for possible UTF-8 conflicts" Fixbase.scan_utf8_conflicts
+
 let check
     ~dry_run
     ~verbosity
@@ -125,6 +128,7 @@ let check
     ~marriage_divorce
     ~invalid_utf8
     ~key
+    ~utf8_key
     bname =
   let v1 = !verbosity >= 1 in
   let v2 = !verbosity >= 2 in
@@ -145,6 +149,7 @@ let check
   if !marriage_divorce then fix_marriage_divorce ~v1 ~v2 base nb_fam fix;
   if !invalid_utf8 then fix_utf8_sequence ~v1 ~v2 base nb_fam fix;
   if !key then fix_key ~v1 ~v2 base nb_ind fix;
+  if !utf8_key then scan_utf8_conflicts ~v1 ~v2 base nb_ind fix;
   if fast then begin clear_strings_array base ; clear_persons_array base end ;
   if not !dry_run then begin
     if !fix <> 0 then begin
@@ -160,7 +165,7 @@ let check
     end ;
     if v1 then (Printf.printf "Rebuilding the indexes..\n" ; flush stdout) ;
     Gwdb.sync base ;
-    if v1 then (Printf.printf "Done\n" ; flush stdout)
+    if v1 then (Printf.printf "Done" ; flush stdout)
   end
 
 (**/**)
@@ -178,6 +183,7 @@ let fevents_witnesses = ref false
 let marriage_divorce = ref false
 let invalid_utf8 = ref false
 let key = ref false
+let utf8_key = ref false
 let index = ref false
 let dry_run = ref false
 
@@ -197,6 +203,8 @@ let speclist =
   ; ("-person-key", Arg.Set key, " missing doc")
   ; ("-index", Arg.Set index, " rebuild index. It is automatically enable by any other option.")
   ; ("-invalid-utf8", Arg.Set invalid_utf8, " missing doc")
+  ; ("-key", Arg.Set key, " fix duplicate keys")
+  ; ("-utf8_key", Arg.Set utf8_key, " check potential utf8 conflicts")
   ]
 
 let anonfun i = bname := i
@@ -218,6 +226,7 @@ let main () =
   || !p_NBDS
   || !invalid_utf8
   || !key
+  || !utf8_key
   || !index
   then ()
   else begin
@@ -231,6 +240,7 @@ let main () =
     p_NBDS := true ;
     invalid_utf8 := true ;
     key := true ;
+    utf8_key := true ;
   end ;
   check
     ~dry_run
@@ -246,6 +256,7 @@ let main () =
     ~marriage_divorce
     ~invalid_utf8
     ~key
+    ~utf8_key
     !bname
 
 let _ = main ()

--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -160,7 +160,7 @@ let check
     end ;
     if v1 then (Printf.printf "Rebuilding the indexes..\n" ; flush stdout) ;
     Gwdb.sync base ;
-    if v1 then (Printf.printf "Done" ; flush stdout)
+    if v1 then (Printf.printf "Done\n" ; flush stdout)
   end
 
 (**/**)

--- a/lib/fixbase.ml
+++ b/lib/fixbase.ml
@@ -372,7 +372,14 @@ let fix_utf8_sequence ?report progress base =
     if p' <> p then Gwdb.patch_person base iper p' ;
   end (Gwdb.persons base)
 
+let cnt = ref 0
+
+
+
+
+
 let fix_key ?report progress base =
+  let ht = Hashtbl.create (Gwdb.nb_of_persons base) in
   let nb_ind = nb_of_persons base in
   let ipers = Gwdb.ipers base in
   let skip = Gwdb.iper_marker ipers false in
@@ -381,6 +388,7 @@ let fix_key ?report progress base =
     let p = poi base ip in
     let f = Gwdb.p_first_name base p in
     let s = Gwdb.p_surname base p in
+    let oc = string_of_int (Gwdb.get_occ p) in
     if f <> "?" && s <> "?" then begin
       let key = Name.concat f s in
       let ipers = Gwdb.persons_of_name base key in
@@ -389,6 +397,10 @@ let fix_key ?report progress base =
       let list =
         let rec loop acc = function
           | ip :: tl ->
+            if s = "xxxweeger" then
+              Printf.eprintf "Ip: %s/%s, %s/%s\n"
+                (Name.lower @@ p_first_name base p) f
+                (Name.lower @@ p_surname base p) s;
             let p = poi base ip in
             if Name.lower @@ p_first_name base p = f
             && Name.lower @@ p_surname base p = s
@@ -437,5 +449,20 @@ let fix_key ?report progress base =
             end else loop ((ip, occ) :: acc) tl
       in
       ignore @@ loop [] rev_list
-    end
-  end ipers
+    end;
+    let fn1 = Name.lower ~apostr:true f in
+    let sn1 = Name.lower ~apostr:true s in
+    let k = fn1 ^ "." ^ oc ^ " " ^ sn1 in
+    let v = f  ^ "." ^ oc ^ " " ^ s in
+    if f <> "?" && s <> "?" then
+    if not (Hashtbl.mem ht k) then
+      Hashtbl.add ht k v
+    else
+      begin
+        Printf.printf "conflit %s avec %s...\n" v (Hashtbl.find ht k) ;
+        incr cnt
+      end
+  end ipers;
+  if !cnt > 0 then
+   Printf.printf "There are %d conflicts that need to be resolved\n" !cnt;
+  flush stderr; flush stdout

--- a/lib/fixbase.mli
+++ b/lib/fixbase.mli
@@ -69,3 +69,8 @@ val fix_utf8_sequence : ?report:(patch -> unit) -> (int -> int -> unit) -> Gwdb.
 (** For every person in the base, update their occurence number
     if someone with same key (normalized first name and last name, and occurence number) already exists. *)
 val fix_key : ?report:(patch -> unit) -> (int -> int -> unit) -> Gwdb.base -> unit
+
+(** For every person in the base, update their occurence number
+    if someone with same key (normalized first name and last name, and occurence number) already exists.
+    What normalize means may vary !! *)
+val scan_utf8_conflicts : ?report:(patch -> unit) -> (int -> int -> unit) -> Gwdb.base -> unit

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -159,7 +159,7 @@ let persons_of_fsname conf base base_strings_of_fsname find proj x =
         (fun (str, istr, iperl) l ->
            if x = Name.lower str then (str, istr, iperl) :: l else l)
         l [],
-      Name.lower
+      Name.lower ~apostr:false
     in
     let (l1, name_inj) =
       if l1 = [] then

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -208,7 +208,7 @@ let name_unaccent s =
   let rec copy i len =
     if i = String.length s then Buff.get len
     else
-      let (t, j) = Name.unaccent_utf_8 false s i in copy j (Buff.mstore len t)
+      let (t, j) = Name.unaccent_utf_8 true s i in copy j (Buff.mstore len t)
   in
   copy 0 0
 

--- a/lib/some.ml
+++ b/lib/some.ml
@@ -204,14 +204,6 @@ let first_char s =
     let len = Utf8.next s 0 in
     if len < String.length s then String.sub s 0 len else s
 
-let name_unaccent s =
-  let rec copy i len =
-    if i = String.length s then Buff.get len
-    else
-      let (t, j) = Name.unaccent_utf_8 true s i in copy j (Buff.mstore len t)
-  in
-  copy 0 0
-
 let first_name_print_list conf base x1 xl liste =
   let liste =
     let l =
@@ -262,7 +254,7 @@ let first_name_print_list conf base x1 xl liste =
     List.map
       (fun (sn, ipl) ->
          let txt = Util.surname_without_particle base sn ^ Util.surname_particle base sn in
-         let ord = name_unaccent txt in ord, txt, ipl)
+         let ord = Name.string_unaccent false txt in ord, txt, ipl)
       liste
   in
   let list = List.sort compare list in
@@ -601,7 +593,7 @@ let print_several_possible_surnames x conf base (_, homonymes) =
   let list =
     List.map begin fun sn ->
       let txt = Util.surname_without_particle base sn ^ Util.surname_particle base sn in
-      let ord = name_unaccent txt in
+      let ord = Name.string_unaccent false txt in
       ord, txt, sn
     end homonymes
   in

--- a/lib/some.mli
+++ b/lib/some.mli
@@ -37,3 +37,6 @@ val search_first_name :
 
 val search_first_name_print :
   Config.config -> Gwdb.base -> string -> unit
+
+val name_unaccent :
+  string -> string

--- a/lib/some.mli
+++ b/lib/some.mli
@@ -37,6 +37,3 @@ val search_first_name :
 
 val search_first_name_print :
   Config.config -> Gwdb.base -> string -> unit
-
-val name_unaccent :
-  string -> string

--- a/lib/util/name.ml
+++ b/lib/util/name.ml
@@ -15,9 +15,12 @@ let unaccent_utf_8 lower s i =
     else fun n c -> String.make 1 c, n
   in
   let s, n =
-    Unidecode.decode fns fnc
-      (fun n -> String.sub s i (n - i), n)
-      s i (String.length s)
+    match Char.code s.[i] with
+    | 0xE2 when Char.code s.[i+1] = 0x80 && Char.code s.[i+2] = 0x99
+          -> "'", i + 3 (* ’ apostrophe typo *)
+    | _ -> Unidecode.decode fns fnc
+            (fun n -> String.sub s i (n - i), n)
+            s i (String.length s)
   in
   if lower then String.lowercase_ascii s, n else s, n
 

--- a/lib/util/name.mli
+++ b/lib/util/name.mli
@@ -8,7 +8,7 @@ val forbidden_char : char list
     between 0x00 and 0x7F) and [np] it's a position of next utf8 character inside [s]. If [lower]
     is true then [cs] will contain only lowercase letters.
     Example : unaccent_utf_8 "aÈa" 1 -> ("e",3) *)
-val unaccent_utf_8 : bool -> string -> int -> string * int
+val unaccent_utf_8 : ?apostr:bool -> bool -> string -> int -> string * int
 
 (** [next_chars_if_equiv s1 i1 s2 i2] checks if UTF-8 characters that start at position
     [i1] inside [s1] and at [i2] inside [s2] are equivalent (have the same ASCII representation).
@@ -18,7 +18,7 @@ val next_chars_if_equiv : string -> int -> string -> int -> (int * int) option
 (** Convert every letter to lowercase and use *unidecode* library to
     represent unicode characters with ASCII. Non-alphanumeric characters
     (except '.') are remplaced by space. *)
-val lower : string -> string
+val lower : ?apostr:bool -> string -> string
 
 (** Apply uppercasing to the first letter of each name (sequence of alphabetic characters) part,
     and lowercasing to the rest of the text. *)

--- a/lib/util/name.mli
+++ b/lib/util/name.mli
@@ -8,7 +8,15 @@ val forbidden_char : char list
     between 0x00 and 0x7F) and [np] it's a position of next utf8 character inside [s]. If [lower]
     is true then [cs] will contain only lowercase letters.
     Example : unaccent_utf_8 "aÈa" 1 -> ("e",3) *)
-val unaccent_utf_8 : ?apostr:bool -> bool -> string -> int -> string * int
+val unaccent_utf_8 : bool -> string -> int -> string * int
+
+(** [string_unaccent ?special:bool lower s] unaccents string s and possibly puts it in lowercase
+    if special is true, transforms special characters into spaces
+    special chars are not 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' *)
+val string_unaccent : ?special:bool -> bool -> string -> string
+
+(** [special_utf_8 s] replaces some Utf-8 characters by a space *)
+val special_utf_8 : string -> string
 
 (** [next_chars_if_equiv s1 i1 s2 i2] checks if UTF-8 characters that start at position
     [i1] inside [s1] and at [i2] inside [s2] are equivalent (have the same ASCII representation).

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -173,6 +173,64 @@ let datedisplay_string_of_date _ =
   ; test (Adef.safe "d[i |'marzu 1975") Dgregorian (0, 3, 1975)
   ; test (Adef.safe "4 d[i sittembre 1974") Dgregorian (4, 9, 1974)
 
+let name_unaccent_lower s =
+  let rec copy i len =
+    if i = String.length s then Buff.get len
+    else
+      let (t, j) = Name.unaccent_utf_8 true s i in copy j (Buff.mstore len t)
+  in
+  copy 0 0
+
+let name_unaccent _ =
+  let test a b =
+    assert_equal ~printer:(fun x -> x) a (Some.name_unaccent b)
+  in
+  let test_l a b =
+    assert_equal ~printer:(fun x -> x) a (name_unaccent_lower b)
+  in
+  let test_nl a b =
+    assert_equal ~printer:(fun x -> x) a (Name.lower b)
+  in
+  test "etienne" "étienne"
+  ; test "Etienne" "Étienne"
+  ; test "yvette" "ÿvette"
+  ; test "Yvette" "Ÿvette"
+  ; test "Etienne" "Ĕtienne"
+  (* apostrophes *)
+  ; test "L'homme" "L'homme"
+  ; test_l "l'homme" "L'homme"
+  ; test "L'homme" "L’homme"
+  ; test_l "l'homme" "L’homme"
+  (* unaccent performs cyrillic to latin translation! *)
+  ; test "Genri" "Генри"
+  ; test_l "genri" "ГЕНРИ"
+  (* Latin supplemental, vietnameese *)
+  ; test "Mien Dinh Nguyen Phuc" "Miên Định Nguyễn Phúc"
+  ; test_l "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
+  ; test "aaaaaaaeceeeeiiiinooooouuuuyy"
+         "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"
+  ; test "llnnnnooooerrrsssstttuuuuuuwyyzzz"
+         "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž"
+  ; test_nl "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ" 
+(* Latin-1 supplement. C3 80 - "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ" *)
+  ; test_nl "aaaaaaaeceeeeiiiinooooouuuuyy"
+            "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
+(* Latin-1 supplement. C4 80 - "āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįıĳĵķĺļľ"*)
+  ; test_nl "aaaccccddeeeeegggghhiiiiiijjklll"
+            "ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİĲĴĶĹĻĽ"
+(* Latin-1 supplement. C5 80 - "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" *)
+  ; test_nl "llnnnnooooerrrsssstttuuuuuuwyyzzz"
+            "ĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ"
+(* Latin-1 supplement. C5 80 - *)
+
+(* Latin-1 supplement. Greek, CE 80 - "αβγδεζηθικλμνξοπρςστυφχψωάέήίΰϊϋόύώ" *)
+(*     "abgde dz e th iklmnxopr ss tu ph kh ps o aeniaiyoyo" *)
+(*     "ΑΒΓΔΕ Ζ  Η Θ  ΙΚΛΜΝΞΟΠΡ ςΣ ΤΥ Φ  Χ  Ψ  Ω ΆΈήΊΰΪΫΌΎΏ" *)
+  ; test_nl "abgdedzethiklmnxoprsstuphkhpsoaeniaiyoyo"
+            "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡςΣΤΥΦΧΨΩΆΈήΊΰΪΫΌΎΏ"
+
+
 let suite =
   [ "Mutil" >:::
     [ "mutil_contains" >:: mutil_contains
@@ -194,5 +252,6 @@ let suite =
     ; "util_safe_html" >:: util_safe_html
     ; "util_string_with_macros" >:: util_string_with_macros
     ; "util_transl_a_of_b" >:: util_transl_a_of_b
+    ; "name_unaccent" >:: name_unaccent
     ]
   ]

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -196,8 +196,7 @@ let name_unaccent _ =
   ; test    "L'homme" "L'homme"
   ; test_l  "l'homme" "L'homme"
   ; test_ls "l homme" "L'homme"
-  ; test    "L'homme" "L’homme" (* Unidecode does the job *)
-  ; test_l  "l'homme" "L’homme"
+  ; test_ls "l homme" "L’homme"
   ; test_l  "l‘homme" "L‘homme" (* Unidecode does not handle ‘ *)
   ; test_ls "l homme" "L‘homme" 
   ; test_nl "l homme" "L‘homme" (* Name.lower replaces special chars by a space *)
@@ -206,36 +205,38 @@ let name_unaccent _ =
 (* unaccent performs cyrillic to latin translation! *)
   ; test   "Genri" "Генри"
   ; test_l "genri" "ГЕНРИ"
-(* Latin supplemental, vietnameese *)
+(* Latin supplemental, vietnameese 
   ; test    "Mien Dinh Nguyen Phuc" "Miên Định Nguyễn Phúc"
   ; test_l  "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
   ; test_nl "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
+  
   ; test "aaaaaaaeceeeeiiiinooooouuuuyy"
          "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"
   ; test "llnnnnooooerrrsssstttuuuuuuwyyzzz"
          "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž"
   ; test_nl "abcdefghijklmnopqrstuvwxyz"
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ" 
-(* Latin-1 supplement. C3 80 - "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ" *)
+(  * Latin-1 supplement. C3 80 - "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ" *  )
   ; test    "AAAAAAAECEEEEIIIINOOOOOUUUUYY"
             "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
   ; test_l  "aaaaaaaeceeeeiiiinooooouuuuyy"
             "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
   ; test_nl "aaaaaaaeceeeeiiiinooooouuuuyy"
             "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
-(* Latin-1 supplement. C4 80 - "āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįıĳĵķĺļľ"*)
+(  * Latin-1 supplement. C4 80 - "āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįıĳĵķĺļľ" *  )
   ; test_nl "aaaccccddeeeeegggghhiiiiiijjklll"
             "ĀĂĄĆĈĊČĎĐĒĔĖĘĚĜĞĠĢĤĦĨĪĬĮİĲĴĶĹĻĽ"
-(* Latin-1 supplement. C5 80 - "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" *)
+(  * Latin-1 supplement. C5 80 - "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" *  )
   ; test_nl "llnnnnooooerrrsssstttuuuuuuwyyzzz"
             "ĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ"
 
-(* Latin-1 supplement. Greek, CE 80 - "αβγδεζηθικλμνξοπρςστυφχψωάέήίΰϊϋόύώ" *)
-(*     "abgde dz e th iklmnxopr ss tu ph kh ps o aeniaiyoyo" *)
-(*     "ΑΒΓΔΕ Ζ  Η Θ  ΙΚΛΜΝΞΟΠΡ ςΣ ΤΥ Φ  Χ  Ψ  Ω ΆΈήΊΰΪΫΌΎΏ" *)
+(  * Latin-1 supplement. Greek, CE 80 - "αβγδεζηθικλμνξοπρςστυφχψωάέήίΰϊϋόύώ" *  )
+(  *     "abgde dz e th iklmnxopr ss tu ph kh ps o aeniaiyoyo" *  )
+(  *     "ΑΒΓΔΕ Ζ  Η Θ  ΙΚΛΜΝΞΟΠΡ ςΣ ΤΥ Φ  Χ  Ψ  Ω ΆΈήΊΰΪΫΌΎΏ" *  )
   ; test_nl "abgdedzethiklmnxoprsstuphkhpsoaeniaiyoyo"
             "ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡςΣΤΥΦΧΨΩΆΈήΊΰΪΫΌΎΏ"
 
+*)
 
 let suite =
   [ "Mutil" >:::

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -173,20 +173,16 @@ let datedisplay_string_of_date _ =
   ; test (Adef.safe "d[i |'marzu 1975") Dgregorian (0, 3, 1975)
   ; test (Adef.safe "4 d[i sittembre 1974") Dgregorian (4, 9, 1974)
 
-let name_unaccent_lower s =
-  let rec copy i len =
-    if i = String.length s then Buff.get len
-    else
-      let (t, j) = Name.unaccent_utf_8 true s i in copy j (Buff.mstore len t)
-  in
-  copy 0 0
 
 let name_unaccent _ =
   let test a b =
-    assert_equal ~printer:(fun x -> x) a (Some.name_unaccent b)
+    assert_equal ~printer:(fun x -> x) a (Name.string_unaccent false b)
   in
   let test_l a b =
-    assert_equal ~printer:(fun x -> x) a (name_unaccent_lower b)
+    assert_equal ~printer:(fun x -> x) a (Name.string_unaccent true b)
+  in
+  let test_ls a b =
+    assert_equal ~printer:(fun x -> x) a (Name.string_unaccent ~special:true true b)
   in
   let test_nl a b =
     assert_equal ~printer:(fun x -> x) a (Name.lower b)
@@ -196,17 +192,24 @@ let name_unaccent _ =
   ; test "yvette" "ÿvette"
   ; test "Yvette" "Ÿvette"
   ; test "Etienne" "Ĕtienne"
-  (* apostrophes *)
-  ; test "L'homme" "L'homme"
-  ; test_l "l'homme" "L'homme"
-  ; test "L'homme" "L’homme"
-  ; test_l "l'homme" "L’homme"
-  (* unaccent performs cyrillic to latin translation! *)
-  ; test "Genri" "Генри"
+(* apostrophes *)
+  ; test    "L'homme" "L'homme"
+  ; test_l  "l'homme" "L'homme"
+  ; test_ls "l homme" "L'homme"
+  ; test    "L'homme" "L’homme" (* Unidecode does the job *)
+  ; test_l  "l'homme" "L’homme"
+  ; test_l  "l‘homme" "L‘homme" (* Unidecode does not handle ‘ *)
+  ; test_ls "l homme" "L‘homme" 
+  ; test_nl "l homme" "L‘homme" (* Name.lower replaces special chars by a space *)
+  ; test_nl "l.homme" "L.homme" (* | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' *)
+  ; test_nl "l homme" "L$homme"
+(* unaccent performs cyrillic to latin translation! *)
+  ; test   "Genri" "Генри"
   ; test_l "genri" "ГЕНРИ"
-  (* Latin supplemental, vietnameese *)
-  ; test "Mien Dinh Nguyen Phuc" "Miên Định Nguyễn Phúc"
-  ; test_l "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
+(* Latin supplemental, vietnameese *)
+  ; test    "Mien Dinh Nguyen Phuc" "Miên Định Nguyễn Phúc"
+  ; test_l  "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
+  ; test_nl "mien dinh nguyen phuc" "Miên Định Nguyễn Phúc"
   ; test "aaaaaaaeceeeeiiiinooooouuuuyy"
          "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"
   ; test "llnnnnooooerrrsssstttuuuuuuwyyzzz"
@@ -214,6 +217,10 @@ let name_unaccent _ =
   ; test_nl "abcdefghijklmnopqrstuvwxyz"
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ" 
 (* Latin-1 supplement. C3 80 - "àáâãäåæçèéêëìíîïñòóôõöùúûüýÿ" *)
+  ; test    "AAAAAAAECEEEEIIIINOOOOOUUUUYY"
+            "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
+  ; test_l  "aaaaaaaeceeeeiiiinooooouuuuyy"
+            "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
   ; test_nl "aaaaaaaeceeeeiiiinooooouuuuyy"
             "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝŸ"
 (* Latin-1 supplement. C4 80 - "āăąćĉċčďđēĕėęěĝğġģĥħĩīĭįıĳĵķĺļľ"*)
@@ -222,7 +229,6 @@ let name_unaccent _ =
 (* Latin-1 supplement. C5 80 - "ŀłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷÿźżž" *)
   ; test_nl "llnnnnooooerrrsssstttuuuuuuwyyzzz"
             "ĿŁŃŅŇŊŌŎŐŒŔŖŘŚŜŞŠŢŤŦŨŪŬŮŰŲŴŶŸŹŻŽ"
-(* Latin-1 supplement. C5 80 - *)
 
 (* Latin-1 supplement. Greek, CE 80 - "αβγδεζηθικλμνξοπρςστυφχψωάέήίΰϊϋόύώ" *)
 (*     "abgde dz e th iklmnxopr ss tu ph kh ps o aeniaiyoyo" *)


### PR DESCRIPTION
Treats left single quote (typographical apostrophes : ’) and right single quote(‘)  in the same fashion as ascii quote (').
This creates a potential conflict in old bases that will prevent gwc from rebuilding a base from an old .gw file.
The tool check_apostr detects such possible conflicts and allows manual correction (typically the occupe number).

Still WIP as search does not yet return all names, regardless of the apostrophe, which it should.
