### PR TITLE
Avoid Erreur d analyse de la valeur pour line-height

### DIFF
--- a/hd/etc/dag.txt
+++ b/hd/etc/dag.txt
@@ -147,7 +147,7 @@
           %if;(dag_cell.colspan>1) colspan="%dag_cell.colspan;"%end;
           style="line-height:%if;(dag_cell.item!="")1%nn;
                              %elseif;dag_cell.is_bar;1%nn;
-                             %elseif;dag_cell.is_nothing;0%end;;"%nn;
+                             %elseif;dag_cell.is_nothing;0%else;0%end;;"%nn;
         %if;(e.im="") valign="bottom"%end;
         align="%dag_cell.align;">
         %if;dag_cell.is_nothing;&nbsp;%nn;


### PR DESCRIPTION
Avoid Erreur d analyse de la valeur pour line-height

as reported by browser console, when display descendant compact tree.

Full reported browser console error:
07:21:50,225 Erreur d’analyse de la valeur pour « line-height ».  Déclaration abandonnée.

I identified source of the problem in dag.txt as a missing else leg in the code change of commit b9fbd74 "a few new features for templates"