### PR TITLE
Open welcome.txt rather than index.txt if only one base in -bd folder

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1056,9 +1056,7 @@ let make_conf from_addr request script_name env =
       | _ -> assert false
     in
     let bases = Util.get_bases_list () in
-    let bname =
-      if bname = "" && List.length bases = 1 then List.nth bases 0 else bname
-    in
+    let bname = match  bases with [x] -> x | _ -> bname in
     let (passwd, env, access_type) =
       let has_passwd = List.mem_assoc "w" env in
       let (x, env) = extract_assoc "w" env in

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1055,6 +1055,10 @@ let make_conf from_addr request script_name env =
       | [ bname ; access ] -> bname, access
       | _ -> assert false
     in
+    let bases = Util.get_bases_list () in
+    let bname =
+      if bname = "" && List.length bases = 1 then List.nth bases 0 else bname
+    in
     let (passwd, env, access_type) =
       let has_passwd = List.mem_assoc "w" env in
       let (x, env) = extract_assoc "w" env in

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -461,11 +461,11 @@ let treat_request =
         let incorrect_request conf _ = incorrect_request conf in
         match m with
         | "" ->
-           let base =
-             match bfile with
-             | None -> None
-             | Some bfile -> try Some (Gwdb.open_base bfile) with _ -> None
-           in
+          let base =
+            match bfile with
+            | None -> None
+            | Some bfile -> try Some (Gwdb.open_base bfile) with _ -> None
+          in
           if base <> None then
             w_base @@
             if only_special_env conf.env then SrcfileDisplay.print_start
@@ -477,7 +477,7 @@ let treat_request =
           else if conf.bname = ""
           then fun conf _ -> include_template conf [] "index" (fun () -> propose_base conf)
           else
-            w_base begin
+            w_base begin (* print_start -> welcome.txt *)
               if only_special_env conf.env then SrcfileDisplay.print_start
               else w_person @@ fun conf base p ->
                 match p_getenv conf.env "ptempl" with

--- a/hd/etc/index.txt
+++ b/hd/etc/index.txt
@@ -19,14 +19,13 @@
 
 <form class="form-inline d-flex justify-content-center my-2" method="get" action="%prefix;">
   <input type="hidden" name="lang" value="%evar.lang;">
-  <input name="b" class="form-control col-4">
+  <input name="b" placeholder="%bases_list;"  class="form-control col-4">
   <button type="submit" class="btn btn-outline-secondary ml-2" value="">Ok</button>
 </form>
 
 %( TODO find server name and port number %)
-%if;(not cgi)
-  <a href="http://localhost:2316/gwsetup?v=list.htm">[*available genealogies]</a>
-%end;
+[*available genealogies][:]<br>
+%bases_list;
 </div>
 
 <h3 class="text-center mt-5">[*select lang]</h3>

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -2843,13 +2843,13 @@ sv: samtidigt
 tr: aynı zamanda
 
     available genealogies
-co: lista di e genealugie dispunibule (impiegheghja gwsetup)
-de: Liste der verfügbaren Genealogien (verwende gwsetup)
-en: list of available genealogies (use gwsetup)
-fr: listes des généalogies disponibles (utilise gwsetup)
-pt: lista das genealogias disponíveis (utilize gwsetup)
-sv: lista över tillgängliga släktdatabaser (använd gwsetup)
-tr: mevcut şecere listesi (gwsetup kullanın)
+co: lista di e genealugie dispunibule
+de: Liste der verfügbaren Genealogien
+en: list of available genealogies
+fr: listes des généalogies disponibles
+pt: lista das genealogias disponíveis
+sv: lista över tillgängliga släktdatabaser
+tr: Mevcut şecere listesi
 
     average age at death
 bg: средна продължителност на живота

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1121,6 +1121,11 @@ and print_simple_variable conf = function
   | "base_trailer" -> include_hed_trl conf "trl"
   | "body_prop" -> print_body_prop conf
   | "copyright" -> print_copyright conf
+  | "number_of_bases" ->
+      Output.print_sstring conf
+        (string_of_int (List.length (Util.get_bases_list ())))
+  | "bases_list" ->
+      Output.print_sstring conf (String.concat ", " (Util.get_bases_list ()))
   | "hidden" -> Util.hidden_env conf
   | "message_to_wizard" -> Util.message_to_wizard conf
   | _ -> raise Not_found

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2721,3 +2721,17 @@ let has_children base u =
       let des = foi base ifam in
       Array.length (get_children des) > 0)
     (get_family u)
+
+let get_bases_list () =
+  let list = ref [] in
+  let dh = Unix.opendir (!GWPARAM.bpath "") in
+  (try
+     while true do
+       let e = Unix.readdir dh in
+       if Filename.check_suffix e ".gwb" then
+         list := Filename.chop_suffix e ".gwb" :: !list
+     done
+   with End_of_file -> ());
+  Unix.closedir dh;
+  list := List.sort compare !list;
+  !list

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -588,3 +588,4 @@ val designation : base -> person -> Adef.escaped_string
 (** [designation base p] is [Gutil.designation base p |> escape_html] *)
 
 val has_children : base -> person -> bool
+val get_bases_list : unit -> string list


### PR DESCRIPTION
When only one base is available in -bd, open directly its welcome page (ignoring index.txt)