### PR TITLE
Add search of books, template cleanup

### DIFF
--- a/hd/etc/upddata.txt
+++ b/hd/etc/upddata.txt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="%lang;">
 <head>
-  <!-- $Id: upddata.txt v7.1 17/01/2023 20:01:49 $ -->
+  <!-- $Id: upddata.txt v7.1 09/08/2023 17:16:02 $ -->
   <!-- Copyright (c) 2006-2007 INRIA -->
   <title>%title;</title>
   <meta name="robots" content="none">
@@ -12,154 +12,82 @@
 </head>
 <body%body_prop;>
 %include;hed
-%(
-%(Affichage court: %foreach;initial identique à %foreach;entry juste en-dessous%)
-%define;print_short()
-  <div class="clearfix mt-3 mx-5">
-    <div class="float-%left; font-weight-bold">%if;(evar.s="")[*select a letter]%else;[*specify]%end;[:]</div>
-  </div>
-  <div class="row justify-content-center mt-3 mb-1">
-    <div class="col-xl-9 ml-xl-3 col-lg-11 ml-lg-5">
-      <div class="d-flex flex-wrap" role="toolbar" aria-label="First character selection">
-        %foreach;initial;
-          <a class="btn btn-primary text-center text-monospace" role="button"
-            href="%prefix;m=MOD_DATA&data=%evar.data;&s=%encode.ini;">%html_encode.ini;</a>
-        %end;
-      </div>
-    </div>
-  </div>
-%end;
-%)
 <div class="container">
-  <div class="d-flex justify-content-between mt-1">
-    <div class="col-1">%if;(evar.s!="")<a title="[*help modify data]" class="mt-2" role="alert"><i class="fas fa-hat-wizard fa-lg text-danger"></i></a>%else; %end;</div>
-    <h1 class="text-center">%title;</h1>
+  <div class="d-flex justify-content-between mt-2">
+    <div class="col-1">
+      %if;(e.s!="")
+        <a title="[*help modify data]" class="mt-2" role="alert">
+          <i class="fas fa-hat-wizard fa-fw text-danger"></i>
+        </a>
+      %end;
+    </div>
+    <h1 class="text-center mt-3">%title;</h1>
     %if;not cancel_links;
       <div class="btn-group col-1">
-        %if;(referer != "")
-          <a href="%referer;"><i class="fa fa-arrow-left fa-lg" title="<<"></i></a>
+        %if;(referer!="")
+          <a href="%referer;"><i class="fa fa-arrow-left fa-fw" title="<<"></i></a>
         %end;
-        <a href="%prefix;"><i class="fa fa-home fa-lg ml-1" title="[*home]"></i></a>
+        <a href="%prefix;"><i class="fa fa-home fa-fw" title="[*home]"></i></a>
       </div>
     %end;
   </div>
-
-  %let;length_s;%if;(evar.s!="")%evar.length.s;%else;0%end;%in;
-  %let;nbs;%if;(evar.nbs!="" and evar.nbs<=length_s)%evar.nbs;%else;%length_s;%end;%in;
-  %let;enbs;&nbs=%nbs;%in;
-%( Boutons %)
-  <div class="d-flex">
-    <div class="ml-auto">
-    <a role="button" class="btn"
-      href="%prefix_base_password;%nn;
-        %foreach;env_binding;%if;(env.val!="" and env.key!="rev")%nn;
-         &%env.key=%env.val;%end;%nn;
-        %end;%nn;
-        %if;(evar.rev!="" and evar.rev!="on")&rev=on%elseif;(evar.rev="")&rev=on%end;%nn;"
-        title="[*invert elements]">
-      <i class="fas fa-arrows-alt-h fa-lg"></i>%nn;
-    </a>%nn;
-    %if;(evar.s!="")
-      <a role="button" class="btn pl-2"%sp;
-        title="[*delete] 1 [substr]"%sp;
-        href="%prefix_base_password;%nn;
-            %foreach;env_binding;
-              %if;(env.key="nbs" and evar.nbs>=1)&nbs=%expr(evar.nbs-1)%nn;
-              %elseif;(env.key!="")&%env.key=%env.val;%nn;
-              %end;
-            %end;">%nn;
-        <i class="fa fa-minus fa-lg %if;(evar.nbs<1) disabled text-muted%end;" aria-hidden="true"></i>
-        <span class="sr-only">-</span>
-      </a>
-      <span class="sr-only">/</span>
-      <a role="button" class="btn pl-2"%sp;
-        title="[*add] 1 [substr]0"%sp;
-        href="%prefix_base_password;%nn;
-              %foreach;env_binding;
-                %if;(env.key="nbs" and evar.nbs+3<length_s)&nbs=%expr(evar.nbs+1)%nn;
-                %elseif;(env.key!="")&%env.key=%env.val;%nn;
-                %end;
-              %end;">%nn;
-        <i class="fa fa-plus fa-lg %if;(evar.nbs+3>=length_s) disabled text-muted%end;" aria-hidden="true"></i>%nn;
-        <span class="sr-only">+</span>%nn;
-      </a>
-    %end;
-    </div>
-  </div>
-
-%( Idée facile mais moins esthétique pour les cas longs, fixé à 7, sans utiliser nbs atm, une bvar plutôt qu'evar ? %)
-  %reset_count;
-  %foreach;entry;
-    %foreach;value;
-      %incr_count;
-    %end;
-  %end;
+  %let;length_s;%if;(e.s!="")%e.length.s;%else;0%end;%in;
+  %let;nbs;%if;(e.nbs!="" and e.nbs<=length_s)%e.nbs;%else;%length_s;%end;%in;
+    %reset_count;
+  %foreach;entry;%foreach;value;%incr_count;%end;%end;
   %let;value_list_len;%count;%in;
-  
-    %if;(nb_results>1000)<div class="col-12 font-weight-bold my-3 mx-3">%if;(evar.s="")[*select a letter]%else;[*specify][:]%end;</div>%end;
-  %(
+  %if;(nb_results>1000)<div class="my-2 mx-3">%if;(e.s="")[*select a letter]%else;[*specify]%end;[:]</div>%end;
   <div class="col-auto">
     <div class="btn-group" role="toolbar" aria-label="sub-selection">
-      %if;(evar.s!="")
-        <a class="mr-2" href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;" title="Index"><i class="fa fa-book fa-lg"></i></a>
-      %end;
-  <span class="text-monospace">
-          %foreach;substr.s;
-            <a href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;&s=%substr;" title="%substr;">%if;(length_s>7)%tail;%else;%substr;%end;</a>%nn;
-            %if;(length_s>7) %else; > %end;%nn;
-          %end;%if;(length_s>7)>%end; <b>%evar.s;</b>%nn;
-          %if;(value_list_len>1)
-            %foreach;entry;
-              %sp;%if;(max>0)<a href="%prefix;m=MOD_DATA%enbs;&data=%evar.data&s=%entry_ini;#%entry_ini;">%html_encode.entry_ini;</a>%else;%html_encode.entry_ini;%end;
-              %if;(evar.s!="")(%sp;%if;(max>0 and not first)<a href="#_%entry_ini;" title="↓ %entry_ini;">·</a>%else;·%end;
-              %else; %end;
-            %end;
-          %end;
-        </span>
-      
-    </div>
-  </div>
-  %)
-  %( autre façon? à décrire %)
-  %(--------%)
-  <div class="col-auto">
-    <div class="btn-group" role="toolbar" aria-label="sub-selection">
-      %if;(evar.s!="")<a class="mr-2" href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;%if;(evar.nbs!="")&nbs=%evar.nbs;%end;" title="Index"><i class="fa fa-book fa-lg"></i></a>%end;
+      %if;(e.s!="")<a class="mr-3 align-self-center" href="%prefix;m=MOD_DATA&data=%e.data;" title="Index"><i class="fa fa-book fa-2x"></i></a>%end;
       <div class="btn-group d-flex align-content-around flex-wrap">
         <span class="text-monospace">
-          %if;(substr_start_e.1.s!="" and length_s > 1)<a href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;&s=%substr_start_e.1.s;">%substr_start_e.1.s;</a> >%end;
-          %if;(substr_start_e.2.s!="" and length_s > 2) <a href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;&s=%substr_start_e.2.s;">%substr_start_e.2.s;</a> >%end;
-          %if;(substr_start_e.3.s!="" and length_s > 3) <a href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;&s=%substr_start_e.3.s;">%substr_start_e.3.s;</a> >%end;
-          %if;(length_s-nbs>4 and nbs>0) … >%end;
-          %if;(evar.s!="")
+          %if;(substr_start_e.1.s!="" and length_s>1)<a href="%prefix;m=MOD_DATA&data=%e.data;&s=%substr_start_e.1.s;">%substr_start_e.1.s;</a> >%end;
+          %if;(substr_start_e.2.s!="" and length_s>2) <a href="%prefix;m=MOD_DATA&data=%e.data;&s=%substr_start_e.2.s;">%substr_start_e.2.s;</a> >%end;
+          %if;(substr_start_e.3.s!="" and length_s>3) <a href="%prefix;m=MOD_DATA&data=%e.data;&s=%substr_start_e.3.s;">%substr_start_e.3.s;</a> >%end;
+          %if;(length_s-nbs>4 and nbs>0) … >%end;
+          %if;(e.s!="")
             %foreach;substr.s;
-              %if;(cnt > 2 and cnt+1 >= length_s-nbs )<a href="%prefix;m=MOD_DATA%nbs;&data=%evar.data;%if;(evar.rev!="" and evar.rev="on")&rev=on%end;&s=%substr;"> %substr;</a> > %end;%nn;
-            %end;<b> %evar.s;</b>%nn;
+              %if;(cnt>2 and cnt+1 >= length_s-nbs )<a href="%prefix;m=MOD_DATA&data=%e.data;&s=%substr;"> %substr;</a> > %end;%nn;
+            %end;<b> %e.s;</b>%nn;
           %end;
           %if;(value_list_len>1)
             %foreach;entry;
-              %sp;%if;(max>0)<a href="#_%entry_ini;">·</a>%else;·%end;
-              %sp;%if;(max>0)<a href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;%if;(evar.rev!="" and evar.rev="on")&rev=on%end;&s=%entry_ini;#%entry_ini;">%html_encode.entry_ini;</a>%else;%html_encode.entry_ini;%end;
+              %if;(e.s!="")%sp;%if;(max>0)<a href="#_%entry_ini;">·</a>%else;·%end;%end;
+              %sp;%if;(max>0)<a href="%prefix;m=MOD_DATA&data=%e.data;&s=%html_encode.entry_ini;#%html_encode.entry_ini;">%entry_ini;</a>%else;%entry_ini;%end;
             %end;
           %end;
         </span>
       </div>
     </div>
   </div>
-  %if;(evar.s!="" and nb_results<1000)
+     <div class="mt-2 ml-3">
+      <form class="form-inline" method="get" action="%action;">
+        %hidden;
+        <input type="hidden" name="m" value="MOD_DATA">
+        <input type="hidden" name="data" value="%e.data;">
+        %if;(e.nbs!="")<input type="hidden" name="nbs" value="%e.nbs;">%end;
+        <div class="form-group">
+          <label for="search_s">[*search/case sensitive]0</label>
+          <input type="search" class="form-control ml-2" name="s" id="search_s" aria-describedby="personnal input">
+          <button type="submit" class="btn btn-primary ml-2">Ok</button>
+        </div>
+      </form>
+    </div>
+  %if;(e.s!="")
   %( liste des entrées et formulaire d'édition %)
   <ul class="list-group">
     %foreach;entry;
       <li class="list-group-item list-group-item-primary py-0 mt-2 justify-content-between">
         <a class="btn btn-link p-0 ml-1" href="#top" title="Return to top" tabindex="-1"><i class="fa fa-arrow-up fa-fw mx-1"></i></a>%nn;
-        <a class="font-weight-bold text-monospace" id="_%entry_ini;" href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;&s=%html_encode.entry_ini;">%html_encode.entry_ini;</a>
+        <a class="font-weight-bold text-monospace" id="_%entry_ini;" href="%prefix;m=MOD_DATA&data=%e.data;&s=%html_encode.entry_ini;">%entry_ini;</a>
       </li>
       <li class="list-unstyled mt-1">
         <ul class="list-group">
           %foreach;value;
             <li class="list-unstyled ml-4">
               <table><tr><td>
-                %if;(evar.data="place")
+                %if;(e.data="place")
                 <a href="https://www.wikidata.org/w/index.php?search=%nn;
                   %if;(not first and suburb!="")%escape.printable.suburb;%else;%escape.printable.other;%end;"
                   role="button" class="btn btn-link p-0 ml-1"
@@ -179,8 +107,8 @@
                 </td><td>
               <a role="button" id="%escape.entry_value;" class="btn btn-link d-inline text-wrap ml-%if;is_modified;5 pl-4%else;2%end;%nn;
                 %if;is_modified; disabled" tabindex="-1" aria-disabled="true%end;"
-                href="%prefix;m=MOD_DATA%enbs;&data=%evar.data;%if;(evar.rev!="" and evar.rev="on")&rev=on%end;&key=%entry_key;&s=%encode.evar.s;">
-                  %if;(evar.data="place" and suburb!="")
+                href="%prefix;m=MOD_DATA&data=%e.data;&key=%entry_key;&s=%encode.e.s;">
+                  %if;(e.data="place" and suburb!="")
                     %if;is_modified;%escape.entry_value;
                     %else;
                       %if;(first)
@@ -198,20 +126,17 @@
                   %hidden;
                   <input type="hidden" name="key" value="%entry_key;">
                   <input type="hidden" name="m" value="MOD_DATA_OK">
-                  <input type="hidden" name="data" value="%evar.data;">
-                  <input type="hidden" name="s" value="%evar.s;">
+                  <input type="hidden" name="data" value="%e.data;">
+                  <input type="hidden" name="s" value="%e.s;">
                   <input type="hidden" name="k" value="kkk">
-                  %if;(evar.rev!="" and evar.rev="on")
-                    <input type="hidden" name="rev" value="on">
-                  %end;
-                  %if;(evar.data = "fn")
+                  %if;(e.data="fn")
                     <div class="form-check form-check-inline ml-sm-2 ml-md-5">
                       <label class="form-check-label">
                         <input class="form-check-input" type="checkbox" id="first_name_aliases" name="first_name_aliases" value="yes" autofocus> [*add the previous name as a first name alias]
                       </label>
                     </div>
                   %end;
-                  %if;(evar.data = "sn")
+                  %if;(e.data="sn")
                     <div class="form-check form-check-inline mt-2 ml-5">
                       <label class="form-check-label">
                         <input class="form-check-input" type="checkbox" id="surname_aliases" name="surname_aliases" value="yes" autofocus> [*add the previous name as a surname alias]
@@ -219,31 +144,28 @@
                     </div>
                   %end;
                   <div class="input-group col-12 px-0 mx-2">
-                    %let;entry_v;%if;(evar.rev!="" and evar.rev="on")%escape.printable.entry_value_rev;%else;%escape.printable.entry_value;%end;%in;
-                    %if;(bvar.notextarea="yes" or evar.data="fn" or evar.data="sn" or evar.data="place")
+                    %if;(b.notextarea="yes" or e.data="fn" or e.data="sn" or e.data="place")
                       <input type="text" class="form-control col-11" id="nx_input" name="nx_input"%nn
-                        maxlength="%if;(evar.data="src" or evar.data="occu" or evar.data="place")1000%else;200%end;"
-                        value="%entry_v;" placeholder="%entry_v;"
-                        %if;(evar.data!="fn" or evar.data!="sn") autofocus%end; aria-label="Recipient's username" aria-describedby="button-addon2" required>
+                        maxlength="%if;(e.data="src" or e.data="occu" or e.data="place")1000%else;200%end;"
+                        value="%escape.printable.entry_value;" placeholder="%escape.printable.entry_value;"
+                        %if;(e.data!="fn" or e.data!="sn") autofocus%end; aria-label="Recipient's username" aria-describedby="button-addon2" required>
                     %else;
                       <textarea class="form-control col-11" id="nx_input" name="nx_input" rows="1"
-                        maxlength="%if;(evar.data="src" or evar.data="occu" or evar.data="place")1000%else;200%end;"
-                        placeholder="%entry_v;"%if;(evar.data!="fn" or evar.data!="sn") autofocus%end; required>%entry_v;</textarea>
+                        maxlength="%if;(e.data="src" or e.data="occu" or e.data="place")1000%else;200%end;"
+                        placeholder="%escape.printable.entry_value;"%if;(e.data!="fn" or e.data!="sn") autofocus%end; required>%escape.printable.entry_value;</textarea>
                     %end;
                     <div class="valid-feedback">
                       must be different!
                     </div>
-                    <div class="input-group-append">
-                      <button type="submit" class="btn btn-primary" title="[*modify]">OK</button>
-                      %if;(evar.data="place" and suburb="")
-                        <div class="custom-control custom-checkbox ml-2">
-                        <input type="checkbox" class="custom-control-input ml-3" name="all"
-                          id="all" value="on" checked>
-                        <label class="custom-control-label" title="[*apply to same places with suburb (wip)]"
+                    <button type="submit" class="btn btn-primary ml-2" title="[*modify]">OK</button>
+                    %(%if;(e.data="place" and suburb="")
+                      <div class="custom-control custom-checkbox ml-2">
+                        %( TODO: wip rename all places %)
+                        <input type="checkbox" class="custom-control-input ml-3" name="all" id="all" value="on" checked>
+                        <label class="custom-control-label my-2" title="!! [*apply to same places with suburb] (WIP) !!"
                           for="all">[*all]</label>
-                        </div>
-                      %end;
-                    </div>
+                      </div>
+                    %end;%)
                   </div>
                 </form>
               %end;
@@ -254,15 +176,7 @@
       </li>
     %end;
   </ul>
-
 %end;
-%(
-%( boucle principale %)
-%if;(evar.s="" or nb_results > 1000)
-  %apply;print_short()
-%else;
-  %apply;print_long()
-%end;%)
 %base_trailer;
 %include;copyr
 </div>

--- a/lib/updateDataDisplay.ml
+++ b/lib/updateDataDisplay.ml
@@ -66,7 +66,7 @@ let print_mod_ok conf base =
     Output.print_sstring conf " ";
     Output.print_sstring conf (min nb_pers max_updates |> string_of_int);
     if List.assoc_opt "history" conf.base_env = Some "yes" then (
-      Output.print_sstring conf "<a href=\"";
+      Output.print_sstring conf " <a href=\"";
       Output.print_string conf (commd conf);
       Output.print_sstring conf "m=HIST&k=20\">";
       Output.print_sstring conf
@@ -218,12 +218,11 @@ and eval_simple_str_var conf _base env _xx = function
       let ini = Option.value ~default:"" (p_getenv conf.env "s") in
       let book_of, title = translate_title conf in
       let result =
-        if ini = "" then Printf.sprintf " (%d %s)" len title
+        if ini = "" then Printf.sprintf "%d %s" len title
         else
-          " - "
-          ^ Printf.sprintf (ftransl conf "%d %s starting with %s") len title ini
+          Printf.sprintf (ftransl conf "%d %s starting with %s") len title ini
       in
-      Utf8.capitalize_fst book_of ^ result
+      Utf8.capitalize_fst book_of ^ "<br>" ^ result
   | _ -> raise Not_found
 
 and eval_compound_var conf base env xx sl =


### PR DESCRIPTION
* Split long title in two lines.
* Few aesthetical modifications.
* Add a new search form for a quicker access to entries when doing multiple modifications.
* Cleanup old mess (non existant ml functions for it) that shouldn't have been merged!

![image](https://github.com/geneweb/geneweb/assets/10353895/74eed669-2ce4-479f-969c-eb8aa7cfb1f9)
