### PR TITLE
fix places dict display if only one suburb entry

### DIFF
--- a/hd/etc/upddata.txt
+++ b/hd/etc/upddata.txt
@@ -235,6 +235,14 @@
                     </div>
                     <div class="input-group-append">
                       <button type="submit" class="btn btn-primary" title="[*modify]">OK</button>
+                      %if;(evar.data="place" and suburb="")
+                        <div class="custom-control custom-checkbox ml-2">
+                        <input type="checkbox" class="custom-control-input ml-3" name="all"
+                          id="all" value="on" checked>
+                        <label class="custom-control-label" title="[*apply to same places with suburb (wip)]"
+                          for="all">[*all]</label>
+                        </div>
+                      %end;
                     </div>
                   </div>
                 </form>

--- a/lib/updateData.ml
+++ b/lib/updateData.ml
@@ -23,6 +23,12 @@ module IstrSet = Set.Make (struct
   let compare = compare
 end)
 
+
+(* if env parameter "all" is "on", then we should search for places
+   without suburb.
+   Later, we should update places values while keeping the suburb value.
+*)
+
 let get_data conf =
   match p_getenv conf.env "data" with
   | Some "occu" -> ([ get_occupation ], [], [], [])

--- a/lib/updateDataDisplay.ml
+++ b/lib/updateDataDisplay.ml
@@ -331,16 +331,20 @@ let print_foreach conf print_ast _eval_expr =
       | _ -> []
     in
     let max = List.length l in
-    List.iteri
-      (fun i (k, s) ->
-        let env =
-          ("cnt", Vint i) :: ("max", Vint max) :: ("entry_value", Vstring s)
-          :: ("entry_value_rev", Vstring (unfold_place_long false s))
-          :: ("entry_key", Vstring (string_of_istr k))
-          :: env
-        in
-        List.iter (print_ast env xx) al)
-      l
+    let rec loop i l prev =
+      match l with
+      | [] -> ()
+      | (k, s) :: l -> (
+          let env =
+            ("cnt", Vint i) :: ("max", Vint max) :: ("entry_value", Vstring s)
+            :: ("entry_value_rev", Vstring (unfold_place_long false s))
+            :: ("entry_key", Vstring (string_of_istr k))
+            :: ("first", Vbool (Place.without_suburb s <> prev))
+            :: env
+          in
+          List.iter (print_ast env xx) al;
+          loop (i + 1) l (Place.without_suburb s))
+    in loop 0 l ""
   and print_foreach_initial env xx al =
     let l = match get_env "list" env with Vlist_data l -> l | _ -> [] in
     let ini_l = build_list_short conf l in


### PR DESCRIPTION
Current version fails to display places for a single place with suburb.
It shows only the suburb. Modification applies correctly to place+suburb.
The value of the "first" parameter when scanning the list of places was not handled properly.
The display is now: 
   W   Places list
   W         suburb
When clicking on either lines, the full places+suburb entry is proposed for modification.

Beware that the display will be the same if there are two entries with the same places, one with and the other without suburb.
In this case, clicking on the first line will modify places only, while clicking on the second line will modify the entry with suburb.

Note also that at the present time, modifying places does not modify the occurence of places in the entry places+suburb.
Providing this (optional) possibility will be the subject of another PR.