### PR TITLE
New function has_image_url replacing image = ""

### DIFF
--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -178,7 +178,7 @@ fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
           %if;(not (bvar.wizard_just_friend="yes") and wizard)
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="%prefix;m=CHG_EVT_IND_ORD;i=%index;" title="[*changed order of person's events]"><span class="fa fa-sort fa-fw mr-2"></span>[*invert::event/events]1</a>
-                %if;(bvar.can_send_image != "no" and image = "" and first_name != "?" and surname != "?")
+                %if;(bvar.can_send_image != "no" and (not has_image_url) and first_name != "?" and surname != "?")
                   <a class="dropdown-item" href="%prefix;m=SND_IMAGE;i=%index;" %laI;><span class="far fa-file-image fa-fw mr-2"></span>%if;has_image;[*modify picture]%else;[*add picture]%end;</a>
                 %end;
                 <div class="dropdown-divider"></div>

--- a/hd/etc/templm/perso.txt
+++ b/hd/etc/templm/perso.txt
@@ -126,7 +126,7 @@
             <a id="hist" href="%prefix;m=HIST_DIFF;t=DIFF;f=%history_file;;new=0;old=1" style="display:inline-block;width:125px" %laD;>≏ [*last diff]</a>
             <a href="%prefix;m=HIST_DIFF;t=SUM;f=%history_file;" style="display:inline-block;width:125px" title="[*revision history]">∴ [*history]</a>
           %end;
-          %if;(bvar.can_send_image != "no" and image = "" and first_name != "?" and surname != "?")
+          %if;(bvar.can_send_image != "no" and not has_image_url and first_name != "?" and surname != "?")
           <a href="%prefix;m=SND_IMAGE;i=%index;" style="display:inline-block;width:125px" %laI; >🎴 [*send::image/images]0</a>%nn;
             %if;(auto_image_file_name != "")<a href="%prefix;m=DEL_IMAGE;i=%index;" style="color:red;display:inline-block;width:125px"><small>[*delete::image/images]0</small></a>%end;
           %end;

--- a/hd/etc/templm/updmenu1.txt
+++ b/hd/etc/templm/updmenu1.txt
@@ -35,8 +35,8 @@
     <br%/>
     <a href="%prefix;m=MOD_IND;i=%index;" title="[*modify::person/persons]0 (P)" accesskey="P">[*modify::] (P)</a>
     <br%/>
-    %if;(bvar.can_send_image != "no" and image = "" and first_name != "?"
-         and surname != "?")
+    %if;(bvar.can_send_image != "no" and not has_image_url
+      and first_name != "?" and surname != "?")
       <a href="%prefix;m=SND_IMAGE;i=%index;">[*send::image/images]0</a>
       <br%/>
       %if;(auto_image_file_name != "")

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -757,7 +757,7 @@
 <div class="card-body">
   <h5 class="card-title"><b>[*other action][:] </b>
     <a href="%prefix;m=CHG_EVT_IND_ORD;i=%index;" title="[*changed order of person's events]">[*invert::event/events]1</a> |
-    %if;(bvar.can_send_image != "no" and image = "" and first_name != "?" and surname != "?")
+    %if;(bvar.can_send_image != "no" and not has_image_url and first_name != "?" and surname != "?")
       <a href="%prefix;m=SND_IMAGE;i=%index;">[*modify::]/[delete::]/[add picture]</a>
     %end; | <a href="%prefix;m=MRG;i=%index;">[*merge::]</a> | <a href="%prefix;m=DEL_IND;i=%index;">[*delete::]</a></h5>
   <div class="form-group mt-4">

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3137,6 +3137,11 @@ and eval_bool_person_field conf base env (p, p_auth) =
       else get_first_names_aliases p <> []
   | "has_history" -> has_history conf base p p_auth
   | "has_image" -> Image.get_portrait conf base p |> Option.is_some
+  | "has_image_url" -> begin match Image.get_portrait conf base p with
+    | Some (`Url _url) -> true
+    | Some (`Path _fname) -> false
+    | None -> false
+    end
   | "has_nephews_or_nieces" -> has_nephews_or_nieces conf base p
   | "has_nobility_titles" -> p_auth && Util.nobtit conf base p <> []
   | "has_notes" | "has_pnotes" ->


### PR DESCRIPTION
`%image;` now returns a path to the image file when it was returning "" .
The test `image = ""`, used at several places in the templates does not work anymore.
The new function `has_image_url` returns `false` when a portrait is available (path to the standard `fn.occ.sn.ext` file) or not available, and `true` when the portrait is served by a remote server.
Fix issue #1387