### PR TITLE
small fixes: double home button, missing space, extra )

### DIFF
--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -28,6 +28,11 @@ let gen_print_link_to_welcome f conf _right_aligned =
 
 let print_link_to_welcome = gen_print_link_to_welcome (fun () -> ())
 
+let print_link_to_home conf =
+  match Util.open_etc_file conf "home" with
+  | Some (ic, _) -> Templ.copy_from_templ conf [] ic
+  | None -> ()
+
 (* S: use Util.include_template for "hed"? *)
 
 let header_without_http_nor_home conf title =
@@ -69,6 +74,9 @@ let header_without_http_nor_home conf title =
 let header_without_page_title conf title =
   Util.html conf;
   header_without_http_nor_home conf title;
+  (match Util.open_etc_file conf "home" with
+  | Some (ic, _) -> Templ.copy_from_templ conf [] ic
+  | None -> ());
   (* balancing </div> in gen_trailer *)
   Output.printf conf "<div class=\"container\">"
 

--- a/lib/hutil.mli
+++ b/lib/hutil.mli
@@ -56,6 +56,9 @@ val gen_print_link_to_welcome : (unit -> unit) -> config -> bool -> unit
 val print_link_to_welcome : config -> bool -> unit
 (** Calls [gen_print_link_to_welcome] with empty function [f]. *)
 
+val print_link_to_home : config -> unit
+(** Prints the home, referer, search buttons and timing/errors data *)
+
 val incorrect_request : ?comment:string -> config -> unit
 (** Sends [Bad Request] HTTP response (same as [GWPARAM.output_error conf Bad_Request]) *)
 

--- a/lib/place.ml
+++ b/lib/place.ml
@@ -683,8 +683,10 @@ let print_all_places_surnames_aux conf base _ini ~add_birth ~add_baptism
   let opt = get_opt conf in
   let long = p_getenv conf.env "display" = Some "long" in
   let keep = match p_getint conf.env "keep" with Some t -> t | None -> 1 in
-  Hutil.header conf title;
-  Hutil.print_link_to_welcome conf true;
+  Hutil.header_no_page_title conf title;
+  Output.print_sstring conf "<h1>";
+  title false;
+  Output.print_sstring conf "</h1>";
   Hutil.interp_no_header conf "buttons_places"
     {
       Templ.eval_var = (fun _ -> raise Not_found);

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -275,7 +275,6 @@ let print_main conf base auth_file =
   let wddir = dir conf base in
   Hutil.header_no_page_title conf title;
   (* mouais... *)
-  Hutil.print_link_to_welcome conf true;
   Output.print_sstring conf "<h1>";
   title false;
   Output.print_sstring conf "</h1>";
@@ -303,7 +302,7 @@ let print_main conf base auth_file =
     Output.print_string conf (commd conf);
     Output.print_sstring conf {|m=WIZNOTES&o=H">|};
     Output.print_sstring conf (transl conf "here");
-    Output.print_sstring conf "</a>";
+    Output.print_sstring conf "</a> ";
     Output.print_sstring conf
       (transl conf "for the list ordered by the date of the last modification");
     Output.print_sstring conf ".</em></p>";


### PR DESCRIPTION
avoid double home info on places; 
missing space in wiznotes;
extra ) in arbre_3_gen