### PR TITLE
move header template in HTML body instead of head

### DIFF
--- a/hd/etc/advanced.txt
+++ b/hd/etc/advanced.txt
@@ -7,9 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container">
 <div class="d-flex justify-content-between">
 

--- a/hd/etc/anclist.txt
+++ b/hd/etc/anclist.txt
@@ -19,9 +19,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container%if;(e.wide="on")-fluid%end;">
 %include;perso_utils

--- a/hd/etc/ancmenu.txt
+++ b/hd/etc/ancmenu.txt
@@ -18,9 +18,9 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;favicon
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container ml-xs-auto">
 %message_to_wizard;
 %include;perso_header

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -58,9 +58,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop; id="ancsosa">
+%include;hed
 %message_to_wizard;
 <div class="container-fluid">
 

--- a/hd/etc/anctree.txt
+++ b/hd/etc/anctree.txt
@@ -17,9 +17,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 
 <div class="container-fluid">

--- a/hd/etc/annivmenu.txt
+++ b/hd/etc/annivmenu.txt
@@ -8,9 +8,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container">
 <h1>[*anniversaries]</h1>
 

--- a/hd/etc/calendar.txt
+++ b/hd/etc/calendar.txt
@@ -9,9 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 

--- a/hd/etc/cousins.txt
+++ b/hd/etc/cousins.txt
@@ -21,9 +21,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container%if;(evar.wide="on")-fluid%end;">
 %include;perso_utils

--- a/hd/etc/cousmenu.txt
+++ b/hd/etc/cousmenu.txt
@@ -14,7 +14,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   %include;favicon
   %include;css
-  %include;hed
 </head>
 %(TODO :
 * highlight/filter by nbr
@@ -23,6 +22,7 @@
 * highlight sur les cases avec des individus vivants + counts
 %)
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container%if;(e.v!="" and e.v>6)-fluid%end;">
 <div class="d-flex flex-column justify-content-center">

--- a/hd/etc/deslist.txt
+++ b/hd/etc/deslist.txt
@@ -17,9 +17,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 %include;perso_utils

--- a/hd/etc/deslist_hr.txt
+++ b/hd/etc/deslist_hr.txt
@@ -17,9 +17,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container-fluid">
 %include;perso_utils

--- a/hd/etc/desmenu.txt
+++ b/hd/etc/desmenu.txt
@@ -18,9 +18,9 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;favicon
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 %include;perso_header

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -13,9 +13,9 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %include;perso_utils
 %message_to_wizard;
 <div class="container-fluid">

--- a/hd/etc/destree.txt
+++ b/hd/etc/destree.txt
@@ -11,9 +11,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container%if;(evar.wide="on")-fluid%end;">
 %include;perso_utils

--- a/hd/etc/family.txt
+++ b/hd/etc/family.txt
@@ -17,9 +17,9 @@
 <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %include;perso_utils
 <a href="#content" class="sr-only sr-only-focusable">Skip navigation menu</a>
 <div class="container%if;(evar.wide="on")-fluid%end;">

--- a/hd/etc/forum.txt
+++ b/hd/etc/forum.txt
@@ -22,9 +22,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 

--- a/hd/etc/list.txt
+++ b/hd/etc/list.txt
@@ -11,9 +11,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container%if;(evar.wide="on")-fluid%end;">
 %include;perso_utils

--- a/hd/etc/perso.txt
+++ b/hd/etc/perso.txt
@@ -18,9 +18,9 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <a href="#content" class="sr-only sr-only-focusable">Skip navigation menu</a>
 <div class="container%if;(evar.wide="on")-fluid%end;">

--- a/hd/etc/relmenu.txt
+++ b/hd/etc/relmenu.txt
@@ -13,7 +13,6 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;favicon
   %include;css
-  %include;hed
 </head>
 %define;nth_cousins(xx)
   %let;xx;xx-1;%in;
@@ -23,6 +22,7 @@
   [<em>Sosa number</em> relative to %t:::sosa_link]
 %end;
 <body%body_prop; onload="main()">
+%include;hed
 <div class="container">
 %message_to_wizard;
 %include;perso_header

--- a/hd/etc/stats.txt
+++ b/hd/etc/stats.txt
@@ -9,9 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 <h1>[*statistics]</h1>

--- a/hd/etc/templm/advanced.txt
+++ b/hd/etc/templm/advanced.txt
@@ -8,7 +8,6 @@
   <meta http-equiv="content-style-type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 %let;ltd; title="[year/month/day]2" class="d" size="2" maxlength="2" %in;
 %let;ltm; title="[year/month/day]1" class="m" size="2" maxlength="2" %in;
@@ -36,6 +35,7 @@
 %end;
 
 <body%body_prop; id="upd" %if;(evar.focus != "")onload="javascript:document.getElementById('%evar.focus;').focus();%ol1;"%end;>
+%include;hed
 %message_to_wizard;
 
 %if;(evar.birth1_yyyy != "" or evar.death2_yyyy != "")

--- a/hd/etc/templm/anclist.txt
+++ b/hd/etc/templm/anclist.txt
@@ -27,7 +27,6 @@
       var varZIndex = 1;
     //-->
   </script>
-  %include;hed
 </head>
 %(<!-- Begin define --> %)
 %let;birth_symbol;%if;(bvar.birth_symbol != "")%bvar.birth_symbol;%else;&deg;%end;%in;
@@ -71,6 +70,7 @@
 
 %(<!-- End define --> %)
 <body%body_prop; id="anclist">
+%include;hed
 %message_to_wizard;
 <h1>%nn;
   %if;(evar.tf1 != "csv")

--- a/hd/etc/templm/ancmenu.txt
+++ b/hd/etc/templm/ancmenu.txt
@@ -17,7 +17,6 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 
 %define;checkbox(cc,xx,yy,uu)
@@ -45,6 +44,7 @@
 %end;
 
 <body%body_prop; id="menutxt">
+%include;hed
 %message_to_wizard;
 <h1>%nn;
   %apply;a_of_b%with;

--- a/hd/etc/templm/ancsosa.txt
+++ b/hd/etc/templm/ancsosa.txt
@@ -26,7 +26,6 @@
   <meta name="format-detection" content="telephone=no"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 
 %( <!-- Begin define --> %)
@@ -66,6 +65,7 @@
 
 %(   Main   %)
 <body%body_prop; id="ancsosa">
+%include;hed
 %message_to_wizard;
 
 <h1>%nn;

--- a/hd/etc/templm/anctree.txt
+++ b/hd/etc/templm/anctree.txt
@@ -24,7 +24,6 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 
 %define;symbol(xx)
@@ -196,6 +195,7 @@
 %end;
 
 <body%body_prop; id="anctree">
+%include;hed
 %message_to_wizard;
 
 %if;not cancel_links;

--- a/hd/etc/templm/calendar.txt
+++ b/hd/etc/templm/calendar.txt
@@ -9,9 +9,9 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 
 <h1>[*calendar/calendars]1</h1>

--- a/hd/etc/templm/cousmenu.txt
+++ b/hd/etc/templm/cousmenu.txt
@@ -10,9 +10,9 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   %include;favicon
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 
 <h1>[*link between] <a href="%prefix;%access;">%self;</a> %dates; [and]0…</h1>

--- a/hd/etc/templm/dag.txt
+++ b/hd/etc/templm/dag.txt
@@ -9,9 +9,9 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 <body%body_prop; id="dag">
+%include;hed
 %message_to_wizard;
 
 %if;(not cancel_links and evar.notab != "on" )

--- a/hd/etc/templm/deslist.txt
+++ b/hd/etc/templm/deslist.txt
@@ -17,7 +17,6 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 
 %( <!-- Begin define --> %)
@@ -57,6 +56,7 @@
 
 %(   Main   %)
 <body%body_prop; id="deslist">
+%include;hed
   %message_to_wizard;
   <h1>%nn;
     %apply;a_of_b_gr_eq_lev%with;

--- a/hd/etc/templm/desmenu.txt
+++ b/hd/etc/templm/desmenu.txt
@@ -17,7 +17,6 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 
 %define;tothegen(xx)
@@ -29,6 +28,7 @@
 %end;
 
 <body%body_prop; id="menutxt">
+%include;hed
 %message_to_wizard;
 
 <h1>%nn;

--- a/hd/etc/templm/doc_templm.txt
+++ b/hd/etc/templm/doc_templm.txt
@@ -7,9 +7,9 @@
   <meta http-equiv="content-type" content="text/html; charset=%charset;"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <h1>Configuration de templm dans /bases/%base.name;.gwf</h1>
 <h2>Documentation en ligne</h2>

--- a/hd/etc/templm/perso.txt
+++ b/hd/etc/templm/perso.txt
@@ -21,7 +21,6 @@
        .image_sheet {font-size: 71%%;}
     %end;
   </style>
-  %include;hed
 </head>
 %( <!-- Begin define --> %)
 %include;tools
@@ -1095,6 +1094,7 @@
 %end;
 %( <!-- End define --> %)
 <body%body_prop; id="perso">
+%include;hed
 <div class="container" onclick="void(0);">
 %message_to_wizard;
 %if;(evar.del = "on")<h1 class="del">[*delete::] [person/persons]0 (-) [or] [family/families]0 (&)</h1>

--- a/hd/etc/templm/relmenu.txt
+++ b/hd/etc/templm/relmenu.txt
@@ -13,9 +13,9 @@
   <meta http-equiv="Content-Style-Type" content="text/css"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 <body%body_prop; id="menutxt">
+%include;hed
 %message_to_wizard;
 
 %let;l_on;onclick="this.focus()" onkeydown="if (event.keyCode == 13) javascript:document.relmenu.submit();"%in;

--- a/hd/etc/templm/upddag.txt
+++ b/hd/etc/templm/upddag.txt
@@ -10,9 +10,9 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
   %include;templm/js_upd
-  %include;hed
 </head>
 <body%body_prop; id="dag">
+%include;hed
 %message_to_wizard;
 %include;templm/updind_updfam
 

--- a/hd/etc/templm/upddata1.txt
+++ b/hd/etc/templm/upddata1.txt
@@ -10,7 +10,6 @@
   <meta name="robots" content="none"%/>
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
   <script type="text/javascript">
   <!--
 
@@ -133,6 +132,7 @@
 %end;
 
 <body%body_prop;>
+%include;hed
 <div id="nx_span" style="display:none">a</div>
 <div id="nx_a" style="display:none">a</div>
 

--- a/hd/etc/templm/updfam.txt
+++ b/hd/etc/templm/updfam.txt
@@ -18,7 +18,6 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"/>
   %include;css
   %include;js_upd
-  %include;hed
   %include;updind_updfam
 %( <!-- Begin define --> %)
 %let;lt1;<abbr title="%ak1;%ak2;%ak3;%ak7;">#</abbr>%in;
@@ -150,6 +149,7 @@
 %( <!-- End define --> %)
 </head>
 <body%body_prop; id="upd" %apply;load_focus()>
+%include;hed
 %message_to_wizard;
 <form name="upd" method="post" action="%action;">
 <div id="jq" style="display:none"> </div>

--- a/hd/etc/templm/updind.txt
+++ b/hd/etc/templm/updind.txt
@@ -15,7 +15,6 @@
   %include;css
   %include;js_upd
   %include;updind_updfam
-  %include;hed
 </head>
 %(<!-- Begin define -->%)
 %let;l_r_father; placeholder="M" %in;
@@ -84,6 +83,7 @@
 %end;
 %(<!-- End define -->%)
 <body%body_prop; id="upd" %apply;load_focus()>
+%include;hed
 <div class="container-fluid">
 %message_to_wizard;
 <form name="upd" method="post" action="%action;">

--- a/hd/etc/templm/updmenu1.txt
+++ b/hd/etc/templm/updmenu1.txt
@@ -14,9 +14,9 @@
      text-align: left;
     }
   </style>
-  %include;hed
 </head>
 <body%body_prop; id="menutxt">
+%include;hed
 %message_to_wizard;
 
 <h1>%nn;

--- a/hd/etc/templm/welcome.txt
+++ b/hd/etc/templm/welcome.txt
@@ -8,7 +8,6 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png"%/>
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png"%/>
   %include;css
-  %include;hed
 </head>
 
 %let;l_on;onclick="this.focus()" onkeydown="if (event.keyCode == 13) javascript:document.upd.submit();"%in;
@@ -112,6 +111,7 @@ zh: 已经有 %nb_accesses; 次访问数据库，其中 %nb_accesses_to_welcome;
 %end;
 
 <body%body_prop; id="welcome">
+%include;hed
 <div class="container">
 <div style="float:right;margin-top:1.8em;margin-right:1.8em;">
 %apply;login()

--- a/hd/etc/tp0_updDAG.txt
+++ b/hd/etc/tp0_updDAG.txt
@@ -8,7 +8,6 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 
 %define;pline(znz,zocz,zfnz,zsnz,zbdz,zparamz)
@@ -91,6 +90,7 @@
 %end;
 
 <body%body_prop;>
+%include;hed
 <div class="container-fluid">
 
 <form id="upd" method="post" action="%action;">

--- a/hd/etc/tp0_updRLM.txt
+++ b/hd/etc/tp0_updRLM.txt
@@ -8,7 +8,6 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 
 %define;one_pvar_line(znz,zocz,zfnz,zsnz,zbdz,ztz,zparamz)
@@ -50,6 +49,7 @@
 %end;
 
 <body%body_prop;>
+%include;hed
 <div class="container-fluid">
 
 <form id="upd" method="post" action="%action;">

--- a/hd/etc/upddata.txt
+++ b/hd/etc/upddata.txt
@@ -9,9 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %(
 %(Affichage court: %foreach;initial identique à %foreach;entry juste en-dessous%)
 %define;print_short()

--- a/hd/etc/upddatamenu.txt
+++ b/hd/etc/upddatamenu.txt
@@ -9,9 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container">
 
 %define;list_of(xx)

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -19,9 +19,9 @@
     %end;
   </title>
   %include;css
-  %include;hed
 </head>
 <body%body_prop; id="family">
+%include;hed
 %message_to_wizard;
 <div class="container">
 %( do not use %include;perso_header %)

--- a/hd/etc/updfamevt.txt
+++ b/hd/etc/updfamevt.txt
@@ -9,9 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container">
 %include;perso_header
 

--- a/hd/etc/updhist.txt
+++ b/hd/etc/updhist.txt
@@ -9,9 +9,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
 %include;css
-%include;hed
 </head>
 <body %body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 %define;search_form(xxx)

--- a/hd/etc/updhist_diff.txt
+++ b/hd/etc/updhist_diff.txt
@@ -8,9 +8,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container">
 <script><!--
 

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -15,9 +15,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop; id="person">
+%include;hed
 <div class="container pl-lg-0 pr-lg-3 px-xl-3">
 %message_to_wizard;
 %( do not use %include;perso_header %)

--- a/hd/etc/updindevt.txt
+++ b/hd/etc/updindevt.txt
@@ -8,9 +8,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 <div class="container">
 %include;perso_header
 <h1>[*changed order of person's events]</h1>

--- a/hd/etc/updmenu1.txt
+++ b/hd/etc/updmenu1.txt
@@ -10,9 +10,9 @@
   <link rel="shortcut icon" href="%image_prefix;/favicon_gwd.png">
   %include;favicon
   %include;css
-  %include;hed
 </head>
 <body%body_prop;>
+%include;hed
 %message_to_wizard;
 <div class="container">
 %include;perso_header

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -10,7 +10,6 @@
   <link rel="icon" href="favicon.ico">
   <link rel="apple-touch-icon" href="%image_prefix;/favicon_gwd.png">
   %include;css
-  %include;hed
 </head>
 %define;book_of(xx)
   [book of %s:::xx]%nn;
@@ -38,6 +37,7 @@ fr: Accès réservé aux amis et magiciens de la base de donnée !
 %end;
 
 <body%body_prop;>
+%include;hed
 <div class="container">
   <div class="d-flex flex-column flex-md-row justify-content-lg-center mt-2 mt-lg-4">
     %if;(bvar.auth_file="" and bvar.wizard_passwd!="" or bvar.friend_passwd!="")


### PR DESCRIPTION
This was a confusion that seems to have been done and replicated since the beginnings, at last a very very long time ago because it's here in v5.02 in 2007: I used a regex to move ```%include;hed``` (our personnalised template header file) under the ```<body>``` element of all template files instead of being at the end of their ```<head>```.

I notice it could also be also be thrown in a new [```<header>``` element introduced in HTML5](https://developer.mozilla.org/fr/docs/Web/HTML/Element/header), that is different from ```<head>```.