### PR TITLE
show all ancestor’s relations and children in table ancestor by couple

### DIFF
--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="%lang;">
 <head>
-  <!-- $Id: ancsosa.txt v7.1 10/05/2023 04:58:54 $ -->
+  <!-- $Id: ancsosa.txt v7.0.1-α3 09/08/2023 13:37:57 $ -->
   <!-- Copyright (c) 1998-2007 INRIA -->
 %define;tothegen(xx)
   [to the %s generation:::xx]%nn;
@@ -293,7 +293,6 @@
   %xx.title;%xx.dates;
 %end;
 
-
 %define;married_to(is_male, date_place)
   %if;("is_male" = 1)
     %if;are_married;[married%t to:::date_place]0%nn;
@@ -356,18 +355,24 @@
   %end;
 %end;
 
-%define;link_marriage1(xx)
+%define;link_marriage1(yy)
   %if;(wizard and not cancel_links)
-    <a id="mf%family.index;" class="date p_%left;" href="#mf%family.index;" %ltmf;
-      onclick="window.open('%prefix;m=MOD_FAM&i=%family.index;&ip=%index;');">%nn;
-      <span>&amp;</span>%nn;
-        %if;(nb_children >= 1)%nb_children;<br>%end;
-        %slash_marriage_date; %marriage_place;
+    <a id="mf%family.index;" class="date p_%left;" href="#mf%family.index;"
+      onclick="window.open('%prefix;m=MOD_FAM;i=%family.index;;ip=%index;;');">%nn;
+  %end;
+      <div><span class="sure_dates%ancestor.has_linked_page.MARRIAGEA;%ancestor.spouse.has_linked_page.MARRIAGEA;
+        %if;((marriage_date.prec != "" or on_marriage_date = "" or marriage_place = "") and (are_married or not_are_married)) not_sure_dates%end;"
+        title="%if;(wizard)([modify::family/families]0)%end;
+          %if;(yy=0 and spouse.surname!="?" and spouse.first_name!="?")&#010;
+            %if;(are_not_married)([*not married])&#010;%end;
+            %if;(ancestor.is_male)[*him/her]0 %if;(are_not_married)[with]%else;[married%t to:::]0%end;
+            %elseif;(ancestor.is_female)[*him/her]1 %if;(are_not_married)[with]%else;[married%t to:::]1%end;
+            %end; %spouse;&#010;
+            %if;(nb_children>0)%nb_children; %end;%if;(nb_children=0)[*no descendants]%elseif(nb_children>1)[child/children]1%else;[child/children]0%end;%end;"
+        %if;(yy=0) style="color:%if;(ancestor.same!="")#fff069c9;%else;%if;(ancestor.is_male)blue;%elseif(ancestor.is_female)red;%end;font-size:small;%end;"%end;>
+        %nb_children;· %slash_marriage_date; %marriage_place; %if;(are_not_married)–%end;</span></div>
+  %if;(wizard and not cancel_links)
     </a>
-  %else;
-    <span>&amp;</span>%nn;
-    %slash_marriage_date; %marriage_place;
-    <br>&amp;%nb_children;
   %end;
 %end;
 
@@ -386,7 +391,7 @@
 %end;
 
 %define;imgtdz(xx)
-  %if;(e.image!="off" and xx.has_image)
+  %if;(e.im!=0 and e.image!="off" and xx.has_image)
     <img class="imgtdz img-fluid w-50" src="%xx.image_url;" %lai; title="%xx;">%nn;
   %end;
 %end;
@@ -480,28 +485,53 @@
     </td>
 %end;
 
+%define;month(mmm)
+  %if;(mmm.month="")%if;(mmm.prec="&gt;")12%else;00%end;
+  %elseif;(mmm.month<10)0%mmm.month;%else;%mmm.month;%end;
+%end;
+
+%define;day(ddd)
+  %if;(ddd.day="")%if;(ddd.prec="&gt;")32%else;00%end;
+  %elseif;(ddd.day<10)0%ddd.day;%else;%ddd.day;%end;
+%end;
+
+%define;dprec(ddd)
+  %if;(ddd.prec="&lt;")2%elseif;(ddd.prec="&gt;")2%else;2%end;
+%end;
+
+%define;addlist(xxx)
+  %apply;add_in_sorted_list%with;
+    %if;(e.rev=1)-%end;%ancestor.marriage_date.year;%nn;
+    %and;%apply;month("ancestor.marriage_date")%nn;
+    %and;%apply;day("ancestor.marriage_date")%nn;
+    %and;%apply;dprec("ancestor.marriage_date")%nn;
+    %and;%apply;link_marriage1(xxx)%end;
+%end;
+
 %define;one_line(z1)
   %if;(ancestor.anc_sosa.v % 2 = 0)
     <tr id="i%ancestor.anc_sosa.v;">
       %apply;male_line("ancestor","z1")
       <td class="align-middle" style="text-align:%left;">
+        %end;
       %if;(ancestor.same = "")
         %foreach;ancestor.family;
-          %if;(family.index = ancestor.family.index)
-            %apply;link_marriage1("ancestor")
+          %if;(ancestor.is_male and family.index = ancestor.family.index)
+            %apply;addlist(1)
+          %elseif;(ancestor.is_male or (ancestor.is_female and family.index != ancestor.family.index))
+            %apply;addlist(0)
           %end;
         %end;
       %end;
-      </td>
-  %end;
   %if;(ancestor.anc_sosa.v % 2 = 1)
+              %foreach;sorted_list_item;%item.5;%end;
+            %empty_sorted_list;
+            </td>
     %apply;female_line("ancestor","z1")</tr>
   %end;
 %end;
 
-%(
-  Long display
-%)
+%( Long display %)
 
 %define;child_notes(spec)
   %if;(child.sosa_in_list = "" and
@@ -1484,10 +1514,10 @@
 %end;
 
 %define;table_ancestor_to_somebody()
-  %p_of_index.1.mark_descendants;
+  %pvar.1.mark_descendants;
   %foreach;ancestor_level;
     %apply;lazy_print%with;
-      <tr><th colspan="7" >%nl;[*generation/generations]0 %level;%nl;</th></tr>
+      %if;(e.gen=1)<tr><th colspan="7" >%nl;[*generation/generations]0 %level;%nl;</th></tr>%end;
     %end;
     %if;(level <= e.l)
       %foreach;ancestor;
@@ -1504,9 +1534,9 @@
 %define;table_double()
   %foreach;ancestor_level(l_v)
     %if;(level>0 and (e.only!="on" or level=l_v))
-      <tr><th colspan="7" >%nl;[*generation/generations]0 %level;%nl;</th></tr>
-      %foreach;ancestor
-          %if;(ancestor.same = "")%incr_count;%end;
+      %if;(e.gen=1)<tr><th colspan="7">%nl;[*generation/generations]0 %level;%nl;</th></tr>%end;
+      %foreach;ancestor;
+          %if;(ancestor.same="" and ancestor.first_name!="?" and ancestor.surname!="?")%incr_count;%end;
           %apply;one_line("")
       %end;
     %end;
@@ -1570,12 +1600,13 @@ TODO: obtenir les secondes valeurs valeurs jj/mm/aaaa pour les cas « ou | » 
     %if;(public_name != "")%public_name;%else;%first_name;%end;
     %if;(qualifier != "") <em>%qualifier;</em>%end;
     %sp;%surname;
-    %if;(alias != "") <em>(%alias;)</em>%end;
+    %if;(alias != "") <em>(%alias;)</em>%end; %dates;
   %end;
   %if;(e.t = "D") [up to] %p_of_index.1;
   %else;
      %if;(cancel_links and e.v > 4) %apply;togena(e.v)%end;
   %end;
+  %if;(e.t="X")…<br>[only] [up to] %pvar.1; %pvar.1.dates;%end;
 </h1>
 %end;
 
@@ -2012,17 +2043,9 @@ TODO: obtenir les secondes valeurs valeurs jj/mm/aaaa pour les cas « ou | » 
   </ul>
 
 %elseif;(e.t = "X" or e.t = "Y")
-  %if;(e.t = "X")
-    <p>[*only] [up to] %p_of_index.1; %p_of_index.1.dates; </p>
-     %(%if;(not cancel_links)
-       <div class="menu">
-         %if;(has_sosa)<span><a href="%prefix;m=X&t=X&t1=1&i=%e.i1;&i1=%index;&siblings=on&alias=on&spouse=on&parents=on&rel=on&notes=on&src=on&hide=on&witn=on&v=%e.l;&maxv=%e.l;&l=%e.l;">[*descendants]0</a></span>%end;
-         <span><a href="%prefix;m=A&t=G&i=%index;&i1=%e.i1;&siblings=on&alias=on&spouse=on&parents=on&rel=on&witn=on&notes=on&src=on&hide=on&l=%e.l;">[*ancestor/ancestors]1</a></span>
-       </div>
-     %end;%)
-  %end;
+  %empty_sorted_list;
   %reset_count;
-  <table class="table table-sm table-hover table-bordered text-center short_display_table">
+  <table class="table table-sm table-bordered text-center short_display_table">
     <colgroup>
       <col width="10"%/>
       <col width="400"%/>

--- a/hd/etc/buttons.txt
+++ b/hd/etc/buttons.txt
@@ -1,4 +1,4 @@
-<!-- $Id: buttons.txt v7.1 26/11/2022 00:12:36 $ -->
+<!-- $Id: buttons.txt v7.0.1-α3 08/08/2023 00:46:50 $ -->
 <!-- Copyright (c) 1998-2007 INRIA -->
 %( Boutons de configurations et d'options %) 
 %let;istable;%if;((evar.m="D" and (evar.t="H" or evar.t="I")) or (evar.m="A" and (evar.t="Z" or evar.t="Y")))1%end;%in;
@@ -144,17 +144,16 @@
       </a>
     %end;
     <span class="sr-only">—</span>
-    %let;couple_table;%prefix_base;%access;&m=A&t=Y%if;(e.only="on")&only=on%end;%if;(e.im!="")&im=0%end;&v=%e.v&%in;
-    %if;(e.csv!="on" and e.m="A" and e.t="Z" or e.t="Y")
+    %if;(e.csv!="on" and e.m="A" and (e.t="Z" or e.t="Y"))
       <span class="sr-only">—</span>
       <a role="button" class="btn btn-link px-0"
-        href="%prefix_base_password;%nn;
+        href="%prefix_base_password;%access;&m=A%nn;
                  %foreach;env_binding;
                    %if;(env.key="t")&t=%if;(e.t!="Y")Y%else;Z%end;%nn;
-                   %elseif;(env.key!="")&%env.key=%env.val;%end;%nn;
+                   %elseif;(env.key="v" or env.key="maxv" or env.key="only" or env.key="im" or env.key="gen")&%env.key=%env.val;%end;%nn;
                  %end;%nn;
                  %( ajout des variables par défaut du tableau asc. pour sortir du tableau par couple qui n'en a quasi pas %)
-                 %if;(url=couple_table)&num=on&birth=on&birth_place=on&marr=on&marr_date=on&marr_place=on&child=on&death=on&death_place=on&age=on&occu=on&gen=1&repeat=on&ns=1%end;"
+                 %if;(e.t="Y")&num=on&birth=on&birth_place=on&marr=on&marr_date=on&marr_place=on&child=on&death=on&death_place=on&age=on&occu=on&repeat=on%end;"
         title="[*visualize/show/hide/summary]1 [table] %if;(e.t="Y")[ancestor/ancestors]1%else;[by couple]%end;">%nn;
           <i class="fa fa-restroom fa-lg fa-fw%if;(e.t="Y") text-danger%end;" aria-hidden="true"></i>
       </a>


### PR DESCRIPTION
This PR allows to see more clearly the “state” of other ancestors families (out of the couple of ancestor itself) when there are multiple relations/beds:
* It uses a sorted_list to stack all the relations of the couple of ancestors:
  * His relations are printed in blue and hers in red, a smaller font size is used, events of the list are sorted by ascending dates (with precision of date taken in account); non married relation are marked with an endash –.
  * The number before the event is the number of child of the relation like before (but we now see all half-siblings).
  * The names of the other spouses are given in tooltips only.
  * Like nearly everywhere, a link to forms on date allow to edit those extra families.
* Fix the switching button between ascending table and the one by couple.
* Fix table of ancestor to somebody (s/p_of_index/pvar) [was failing totaly giving an empty page].
* Remove unknown individuals (? ?) from ancestor's count.

![image](https://github.com/geneweb/geneweb/assets/10353895/7730e6c2-57f6-466d-9b3e-23f4b95d6646)

![image](https://github.com/geneweb/geneweb/assets/10353895/9ce63765-a603-42f1-b894-d5ec156e5528)

