### PR TITLE
revert event comparison change 

### DIFF
--- a/lib/checkItem.ml
+++ b/lib/checkItem.ml
@@ -469,9 +469,16 @@ let check_order_pfevents get_name get_date warning events =
             | Event.Pevent (Epers_Name _) | Event.Fevent (Efam_Name _) ->
                 loop (e1 :: events)
             | n2 ->
-                if Event.compare_event_name n1 n2 = 1 then warning e1 e2;
+                if Event.compare_event_name n1 n2 = 1 then
+                  (* BUG:
+                     - `sort_events` sorts events like points on a timeline
+                     - date with precision (Before|After) are exlusive
+                     so we can have this sorted list of events:
+                       [ baptism at date n ; birth at date (Before n+1)]
+                       which will raise an invalid warning *)
+                  warning e1 e2;
                 loop (e2 :: events)))
-    | _ -> ()
+    | _l -> ()
   in
   loop events
 

--- a/lib/event.ml
+++ b/lib/event.ml
@@ -40,7 +40,7 @@ let compare get_name get_date e1 e2 =
       match Date.cdate_to_dmy_opt (get_date e2) with
       | None -> compare_event_name (get_name e1) (get_name e2)
       | Some d2 -> (
-          match Date.compare_dmy_opt ~strict:true d1 d2 with
+          match Date.compare_dmy_opt ~strict:false d1 d2 with
           | Some 0 | None -> compare_event_name (get_name e1) (get_name e2)
           | Some x -> x))
 

--- a/lib/util/calendar.ml
+++ b/lib/util/calendar.ml
@@ -1,3 +1,5 @@
+(* TODO this is probably buggy,
+   because geneweb uses month|day = 0 for incomplete dates *)
 (** Convert [Adef.date] to Calendars.d *)
 let to_calendars : Def.dmy -> Calendars.d =
  fun { Def.day; month; year; delta; _ } -> { Calendars.day; month; year; delta }

--- a/lib/util/date.ml
+++ b/lib/util/date.ml
@@ -92,6 +92,7 @@ let nb_days_in_month m a =
     [| 31; 28; 31; 30; 31; 30; 31; 31; 30; 31; 30; 31 |].(m - 1)
   else 0
 
+(* TODO use SDN instead *)
 let time_elapsed d1 d2 =
   let prec =
     match (d1.prec, d2.prec) with
@@ -140,6 +141,9 @@ let time_elapsed_opt d1 d2 =
   | After, After | Before, Before -> None
   | _ -> Some (time_elapsed d1 d2)
 
+(* TODO use SDN to compare date (?) *)
+(* use strict = false to compare date as if they are points on a timeline.
+   use strict = true to compare date by taking precision in account. This makes some dates not comparable, do not use to sort a list *)
 let rec compare_dmy_opt ?(strict = false) dmy1 dmy2 =
   match compare dmy1.year dmy2.year with
   | 0 -> compare_month_or_day ~is_day:false strict dmy1 dmy2


### PR DESCRIPTION
- `Event.sort_events` sort event by date (and event name) without taking in account "precision"
- add comments

Date handling in geneweb should be revised