### PR TITLE
Update lexicon.txt to cause proper dates in Russian

### DIFF
--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -11704,6 +11704,7 @@ oc: lo
 pl: dnia
 pt: a
 ro: la
+ru:
 sk: dňa
 sv: den
 tr: -da,-de
@@ -11721,6 +11722,7 @@ lt:
 oc: lo
 pl: w :a:
 pt: em
+ru: в
 sv: på
 tr: -da,-de
 


### PR DESCRIPTION
The tables on (day month year) and on (weakday day month year) in hd/lang/lexicon.txt was missing entries for Russian causing display in the default language. Entries are added. An empty entry for the first and a в for the second, (even if it would be better with во on Tuesdays. 

Solves issue #1471