### PR TITLE
provide all witnesses for all family events

### DIFF
--- a/hd/etc/modules/unions.txt
+++ b/hd/etc/modules/unions.txt
@@ -157,9 +157,9 @@
         %let;prev_count;%count;%in;
         %if;(has_witnesses)
           %sp;([witness/witnesses]w[:]
-          %foreach;witness;%(attention witness_kind ne marche pas dans ce contexte !! fwitness non plus %)
+          %foreach;witness;
             %if;not is_first;, %end;
-            %apply;short_display_person("witness")%nn;
+            %apply;short_display_person("witness")%if;(witness_kind!="") (%witness_kind;)%end;%nn;
           %end;
           %if;(not cancel_links)
             <a %apply;relations_tree(index)>%nn;
@@ -313,7 +313,7 @@
                 <span class="small_image noimage rounded align-self-center display-3 text-center text-muted ml-2 pb-2">&nbsp;</span>
               %end;
               <div class="ml-2 align-self-center">%nn;
-                %apply;short_display_person_tree("witness")<br>
+                %apply;short_display_person_tree("witness")%if;(witness_kind!="") (%witness_kind;)%end;<br>
                 %if;witness.computable_age;%sp;%witness.age;
                 %elseif;witness.computable_death_age;%sp;%witness.death_age;
                 %else;&#8203;
@@ -395,7 +395,7 @@
           &nbsp;([witness/witnesses]w[:]
           %foreach;witness;
             %if;not is_first;, %end;
-            %apply;short_display_person("witness")
+            %apply;short_display_person("witness")%if;(witness_kind!="") (%witness_kind;)%end;
           %end;)%nn;
         %end;
         %if;((wizard or friend or bvar.no_note_for_visitor!="yes") and has_comment)
@@ -457,7 +457,7 @@
           &nbsp;([witness/witnesses]w[:]
           %foreach;witness;
             %if;not is_first;, %end;
-            %apply;short_display_person("witness")
+            %apply;short_display_person("witness")%if;(witness_kind!="") (%witness_kind;)%end;
           %end;)%nn;
         %end;%nn;
         %if;((wizard or friend or bvar.no_note_for_visitor!="yes") and has_comment)%nn;
@@ -567,7 +567,7 @@
           &nbsp;([witness/witnesses]w[:]
           %foreach;witness;
             %if;not is_first;, %end;
-            %apply;short_display_person("witness")
+            %apply;short_display_person("witness")%if;(witness_kind!="") (%witness_kind;)%end;
           %end;)%nn;
         %end;%nn;
         %if;((wizard or friend or bvar.no_note_for_visitor!="yes") and has_comment)%nn;
@@ -639,6 +639,7 @@
                                           %apply;short_display_person_f("child")
                                           %if;(child_cnt=nb_children).%end;
                                         %end;
+
                                       </td>
                                     </tr></table>
                                   %end;

--- a/hd/etc/modules/unions.txt
+++ b/hd/etc/modules/unions.txt
@@ -159,7 +159,7 @@
           %sp;([witness/witnesses]w[:]
           %foreach;witness;%(attention witness_kind ne marche pas dans ce contexte !! fwitness non plus %)
             %if;not is_first;, %end;
-            %apply;short_display_person("witness")
+            %apply;short_display_person("witness")%nn;
           %end;
           %if;(not cancel_links)
             <a %apply;relations_tree(index)>%nn;
@@ -167,7 +167,7 @@
             </a>%nn;
           %else;
             <img class="ml-1 mb-1" src="%images_prefix;gui_create.png" height="16" alt="tree">%nn;
-          %end;
+          %end;)%nn;
         %end;%nn;
         %apply;init_count(prev_count)
         %if;((wizard or friend or bvar.no_note_for_visitor!="yes") and has_comment)

--- a/hd/etc/perso_utils.txt
+++ b/hd/etc/perso_utils.txt
@@ -231,7 +231,7 @@
   %if;(xx.index=central_index)<b>%xx;</b>%else;
     %if;(cancel_links or xx.is_restricted)%xx;
     %else;<a %apply;ext_link("xx") href="%xx.bname_prefix;%xx.access;" %nn;
-        class="%if;(xx.sex=0)male%elseif;(xx.sex=1)female%else;neuter%end;-underline">%xx;</a>
+        class="%if;(xx.sex=0)male%elseif;(xx.sex=1)female%else;neuter%end;-underline">%xx;</a>%nn;
     %end;
   %end;
   <span title="%if;xx.computable_age;%xx.age;%elseif;xx.computable_death_age;%xx.death_age;%end;"

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1362,12 +1362,7 @@ let date_aux conf p_auth date =
 
 let get_marriage_witnesses fam =
   let fevents = Gwdb.get_fevents fam in
-  let marriages =
-    List.filter (fun fe -> fe.efam_name = Efam_Marriage) fevents
-  in
-  let witnesses =
-    List.map (fun marriage -> marriage.efam_witnesses) marriages
-  in
+  let witnesses = List.map (fun marriage -> marriage.efam_witnesses) fevents in
   witnesses |> Array.concat
 
 let get_nb_marriage_witnesses_of_kind fam wk =
@@ -4570,19 +4565,15 @@ let print_foreach conf base print_ast eval_expr =
           List.iter (print_ast env ep) al)
       events_witnesses
   in
-  let print_foreach_witness env al ep witness_kind = function
+  let print_foreach_witness env al ep _witness_kind = function
     | Vfam (_, fam, _, true) ->
         let _ =
           Array.fold_left
-            (fun (i, first) (ip, wk) ->
-              if wk = witness_kind then (
-                let p = pget conf base ip in
-                let env =
-                  ("witness", Vind p) :: ("first", Vbool first) :: env
-                in
-                List.iter (print_ast env ep) al;
-                (i + 1, false))
-              else (i + 1, first))
+            (fun (i, first) (ip, _wk) ->
+              let p = pget conf base ip in
+              let env = ("witness", Vind p) :: ("first", Vbool first) :: env in
+              List.iter (print_ast env ep) al;
+              (i + 1, false))
             (0, true)
             (get_marriage_witnesses fam)
         in

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1979,6 +1979,10 @@ and eval_compound_var conf base env ((a, _) as ep) loc = function
       match get_env "event_witness_kind" env with
       | Vstring s -> VVstring s
       | _ -> raise Not_found)
+  | "witness_kind" :: _ -> (
+      match get_env "witness_kind" env with
+      | Vstring s -> VVstring s
+      | _ -> raise Not_found)
   | "family" :: sl -> (
       (* TODO ???
          let mode_local =
@@ -4487,7 +4491,7 @@ let print_foreach conf base print_ast eval_expr =
       | Epers_Death -> "death_witness"
       | Epers_Baptism -> "batism_witness"
       | Epers_Birth -> "birth_witness"
-      | _ -> "" (* TODO: ? *)
+      | _ -> "witness"
     in
     List.iter
       (fun (name, _, _, _, _, wl, _) ->
@@ -4565,15 +4569,26 @@ let print_foreach conf base print_ast eval_expr =
           List.iter (print_ast env ep) al)
       events_witnesses
   in
-  let print_foreach_witness env al ep _witness_kind = function
+  let print_foreach_witness env al ep witness_kind = function
     | Vfam (_, fam, _, true) ->
         let _ =
           Array.fold_left
-            (fun (i, first) (ip, _wk) ->
+            (fun (i, first) (ip, wk) ->
               let p = pget conf base ip in
-              let env = ("witness", Vind p) :: ("first", Vbool first) :: env in
-              List.iter (print_ast env ep) al;
-              (i + 1, false))
+              (* TODO if witness_kind = Witness, we might want wk = "" *)
+              let wks =
+                if witness_kind = Witness && wk = Witness then ""
+                else (Util.string_of_witness_kind conf (get_sex p) wk :> string)
+              in
+              let env =
+                ("witness", Vind p) :: ("first", Vbool first)
+                :: ("witness_kind", Vstring wks)
+                :: env
+              in
+              if witness_kind = Witness || witness_kind = wk then (
+                List.iter (print_ast env ep) al;
+                (i + 1, false))
+              else (i, first))
             (0, true)
             (get_marriage_witnesses fam)
         in
@@ -4588,7 +4603,7 @@ let print_foreach conf base print_ast eval_expr =
       List.iter
         (fun ic ->
           let c = pget conf base ic in
-          (* TODOWHY: only on Male? probably bugged on same sex or neuter couples *)
+          (* TODO WHY: only on Male? probably bugged on same sex or neuter couples *)
           if get_sex c = Male then
             Array.iter
               (fun ifam ->

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -316,6 +316,10 @@ and eval_event_var e = function
       | Some { efam_src = x } ->
           safe_val (Util.escape_html x :> Adef.safe_string)
       | _ -> str_val "")
+  | [ "e_w_nbr" ] -> (
+      match e with
+      | Some e -> str_val (string_of_int (Array.length e.efam_witnesses))
+      | _ -> str_val "0")
   | _ -> raise Not_found
 
 and eval_parent' conf base env k = function


### PR DESCRIPTION
The previous situation was giving witnesses only for Marriage event, and limited the foreach;witness to Witness only, excluding other witness kind.
If a detailed list, kind by kind, then use  %foreach;witness_kind; or test for witness_kind