### PR TITLE
Fix gwc

### DIFF
--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -475,7 +475,7 @@ let insert_undefined gen key =
       sou gen.g_base x.m_first_name <> key.pk_first_name
       || sou gen.g_base x.m_surname <> key.pk_surname
     then (
-      Printf.printf "\nPerson defined with two spellings:\n";
+      Printf.printf "\nError: Person defined with two spellings:\n";
       Printf.printf "  \"%s%s %s\"\n" key.pk_first_name
         (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
         key.pk_surname;
@@ -562,7 +562,7 @@ let insert_person gen so =
   (* if person wad defined before (not just referenced) *)
   if gen.g_def.(ip) then (
     (* print error about person beeing already defined *)
-    Printf.printf "\nPerson already defined: \"%s%s %s\"\n" so.first_name
+    Printf.printf "\nError: Person already defined: \"%s%s %s\"\n" so.first_name
       (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
       so.surname;
     if
@@ -583,7 +583,7 @@ let insert_person gen so =
       || sou gen.g_base x.m_surname <> so.surname
     then (
       (* print error about person defined with two spellings *)
-      Printf.printf "\nPerson defined with two spellings:\n";
+      Printf.printf "\nError: Person defined with two spellings:\n";
       Printf.printf "  \"%s%s %s\"\n" so.first_name
         (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
         so.surname;
@@ -662,7 +662,8 @@ let check_parents_not_already_defined gen ix fath moth =
       let p = Adef.father cpl in
       let m = Adef.mother cpl in
       Printf.printf
-        "I cannot add \"%s\", child of\n\
+        "\n\
+         Error: I cannot add \"%s\", child of\n\
         \    - \"%s\"\n\
         \    - \"%s\",\n\
          because this persons still exists as child of\n\
@@ -1014,8 +1015,8 @@ let insert_pevents fname gen sb pevtl =
   (* insert concered person *)
   let p, ip = insert_somebody gen sb in
   if p.m_pevents <> [] then (
-    Printf.printf "\nFile \"%s\"\n" fname;
-    Printf.printf "Individual events already defined for \"%s%s %s\"\n"
+    Printf.printf "\nFile \"%s\"" fname;
+    Printf.printf "\nError: Individual events already defined for \"%s%s %s\"\n"
       (sou gen.g_base p.m_first_name)
       (if p.m_occ = 0 then "" else "." ^ string_of_int p.m_occ)
       (sou gen.g_base p.m_surname);
@@ -1068,8 +1069,8 @@ let insert_notes fname gen key str =
   | Some ip ->
       let p = poi gen.g_base ip in
       if sou gen.g_base p.m_notes <> "" then (
-        Printf.printf "\nFile \"%s\"\n" fname;
-        Printf.printf "Notes already defined for \"%s%s %s\"\n"
+        Printf.printf "\nFile \"%s\"" fname;
+        Printf.printf "\nError: Notes already defined for \"%s%s %s\"\n"
           key.pk_first_name
           (if occ = 0 then "" else "." ^ string_of_int occ)
           key.pk_surname;
@@ -1150,8 +1151,8 @@ let insert_relations fname gen sb sex rl =
   (* insert concerned person *)
   let p, ip = insert_somebody gen sb in
   if p.m_rparents <> [] then (
-    Printf.printf "\nFile \"%s\"\n" fname;
-    Printf.printf "Relations already defined for \"%s%s %s\"\n"
+    Printf.printf "\nFile \"%s\"" fname;
+    Printf.printf "\nError: Relations already defined for \"%s%s %s\"\n"
       (sou gen.g_base p.m_first_name)
       (if p.m_occ = 0 then "" else "." ^ string_of_int p.m_occ)
       (sou gen.g_base p.m_surname);
@@ -1692,11 +1693,13 @@ let link next_family_fun bdir =
   if !do_check && gen.g_pcnt > 0 then (
     Check.check_base base (set_error base gen) (set_warning base) ignore;
     if !pr_stats then Stats.(print_stats base @@ stat_base base));
+  Mutil.remove_dir tmp_dir;
   if not gen.g_errored then (
     if !do_consang then ignore @@ ConsangAll.compute base true;
     Gwdb.sync base;
     output_wizard_notes bdir gen.g_wiznotes;
-    Mutil.remove_dir tmp_dir;
     output_command_line bdir;
     true)
-  else false
+  else (
+    Mutil.remove_dir bdir;
+    false)

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -199,6 +199,7 @@ let main () =
         let next_family_fun = next_family_fun_templ (List.rev !gwo) in
         if Db1link.link next_family_fun bdir then ()
         else (
+          flush stderr;
           Printf.eprintf "*** database not created\n";
           flush stderr;
           exit 2)))

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -1575,7 +1575,9 @@ let gwu opts isolated base in_dir out_dir src_oc_ht (per_sel, fam_sel) =
         let ifaml = connected_families base gen.fam_sel ifam fam in
         let oc, first, _close =
           if to_separate ifam then (oc, out_oc_first, close)
-          else origin_file (sou base (get_origin_file fam))
+          else
+            let fname = get_origin_file fam in
+            origin_file (if is_empty_string fname then "" else sou base fname)
         in
         let f, _ooc, c = opts.oc in
         let opts = { opts with oc = (f, oc, c) } in


### PR DESCRIPTION
gwc was failing (byte_sub/string_sub when origin_file was empty
added "Error: " in front of db1link error messages
destroy tmp_dir AND bdir in case of errors

It could be useful to propose a gwc option to suppress warning messages. Roglo generates a large quantity of warnings, and sorting the real error messages is painful.