### PR TITLE
add consent to access status

### DIFF
--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -519,6 +519,8 @@ let get_access l =
   match l with
   | "#apubl" :: l' -> (Public, l')
   | "#apriv" :: l' -> (Private, l')
+  | "#afriend" :: l' -> (Consent, l') (* for retro compatibility *)
+  | "#consent" :: l' -> (Consent, l')
   | _ -> (IfTitles, l)
 
 (** Create [gen_title] from string *)

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -341,7 +341,8 @@ let print_infos opts base is_child csrc cbp p =
   (match get_access p with
   | IfTitles -> ()
   | Public -> Printf.ksprintf (oc opts) " #apubl"
-  | Private -> Printf.ksprintf (oc opts) " #apriv");
+  | Private -> Printf.ksprintf (oc opts) " #apriv"
+  | Consent -> Printf.ksprintf (oc opts) " #consent");
   print_if_no_empty opts base "#occu" (get_occupation p);
   print_src_if_not_equal_to opts csrc base "#src" (get_psources p);
   (match Date.od_of_cdate (get_birth p) with

--- a/hd/etc/templm/updind.txt
+++ b/hd/etc/templm/updind.txt
@@ -224,9 +224,10 @@
   </div>
   <div>
     [access]0
-    <label><input type="radio" name="access" value="IfTitles"%if;acc_if_titles; checked="checked"%end;%/>[if titles]0</label>
-    <label><input type="radio" name="access" value="Public"%if;acc_public; checked="checked"%end;%/>[public]0</label>
-    <label><input type="radio" name="access" value="Private"%if;acc_private; checked="checked"%end;%/>[private]0</label>
+    <label><input type="radio" name="access" value="IfTitles"%if;acc_if_titles; checked="checked"%end;%/>[iftitles/public/private/consent]0</label>
+    <label><input type="radio" name="access" value="Public"%if;acc_public; checked="checked"%end;%/>[iftitles/public/private/consent]1</label>
+    <label><input type="radio" name="access" value="Private"%if;acc_private; checked="checked"%end;%/>[iftitles/public/private/consent]2</label>
+    <label><input type="radio" name="access" value="Consent"%if;acc_consent; checked="checked"%end;%/>[iftitles/public/private/consent]3</label>
   </div>
 </fieldset>
 <fieldset id="notes1">

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -794,15 +794,19 @@
             <div class="col mt-2">
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="access" value="IfTitles" id="IfTitles"%if;acc_if_titles; checked%end;>
-                <label class="form-check-label" for="IfTitles">[*if titles]0</label>
+                <label class="form-check-label" for="IfTitles">[*iftitles/public/private/consent]0</label>
               </div>
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="access" value="Public" id="Public"%if;acc_public; checked%end;>
-                <label class="form-check-label" for="Public">[*public]0</label>
+                <label class="form-check-label" for="Public">[*iftitles/public/private/consent]1</label>
               </div>
               <div class="form-check">
                 <input class="form-check-input" type="radio" name="access" value="Private" id="Private"%if;acc_private; checked%end;>
-                <label class="form-check-label" for="Private">[*private]0</label>
+                <label class="form-check-label" for="Private">[*iftitles/public/private/consent]2</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="access" value="Consent" id="Consent"%if;acc_consent; checked%end;>
+                <label class="form-check-label" for="Consent">[*iftitles/public/private/consent]3</label>
               </div>
             </div>
           </div>

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -9111,17 +9111,17 @@ sl: če so nazivi
 sv: om titlar
 tr: eğer başlıklar
 
-    iftitles/public/private
-co: s’è tituli/publicu/privatu
-de: Adelstitel/öffentlich/privat
-en: if titles/public/private
-es: si hay títulos/público/privado
-fr: si titres/public/privé
-it: se titoli/pubblico/privato
-oc: si i a de títols/public/privat
-pt: se títulos/público/privado
-sv: om titlar/publik/privat
-tr: başlıklar/herkese Açık/özel ise
+    iftitles/public/private/consent
+co: s’è tituli/publicu/privatu/consentant
+de: Adelstitel/öffentlich/privat/consent
+en: if titles/public/private/consenting
+es: si hay títulos/público/privado/consent
+fr: si titres/public/privé/consentant
+it: se titoli/pubblico/privato/consent
+oc: si i a de títols/public/privat/consent
+pt: se títulos/público/privado/consent
+sv: om titlar/publik/privat/consent
+tr: başlıklar/herkese Açık/özel ise/consent
 
     ignore implex
 co: ignurà l’implessi

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -87,7 +87,7 @@ type death =
 type burial = UnknownBurial | Buried of cdate | Cremated of cdate
 
 (** Rights for access to the personal data *)
-type access = IfTitles | Public | Private
+type access = IfTitles | Public | Private | Consent
 
 (** Title name *)
 type 'string gen_title_name = Tmain | Tname of 'string | Tnone

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -56,7 +56,7 @@ type death = Def.death =
   | OfCourseDead
 
 type burial = Def.burial = UnknownBurial | Buried of cdate | Cremated of cdate
-type access = Def.access = IfTitles | Public | Private
+type access = Def.access = IfTitles | Public | Private | Consent
 
 type 'string gen_title_name = 'string Def.gen_title_name =
   | Tmain

--- a/lib/historyDiffDisplay.ml
+++ b/lib/historyDiffDisplay.ml
@@ -573,9 +573,14 @@ and eval_str_gen_record conf base env (bef, aft, p_auth) :
   | "access" ->
       aux (fun x ->
           match x.gen_p.access with
-          | IfTitles -> transl_nth conf "iftitles/public/private" 0 |> Adef.safe
-          | Public -> transl_nth conf "iftitles/public/private" 1 |> Adef.safe
-          | Private -> transl_nth conf "iftitles/public/private" 2 |> Adef.safe)
+          | IfTitles ->
+              transl_nth conf "iftitles/public/private/consent" 0 |> Adef.safe
+          | Public ->
+              transl_nth conf "iftitles/public/private/consent" 1 |> Adef.safe
+          | Private ->
+              transl_nth conf "iftitles/public/private/consent" 2 |> Adef.safe
+          | Consent ->
+              transl_nth conf "iftitles/public/private/consent" 3 |> Adef.safe)
   | "birth" -> aux (fun x -> string_of_cdate conf x.gen_p.birth)
   | "birth_place" -> aux (fun x -> Util.escape_html x.gen_p.birth_place)
   | "birth_note" -> aux (fun x -> Util.escape_html x.gen_p.birth_note)

--- a/lib/show/def_show.mli
+++ b/lib/show/def_show.mli
@@ -120,7 +120,7 @@ val pp_burial : Format.formatter -> burial -> unit
 val show_burial : burial -> string
 (** Convert [burial] to string *)
 
-type access = Def.access = IfTitles | Public | Private
+type access = Def.access = IfTitles | Public | Private | Consent
 
 val pp_access : Format.formatter -> access -> unit
 (** Printer for [access] *)

--- a/lib/updateInd.ml
+++ b/lib/updateInd.ml
@@ -43,6 +43,7 @@ and eval_simple_var conf base env p = function
   | [ "acc_if_titles" ] -> bool_val (p.access = IfTitles)
   | [ "acc_private" ] -> bool_val (p.access = Private)
   | [ "acc_public" ] -> bool_val (p.access = Public)
+  | [ "acc_consent" ] -> bool_val (p.access = Consent)
   | [ "bapt_place" ] ->
       safe_val (Util.escape_html p.baptism_place :> Adef.safe_string)
   | [ "bapt_note" ] ->

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -575,6 +575,7 @@ let reconstitute_person conf =
     match p_getenv conf.env "access" with
     | Some "Public" -> Public
     | Some "Private" -> Private
+    | Some "Consent" -> Consent
     | Some _ | None -> IfTitles
   in
   let occupation = only_printable (get conf "occu") in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -712,6 +712,8 @@ let is_public conf base p =
      && nobtit conf base p <> []
   || is_old_person conf (gen_person_of_person p)
 
+let is_consent _conf _base p = get_access p = Consent
+
 (* ********************************************************************** *)
 (* [Fonc] accessible_by_key :
             config -> base -> person -> string -> string -> bool *)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -133,9 +133,13 @@ val is_hidden : person -> bool
 
 val is_public : config -> base -> person -> bool
 (** Tells if person is public
-    - access=Public or
+    - access = Public or
     - IfTitle and has titles or
     - is_old_person) *)
+
+val is_consent : config -> base -> person -> bool
+(** tells if person is consenting
+    - access = Consent *)
 
 val pget : config -> base -> iper -> person
 (** Returns person with giving id from the base.


### PR DESCRIPTION
Add "Consent" to the access values in addition to IfTitle, Public, Private.
Creation and management of this Consent status is left to another PR, as well as usage for data visibility.

This PR allows to read Roglo source files which maintain this Consent status.
  