### PR TITLE
fix #1545 side effect of previous cid f9acd4256 on copyr.txt

### DIFF
--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -90,6 +90,7 @@
           %else;[wizard/wizards/friend/friends/exterior]1
           %end;
           %if;(wizard)</a>%end;
+        %end;
         %if;(connections.total>0)<span>%connections.total; %nn;
           %if;(connections.total=1)[connection/connections]0
           %else;[connection/connections]1


### PR DESCRIPTION
The consequence of a missing %endif in copyr.txt make the geneweb version not to be displayed.

this is a fix to issue #1545 consequence of previous cid f9acd4256 