### PR TITLE
[gwd] Static caching for database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bin/setup/dune
 bin/update_nldb/dune
 lib/core/dune
 lib/dune
+lib/ancient/dune
 lib/gwdb/dune
 lib/util/dune
 plugins/welcome/dune

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ endif
 	-e "s/%%%GWDB_PKG%%%/$(GWDB_PKG)/g" \
 	-e "s/%%%SYSLOG_PKG%%%/$(SYSLOG_PKG)/g" \
 	-e "s/%%%DUNE_DIRS_EXCLUDE%%%/$(DUNE_DIRS_EXCLUDE)/g" \
+	-e "s/%%%ANCIENT_LIB%%%/$(ANCIENT_LIB)/g" \
+	-e "s/%%%ANCIENT_FILE%%%/$(ANCIENT_FILE)/g" \
 	> $@ \
 	&& printf " Done.\n"
 
@@ -78,6 +80,7 @@ GENERATED_FILES_DEP = \
 	lib/gwdb/dune \
 	lib/core/dune \
 	lib/util/dune \
+	lib/ancient/dune \
 	benchmark/dune \
 	bin/connex/dune \
 	bin/cache_files/dune \

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2032,6 +2032,10 @@ let main () =
     ; ("-conn_tmout", Arg.Int (fun x -> conn_timeout := x), "<SEC> Connection timeout (default " ^ string_of_int !conn_timeout ^ "s; 0 means no limit)." )
     ; ("-daemon", Arg.Set daemon, " Unix daemon mode.")
 #endif
+    ; ("-cache-in-memory", Arg.String (fun s ->
+        let _db : Gwdb_driver.base = Gwdb.open_base ~keep_in_memory:true s in
+        ()
+      ), "<DATABASE> Preload this database in memory")
     ]
   in
   let speclist = List.sort compare speclist in

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -24,6 +24,7 @@ let printer_conf = { Config.empty with output_conf }
 
 let auth_file = ref ""
 let cache_langs = ref []
+let cache_databases = ref []
 let choose_browser_lang = ref false
 let conn_timeout = ref 120
 let daemon = ref false
@@ -2034,8 +2035,7 @@ let main () =
 #endif
     ; ("-cache-in-memory", Arg.String (fun s ->
         if Gw_ancient.is_available then
-          let _db : Gwdb_driver.base = Gwdb.open_base ~keep_in_memory:true s in
-          ()
+          cache_databases := s::!cache_databases
         else
           failwith "-cache-in-memory option unavailable for this build."
       ), "<DATABASE> Preload this database in memory")
@@ -2068,6 +2068,13 @@ let main () =
   List.iter register_plugin !plugins ;
   !GWPARAM.init () ;
   cache_lexicon () ;
+  List.iter
+    (fun dbn ->
+       Printf.eprintf "Caching %s... %!" dbn;
+       ignore (Gwdb.open_base ~keep_in_memory:true dbn);
+       Printf.eprintf "Done.\n%!"
+    )
+    !cache_databases;
   if !auth_file <> "" && !force_cgi then
     GwdLog.syslog `LOG_WARNING "-auth option is not compatible with CGI mode.\n \
       Use instead friend_passwd_file= and wizard_passwd_file= in .cgf file\n";

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2033,8 +2033,11 @@ let main () =
     ; ("-daemon", Arg.Set daemon, " Unix daemon mode.")
 #endif
     ; ("-cache-in-memory", Arg.String (fun s ->
-        let _db : Gwdb_driver.base = Gwdb.open_base ~keep_in_memory:true s in
-        ()
+        if Gw_ancient.is_available then
+          let _db : Gwdb_driver.base = Gwdb.open_base ~keep_in_memory:true s in
+          ()
+        else
+          failwith "-cache-in-memory option unavailable for this build."
       ), "<DATABASE> Preload this database in memory")
     ]
   in

--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,7 @@
   (tags (genealogy))
   (depends
     (alcotest :with-test)
+    ancient
     benchmark
     (calendars (= "1.0.0"))
     (camlp5 (>= "8.00.01"))

--- a/dune-project
+++ b/dune-project
@@ -32,6 +32,7 @@
     markup
     num
     (ocaml (>= 4.08))
+    ocaml-option-nnp
     (ocamlformat (and :dev (= 0.24.1)))
     ounit
     ppx_blob

--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,6 @@
   (tags (genealogy))
   (depends
     (alcotest :with-test)
-    ancient
     benchmark
     (calendars (= "1.0.0"))
     (camlp5 (>= "8.00.01"))
@@ -32,7 +31,6 @@
     markup
     num
     (ocaml (>= 4.08))
-    ocaml-option-nnp
     (ocamlformat (and :dev (= 0.24.1)))
     ounit
     ppx_blob
@@ -46,4 +44,9 @@
     uunf
     uutf
     zarith
-  ))
+  )
+  (depopts
+    ocaml-option-nnp
+    ancient
+  )
+)

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -24,6 +24,7 @@ depends: [
   "markup"
   "num"
   "ocaml" {>= "4.08"}
+  "ocaml-option-nnp"
   "ocamlformat" {dev & = "0.24.1"}
   "ounit"
   "ppx_blob"

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -13,6 +13,7 @@ bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "2.9"}
   "alcotest" {with-test}
+  "ancient"
   "benchmark"
   "calendars" {= "1.0.0"}
   "camlp5" {>= "8.00.01"}

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -13,7 +13,6 @@ bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "2.9"}
   "alcotest" {with-test}
-  "ancient"
   "benchmark"
   "calendars" {= "1.0.0"}
   "camlp5" {>= "8.00.01"}
@@ -24,7 +23,6 @@ depends: [
   "markup"
   "num"
   "ocaml" {>= "4.08"}
-  "ocaml-option-nnp"
   "ocamlformat" {dev & = "0.24.1"}
   "ounit"
   "ppx_blob"
@@ -40,6 +38,7 @@ depends: [
   "zarith"
   "odoc" {with-doc}
 ]
+depopts: ["ocaml-option-nnp" "ancient"]
 dev-repo: "git+https://github.com/geneweb/geneweb.git"
 build: [
   [ "ocaml" "./configure.ml" "--release" ]

--- a/lib/ancient/dune.in
+++ b/lib/ancient/dune.in
@@ -1,0 +1,8 @@
+(library
+ (public_name geneweb.ancient)
+ (name gw_ancient)
+ (libraries
+  (select gw_ancient.ml from
+    (%%%ANCIENT_LIB%%% -> %%%ANCIENT_FILE%%%)
+   ))
+)

--- a/lib/ancient/gw_ancient.dum.ml
+++ b/lib/ancient/gw_ancient.dum.ml
@@ -1,0 +1,7 @@
+let is_available = false
+
+type _ ancient = unit
+
+let mark _ = assert false
+let follow _ = assert false
+let delete _ = assert false

--- a/lib/ancient/gw_ancient.mli
+++ b/lib/ancient/gw_ancient.mli
@@ -1,0 +1,9 @@
+val is_available : bool
+
+(* Trimmed ocaml-ancient library signature *)
+
+type 'a ancient
+
+val mark : 'a -> 'a ancient
+val follow : 'a ancient -> 'a
+val delete : 'a ancient -> unit

--- a/lib/ancient/gw_ancient.wrapped.ml
+++ b/lib/ancient/gw_ancient.wrapped.ml
@@ -1,0 +1,3 @@
+let is_available = true
+
+include Ancient

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -673,7 +673,7 @@ let make_record_exists patches pending len i =
   || (i < len && i >= 0)
 
 type 'a data_array =
-  | ReadOnly of 'a array Ancient.ancient
+  | ReadOnly of 'a array Gw_ancient.ancient
   | ReadWrite of 'a array
 
 type 'a immut_record = {
@@ -689,7 +689,7 @@ let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
   let im_get i =
     match !tab with
     | Some (ReadWrite x) -> x.(i)
-    | Some (ReadOnly x) -> (Ancient.follow x).(i)
+    | Some (ReadOnly x) -> (Gw_ancient.follow x).(i)
     | None -> (
         if i < 0 || i >= len then
           failwith ("access " ^ name ^ " out of bounds; i = " ^ string_of_int i)
@@ -712,7 +712,7 @@ let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
         seek_in ic array_pos;
         let t =
           if read_only then (
-            let t = ReadOnly (Ancient.mark (input_array ic)) in
+            let t = ReadOnly (Gw_ancient.mark (input_array ic)) in
             Gc.compact ();
             t)
           else ReadWrite (input_array ic)
@@ -731,7 +731,7 @@ let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
           | None -> ()
           | Some a ->
               (match a with
-              | ReadOnly a -> Ancient.delete a
+              | ReadOnly a -> Gw_ancient.delete a
               | ReadWrite _ -> ());
               tab := None);
     }

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -676,37 +676,36 @@ type 'a data_array =
   | ReadOnly of 'a array Ancient.ancient
   | ReadWrite of 'a array
 
-let make_record_access ~read_only ic ic_acc shift array_pos (plenr, patches)
-    (_, pending) len name input_array input_item =
+type 'a immut_record = {
+  im_array : unit -> 'a data_array;
+  im_get : int -> 'a;
+  im_cl_array : unit -> unit;
+}
+
+let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
+    input_array input_item =
   let (tab : _ data_array option ref) = ref None in
   let cleared = ref false in
-  let gen_get nopending i =
-    match if nopending then None else Hashtbl.find_opt pending i with
-    | Some v -> v
+  let im_get i =
+    match !tab with
+    | Some (ReadWrite x) -> x.(i)
+    | Some (ReadOnly x) -> (Ancient.follow x).(i)
     | None -> (
-        match Hashtbl.find_opt patches i with
-        | Some v -> v
-        | None -> (
-            match !tab with
-            | Some (ReadWrite x) -> x.(i)
-            | Some (ReadOnly x) -> (Ancient.follow x).(i)
-            | None -> (
-                if i < 0 || i >= len then
-                  failwith
-                    ("access " ^ name ^ " out of bounds; i = " ^ string_of_int i)
-                else
-                  match ic_acc with
-                  | Some ic_acc ->
-                      seek_in ic_acc (shift + (Iovalue.sizeof_long * i));
-                      let pos = input_binary_int ic_acc in
-                      seek_in ic pos;
-                      input_item ic
-                  | None ->
-                      Printf.eprintf "Sorry; I really need base.acc\n";
-                      flush stderr;
-                      failwith "cannot access database")))
+        if i < 0 || i >= len then
+          failwith ("access " ^ name ^ " out of bounds; i = " ^ string_of_int i)
+        else
+          match ic_acc with
+          | Some ic_acc ->
+              seek_in ic_acc (shift + (Iovalue.sizeof_long * i));
+              let pos = input_binary_int ic_acc in
+              seek_in ic pos;
+              input_item ic
+          | None ->
+              Printf.eprintf "Sorry; I really need base.acc\n";
+              flush stderr;
+              failwith "cannot access database")
   in
-  let array () =
+  let im_array () =
     match !tab with
     | Some x -> x
     | None ->
@@ -721,21 +720,11 @@ let make_record_access ~read_only ic ic_acc shift array_pos (plenr, patches)
         tab := Some t;
         t
   in
-  let len = max len !plenr in
-  let rec r =
+  let r =
     {
-      load_array = (fun () -> ignore @@ array ());
-      get = gen_get false;
-      get_nopending = gen_get true;
-      len;
-      output_array =
-        (fun oc ->
-          match array () with
-          | ReadOnly _ -> failwith "cannot modify read-only data"
-          | ReadWrite v ->
-              let a = apply_patches v patches r.len in
-              Dutil.output_value_no_sharing oc (a : _ array));
-      clear_array =
+      im_array;
+      im_get;
+      im_cl_array =
         (fun () ->
           cleared := true;
           match !tab with
@@ -745,6 +734,34 @@ let make_record_access ~read_only ic ic_acc shift array_pos (plenr, patches)
               | ReadOnly a -> Ancient.delete a
               | ReadWrite _ -> ());
               tab := None);
+    }
+  in
+  r
+
+let make_record_access immut_record (plenr, patches) (_, pending) len =
+  let gen_get nopending i =
+    match if nopending then None else Hashtbl.find_opt pending i with
+    | Some v -> v
+    | None -> (
+        match Hashtbl.find_opt patches i with
+        | Some v -> v
+        | None -> immut_record.im_get i)
+  in
+  let len = max len !plenr in
+  let rec r =
+    {
+      load_array = (fun () -> ignore @@ immut_record.im_array ());
+      get = gen_get false;
+      get_nopending = gen_get true;
+      len;
+      output_array =
+        (fun oc ->
+          match immut_record.im_array () with
+          | ReadOnly _ -> failwith "cannot modify read-only data"
+          | ReadWrite v ->
+              let a = apply_patches v patches r.len in
+              Dutil.output_value_no_sharing oc (a : _ array));
+      clear_array = immut_record.im_cl_array;
     }
   in
   r
@@ -823,6 +840,17 @@ let person_of_key persons strings persons_of_name first_name surname occ =
     | _ -> None
   in
   find ipl
+
+type ro_data_records =
+  dsk_person immut_record
+  * dsk_ascend immut_record
+  * dsk_union immut_record
+  * dsk_family immut_record
+  * dsk_couple immut_record
+  * dsk_descend immut_record
+  * string immut_record
+
+let cached_records = ref []
 
 let opendb ?(read_only = false) bname =
   let bname =
@@ -911,53 +939,96 @@ let opendb ?(read_only = false) bname =
     make_record_exists (snd patches.h_family) (snd pending.h_family)
       families_len
   in
+  let ( im_persons,
+        im_ascends,
+        im_unions,
+        im_families,
+        im_couples,
+        im_descends,
+        im_strings )
+        : ro_data_records =
+    let bfname = Unix.realpath bname in
+    match
+      List.find_opt (fun (n, _) -> String.equal bfname n) !cached_records
+    with
+    | Some (_, records) -> records
+    | None ->
+        let persons =
+          make_immut_record_access ~read_only ic ic_acc shift persons_array_pos
+            persons_len "persons"
+            (input_value : _ -> person array)
+            (Iovalue.input : _ -> person)
+        in
+        let shift = shift + (persons_len * Iovalue.sizeof_long) in
+        let ascends =
+          make_immut_record_access ~read_only ic ic_acc shift ascends_array_pos
+            persons_len "ascends"
+            (input_value : _ -> ascend array)
+            (Iovalue.input : _ -> ascend)
+        in
+        let shift = shift + (persons_len * Iovalue.sizeof_long) in
+        let unions =
+          make_immut_record_access ~read_only ic ic_acc shift unions_array_pos
+            persons_len "unions"
+            (input_value : _ -> union array)
+            (Iovalue.input : _ -> union)
+        in
+        let shift = shift + (persons_len * Iovalue.sizeof_long) in
+        let families =
+          make_immut_record_access ~read_only ic ic_acc shift families_array_pos
+            families_len "families"
+            (input_value : _ -> family array)
+            (Iovalue.input : _ -> family)
+        in
+        let shift = shift + (families_len * Iovalue.sizeof_long) in
+        let couples =
+          make_immut_record_access ~read_only ic ic_acc shift couples_array_pos
+            families_len "couples"
+            (input_value : _ -> couple array)
+            (Iovalue.input : _ -> couple)
+        in
+        let shift = shift + (families_len * Iovalue.sizeof_long) in
+        let descends =
+          make_immut_record_access ~read_only ic ic_acc shift descends_array_pos
+            families_len "descends"
+            (input_value : _ -> descend array)
+            (Iovalue.input : _ -> descend)
+        in
+        let shift = shift + (families_len * Iovalue.sizeof_long) in
+        let strings =
+          make_immut_record_access ~read_only ic ic_acc shift strings_array_pos
+            strings_len "strings"
+            (input_value : _ -> string array)
+            (Iovalue.input : _ -> string)
+        in
+        let dr =
+          (persons, ascends, unions, families, couples, descends, strings)
+        in
+        if read_only then cached_records := (bfname, dr) :: !cached_records;
+        dr
+  in
   let persons =
-    make_record_access ~read_only ic ic_acc shift persons_array_pos
-      patches.h_person pending.h_person persons_len "persons"
-      (input_value : _ -> person array)
-      (Iovalue.input : _ -> person)
+    make_record_access im_persons patches.h_person pending.h_person persons_len
   in
-  let shift = shift + (persons_len * Iovalue.sizeof_long) in
   let ascends =
-    make_record_access ~read_only ic ic_acc shift ascends_array_pos
-      patches.h_ascend pending.h_ascend persons_len "ascends"
-      (input_value : _ -> ascend array)
-      (Iovalue.input : _ -> ascend)
+    make_record_access im_ascends patches.h_ascend pending.h_ascend persons_len
   in
-  let shift = shift + (persons_len * Iovalue.sizeof_long) in
   let unions =
-    make_record_access ~read_only ic ic_acc shift unions_array_pos
-      patches.h_union pending.h_union persons_len "unions"
-      (input_value : _ -> union array)
-      (Iovalue.input : _ -> union)
+    make_record_access im_unions patches.h_union pending.h_union persons_len
   in
-  let shift = shift + (persons_len * Iovalue.sizeof_long) in
   let families =
-    make_record_access ~read_only ic ic_acc shift families_array_pos
-      patches.h_family pending.h_family families_len "families"
-      (input_value : _ -> family array)
-      (Iovalue.input : _ -> family)
+    make_record_access im_families patches.h_family pending.h_family
+      families_len
   in
-  let shift = shift + (families_len * Iovalue.sizeof_long) in
   let couples =
-    make_record_access ~read_only ic ic_acc shift couples_array_pos
-      patches.h_couple pending.h_couple families_len "couples"
-      (input_value : _ -> couple array)
-      (Iovalue.input : _ -> couple)
+    make_record_access im_couples patches.h_couple pending.h_couple families_len
   in
-  let shift = shift + (families_len * Iovalue.sizeof_long) in
   let descends =
-    make_record_access ~read_only ic ic_acc shift descends_array_pos
-      patches.h_descend pending.h_descend families_len "descends"
-      (input_value : _ -> descend array)
-      (Iovalue.input : _ -> descend)
+    make_record_access im_descends patches.h_descend pending.h_descend
+      families_len
   in
-  let shift = shift + (families_len * Iovalue.sizeof_long) in
   let strings =
-    make_record_access ~read_only ic ic_acc shift strings_array_pos
-      patches.h_string pending.h_string strings_len "strings"
-      (input_value : _ -> string array)
-      (Iovalue.input : _ -> string)
+    make_record_access im_strings patches.h_string pending.h_string strings_len
   in
   let cleanup () =
     close_in ic;

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -674,7 +674,7 @@ let make_record_exists patches pending len i =
 
 let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
     len name input_array input_item =
-  let tab = ref None in
+  let (tab : _ Ancient.ancient option ref) = ref None in
   let cleared = ref false in
   let gen_get nopending i =
     match if nopending then None else Hashtbl.find_opt pending i with
@@ -684,7 +684,7 @@ let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
         | Some v -> v
         | None -> (
             match !tab with
-            | Some x -> x.(i)
+            | Some x -> (Ancient.follow x).(i)
             | None -> (
                 if i < 0 || i >= len then
                   failwith
@@ -706,25 +706,34 @@ let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
     | Some x -> x
     | None ->
         seek_in ic array_pos;
-        let t = input_array ic in
+        let t = Ancient.mark (input_array ic) in
+        Gc.compact ();
         tab := Some t;
         t
   in
-  let rec r =
+  let len = max len !plenr in
+  let r =
     {
       load_array = (fun () -> ignore @@ array ());
       get = gen_get false;
       get_nopending = gen_get true;
-      len = max len !plenr;
+      len;
       output_array =
         (fun oc ->
-          let v = array () in
-          let a = apply_patches v patches r.len in
+          let v = Ancient.follow (array ()) in
+          (* Objects from Ancient pointer should not be mutated.
+             We have to pull a fresh copy to work on. *)
+          let v = Array.copy v in
+          let a = apply_patches v patches len in
           Dutil.output_value_no_sharing oc (a : _ array));
       clear_array =
         (fun () ->
           cleared := true;
-          tab := None);
+          match !tab with
+          | None -> ()
+          | Some a ->
+              Ancient.delete a;
+              tab := None);
     }
   in
   r

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -672,9 +672,13 @@ let make_record_exists patches pending len i =
   || Hashtbl.find_opt patches i <> None
   || (i < len && i >= 0)
 
-let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
-    len name input_array input_item =
-  let (tab : _ Ancient.ancient option ref) = ref None in
+type 'a data_array =
+  | ReadOnly of 'a array Ancient.ancient
+  | ReadWrite of 'a array
+
+let make_record_access ~read_only ic ic_acc shift array_pos (plenr, patches)
+    (_, pending) len name input_array input_item =
+  let (tab : _ data_array option ref) = ref None in
   let cleared = ref false in
   let gen_get nopending i =
     match if nopending then None else Hashtbl.find_opt pending i with
@@ -684,7 +688,8 @@ let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
         | Some v -> v
         | None -> (
             match !tab with
-            | Some x -> (Ancient.follow x).(i)
+            | Some (ReadWrite x) -> x.(i)
+            | Some (ReadOnly x) -> (Ancient.follow x).(i)
             | None -> (
                 if i < 0 || i >= len then
                   failwith
@@ -706,13 +711,18 @@ let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
     | Some x -> x
     | None ->
         seek_in ic array_pos;
-        let t = Ancient.mark (input_array ic) in
-        Gc.compact ();
+        let t =
+          if read_only then (
+            let t = ReadOnly (Ancient.mark (input_array ic)) in
+            Gc.compact ();
+            t)
+          else ReadWrite (input_array ic)
+        in
         tab := Some t;
         t
   in
   let len = max len !plenr in
-  let r =
+  let rec r =
     {
       load_array = (fun () -> ignore @@ array ());
       get = gen_get false;
@@ -720,19 +730,20 @@ let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
       len;
       output_array =
         (fun oc ->
-          let v = Ancient.follow (array ()) in
-          (* Objects from Ancient pointer should not be mutated.
-             We have to pull a fresh copy to work on. *)
-          let v = Array.copy v in
-          let a = apply_patches v patches len in
-          Dutil.output_value_no_sharing oc (a : _ array));
+          match array () with
+          | ReadOnly _ -> failwith "cannot modify read-only data"
+          | ReadWrite v ->
+              let a = apply_patches v patches r.len in
+              Dutil.output_value_no_sharing oc (a : _ array));
       clear_array =
         (fun () ->
           cleared := true;
           match !tab with
           | None -> ()
           | Some a ->
-              Ancient.delete a;
+              (match a with
+              | ReadOnly a -> Ancient.delete a
+              | ReadWrite _ -> ());
               tab := None);
     }
   in
@@ -813,7 +824,7 @@ let person_of_key persons strings persons_of_name first_name surname occ =
   in
   find ipl
 
-let opendb bname =
+let opendb ?(read_only = false) bname =
   let bname =
     if Filename.check_suffix bname ".gwb" then bname else bname ^ ".gwb"
   in
@@ -901,50 +912,50 @@ let opendb bname =
       families_len
   in
   let persons =
-    make_record_access ic ic_acc shift persons_array_pos patches.h_person
-      pending.h_person persons_len "persons"
+    make_record_access ~read_only ic ic_acc shift persons_array_pos
+      patches.h_person pending.h_person persons_len "persons"
       (input_value : _ -> person array)
       (Iovalue.input : _ -> person)
   in
   let shift = shift + (persons_len * Iovalue.sizeof_long) in
   let ascends =
-    make_record_access ic ic_acc shift ascends_array_pos patches.h_ascend
-      pending.h_ascend persons_len "ascends"
+    make_record_access ~read_only ic ic_acc shift ascends_array_pos
+      patches.h_ascend pending.h_ascend persons_len "ascends"
       (input_value : _ -> ascend array)
       (Iovalue.input : _ -> ascend)
   in
   let shift = shift + (persons_len * Iovalue.sizeof_long) in
   let unions =
-    make_record_access ic ic_acc shift unions_array_pos patches.h_union
-      pending.h_union persons_len "unions"
+    make_record_access ~read_only ic ic_acc shift unions_array_pos
+      patches.h_union pending.h_union persons_len "unions"
       (input_value : _ -> union array)
       (Iovalue.input : _ -> union)
   in
   let shift = shift + (persons_len * Iovalue.sizeof_long) in
   let families =
-    make_record_access ic ic_acc shift families_array_pos patches.h_family
-      pending.h_family families_len "families"
+    make_record_access ~read_only ic ic_acc shift families_array_pos
+      patches.h_family pending.h_family families_len "families"
       (input_value : _ -> family array)
       (Iovalue.input : _ -> family)
   in
   let shift = shift + (families_len * Iovalue.sizeof_long) in
   let couples =
-    make_record_access ic ic_acc shift couples_array_pos patches.h_couple
-      pending.h_couple families_len "couples"
+    make_record_access ~read_only ic ic_acc shift couples_array_pos
+      patches.h_couple pending.h_couple families_len "couples"
       (input_value : _ -> couple array)
       (Iovalue.input : _ -> couple)
   in
   let shift = shift + (families_len * Iovalue.sizeof_long) in
   let descends =
-    make_record_access ic ic_acc shift descends_array_pos patches.h_descend
-      pending.h_descend families_len "descends"
+    make_record_access ~read_only ic ic_acc shift descends_array_pos
+      patches.h_descend pending.h_descend families_len "descends"
       (input_value : _ -> descend array)
       (Iovalue.input : _ -> descend)
   in
   let shift = shift + (families_len * Iovalue.sizeof_long) in
   let strings =
-    make_record_access ic ic_acc shift strings_array_pos patches.h_string
-      pending.h_string strings_len "strings"
+    make_record_access ~read_only ic ic_acc shift strings_array_pos
+      patches.h_string pending.h_string strings_len "strings"
       (input_value : _ -> string array)
       (Iovalue.input : _ -> string)
   in

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -715,7 +715,6 @@ let make_record_access ic ic_acc shift array_pos (plenr, patches) (_, pending)
       load_array = (fun () -> ignore @@ array ());
       get = gen_get false;
       get_nopending = gen_get true;
-      set = (fun i v -> (array ()).(i) <- v);
       len = max len !plenr;
       output_array =
         (fun oc ->
@@ -1218,7 +1217,6 @@ let record_access_of tab =
     Dbdisk.load_array = (fun () -> ());
     get = (fun i -> tab.(i));
     get_nopending = (fun i -> tab.(i));
-    set = (fun i v -> tab.(i) <- v);
     output_array = (fun oc -> Dutil.output_value_no_sharing oc (tab : _ array));
     len = Array.length tab;
     clear_array = (fun () -> ());

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -679,7 +679,7 @@ type 'a data_array =
 type 'a immut_record = {
   im_array : unit -> 'a data_array;
   im_get : int -> 'a;
-  im_cl_array : unit -> unit;
+  im_clear_array : unit -> unit;
 }
 
 let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
@@ -724,7 +724,7 @@ let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
     {
       im_array;
       im_get;
-      im_cl_array =
+      im_clear_array =
         (fun () ->
           cleared := true;
           match !tab with
@@ -761,7 +761,7 @@ let make_record_access immut_record (plenr, patches) (_, pending) len =
           | ReadWrite v ->
               let a = apply_patches v patches r.len in
               Dutil.output_value_no_sharing oc (a : _ array));
-      clear_array = immut_record.im_cl_array;
+      clear_array = immut_record.im_clear_array;
     }
   in
   r

--- a/lib/gwdb-legacy/database.mli
+++ b/lib/gwdb-legacy/database.mli
@@ -1,8 +1,14 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-val opendb : string -> Dbdisk.dsk_base
+val opendb : ?read_only:bool -> string -> Dbdisk.dsk_base
 (** Initialise [dsk_base] from the database situated in the specified directory.
-    Initialises both data and functionallity part. *)
+    Initialises both data and functionallity part.
+
+    If ~read_only:true, then the database will be loaded in memory,
+    and kept in a cache. All next uses of opendb on the same database
+    will use the memory-loaded database. This constraints operations on the
+    base, and attempt to mutate its values will result in failure.
+*)
 
 val make :
   string ->

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -304,8 +304,6 @@ type 'a record_access = {
   get : int -> 'a;
   (* Same as [get] but doesn't consider pending patches *)
   get_nopending : int -> 'a;
-  (* Set the nth element of array *)
-  set : int -> 'a -> unit;
   (* Return length of an array that by default takes into account
      commited patches *)
   mutable len : int;

--- a/lib/gwdb-legacy/dune
+++ b/lib/gwdb-legacy/dune
@@ -2,6 +2,6 @@
  (name gwdb_legacy)
  (public_name geneweb.gwdb-legacy)
  (implements geneweb.gwdb_driver)
- (libraries geneweb.def geneweb.util re unix)
+ (libraries geneweb.def geneweb.util re unix ancient)
  (modules_without_implementation dbdisk)
  (modules btree database dbdisk dutil gwdb_driver gwdb_gc iovalue outbase))

--- a/lib/gwdb-legacy/dune
+++ b/lib/gwdb-legacy/dune
@@ -2,6 +2,6 @@
  (name gwdb_legacy)
  (public_name geneweb.gwdb-legacy)
  (implements geneweb.gwdb_driver)
- (libraries geneweb.def geneweb.util re unix ancient)
+ (libraries geneweb.def geneweb.util geneweb.ancient re unix)
  (modules_without_implementation dbdisk)
  (modules btree database dbdisk dutil gwdb_driver gwdb_gc iovalue outbase))

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -72,7 +72,7 @@ let open_base ?(keep_in_memory = false) bname : base =
   match List.assoc_opt dname !memory_bound_bases with
   | Some base -> base
   | None ->
-      let base = Database.opendb bname in
+      let base = Database.opendb ~read_only:keep_in_memory bname in
       if keep_in_memory then (
         load_persons_array base;
         load_ascends_array base;

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -30,7 +30,10 @@ let spi_next (spi : string_person_index) istr = spi.next istr
 
 type base = dsk_base
 
-let open_base bname : base = Database.opendb bname
+let open_base ?(keep_in_memory = false) bname : base =
+  ignore keep_in_memory;
+  Database.opendb bname
+
 let sou base i = base.data.strings.get i
 let bname base = Filename.(remove_extension @@ basename base.data.bdir)
 let nb_of_persons base = base.data.persons.len

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -30,10 +30,6 @@ let spi_next (spi : string_person_index) istr = spi.next istr
 
 type base = dsk_base
 
-let open_base ?(keep_in_memory = false) bname : base =
-  ignore keep_in_memory;
-  Database.opendb bname
-
 let sou base i = base.data.strings.get i
 let bname base = Filename.(remove_extension @@ basename base.data.bdir)
 let nb_of_persons base = base.data.persons.len
@@ -66,6 +62,18 @@ let clear_descends_array base = base.data.descends.clear_array ()
 let clear_strings_array base = base.data.strings.clear_array ()
 let clear_persons_array base = base.data.persons.clear_array ()
 let clear_families_array base = base.data.families.clear_array ()
+
+let open_base ?(keep_in_memory = false) bname : base =
+  let base = Database.opendb bname in
+  if keep_in_memory then (
+    load_ascends_array base;
+    load_unions_array base;
+    load_couples_array base;
+    load_descends_array base;
+    load_strings_array base;
+    load_persons_array base;
+    load_families_array base);
+  base
 
 let close_base base =
   base.func.cleanup ();

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -62,29 +62,46 @@ let clear_descends_array base = base.data.descends.clear_array ()
 let clear_strings_array base = base.data.strings.clear_array ()
 let clear_persons_array base = base.data.persons.clear_array ()
 let clear_families_array base = base.data.families.clear_array ()
+let memory_bound_bases = ref []
 
 let open_base ?(keep_in_memory = false) bname : base =
-  let base = Database.opendb bname in
-  if keep_in_memory then (
-    load_ascends_array base;
-    load_unions_array base;
-    load_couples_array base;
-    load_descends_array base;
-    load_strings_array base;
-    load_persons_array base;
-    load_families_array base);
-  base
+  let bname =
+    if Filename.check_suffix bname ".gwb" then bname else bname ^ ".gwb"
+  in
+  let dname = Filename.basename bname in
+  match List.assoc_opt dname !memory_bound_bases with
+  | Some base -> base
+  | None ->
+      let base = Database.opendb bname in
+      if keep_in_memory then (
+        load_persons_array base;
+        load_ascends_array base;
+        load_unions_array base;
+        load_couples_array base;
+        load_descends_array base;
+        load_families_array base;
+        load_strings_array base;
+        memory_bound_bases := (dname, base) :: !memory_bound_bases);
+      base
 
 let close_base base =
-  base.func.cleanup ();
-  clear_ascends_array base;
-  clear_unions_array base;
-  clear_couples_array base;
-  clear_descends_array base;
-  clear_strings_array base;
-  clear_persons_array base;
-  clear_families_array base;
-  ()
+  match
+    List.find_opt
+      (fun (_, b) -> String.equal base.data.bdir b.data.bdir)
+      !memory_bound_bases
+  with
+  | Some (bname, _) ->
+      Printf.eprintf "Warning: tried to close memory bound base '%s'\n%!" bname
+  | None ->
+      base.func.cleanup ();
+      clear_ascends_array base;
+      clear_unions_array base;
+      clear_couples_array base;
+      clear_descends_array base;
+      clear_strings_array base;
+      clear_persons_array base;
+      clear_families_array base;
+      ()
 
 let date_of_last_change base =
   let s =

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -62,46 +62,29 @@ let clear_descends_array base = base.data.descends.clear_array ()
 let clear_strings_array base = base.data.strings.clear_array ()
 let clear_persons_array base = base.data.persons.clear_array ()
 let clear_families_array base = base.data.families.clear_array ()
-let memory_bound_bases = ref []
 
 let open_base ?(keep_in_memory = false) bname : base =
-  let bname =
-    if Filename.check_suffix bname ".gwb" then bname else bname ^ ".gwb"
-  in
-  let dname = Filename.basename bname in
-  match List.assoc_opt dname !memory_bound_bases with
-  | Some base -> base
-  | None ->
-      let base = Database.opendb ~read_only:keep_in_memory bname in
-      if keep_in_memory then (
-        load_persons_array base;
-        load_ascends_array base;
-        load_unions_array base;
-        load_couples_array base;
-        load_descends_array base;
-        load_families_array base;
-        load_strings_array base;
-        memory_bound_bases := (dname, base) :: !memory_bound_bases);
-      base
+  let base = Database.opendb ~read_only:keep_in_memory bname in
+  if keep_in_memory then (
+    load_persons_array base;
+    load_ascends_array base;
+    load_unions_array base;
+    load_couples_array base;
+    load_descends_array base;
+    load_families_array base;
+    load_strings_array base);
+  base
 
 let close_base base =
-  match
-    List.find_opt
-      (fun (_, b) -> String.equal base.data.bdir b.data.bdir)
-      !memory_bound_bases
-  with
-  | Some (bname, _) ->
-      Printf.eprintf "Warning: tried to close memory bound base '%s'\n%!" bname
-  | None ->
-      base.func.cleanup ();
-      clear_ascends_array base;
-      clear_unions_array base;
-      clear_couples_array base;
-      clear_descends_array base;
-      clear_strings_array base;
-      clear_persons_array base;
-      clear_families_array base;
-      ()
+  base.func.cleanup ();
+  clear_ascends_array base;
+  clear_unions_array base;
+  clear_couples_array base;
+  clear_descends_array base;
+  clear_strings_array base;
+  clear_persons_array base;
+  clear_families_array base;
+  ()
 
 let date_of_last_change base =
   let s =

--- a/lib/gwdb-legacy/iovalue.ml
+++ b/lib/gwdb-legacy/iovalue.ml
@@ -160,8 +160,8 @@ let rec output_loop ofuns oc x =
   else if Obj.tag x = Obj.abstract_tag then failwith "Iovalue.output <abstract>"
   else if Obj.tag x = Obj.infix_tag then failwith "Iovalue.output: <infix>"
   else if Obj.tag x = Obj.custom_tag then failwith "Iovalue.output: <custom>"
-  else if Obj.tag x = Obj.out_of_heap_tag then
-    failwith "Iovalue.output: abstract value (outside heap)"
+    (* else if Obj.tag x = Obj.out_of_heap_tag then *)
+    (*   failwith "Iovalue.output: abstract value (outside heap)" *)
   else (
     gen_output_block_header ofuns oc (Obj.tag x) (Obj.size x);
     (* last case of "for" separated, to make more tail recursive cases

--- a/lib/gwdb-legacy/iovalue.ml
+++ b/lib/gwdb-legacy/iovalue.ml
@@ -160,8 +160,6 @@ let rec output_loop ofuns oc x =
   else if Obj.tag x = Obj.abstract_tag then failwith "Iovalue.output <abstract>"
   else if Obj.tag x = Obj.infix_tag then failwith "Iovalue.output: <infix>"
   else if Obj.tag x = Obj.custom_tag then failwith "Iovalue.output: <custom>"
-    (* else if Obj.tag x = Obj.out_of_heap_tag then *)
-    (*   failwith "Iovalue.output: abstract value (outside heap)" *)
   else (
     gen_output_block_header ofuns oc (Obj.tag x) (Obj.size x);
     (* last case of "for" separated, to make more tail recursive cases

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -52,7 +52,7 @@ type string_person_index
 type base
 (** The database representation. *)
 
-val open_base : string -> base
+val open_base : ?keep_in_memory:bool -> string -> base
 (** Open database associated with (likely situated in) the specified directory. *)
 
 val close_base : base -> unit


### PR DESCRIPTION
This PR proposes a new option for `gwd`: `-cache-in-memory <DATABASE>`
It allows to specify that a given database should be read and mapped in memory at launch time to avoid file accesses on a per-request basis. This proves to have a significant impact on response time for requests on huge databases.

## What was

Before this patch, `gwd` worked as follows:
The server launched with no need to be aware of the available databases. Each request handling would open the relevant database by opening some file descriptors and building some closures around them for data fetching functions used throughout the codebase. 
This means that each required piece of data would be read from disk, through systems calls and deserializations, both time-consuming operations.

Also, to handle requests, the server would fork its process for each requests, which is fine, as it ensure the main process would not stall or crash with dubious requests. However, memory generated in child processes is not available to the main, or other children.
In particular, this means that `gwd` won't take advantage of the internal caching mechanisms of the codebase, every loaded (and locally cached) piece of data will be dropped when the request process terminates, leaving every other requests to reload data from the disk.

## What is

The introduced option will make `gwd` open the given databases at launch and force-load (disk read and deserialization) all of its data in the already existing cache mechanism. Then, it uses the [ocaml-ancient](https://github.com/UnixJunkie/ocaml-ancient) library to move these arrays outside of the GC-managed heap as read-only data. This allows these data to be read by every subsequent child processes, without being duplicated at each fork.

This approach is possible thanks to the way databases are structured, the few files written by `gwd` (mainly the `patches` file) are unaltered by this PR, only the read-only data, which usually constitute the vast majority of the database.

## Some numbers

To illustrate the benefits of this PR, I tried to measure the response time of various queries to a server hosted on my poor man's PC. On a database with several million individuals registered, I compared the results of this branch, and of the commit its base on (this repo `master`, with a few commits behind).

Response time was measured by timing `curl` queries, several time to have an rough estimate on variability and to make sure that database files were at least cached by the kernel to discard this variability factor.

| Query | With caching | On `master` | Speed-up |
|--------|--------|--------|--------|
|`?m=N&tri=A`|15.9s|18.4s|1.16x|
|`?m=P&tri=A`|11.2s|16.2s|1.45x|
|`?m=PPS&bi=on&ba=on&ma=on&de=on&bu=on`|31.8s|164.8s|5.18x|
|`?m=LB&k=20`|1.6s|5.9s|3.69x|
|`?m=AN`|1.0s|5.9s|5.90x|
|`?m=NOTES`|4.3s|77.9s|18.12x|
|`?m=S&n=&p=albert`|0.6s|5.3s|8.83x|
|`?m=TT&t=&p=`|1.4s|11.0s|7.86x|
|`?m=POP_PYR`|1.1s|6.1s|5.55x|
|`?em=R&ei=5245870&long=on&et=S&p=albert&n=dupont`|0.2s|0.3s|1.50x|
|`?i=4722419`|0.3s|0.2s|0.67x|

Below the second, variability is too much for the comparison to be significant. This is also why I rounded the timing to the first decimal.

## The catch

All this comes with a few drawbacks: 
- `gwd` with caching is slower to launch because of all the preloading and moving memory around (with my (large) database, it takes approximately 30s for the server to be ready to accept requests).
- to properly use the memory created by `ocaml-ancient`, I needed to use a variant of the OCaml compiler with `no-naked-pointers`, hence the changes in `dune-project` and the opam file, and the reason CI will fail.
- `ocaml-ancient` itself is not available for Windows build.
- as of yet, `ocaml-ancient` is not compatible with OCaml 5

I understand that build accessibility might be an concern, and for that I'm thinking of a way to make this feature and its added dependencies optional at build time, as to not pollute the current distribution workflow.

## How to build

Amid the constraints above, this patch does not really alter the build workflow. All you need is to make sure to use an opam switch with the right compiler variant. 
`opam switch create . --deps-only` in this branch root directory should setup up the right environment to build everything as usual.

#

All those considerations aside, the code itself is in an reasonable state, and early reviews would be greatly appreciated.