### PR TITLE
display image if different. Display fn.oc sn of possible merges

### DIFF
--- a/lib/mergeDisplay.ml
+++ b/lib/mergeDisplay.ml
@@ -74,6 +74,11 @@ let print conf base p =
         Output.print_sstring conf "<label class=\"custom-control-label\" for=\"";
         Output.print_string conf (get_iper p |> string_of_iper |> Mutil.encode);
         Output.print_sstring conf "\">";
+        Output.print_sstring conf
+          (Printf.sprintf "%s.%d %s"
+             (get_first_name p |> sou base)
+             (get_occ p)
+             (get_surname p |> sou base));
         Output.print_sstring conf "</label></div>")
       list;
   Output.print_sstring conf

--- a/lib/mergeIndDisplay.ml
+++ b/lib/mergeIndDisplay.ml
@@ -95,11 +95,20 @@ let print_differences conf base branches p1 p2 =
       match Image.get_portrait conf base p with
       | Some (`Url url) ->
           ({|<img src="|} ^<^ escape_html url
-           ^>^ {|" style="max-width:75px;max-height:100px">|}
+           ^>^ {|" style="max-width:75px;max-height:100px">|} ^ url
             :> Adef.safe_string)
       | Some (`Path path) ->
-          (* TODO: ?? *)
-          (escape_html path :> Adef.safe_string)
+          let k = Image.default_portrait_filename base p in
+          let s = Unix.stat path in
+          Printf.sprintf
+            {|<img src="%sm=IM&d=%s&%s&k=%s" \
+              style="max-width:75px;max-height:100px"> %s|}
+            (commd conf :> string)
+            (string_of_int
+            @@ int_of_float (mod_float s.Unix.st_mtime (float_of_int max_int)))
+            (acces conf base p : Adef.escaped_string :> string)
+            k path
+          |> Adef.safe
       | None -> Adef.safe "");
   string_field
     (transl conf "public name" |> Adef.safe)

--- a/lib/mergeIndDisplay.ml
+++ b/lib/mergeIndDisplay.ml
@@ -35,6 +35,7 @@ let print_differences conf base branches p1 p2 =
         Output.print_sstring conf {|>|};
         Output.printf conf {|<label class="custom-control-label" for="|};
         Output.print_sstring conf name;
+        Output.print_sstring conf (string_of_int i);
         Output.print_sstring conf {|">|};
         Output.print_string conf x;
         Output.print_sstring conf {|</label></div>|}


### PR DESCRIPTION
When merging two persons with different images, show images.

The list of synonyms was not displayed (only the radio button!!)