### PR TITLE
separate ocamlformat from build/distrib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
           opam depext -y geneweb
           opam install -y ./*.opam --deps-only --with-test
           opam pin ocamlformat 0.24.1
-      - name: Make ocamlformat > build > distrib
+      - name: Make ocamlformat > build/distrib
         run: |
           opam exec -- ocaml ./configure.ml --release
-          opam exec -- make build distrib
+          opam exec -- make fmt distrib
       - name: Make CI tests
         run: opam exec -- make ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
 
         include:
           - os: macos-latest
-            ocaml-version: 4.14.0
+            ocaml-version: 4.14.x
             geneweb-archive: geneweb-macos.zip
           - os: ubuntu-latest
-            ocaml-version: 4.14.0
+            ocaml-version: 4.14.x
             geneweb-archive: geneweb-linux.zip
           - os: windows-latest
-            ocaml-version: 4.14.0
+            ocaml-version: 4.14.x
             geneweb-archive: geneweb-windows.zip
 
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -98,20 +98,18 @@ GENERATED_FILES_DEP = \
 
 generated: $(GENERATED_FILES_DEP)
 
-install uninstall build distrib: info $(GENERATED_FILES_DEP)
+install uninstall fmt build distrib: info $(GENERATED_FILES_DEP)
 
-fmt:
-	$(RM) -r $(DISTRIB_DIR)
+fmt: ## Format Ocaml code
+ifneq ($(OS_TYPE),Win)
+	@printf "\n\033[1;37mOcamlformat\033[0m\n"
 	dune build @fmt --auto-promote
+endif
 
 # [BEGIN] Installation / Distribution section
 
 build: ## Build the geneweb package (libraries and binaries)
 build:
-ifneq ($(OS_TYPE),Win)
-	@printf "\n\033[1;37mOcamlformat\033[0m\n"
-	dune build @fmt --auto-promote
-endif
 	@printf "\n\033[1;37mBuilding executables\033[0m\n"
 	dune build -p geneweb --profile $(DUNE_PROFILE)
 

--- a/geneweb_colab.ipynb
+++ b/geneweb_colab.ipynb
@@ -16,7 +16,7 @@
         "id": "_ukucGtwbeI0"
       },
       "source": [
-        "# Live test GeneWeb 7.xx exp\n",
+        "# Live test GeneWeb 7.x exp\n",
         "\n"
       ]
     },
@@ -74,7 +74,7 @@
         "!add-apt-repository -y ppa:avsm/ppa\n",
         "!apt update\n",
         "!apt install opam libgmp-dev xdot\n",
-        "!opam -y init --compiler=4.14.1\n",
+        "!opam -y init --compiler=4.14.2\n",
         "!eval $(opam env)\n",
         "!opam install -y calendars.1.0.0 camlp-streams camlp5 cppo dune jingoo markup oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf"
       ]
@@ -112,7 +112,7 @@
       "source": [
         "#Clone GeneWeb, checkout selected branch\n",
         "!git clone https://github.com/geneweb/geneweb\n",
-        "!cd geneweb && opam exec -- ocaml ./configure.ml --sosa-legacy --release && opam exec -- make distrib"
+        "!cd geneweb && opam exec -- ocaml ./configure.ml --release && opam exec -- make distrib"
       ]
     },
     {
@@ -158,7 +158,7 @@
       "outputs": [],
       "source": [
         "# Launch Geneweb server and clic on previous given Colab URL …-2317-colab.googleusercontent.com/ to test your database in live!\n",
-        "!cd geneweb/distribution/ && gw/gwd -hd gw -bd bases"
+        "!cd geneweb/distribution/ && gw/gwd -blang -log \"<stderr>\""
       ]
     }
   ],


### PR DESCRIPTION
allows Colab to build far quicker with fewer dependencies + bump Ocaml to 4.14.2/4.14.x