### PR TITLE
fix missing age at death; correct templm for asc/desc headings

### DIFF
--- a/hd/etc/modules/individu.txt
+++ b/hd/etc/modules/individu.txt
@@ -338,7 +338,7 @@
         %end;"><span class="fa-li"><i class="far fa-id-card"></i></span>
         %if;(is_dead and computable_death_age)
           %if;(death_date.month!="" and death_date.day!=""
-           and birth_date.month!="" and birth_date.day!="")%apply;curr_age()%else;~ %death_age;%end;
+           and birth_date.month!="" and birth_date.day!="")[*age at death][:] %apply;curr_age()%else;~ %death_age;%end;
         %end;
         %if;(not is_dead and computable_age)
           %if;(birth_date.month!="" and birth_date.day!="")%apply;curr_age()%else;~ %age;%end;

--- a/hd/etc/templm/perso.txt
+++ b/hd/etc/templm/perso.txt
@@ -571,7 +571,7 @@
   %if;has_parents;
     <div><div>
       <span class="menu" style="display:inline;position:relative;background-color:#AAA;">
-        <span style="margin-left:20px"><small>[up to] %apply;ascmax()%apply;implex()</small></span><br>
+        <span style="margin-left:20px"><small>%apply;ascmax()%apply;implex()</small></span><br>
         %let;l1;%apply;min(max_anc_level,5)%in;
         <span>
           <span class="ch2" style="margin-top:-4px;">[*ancestor/ancestors]1</span>
@@ -1045,8 +1045,9 @@
   %if;has_children;
     %foreach;descendant_level;
       %if;(max_desc_level > 1 and level = max_desc_level)
-        %if;(level!= 1 and level!=0)[up to] %number_of_descendants;%nn;
-          %sp;à %level; [generation/generations]1
+        %if;(level!= 1 and level!=0)[up to] %level;%nn;
+          %if;(level = "1") [generation/generations]0%else; [generation/generations]1%end;%nn;
+          %sp;(%number_of_descendants;)
         %end;
       %end;
     %end;
@@ -1059,9 +1060,9 @@
 %end;
 %define;ascmax()
   %foreach;ancestor_level;
-    %if;(level = max_anc_level)
-      %number_of_ancestors; à %level;
-      %if;(level = "1") [generation/generations]0%else; [generation/generations]1%end;
+    %if;(level = max_anc_level)[up to] %level;%nn;
+      %if;(level = "1") [generation/generations]0%else; [generation/generations]1%end;%nn;
+      %sp;(%number_of_ancestors;)
     %end;
   %end;
 %end;


### PR DESCRIPTION
In individu module, add [*age at death|
In templm/perso.txt, adjust the heading of Ascendants and Descendants
Fix issue #1279