### PR TITLE
Manage robot indexing with bvar robot_index and robot_index_forum

### DIFF
--- a/hd/etc/perso.txt
+++ b/hd/etc/perso.txt
@@ -12,7 +12,7 @@
       %else;%first_name; %surname;%if;(occ!="" and occ!=0) (%occ;)%end;%end;
     %end;
   </title>
-  <meta name="robots" content="none">
+  %if;(bvar.robot_index="yes")<meta name="robots" content="index,follow">%else;<meta name="robots" content="none">%end;
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   %include;css

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -149,10 +149,13 @@ module Default = struct
 
   let wrap_output (conf : Config.config) (title : Adef.safe_string)
       (content : unit -> unit) =
+    let robot = List.assoc_opt "robot_index" conf.base_env = Some "yes" in
     Output.print_sstring conf {|<!DOCTYPE html><head><title>|};
     Output.print_string conf title;
     Output.print_sstring conf {|</title>|};
-    Output.print_sstring conf {|<meta name="robots" content="none">|};
+    Output.print_sstring conf
+      (if robot then {|<meta name="robots" content="index,follow">|}
+      else {|<meta name="robots" content="none">|});
     Output.print_sstring conf {|<meta charset="|};
     Output.print_sstring conf conf.charset;
     Output.print_sstring conf {|">|};

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -31,6 +31,7 @@ let print_link_to_welcome = gen_print_link_to_welcome (fun () -> ())
 (* S: use Util.include_template for "hed"? *)
 
 let header_without_http_nor_home conf title =
+  let robot = List.assoc_opt "robot_index" conf.base_env = Some "yes" in
   let str1 =
     Printf.sprintf {|<!DOCTYPE html>
 <html lang="%s">
@@ -40,12 +41,14 @@ let header_without_http_nor_home conf title =
   let str2 =
     Printf.sprintf
       {|</title>
-<meta name="robots" content="none">
+%s
 <meta charset="%s">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link rel="shortcut icon" href="%s/favicon_gwd.png">
 <link rel="apple-touch-icon" href="%s/favicon_gwd.png">
 |}
+      (if robot then {|<meta name="robots" content="index,follow">|}
+      else {|<meta name="robots" content="none">|})
       conf.charset
       (Util.images_prefix conf :> string)
       (Util.images_prefix conf :> string)

--- a/plugins/forum/assets/etc/forum.txt
+++ b/plugins/forum/assets/etc/forum.txt
@@ -17,7 +17,7 @@
       %message.subject.cut.50;%nn;
     %end;
   </title>
-  <meta name="robots" content="none">
+  %if;(bvar.robot_index_forum="yes")<meta name="robots" content="index,follow">%else;<meta name="robots" content="none">%end;
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="%images_prefix;favicon_gwd.png">


### PR DESCRIPTION
allow robot indexing of pages if robot_index = yes in .gwf config file.
default is no indexing, no follow.
robot_index_forum=yes will also index the forum
