### PR TITLE
partial_key: search_by_name then search (not exact) for surname, then…

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -109,6 +109,7 @@ let specify conf base n pl =
   (* Si on est dans un calcul de parenté, on affiche *)
   (* l'aide sur la sélection d'un individu.          *)
   Util.print_tips_relationship conf;
+  (* TODO set possible limit to number of persons displayed (ptll) *)
   Output.print_sstring conf "<ul>\n";
   (* Construction de la table des sosa de la base *)
   let () = SosaCache.build_sosa_ht conf base in

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -782,6 +782,9 @@ let treat_request =
     in
     let user = transl_nth conf "user/password/cancel" 0 in
     let passwd = transl_nth conf "user/password/cancel" 1 in
+    let referer = String.split_on_char '?' (get_referer conf :> string) in
+    let referer = if List.length referer > 1 then (List.nth referer 1) else "" in
+    let referer = if referer = "" then referer else "&" ^ referer in
     let body =
       if conf.cgi then
         Printf.sprintf {|
@@ -800,15 +803,15 @@ let treat_request =
         Printf.sprintf {|
             <div>
               <ul>
-              <li>%s%s <a href="%s?%sw=f"> %s</a></li>
-              <li>%s%s <a href="%s?%sw=w"> %s</a></li>
+              <li>%s%s <a href="%s?%sw=f%s"> %s</a></li>
+              <li>%s%s <a href="%s?%sw=w%s"> %s</a></li>
               </ul>
             </div> |}
             (transl conf "access" |> Utf8.capitalize_fst) (transl conf ":")
-            (conf.command :> string) base_name
+            (conf.command :> string) base_name referer
             (transl_nth conf "wizard/wizards/friend/friends/exterior" 2)
             (transl conf "access" |> Utf8.capitalize_fst) (transl conf ":")
-            (conf.command :> string) base_name
+            (conf.command :> string) base_name referer
             (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
     in
     Output.print_sstring conf

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -33,7 +33,7 @@ let find_all conf base an =
       | _ -> [], false
     else [], false
   | _ ->
-    let acc = SearchName.search_by_key conf base an in
+    let acc = Option.to_list @@ SearchName.search_by_key conf base an in
     if acc <> [] then acc, false
     else
       ( SearchName.search_key_aux begin fun conf base acc an ->
@@ -569,8 +569,8 @@ let treat_request =
           w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_inv
         | "KILL_ANC" ->
           w_wizard @@ w_lock @@ w_base @@ MergeIndDisplay.print_kill_ancestors
-        | "L" -> w_base @@ fun conf base -> Perso.interp_templ "list" conf base 
-              (Gwdb.empty_person base Gwdb.dummy_iper) 
+        | "L" -> w_base @@ fun conf base -> Perso.interp_templ "list" conf base
+              (Gwdb.empty_person base Gwdb.dummy_iper)
         | "LB" when conf.wizard || conf.friend ->
           w_base @@ BirthDeathDisplay.print_birth
         | "LD" when conf.wizard || conf.friend ->
@@ -811,7 +811,7 @@ let treat_request =
             (conf.command :> string) base_name
             (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
     in
-    Output.print_sstring conf 
+    Output.print_sstring conf
       (Printf.sprintf {|
         <form class="form-inline" method="post" action="%s">
           <div class="input-group mt-1">

--- a/lib/advSearchOkDisplay.ml
+++ b/lib/advSearchOkDisplay.ml
@@ -26,7 +26,11 @@ let print_result conf base max_answers (list, len) =
         Output.print_sstring conf "</em>")
       list;
     if len > max_answers then Output.print_sstring conf "<li>&hellip;</li>";
-    Output.print_sstring conf "</ul>"
+    Output.print_sstring conf "</ul>";
+    Output.print_sstring conf
+      (Format.sprintf "%s%s %d<br>"
+         (transl conf "total" |> Utf8.capitalize_fst)
+         (transl conf ":") len)
 
 let print conf base =
   let title _ =

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -138,7 +138,7 @@ let search_for_fn_or_pn conf base fn pl =
             let tbl = Hashtbl.create 512 in
             List.iter (fun k -> Hashtbl.add tbl k ()) fn1_l;
             List.iter (fun k -> Hashtbl.add tbl k ()) fn2_l;
-            List.exists (Hashtbl.mem tbl) fn_l
+            List.exists (fun fn -> Hashtbl.mem tbl fn) fn_l
         then p :: pl
         else pl)
     [] pl
@@ -178,6 +178,16 @@ let search conf base an search_order specify unknown =
         in
         let sn =
           match p_getenv conf.env "n" with Some sn -> sn | None -> ""
+        in
+        let fn, sn =
+          if fn = "" then
+            (* we assume fn1 fn2 sn. For other cases, use fn, sn explicitely *)
+            match String.rindex_opt sn ' ' with
+            | Some i ->
+                ( String.sub sn 0 i,
+                  String.sub sn (i + 1) (String.length sn - i - 1) )
+            | _ -> ("", sn)
+          else (fn, sn)
         in
         let conf =
           { conf with env = ("surname", Adef.encoded sn) :: conf.env }
@@ -282,8 +292,9 @@ let print conf base specify unknown =
       let order = [ FirstName ] in
       search conf base fn order specify unknown
   | None, Some sn ->
+      Printf.eprintf "None, Some sn: %s\n" sn;
       let order =
-        [ Sosa; Key; Surname; ApproxKey; PartialKey; DefaultSurname ]
+        [ Sosa; Key; FullName; Surname; ApproxKey; PartialKey; DefaultSurname ]
       in
       search conf base sn order specify unknown
   | None, None ->

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -286,7 +286,7 @@ let print conf base specify unknown =
   in
   match (real_input "p", real_input "n") with
   | Some fn, Some sn ->
-      let order = [ FullName ] in
+      let order = [ Key; FullName ] in
       search conf base (fn ^ " " ^ sn) order specify unknown
   | Some fn, None ->
       let order = [ FirstName ] in

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -289,6 +289,11 @@ let print conf base specify unknown =
       let order = [ Key; FullName ] in
       search conf base (fn ^ " " ^ sn) order specify unknown
   | Some fn, None ->
+      let fn =
+        match String.rindex_opt fn '.' with
+        | Some i -> String.sub fn 0 i
+        | None -> fn
+      in
       let order = [ FirstName ] in
       search conf base fn order specify unknown
   | None, Some sn ->

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -268,7 +268,7 @@ let search conf base an search_order specify unknown =
 let print conf base specify unknown =
   let real_input label =
     match p_getenv conf.env label with
-    | Some s -> if s = "" then None else Some (Name.lower s)
+    | Some s -> if s = "" then None else Some s
     | None -> None
   in
   match (real_input "p", real_input "n") with

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -135,10 +135,10 @@ let search_for_fn_or_pn conf base fn pl =
         if
           if exact then fn_l = fn1_l || fn_l = fn2_l
           else
-            List.fold_left (fun res fn -> res || List.mem fn fn1_l) false fn_l
-            || List.fold_left
-                 (fun res fn -> res || List.mem fn fn2_l)
-                 false fn_l
+            let tbl = Hashtbl.create 512 in
+            List.iter (fun k -> Hashtbl.add tbl k ()) fn1_l;
+            List.iter (fun k -> Hashtbl.add tbl k ()) fn2_l;
+            List.exists (Hashtbl.mem tbl) fn_l
         then p :: pl
         else pl)
     [] pl

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -165,10 +165,14 @@ let search conf base an search_order specify unknown =
         | _ -> Some.search_first_name_print conf base an)
     | FullName :: l -> (
         let fn =
-          match p_getenv conf.env "p" with Some fn -> fn | None -> ""
+          match p_getenv conf.env "p" with
+          | Some fn -> Name.lower fn
+          | None -> ""
         in
         let sn =
-          match p_getenv conf.env "n" with Some sn -> sn | None -> ""
+          match p_getenv conf.env "n" with
+          | Some sn -> Name.lower sn
+          | None -> ""
         in
         let fn, sn =
           if fn = "" then
@@ -264,7 +268,7 @@ let search conf base an search_order specify unknown =
 let print conf base specify unknown =
   let real_input label =
     match p_getenv conf.env label with
-    | Some s -> if s = "" then None else Some s
+    | Some s -> if s = "" then None else Some (Name.lower s)
     | None -> None
   in
   match (real_input "p", real_input "n") with

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -121,13 +121,13 @@ type search_type =
   | DefaultSurname
 
 let search_for_fn_or_pn conf base fn pl =
+  let fn_l = cut_words fn in
   List.fold_left
     (fun pl p ->
       if search_reject_p conf base p then pl
       else
         let fn1_l = get_first_name p |> sou base |> split_normalize in
         let fn2_l = get_public_name p |> sou base |> split_normalize in
-        let fn_l = cut_words fn in
         let exact = false in
         (* TODO manage exact options according to mode *)
         if

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -76,12 +76,12 @@ let search_by_name conf base n =
         (fun pl (_, _, ipl) ->
           List.fold_left
             (fun pl ip ->
-              let p = pget conf base ip in
-              if search_reject_p conf base p then pl
-              else
-                let fn1_l = split_normalize (sou base (get_first_name p)) in
-                let fn2_l = split_normalize (sou base (get_public_name p)) in
-                if List.mem fn fn1_l || List.mem fn fn2_l then p :: pl else pl)
+              match Util.pget_opt conf base ip with
+              | None -> pl
+              | Some p ->
+                  let fn1_l = split_normalize (sou base (get_first_name p)) in
+                  let fn2_l = split_normalize (sou base (get_public_name p)) in
+                  if List.mem fn fn1_l || List.mem fn fn2_l then p :: pl else pl)
             pl ipl)
         [] p_of_sn_l
 
@@ -96,13 +96,7 @@ let search_key_aux aux conf base an =
       | None -> (an, acc)
     else (an, acc)
   in
-  let acc =
-    Mutil.filter_map
-      (fun i ->
-        let p = Util.pget conf base i in
-        if search_reject_p conf base p then None else Some p)
-      acc
-  in
+  let acc = Mutil.filter_map (fun i -> Util.pget_opt conf base i) acc in
   let acc = aux conf base acc an in
   Gutil.sort_uniq_person_list base acc
 
@@ -112,10 +106,7 @@ let search_approx_key = search_key_aux select_approx_key
 let search_by_key conf base an =
   match Gutil.person_of_string_key base an with
   | None -> None
-  | Some ip ->
-      (* TODO use Util.pget_opt here instead?? *)
-      let p = Util.pget conf base ip in
-      if search_reject_p conf base p then None else Some p
+  | Some ip -> Util.pget_opt conf base ip
 
 (* main *)
 

--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -4,6 +4,8 @@ open Config
 open Gwdb
 open Util
 
+let default_max_answers = 100
+
 (* TODO use function from Util instead? *)
 let empty_sn_or_fn base p =
   is_empty_string (get_surname p)
@@ -169,7 +171,7 @@ let search conf base an search_order specify unknown =
         | _ -> Some.search_first_name_print conf base an)
     | FullName :: l -> (
         let max_answers =
-          match p_getint conf.env "max" with Some n -> n | None -> 100
+          Option.value ~default:default_max_answers (p_getint conf.env "max")
         in
         let fn =
           match p_getenv conf.env "p" with Some fn -> fn | None -> ""
@@ -212,7 +214,6 @@ let search conf base an search_order specify unknown =
         match pl with
         | [] -> (
             (* try advanced search *)
-            let max_answers = 100 in
             (* TODO use split_normalize here? why only split on the first ' '? *)
             let n1 = Name.abbrev (Name.lower an) in
             let fn, sn =
@@ -226,10 +227,11 @@ let search conf base an search_order specify unknown =
               { conf with env = ("surname", Adef.encoded sn) :: conf.env }
             in
             let p_of_sn_l, len =
-              AdvSearchOk.advanced_search conf base max_answers
+              AdvSearchOk.advanced_search conf base default_max_answers
             in
             let p_of_sn_l =
-              if len > max_answers then Util.reduce_list max_answers p_of_sn_l
+              if len > default_max_answers then
+                Util.reduce_list default_max_answers p_of_sn_l
               else p_of_sn_l
             in
             match p_of_sn_l with

--- a/lib/searchName.mli
+++ b/lib/searchName.mli
@@ -17,9 +17,6 @@ val search_by_name : config -> base -> string -> person list
 (** Search persons by name that has format {i "firstname surname"}. Dublicates are possible. Empty persons, persons with private
     names or persons to which there are no rights to access are not listed. *)
 
-val search_partial_key : config -> base -> string -> person list
-(** Calls [search_key_aux] with [aux] fonction that makes calls to [search_by_name] if result is empty. *)
-
 val search_by_sosa : config -> base -> string -> person list
 
 val search_by_key : config -> base -> string -> person list

--- a/lib/searchName.mli
+++ b/lib/searchName.mli
@@ -17,9 +17,9 @@ val search_by_name : config -> base -> string -> person list
 (** Search persons by name that has format {i "firstname surname"}. Dublicates are possible. Empty persons, persons with private
     names or persons to which there are no rights to access are not listed. *)
 
-val search_by_sosa : config -> base -> string -> person list
+val search_by_sosa : config -> base -> string -> person option
 
-val search_by_key : config -> base -> string -> person list
+val search_by_key : config -> base -> string -> person option
 (** Same as [search_by_name] but search by key that has format {i "firstname.occ surname"}. *)
 
 val search_approx_key : config -> base -> string -> person list

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -777,8 +777,11 @@ let is_restricted (conf : config) base (ip : iper) =
   in
   if conf.use_restrict then base_visible_get base fct ip else false
 
-let pget (conf : config) base ip =
-  if is_restricted conf base ip then Gwdb.empty_person base ip else poi base ip
+let pget_opt conf base ip =
+  if is_restricted conf base ip then None else Some (poi base ip)
+
+let pget conf base ip =
+  Option.value ~default:(Gwdb.empty_person base ip) (pget_opt conf base ip)
 
 let string_gen_person base p = Futil.map_person_ps (fun p -> p) (sou base) p
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -1,5 +1,4 @@
 (* Copyright (c) 1998-2007 INRIA *)
-
 open Config
 open Def
 open Gwdb
@@ -141,16 +140,18 @@ val is_semi_public : config -> base -> person -> bool
 (** tells if person is semi_public
     - access = SemiPublic *)
 
-val pget : config -> base -> iper -> person
-(** Returns person with giving id from the base.
+val pget_opt : config -> base -> iper -> person option
+(** Returns person option with giving id from the base.
     Wrapper around `Gwdb.poi` defined such as:
-    - if `conf.use_restrict` (option defined in .gwf file):
+    - Some ip: if user have permissions or `use_restrict` disabled.
+    - None: if `conf.use_restrict` (option defined in .gwf file):
       checks that the user has enought rights to see
       corresponding person (see `authorized_age`).
       If the user does not have enought permissions, returns
-      an empty person.
-    - just an alias to `Gwdb.poi` if `use_restrict` disabled.
-*)
+      None. *)
+
+val pget : config -> base -> iper -> person
+(** Value of [pget_opt], map None to empty_person *)
 
 val string_gen_person :
   base -> (iper, iper, istr) gen_person -> (iper, iper, string) gen_person


### PR DESCRIPTION
in PartialKey,
* search-by-name
* if result is empty, try advanced_search with surname (entry data after first space). 
  (TODO Possibility to ask for exact_surname=on)

new FullName search mode:
* p= and n= are specifiedd, go ahead
* if p= is empty, assume that n= fn1 fn2 sn here sn is delimited by the last space 
  (does not work with multi parts surnames -> use explicit definition of p= n=)
* find all bearers of given surname, in this list identify bearers of fn1 fn2
  (TODO: propose options to control exact match, order, cases, ...)
