### PR TITLE
Capture birth/death data for witness (perso) and fwitness (family)

### DIFF
--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -404,8 +404,11 @@ $(document).ready(function(){
     <h5 class="col-md-2 col-form-label">[*witness/witness/witnesses]0 wcnt</h5>
     <div class="col-md-2">
       <select class="form-control" name="excnt_witnwcnt_p">
-       <option value="link"%if;(fwitness.create = "link") selected%end;>[*link]0</option>
-       <option value="create"%if;(fwitness.create = "create") selected%end;>[*create]0</option>
+        %if;((fwitness.surname="" and fwitness.first_name="") or witness.create = "create")
+          <option value="create "%if;(fwitness.create = "create") selected%end;>[*create]0</option>
+        %else;
+          <option value="link" %if;(fwitness.create = "link") selected%end;>[*link]0</option>
+        %end;
      </select>
     </div>
     <div class="col-md-3">

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -285,10 +285,10 @@ $(document).ready(function(){
   %apply;small_date("death","excnt_witnwcnt_d","fwitness","verbose")
 %end;
 
-%define;parent(xcnt,xx)
+%define;parent(xcnt,xx,psex)
   <div class="row">
-    <label for="paxcnt_fn" class="col-sm-2 col-form-label">[*first name/first names]0 <span class="font-weight-bold text-uppercase">%if;(bvar.multi_parents!="yes")%parent.himher;%nn;
-      %else;pxcnt%end;</span></label>
+    <label for="paxcnt_fn" class="col-sm-2 col-form-label">[*first name/first names]0 <span class="font-weight-bold text-uppercase">pxcnt%nn;
+    %sp;%sp;(%apply;nth_c%with;MFN%and;psex%end;)</span></label>
     <div class="col-sm-8">
       <input class="form-control" type="text" name="paxcnt_fn" value="%xx.first_name;" id="paxcnt_fn" placeholder="[*first name/first names]0" %if;(evar.m="ADD_FAM" and xx.first_name="")autofocus%end;>
     </div>
@@ -586,13 +586,15 @@ $(document).ready(function(){
       <div class="row">
         <div class="col-11">
           %foreach;parent;
+            %let;ps;%parent.sex;%in;
+            %let;os;%parent.sexes;%in;
             %if;(cnt!=1 and bvar.multi_parents="yes")<hr class="w-100">%end;
-            %apply;parent(cnt, "parent")
+            %apply;parent(cnt, "parent", ps)
             %if;(bvar.multi_parents="yes")%apply;insert_parent(cnt)%end;
-            %if;(bvar.multi_parents!="yes" and cnt=1)
+            %if;(cnt=2)
               <div class="form-check my-2">
                 <label class="form-check-label">
-                <input type="checkbox" class="form-check-input" name="nsck" value="on"%if;(mrel="nsck" or mrel="nsckm") checked%end;%/>
+                <input type="checkbox" class="form-check-input" name="nsck" value="on"%if;(os=3) checked%end;%/>
                   [*no sexes check]
                 </label>
               </div>

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -277,6 +277,14 @@ $(document).ready(function(){
   %apply;small_date("death","xvard","xx","verbose")
 %end;
 
+%define;w_birth(xcnt, wcnt,xx,verbose)
+  %apply;small_date("birth","excnt_witnwcnt_b","fwitness","verbose")
+%end;
+
+%define;w_death(xcnt, wcnt,xx,verbose)
+  %apply;small_date("death","excnt_witnwcnt_d","fwitness","verbose")
+%end;
+
 %define;parent(xcnt,xx)
   <div class="row">
     <label for="paxcnt_fn" class="col-sm-2 col-form-label">[*first name/first names]0 <span class="font-weight-bold text-uppercase">%if;(bvar.multi_parents!="yes")%parent.himher;%nn;
@@ -391,6 +399,7 @@ $(document).ready(function(){
 %end;
 
 %define;one_witness(xcnt, wcnt)
+  <hr>
   <div class="row mt-3">
     <h5 class="col-md-2 col-form-label">[*witness/witness/witnesses]0 wcnt</h5>
     <div class="col-md-2">
@@ -401,13 +410,14 @@ $(document).ready(function(){
     </div>
     <div class="col-md-3">
       <select class="form-control" name="excnt_witnwcnt_kind">
-  <option value="" %if;(fwitness_kind = "") selected="selected" %end;>[*witness/witnesses]0</option>
-  <option value="info" %if;(fwitness_kind = "info") selected="selected" %end;>[*informant/informant/informant]2</option>
+        <option value=""> - </option>
+        <option value="" %if;(fwitness_kind = "") selected="selected" %end;>[*witness/witnesses]0</option>
+        <option value="info" %if;(fwitness_kind = "info") selected="selected" %end;>[*informant/informant/informant]2</option>
         <option value="atte" %if;(fwitness_kind = "atte") selected="selected" %end;>[*present/present/present]2</option>
-  <option value="ment" %if;(fwitness_kind = "ment") selected="selected" %end;>[*mentioned/mentioned/mentioned]2</option>
-  <option value="offi" %if;(fwitness_kind = "offi") selected="selected" %end;>[*civil registrar/civil registrar/civil registrar]2</option>
-  <option value="reli" %if;(fwitness_kind = "reli") selected="selected" %end;>[*parrish registrar/parrish registrar/parrish registrar]2</option>
-  <option value="othe" %if;(fwitness_kind = "othe") selected="selected" %end;>[*other/other/other]2</option>
+        <option value="ment" %if;(fwitness_kind = "ment") selected="selected" %end;>[*mentioned/mentioned/mentioned]2</option>
+        <option value="offi" %if;(fwitness_kind = "offi") selected="selected" %end;>[*civil registrar/civil registrar/civil registrar]2</option>
+        <option value="reli" %if;(fwitness_kind = "reli") selected="selected" %end;>[*parrish registrar/parrish registrar/parrish registrar]2</option>
+        <option value="othe" %if;(fwitness_kind = "othe") selected="selected" %end;>[*other/other/other]2</option>
       </select>
     </div>
   </div>
@@ -426,6 +436,8 @@ $(document).ready(function(){
     <div class="col-sm-5">
       <input type="text" class="form-control" name="excnt_witnwcnt_sn" maxlength="200" value="%fwitness.surname;" id="excnt_witnwcnt_sn" placeholder="[*surname/surnames]0">
     </div>
+    %( if new witness %)
+    %if;(fwitness.surname="" and fwitness.first_name="")
     <span class="col-sm-auto col-form-label">[*sex]</span>
     <div class="col-sm-auto mt-2">
       <div class="form-check form-check-inline">
@@ -444,6 +456,25 @@ $(document).ready(function(){
         </label>
       </div>
     </div>
+    <div class="col-sm-auto mt-2">
+      <label class="form-check-label">
+        <input class="form-check-input" type="checkbox" name="excnt_witnwcnt_pub">[*public]
+      </label>
+    </div>
+    <div class="col-sm-auto mt-2">
+      <div id="witnxcnt_div">
+        %apply;w_birth(xcnt, wcnt, "fwitness", "true")
+        %apply;w_death(xcnt, wcnt, "fwitness", "true")
+        <div class="row">
+          <label for="excnt_witnwcnt_occupation" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+          <div class="col-sm">
+             <input class="form-control" type="text" name="excnt_witnwcnt_occupation" value="%fwitness.create.occupation;" id="witnxcnt_occupation" placeholder="[*occupation/occupations]0" %readonly;>
+          </div>
+        </div>
+      </div>
+    </div>
+    %end;
+    %(  end if new witness %)
   </div>
 %end;
 

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -48,7 +48,7 @@ $(document).ready(function(){
         $("#paxcnt_div").hide();
       else
         $("#paxcnt_div").show();
-      %($("#paxcnt_occupation").prop('readonly', true);%)
+      %($("#paxcnt_occu").prop('readonly', true);%)
    }).change();
 });
 %end;
@@ -313,9 +313,9 @@ $(document).ready(function(){
     %apply;birth("paxcnt","xx","true")
     %apply;death("paxcnt","xx","true")
     <div class="row">
-      <label for="paxcnt_occupation" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+      <label for="paxcnt_occu" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
       <div class="col-sm">
-        <input class="form-control" name="paxcnt_occupation" id="paxcnt_occupation" maxlength="300" placeholder="[*occupation/occupations]0" value="%xx.create.occupation;">
+        <input class="form-control" name="paxcnt_occu" id="paxcnt_occu" maxlength="300" placeholder="[*occupation/occupations]0" value="%xx.create.occupation;">
       </div>
     </div>
   </div>
@@ -404,7 +404,7 @@ $(document).ready(function(){
     <h5 class="col-md-2 col-form-label">[*witness/witness/witnesses]0 wcnt</h5>
     <div class="col-md-2">
       <select class="form-control" name="excnt_witnwcnt_p">
-        %if;((fwitness.surname="" and fwitness.first_name="") or witness.create = "create")
+        %if;((fwitness.surname="" and fwitness.first_name="") or fwitness.create = "create")
           <option value="create "%if;(fwitness.create = "create") selected%end;>[*create]0</option>
         %else;
           <option value="link" %if;(fwitness.create = "link") selected%end;>[*link]0</option>
@@ -439,8 +439,8 @@ $(document).ready(function(){
     <div class="col-sm-5">
       <input type="text" class="form-control" name="excnt_witnwcnt_sn" maxlength="200" value="%fwitness.surname;" id="excnt_witnwcnt_sn" placeholder="[*surname/surnames]0">
     </div>
-    %( if new witness %)
-    %if;(fwitness.surname="" and fwitness.first_name="")
+  %( if new witness %)
+  %if;(fwitness.surname="" and fwitness.first_name="")
     <span class="col-sm-auto col-form-label">[*sex]</span>
     <div class="col-sm-auto mt-2">
       <div class="form-check form-check-inline">
@@ -460,24 +460,21 @@ $(document).ready(function(){
       </div>
     </div>
     <div class="col-sm-auto mt-2">
-      <label class="form-check-label">
-        <input class="form-check-input" type="checkbox" name="excnt_witnwcnt_pub">[*public]
-      </label>
+      <label class="form-check-label">[*public]</label>
+        <input class="form-check-input col" type="checkbox" name="excnt_witnwcnt_pub">
+    </div>
+  </div>
+  <div class="row">
+    <label for="excnt_witnwcnt_occu" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+    <div class="col-5">
+       <input class="form-control" type="text" name="excnt_witnwcnt_occu" value="%witness.create.occupation;" id="witnxcnt_occu" placeholder="[*occupation/occupations]0" %readonly;>
     </div>
     <div class="col-sm-auto mt-2">
-      <div id="witnxcnt_div">
-        %apply;w_birth(xcnt, wcnt, "fwitness", "true")
-        %apply;w_death(xcnt, wcnt, "fwitness", "true")
-        <div class="row">
-          <label for="excnt_witnwcnt_occupation" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
-          <div class="col-sm">
-             <input class="form-control" type="text" name="excnt_witnwcnt_occupation" value="%fwitness.create.occupation;" id="witnxcnt_occupation" placeholder="[*occupation/occupations]0" %readonly;>
-          </div>
-        </div>
-      </div>
+    <label class="form-check-label">[*of course dead]</label>
+      <input class="form-check-input col" type="checkbox" name="excnt_witnwcnt_od">
     </div>
-    %end;
-    %(  end if new witness %)
+  %end;
+  %(  end if new witness %)
   </div>
 %end;
 
@@ -710,9 +707,9 @@ $(document).ready(function(){
     %apply;birth("chxcnt", "child", "true")
     %apply;death("chxcnt", "child", "true")
     <div class="row">
-      <label for="chxcnt_occupation" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+      <label for="chxcnt_occu" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
       <div class="col-sm">
-         <input class="form-control" type="text" name="chxcnt_occupation" value="%child.create.occupation;" id="chxcnt_occupation" placeholder="[*occupation/occupations]0" %readonly;>
+         <input class="form-control" type="text" name="chxcnt_occu" value="%child.create.occupation;" id="chxcnt_occu" placeholder="[*occupation/occupations]0" %readonly;>
       </div>
     </div>
   </div>

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -407,45 +407,42 @@
       <div class="col-5">
         <input type="text" class="form-control" name="excnt_witnwcnt_sn" maxlength="200" value="%witness.surname;" id="excnt_witnwcnt_sn" placeholder="[*surname/surnames]0">
       </div>
-    %( if new witness %)
+      %( if new witness %)
     %if;(witness.surname="" and witness.first_name="")
-    <span class="col-sm-auto col-form-label">[*sex]</span>
-    <div class="col-sm-auto mt-2">
-      <div class="form-check form-check-inline">
-        <label class="form-check-label">
-          <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="M" %if;(witness.create.sex="male")checked%end;%/> [M/F]0
-        </label>
-      </div>
-      <div class="form-check form-check-inline">
-        <label class="form-check-label">
-          <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="N" %if;(witness.create.sex="neuter")checked%end;%/> ?
-        </label>
-      </div>
-      <div class="form-check form-check-inline">
-        <label class="form-check-label">
-          <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="F" %if;(witness.create.sex="female")checked%end;%/> [M/F]1
-        </label>
-      </div>
-    </div>
-    <div class="col-sm-auto mt-2">
-      <label class="form-check-label">
-        <input class="form-check-input" type="checkbox" name="excnt_witnwcnt_pub">[*public]
-      </label>
-    </div>
-    <div class="col-sm-auto mt-2">
-      <div id="witnxcnt_div">
-        %apply;w_birth(xcnt, wcnt, "witness", "true")
-        %apply;w_death(xcnt, wcnt, "witness", "true")
-        <div class="row">
-          <label for="excnt_witnwcnt_occupation" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
-          <div class="col-sm">
-             <input class="form-control" type="text" name="excnt_witnwcnt_occupation" value="%witness.create.occupation;" id="witnxcnt_occupation" placeholder="[*occupation/occupations]0" %readonly;>
-          </div>
+      <span class="col-sm-auto col-form-label">[*sex]</span>
+      <div class="col-sm-auto mt-2">
+        <div class="form-check form-check-inline">
+          <label class="form-check-label">
+            <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="M" %if;(witness.create.sex="male")checked%end;%/> [M/F]0
+          </label>
+        </div>
+        <div class="form-check form-check-inline">
+          <label class="form-check-label">
+            <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="N" %if;(witness.create.sex="neuter")checked%end;%/> ?
+          </label>
+        </div>
+        <div class="form-check form-check-inline">
+          <label class="form-check-label">
+            <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="F" %if;(witness.create.sex="female")checked%end;%/> [M/F]1
+          </label>
         </div>
       </div>
+      <div class="col-sm-auto mt-2">
+        <label class="form-check-label">[*public]</label>
+          <input class="form-check-input col" type="checkbox" name="excnt_witnwcnt_pub">
+      </div>
     </div>
+    <div class="row">
+      <label for="excnt_witnwcnt_occu" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+      <div class="col-5">
+         <input class="form-control" type="text" name="excnt_witnwcnt_occu" value="%witness.create.occupation;" id="witnxcnt_occu" placeholder="[*occupation/occupations]0" %readonly;>
+      </div>
+      <div class="col-sm-auto mt-2">
+      <label class="form-check-label">[*of course dead]</label>
+        <input class="form-check-input col" type="checkbox" name="excnt_witnwcnt_od">
+      </div>
     %end;
-    %(  end if new witness %)
+      %(  end if new witness %)
     </div>
   </div>
 %end;
@@ -1239,9 +1236,22 @@
         <input type="text" class="form-control" name="rxcnt_xvar_sn" maxlength="200" value="%relation.xrel.surname;" id="rxcnt_xvar_sn" placeholder="[*surname/surnames]0">
       </div>
       <p class="col-sm-2 mt-1">([sex]0 xsex)</p>
+    %if;(relation.xrel.surname="" and relation.xrel.first_name="")
       <div>
-        <input type="checkbox"  name="rxcnt_xvar_pub" id="rxcnt_xvar_pub"> [*public]
+        <label for="rxcnt_xvar_pub">[*public]</label>
+        <input type="checkbox" name="rxcnt_xvar_pub" id="rxcnt_xvar_pub">
       </div>
+    </div>
+    <div class="row">
+      <label for="rxcnt_xvar_occu" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+      <div class="col-5">
+         <input class="form-control" type="text" name="rxcnt_xvar_occu" id="rxcnt_xvar_occu" placeholder="[*occupation/occupations]0" %readonly;>
+      </div>
+      <div class="col-sm-auto mt-2">
+      <label for="rxcnt_xvar_od">[*of course dead]</label>
+        <input class="form-check-input col" type="checkbox" name="rxcnt_xvar_od">
+      </div>
+    %end;
     </div>
   </div>
 %end;

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -371,8 +371,11 @@
       <h5 class="col-form-label col-2">[*witness/witness/witnesses]0 wcnt </h5>
       <div class="col-2">
         <select class="form-control" name="excnt_witnwcnt_p">
-          <option value="link"  %if;(witness.create = "link") selected%end;>[*link]0</option>
-          <option value="create"%if;(witness.create = "create") selected%end;>[*create]0</option>
+          %if;((witness.surname="" and witness.first_name="") or witness.create = "create")
+            <option value="create" %if;(witness.create = "create") selected%end;>[*create]0</option>
+          %else;
+            <option value="link" %if;(witness.create = "link") selected%end;>[*link]0</option>
+          %end;
         </select>
       </div>
       <div class="col-3">
@@ -1236,6 +1239,9 @@
         <input type="text" class="form-control" name="rxcnt_xvar_sn" maxlength="200" value="%relation.xrel.surname;" id="rxcnt_xvar_sn" placeholder="[*surname/surnames]0">
       </div>
       <p class="col-sm-2 mt-1">([sex]0 xsex)</p>
+      <div>
+        <input type="checkbox"  name="rxcnt_xvar_pub" id="rxcnt_xvar_pub"> [*public]
+      </div>
     </div>
   </div>
 %end;

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -194,6 +194,59 @@
   </div>
 %end;
 
+%define;small_date(kind,xvar,xx,verbose)
+  %let;day_input;pattern="(?:0?[1-9]|1[0-9]|2[0-9]|3[0-1])" size="2" maxlength="2" %readonly;%in;
+  %let;month_input;pattern="(?:0?[1-9]|1[0-2]|VD|BR|FM|NI|PL|VT|GE|FL|PR|ME|TH|FT|JC|vd|br|fm|ni|pl|vt|ge|fl|pr|me|th|ft|jc)" size="1" maxlength="2" %readonly;%in;
+  %let;year_input;pattern="[?><~/-+]?\d*/?" size="4" maxlength="8" %readonly;%in;
+  <div class="row">
+    <span class="col-sm-2 col-form-label">[*kind]</span>
+    <div class="col-sm-auto form-inline">
+      %if;([!dates order]0 = "ddmmyy" or [!dates order]0 = "ddmmyyyy" or [!dates order]0 = "dmyyyy")
+        <label for="xvar_dd" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]2</label>
+        <input type="text" class="form-control mr-auto" name="xvar_dd" id="xvar_dd" value="%xx.create.kind_day;" placeholder="[dd/mm/yyyy]0" %day_input;>
+        <label for="xvar_mm" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]1</label>
+        <input type="text" class="form-control mr-auto" name="xvar_mm" id="xvar_mm" value="%xx.create.kind_month;" placeholder="[dd/mm/yyyy]1" %month_input;>
+        <label for="xvar=yyyy" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]0</label>
+        <input type="text" class="form-control mr-auto" name="xvar_yyyy" id="xvar_yyyy" value="%xx.create.kind_year;" placeholder="[dd/mm/yyyy]2" %year_input;>
+      %elseif;([!dates order]0 = "mmddyyyy")
+        <label for="xvar_mm" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]1</label>
+        <input type="text" class="form-control mr-auto" name="xvar_mm" id="xvar_mm" value="%xx.create.kind_month;" placeholder="[dd/mm/yyyy]1" %month_input;>
+        <label for="xvar_dd" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]2</label>
+        <input type="text" class="form-control mr-auto" name="xvar_dd" id="xvar_dd" value="%xx.create.kind_day;" placeholder="[dd/mm/yyyy]0" %day_input;>
+        <label for="xvar=yyyy" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]0</label>
+        <input type="text" class="form-control mr-auto" name="xvar_yyyy" id="xvar_yyyy" value="%xx.create.kind_year;" placeholder="[dd/mm/yyyy]2" %year_input;>
+      %else;
+        <label for="xvar=yyyy" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]0</label>
+        <input type="text" class="form-control mr-auto" name="xvar_yyyy" id="xvar_yyyy" value="%xx.create.kind_year;" placeholder="[dd/mm/yyyy]2" %year_input;>
+        <label for="xvar_mm" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]1</label>
+        <input type="text" class="form-control mr-auto" name="xvar_mm" id="xvar_mm" value="%xx.create.kind_month;" placeholder="[dd/mm/yyyy]1" %month_input;>
+        <label for="xvar_dd" class="col-form-label %if;(verbose=true)sr-only%end;">[year/month/day]2</label>
+        <input type="text" class="form-control mr-auto" name="xvar_dd" id="xvar_dd" value="%xx.create.kind_day;" placeholder="[dd/mm/yyyy]0" %day_input;>
+      %end;
+    </div>
+    <label for="xvar_pl" class="%if;(verbose=true)sr-only%end; col-sm-1 col-form-label">[place]</label>%nn;
+    <div class="col-sm">
+      <input type="text" class="form-control" name="xvar_pl" value="%xx.create.kind_place;" id="xvar_pl" placeholder="[*place]" %readonly;>
+    </div>
+  </div>
+%end;
+
+%define;birth(xvar,xx,verbose)
+  %apply;small_date("birth","xvarb","xx","verbose")
+%end;
+
+%define;death(xvar,xx,verbose)
+  %apply;small_date("death","xvard","xx","verbose")
+%end;
+
+%define;w_birth(xcnt, wcnt,xx,verbose)
+  %apply;small_date("birth","excnt_witnwcnt_b","witness","verbose")
+%end;
+
+%define;w_death(xcnt, wcnt,xx,verbose)
+  %apply;small_date("death","excnt_witnwcnt_d","witness","verbose")
+%end;
+
 %define;note(xx)
   <div class="row">
     <label for="xx_note" class="col-2 col-form-label">[*note/notes]1</label>
@@ -312,6 +365,7 @@
 %end;
 
 %define;one_witness(xcnt, wcnt, evt_name)
+  <hr>
   <div class="form-group mt-1">
     <div class="row">
       <h5 class="col-form-label col-2">[*witness/witness/witnesses]0 wcnt </h5>
@@ -323,15 +377,15 @@
       </div>
       <div class="col-3">
         <select class="form-control" name="excnt_witnwcnt_kind">
+          <option value=""> - </option>
           <option value="" %if;(witness_kind = "") selected="selected" %end;>[*witness/witnesses]0</option>
-    <option value=""> - </option>
-    <option value="godp" %if;(witness_kind = "godp" or "evt_name" = "#bapt" and witness_kind != "") selected="selected" %end; %if;("evt_name" != "#bapt")style="display:none;"%end;>[*godfather/godmother/godparents]2</option>
-    <option value="info" %if;(witness_kind = "info") selected="selected" %end;>[*informant/informant/informant]2</option>
-    <option value="atte" %if;(witness_kind = "atte") selected="selected" %end;>[*present/present/present]2</option>
-    <option value="ment" %if;(witness_kind = "ment") selected="selected" %end;>[*mentioned/mentioned/mentioned]2</option>
-    <option value="offi" %if;(witness_kind = "offi") selected="selected" %end;>[*civil registrar/civil registrar/civil registrar]2</option>
-    <option value="reli" %if;(witness_kind = "reli") selected="selected" %end;>[*parrish registrar/parrish registrar/parrish registrar]2</option>
-    <option value="othe" %if;(witness_kind = "othe") selected="selected" %end;>[*other/other/other]2</option>
+          <option value="godp" %if;(witness_kind = "godp" or "evt_name" = "#bapt" and witness_kind != "") selected="selected" %end; %if;("evt_name" != "#bapt")style="display:none;"%end;>[*godfather/godmother/godparents]2</option>
+          <option value="info" %if;(witness_kind = "info") selected="selected" %end;>[*informant/informant/informant]2</option>
+          <option value="atte" %if;(witness_kind = "atte") selected="selected" %end;>[*present/present/present]2</option>
+          <option value="ment" %if;(witness_kind = "ment") selected="selected" %end;>[*mentioned/mentioned/mentioned]2</option>
+          <option value="offi" %if;(witness_kind = "offi") selected="selected" %end;>[*civil registrar/civil registrar/civil registrar]2</option>
+          <option value="reli" %if;(witness_kind = "reli") selected="selected" %end;>[*parrish registrar/parrish registrar/parrish registrar]2</option>
+          <option value="othe" %if;(witness_kind = "othe") selected="selected" %end;>[*other/other/other]2</option>
         </select>
       </div>
     </div>
@@ -350,24 +404,45 @@
       <div class="col-5">
         <input type="text" class="form-control" name="excnt_witnwcnt_sn" maxlength="200" value="%witness.surname;" id="excnt_witnwcnt_sn" placeholder="[*surname/surnames]0">
       </div>
-      <span class="col col-form-label">[*sex]</span>
-      <div class="col mt-2">
-        <div class="form-check form-check-inline">
-          <label class="form-check-label">
-            <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="M" %if;(witness.create.sex = "male") checked%end; title="[*male/female/neuter]0"%/>[M/F]0
-          </label>
-        </div>
-        <div class="form-check form-check-inline">
-          <label class="form-check-label">
-            <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="N" %if;(witness.create.sex = "neuter") checked%end; title="[*male/female/neuter]2"%/>?
-          </label>
-        </div>
-        <div class="form-check form-check-inline">
-          <label class="form-check-label">
-            <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="F" %if;(witness.create.sex = "female") checked%end; title="[*male/female/neuter]1"%/>[M/F]1
-          </label>
+    %( if new witness %)
+    %if;(witness.surname="" and witness.first_name="")
+    <span class="col-sm-auto col-form-label">[*sex]</span>
+    <div class="col-sm-auto mt-2">
+      <div class="form-check form-check-inline">
+        <label class="form-check-label">
+          <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="M" %if;(witness.create.sex="male")checked%end;%/> [M/F]0
+        </label>
+      </div>
+      <div class="form-check form-check-inline">
+        <label class="form-check-label">
+          <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="N" %if;(witness.create.sex="neuter")checked%end;%/> ?
+        </label>
+      </div>
+      <div class="form-check form-check-inline">
+        <label class="form-check-label">
+          <input class="form-check-input" type="radio" name="excnt_witnwcnt_sex" value="F" %if;(witness.create.sex="female")checked%end;%/> [M/F]1
+        </label>
+      </div>
+    </div>
+    <div class="col-sm-auto mt-2">
+      <label class="form-check-label">
+        <input class="form-check-input" type="checkbox" name="excnt_witnwcnt_pub">[*public]
+      </label>
+    </div>
+    <div class="col-sm-auto mt-2">
+      <div id="witnxcnt_div">
+        %apply;w_birth(xcnt, wcnt, "witness", "true")
+        %apply;w_death(xcnt, wcnt, "witness", "true")
+        <div class="row">
+          <label for="excnt_witnwcnt_occupation" class="col-sm-2 col-form-label">[*occupation/occupations]0</label>
+          <div class="col-sm">
+             <input class="form-control" type="text" name="excnt_witnwcnt_occupation" value="%witness.create.occupation;" id="witnxcnt_occupation" placeholder="[*occupation/occupations]0" %readonly;>
+          </div>
         </div>
       </div>
+    </div>
+    %end;
+    %(  end if new witness %)
     </div>
   </div>
 %end;

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -1151,6 +1151,7 @@ let insert_person conf base src new_persons (f, s, o, create, var) =
                 ci_death_place = dpl;
               } ->
               (dead, dpl)
+          | Some { ci_death = OfCourseDead } -> (OfCourseDead, "")
           | Some _ | None -> (infer_death_bb conf birth baptism, "")
         in
         let occupation =

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -334,8 +334,7 @@ and get_parent_sex conf base fn sn oc =
   match Gwdb.person_of_key base fn sn oc with
   | Some ip -> (
       match pget conf base ip with
-      | p -> (
-          match get_sex p with Male -> 0 | Female -> 1 | Neuter -> 2))
+      | p -> ( match get_sex p with Male -> 0 | Female -> 1 | Neuter -> 2))
   | _ -> -1
 
 and eval_key conf base (fn, sn, oc, create, _) = function
@@ -345,9 +344,9 @@ and eval_key conf base (fn, sn, oc, create, _) = function
   | [ "occ" ] -> str_val (if oc = 0 then "" else string_of_int oc)
   | [ "surname" ] -> safe_val (Util.escape_html sn :> Adef.safe_string)
   | [ "sex" ] ->
-      if create = Update.Link then (
+      if create = Update.Link then
         let sex = get_parent_sex conf base fn sn oc in
-        str_val (string_of_int sex))
+        str_val (string_of_int sex)
       else Update_util.eval_create create "sex"
   | [ "sexes" ] ->
       (* this is somewhat of a hack to determine same sex situations *)

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -32,7 +32,7 @@ let reconstitute_parent_or_child conf var default_surname =
     in
     let d = Update.reconstitute_date conf (var ^ "d") in
     let dpl = getn conf (var ^ "d") "pl" in
-    let occupation = only_printable (getn conf var "occupation") in
+    let occupation = only_printable (getn conf var "occu") in
     let public = getn conf (var ^ "b") "yyyy" = "p" in
     {
       ci_birth_date = b;

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -185,6 +185,38 @@ let rec reconstitute_events conf ext cnt =
           | None -> ([], ext)
           | Some c -> (
               let witnesses, ext = loop (i + 1) ext in
+              let public =
+                match
+                  p_getenv conf.env
+                    ("e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i
+                   ^ "_pub")
+                with
+                | Some "on" -> true
+                | _ -> false
+              in
+              let c =
+                match c with
+                | fn, sn, occ, Update.Create (s, Some ci), var ->
+                    ( fn,
+                      sn,
+                      occ,
+                      Update.Create (s, Some { ci with ci_public = public }),
+                      var )
+                | fn, sn, occ, Update.Create (s, None), var ->
+                    let ci =
+                      {
+                        ci_birth_date = None;
+                        ci_birth_place = "";
+                        ci_death = DontKnowIfDead;
+                        ci_death_date = None;
+                        ci_death_place = "";
+                        ci_occupation = "";
+                        ci_public = public;
+                      }
+                    in
+                    (fn, sn, occ, Update.Create (s, Some ci), var)
+                | _ -> c
+              in
               let c =
                 match
                   p_getenv conf.env

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -164,23 +164,17 @@ let rec reconstitute_events conf ext cnt =
       in
       let witnesses, ext =
         let rec loop i ext =
+          let key = "e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i in
           match
-            try
-              Some
-                (reconstitute_somebody conf
-                   ("e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i))
-            with Failure _ -> None
+            try Some (reconstitute_somebody conf key) with Failure _ -> None
           with
           | None -> ([], ext)
-          | Some c -> (
+          | Some (fn, sn, occ, create, var) -> (
               let witnesses, ext = loop (i + 1) ext in
-              let c = update_ci conf c cnt i in
+              let create = update_ci conf create key in
+              let c = (fn, sn, occ, create, var) in
               let c =
-                match
-                  p_getenv conf.env
-                    ("e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i
-                   ^ "_kind")
-                with
+                match p_getenv conf.env (key ^ "_kind") with
                 | Some "godp" -> (c, Witness_GodParent)
                 | Some "offi" -> (c, Witness_CivilOfficer)
                 | Some "reli" -> (c, Witness_ReligiousOfficer)

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -9,28 +9,6 @@ open Update_util
 (* Liste des string dont on a supprimé un caractère.       *)
 (* Utilisé pour le message d'erreur lors de la validation. *)
 let removed_string = ref []
-
-type create_info = Update.create_info = {
-  ci_birth_date : date option;
-  ci_birth_place : string;
-  ci_death : death;
-  ci_death_date : date option;
-  ci_death_place : string;
-  ci_occupation : string;
-  ci_public : bool;
-}
-
-let ci_empty =
-  {
-    ci_birth_date = None;
-    ci_birth_place = "";
-    ci_death = DontKnowIfDead;
-    ci_death_date = None;
-    ci_death_place = "";
-    ci_occupation = "";
-    ci_public = false;
-  }
-
 let get_purged_fn_sn = Update_util.get_purged_fn_sn removed_string
 let reconstitute_somebody = Update_util.reconstitute_somebody removed_string
 
@@ -196,29 +174,7 @@ let rec reconstitute_events conf ext cnt =
           | None -> ([], ext)
           | Some c -> (
               let witnesses, ext = loop (i + 1) ext in
-              let public =
-                match
-                  p_getenv conf.env
-                    ("e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i
-                   ^ "_pub")
-                with
-                | Some "on" -> true
-                | _ -> false
-              in
-              let c =
-                let fn, sn, occ, update, var = c in
-                let x =
-                  match update with
-                  | Update.Create (s, Some ci) ->
-                      Some (s, { ci with ci_public = public })
-                  | Update.Create (s, None) ->
-                      Some (s, { ci_empty with ci_public = public })
-                  | Update.Link -> None
-                in
-                match x with
-                | Some (s, ci) -> (fn, sn, occ, Update.Create (s, Some ci), var)
-                | None -> (fn, sn, occ, Update.Link, var)
-              in
+              let c = update_ci conf c cnt i in
               let c =
                 match
                   p_getenv conf.env

--- a/lib/updateInd.ml
+++ b/lib/updateInd.ml
@@ -480,126 +480,12 @@ and eval_person_var (fn, sn, oc, create, _) = function
       match create with
       | Update.Create (_, _) -> bool_val true
       | _ -> bool_val false)
-  | [ "create"; s ] -> eval_create create s
+  | [ "create"; s ] -> Update_util.eval_create create s
   | [ "first_name" ] -> safe_val (Util.escape_html fn :> Adef.safe_string)
   | [ "link" ] -> bool_val (create = Update.Link)
   | [ "occ" ] -> str_val (if oc = 0 then "" else string_of_int oc)
   | [ "surname" ] -> safe_val (Util.escape_html sn :> Adef.safe_string)
   | _ -> raise Not_found
-
-(* TODO : looks bad *)
-and eval_create c = function
-  | "birth_day" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (_, Some { ci_birth_date = Some (Dgreg (dmy, Dfrench)) })
-        ->
-          let dmy = Calendar.french_of_gregorian dmy in
-          if dmy.day <> 0 then string_of_int dmy.day else ""
-      | Update.Create (_, Some { ci_birth_date = Some (Dgreg ({ day = d }, _)) })
-        when d <> 0 ->
-          string_of_int d
-      | _ -> "")
-  | "birth_month" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (_, Some { ci_birth_date = Some (Dgreg (dmy, Dfrench)) })
-        ->
-          let dmy = Calendar.french_of_gregorian dmy in
-          if dmy.month <> 0 then short_f_month dmy.month else ""
-      | Update.Create
-          (_, Some { ci_birth_date = Some (Dgreg ({ month = m }, _)) })
-        when m <> 0 ->
-          string_of_int m
-      | _ -> "")
-  | "birth_place" -> (
-      match c with
-      | Update.Create (_, Some { ci_birth_place = pl }) ->
-          safe_val (Util.escape_html pl :> Adef.safe_string)
-      | _ -> str_val "")
-  | "birth_year" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (_, Some ci) -> (
-          match ci.ci_birth_date with
-          | Some (Dgreg (dmy, Dfrench)) ->
-              let dmy = Calendar.french_of_gregorian dmy in
-              add_precision (string_of_int dmy.year) dmy.prec
-          | Some (Dgreg ({ year = y; prec = p }, _)) ->
-              add_precision (string_of_int y) p
-          | Some _ -> ""
-          | None -> if ci.ci_public then "p" else "")
-      | _ -> "")
-  | "death_day" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (_, Some { ci_death_date = Some (Dgreg (dmy, Dfrench)) })
-        ->
-          let dmy = Calendar.french_of_gregorian dmy in
-          if dmy.day <> 0 then string_of_int dmy.day else ""
-      | Update.Create (_, Some { ci_death_date = Some (Dgreg ({ day = d }, _)) })
-        when d <> 0 ->
-          string_of_int d
-      | _ -> "")
-  | "death_month" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (_, Some { ci_death_date = Some (Dgreg (dmy, Dfrench)) })
-        ->
-          let dmy = Calendar.french_of_gregorian dmy in
-          short_f_month dmy.month
-      | Update.Create
-          (_, Some { ci_death_date = Some (Dgreg ({ month = m }, _)) })
-        when m <> 0 ->
-          string_of_int m
-      | _ -> "")
-  | "death_place" -> (
-      match c with
-      | Update.Create (_, Some { ci_death_place = pl }) ->
-          safe_val (Util.escape_html pl :> Adef.safe_string)
-      | _ -> str_val "")
-  | "death_year" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (_, Some { ci_death_date = Some (Dgreg (dmy, Dfrench)) })
-        ->
-          let dmy = Calendar.french_of_gregorian dmy in
-          add_precision (string_of_int dmy.year) dmy.prec
-      | Update.Create
-          (_, Some { ci_death_date = Some (Dgreg ({ year = y; prec = p }, _)) })
-        ->
-          add_precision (string_of_int y) p
-      | Update.Create (_, Some { ci_death = death; ci_death_date = None }) -> (
-          match death with DeadDontKnowWhen -> "+" | NotDead -> "-" | _ -> "")
-      | _ -> "")
-  | "occupation" -> (
-      match c with
-      | Update.Create (_, Some { ci_occupation = occupation }) ->
-          safe_val (Util.escape_html occupation :> Adef.safe_string)
-      | _ -> str_val "")
-  | "sex" -> (
-      str_val
-      @@
-      match c with
-      | Update.Create (Male, _) -> "male"
-      | Update.Create (Female, _) -> "female"
-      | Update.Create (Neuter, _) -> "neuter"
-      | _ -> "")
-  | _ -> raise Not_found
-
-and add_precision s p =
-  match p with
-  | Maybe -> "?" ^ s
-  | Before -> "&lt;" ^ s
-  | After -> "&gt;" ^ s
-  | About -> "/" ^ s ^ "/"
-  | Sure | OrYear _ | YearInt _ -> s
 
 and eval_is_death_reason dr = function
   | Death (dr1, _) -> bool_val (dr = dr1)

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -6,6 +6,16 @@ open Gwdb
 open Util
 open Update_util
 
+type create_info = Update.create_info = {
+  ci_birth_date : date option;
+  ci_birth_place : string;
+  ci_death : death;
+  ci_death_date : date option;
+  ci_death_place : string;
+  ci_occupation : string;
+  ci_public : bool;
+}
+
 (* Liste des string dont on a supprimé un caractère.       *)
 (* Utilisé pour le message d'erreur lors de la validation. *)
 let removed_string = ref []
@@ -214,6 +224,38 @@ let rec reconstitute_pevents conf ext cnt =
           with
           | Some c -> (
               let witnesses, ext = loop (i + 1) ext in
+              let public =
+                match
+                  p_getenv conf.env
+                    ("e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i
+                   ^ "_pub")
+                with
+                | Some "on" -> true
+                | _ -> false
+              in
+              let c =
+                match c with
+                | fn, sn, occ, Update.Create (s, Some ci), var ->
+                    ( fn,
+                      sn,
+                      occ,
+                      Update.Create (s, Some { ci with ci_public = public }),
+                      var )
+                | fn, sn, occ, Update.Create (s, None), var ->
+                    let ci =
+                      {
+                        ci_birth_date = None;
+                        ci_birth_place = "";
+                        ci_death = DontKnowIfDead;
+                        ci_death_date = None;
+                        ci_death_place = "";
+                        ci_occupation = "";
+                        ci_public = public;
+                      }
+                    in
+                    (fn, sn, occ, Update.Create (s, Some ci), var)
+                | _ -> c
+              in
               let var_c =
                 "e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i ^ "_kind"
               in

--- a/lib/update_util.ml
+++ b/lib/update_util.ml
@@ -78,25 +78,43 @@ let reconstitute_somebody removed_string conf var =
   let create = getn_p conf var sex in
   (first_name, surname, occ, create, var)
 
-let update_ci conf c cnt i =
+let update_ci conf create key =
   let public =
-    match
-      p_getenv conf.env
-        ("e" ^ string_of_int cnt ^ "_witn" ^ string_of_int i ^ "_pub")
-    with
-    | Some "on" -> true
-    | _ -> false
+    match p_getenv conf.env (key ^ "_pub") with Some "on" -> true | _ -> false
   in
-  let fn, sn, occ, update, var = c in
+  let death =
+    match p_getenv conf.env (key ^ "_od") with
+    | Some "on" -> OfCourseDead
+    | _ -> DontKnowIfDead
+  in
+  let occupation =
+    match p_getenv conf.env (key ^ "_occu") with Some s -> s | _ -> ""
+  in
   let x =
-    match update with
-    | Update.Create (s, Some ci) -> Some (s, { ci with ci_public = public })
-    | Update.Create (s, None) -> Some (s, { ci_empty with ci_public = public })
+    match create with
+    | Update.Create (s, Some ci) ->
+        Some
+          ( s,
+            {
+              ci with
+              ci_public = public;
+              ci_occupation = occupation;
+              ci_death = death;
+            } )
+    | Update.Create (s, None) ->
+        Some
+          ( s,
+            {
+              ci_empty with
+              ci_public = public;
+              ci_occupation = occupation;
+              ci_death = death;
+            } )
     | Update.Link -> None
   in
   match x with
-  | Some (s, ci) -> (fn, sn, occ, Update.Create (s, Some ci), var)
-  | None -> (fn, sn, occ, Update.Link, var)
+  | Some (s, ci) -> Update.Create (s, Some ci)
+  | None -> Update.Link
 
 (* -- Template stuff -- *)
 


### PR DESCRIPTION
At the present time, only the "public" status is being recorded in the base.
The template proposes birth/death/occupation that are ignored for the time being, but the mechanism to capture them is understood and implemented for the "public" status.

Display of sex of existing witness has been suppressed in the template as it is ignored.

Comments are welcome