### PR TITLE
Ignore failure on connection shutdown request

### DIFF
--- a/lib/wserver/wserver.ml
+++ b/lib/wserver/wserver.ml
@@ -32,7 +32,7 @@ let skip_possible_remaining_chars fd =
 let close_connection () =
   if not !connection_closed then (
     wflush ();
-    Unix.shutdown !wserver_sock Unix.SHUTDOWN_SEND;
+    (try Unix.shutdown !wserver_sock Unix.SHUTDOWN_SEND with _ -> ());
     skip_possible_remaining_chars !wserver_sock;
     (* Closing the channel flushes the data and closes the underlying file descriptor *)
     close_out !wserver_oc;


### PR DESCRIPTION
to avoid regular messages logged by gwd,
as reported by issue #1517