### PR TITLE
fix `incorrect request` on image update

### DIFF
--- a/lib/image.mli
+++ b/lib/image.mli
@@ -10,6 +10,7 @@ val source_filename : string -> string -> string
 val prefix : config -> Adef.escaped_string
 (** Returns the image prefix (conf.image_prefix), html escaped  *)
 
+(* TODO this should be removed *)
 val default_portrait_filename : base -> person -> string
 (** [default_portrait_filename base p] is the default filename of [p]'s portrait. Without it's file extension.
  e.g: default_portrait_filename_of_key "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond"
@@ -31,6 +32,7 @@ val rename_portrait : config -> base -> person -> string * string * int -> unit
 val src_to_string : [< `Path of string | `Url of string ] -> string
 (** [src_to_string src] is [src] as a string *)
 
+(* TODO this should be removed *)
 val get_portrait_path : config -> base -> person -> [> `Path of string ] option
 (** [get_portrait_path conf base p] is
     - [None] if we don't have access to [p]'s portrait or it doesn't exist.

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3260,6 +3260,7 @@ and eval_str_person_field conf base env (p, p_auth as ep) =
       if p_auth then Util.get_approx_death_date_place conf base p |> snd |> safe_val
       else null_val
   | "auto_image_file_name" -> (
+      (* TODO what do we want here? can we remove this? *)
       match Image.get_portrait_path conf base p with
         | Some (`Path s) -> str_val s
         | None -> null_val

--- a/plugins/v7_im/v7_im_sendImage.ml
+++ b/plugins/v7_im/v7_im_sendImage.ml
@@ -142,14 +142,14 @@ let print_send_image conf base p =
 
 let print conf base =
   match p_getenv conf.env "i" with
+  | None -> Hutil.incorrect_request conf
   | Some ip ->
       let p = poi base (iper_of_string ip) in
       let fn = p_first_name base p in
       let sn = p_surname base p in
-      if Option.is_some (Image.get_portrait conf base p) || fn = "?" || sn = "?" then
+      if fn = "?" || sn = "?" then
         Hutil.incorrect_request conf
       else print_send_image conf base p
-  | None -> Hutil.incorrect_request conf
 
 (* Delete image form *)
 
@@ -183,15 +183,12 @@ let print_delete_image conf base p =
 
 let print_del conf base =
   match p_getenv conf.env "i" with
+  | None -> Hutil.incorrect_request conf
   | Some ip ->
       let p = poi base (iper_of_string ip) in
-      if sou base (get_image p) <> "" then Hutil.incorrect_request conf
-      else
-        begin match Image.get_portrait_path conf base p with
-        | Some _path -> print_delete_image conf base p
-        | None -> Hutil.incorrect_request conf
-        end
-  | None -> Hutil.incorrect_request conf
+      match Image.get_portrait_path conf base p with
+      | Some _path -> print_delete_image conf base p
+      | None -> Hutil.incorrect_request conf
 
 (* Send image form validated *)
 

--- a/plugins/v7_im/v7_im_sendImage.ml
+++ b/plugins/v7_im/v7_im_sendImage.ml
@@ -186,8 +186,8 @@ let print_del conf base =
   | None -> Hutil.incorrect_request conf
   | Some ip ->
       let p = poi base (iper_of_string ip) in
-      match Image.get_portrait_path conf base p with
-      | Some _path -> print_delete_image conf base p
+      match Image.get_portrait conf base p with
+      | Some _src -> print_delete_image conf base p
       | None -> Hutil.incorrect_request conf
 
 (* Send image form validated *)


### PR DESCRIPTION
v7 plugin used to give an incorrect request if get_image was not an empty string. (why?)
This bug did not appears before because image path is not written to the db (if it is the default path)
and thus get_image often gives an empty string.

Using the Image module instead of get_image made it always buggy

fix #1384