### PR TITLE
Remove use of Unix.realpath for backward compatibility

### DIFF
--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -947,9 +947,12 @@ let opendb ?(read_only = false) bname =
         im_descends,
         im_strings )
         : ro_data_records =
-    let bfname = Unix.realpath bname in
+    let bid =
+      let s = Unix.stat bname in
+      s.st_dev, s.st_ino
+    in
     match
-      List.find_opt (fun (n, _) -> String.equal bfname n) !cached_records
+      List.find_opt (fun (n, _) -> bid = n) !cached_records
     with
     | Some (_, records) -> records
     | None ->
@@ -1004,7 +1007,7 @@ let opendb ?(read_only = false) bname =
         let dr =
           (persons, ascends, unions, families, couples, descends, strings)
         in
-        if read_only then cached_records := (bfname, dr) :: !cached_records;
+        if read_only then cached_records := (bid, dr) :: !cached_records;
         dr
   in
   let persons =

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -949,11 +949,9 @@ let opendb ?(read_only = false) bname =
         : ro_data_records =
     let bid =
       let s = Unix.stat bname in
-      s.st_dev, s.st_ino
+      (s.st_dev, s.st_ino)
     in
-    match
-      List.find_opt (fun (n, _) -> bid = n) !cached_records
-    with
+    match List.find_opt (fun (n, _) -> bid = n) !cached_records with
     | Some (_, records) -> records
     | None ->
         let persons =


### PR DESCRIPTION
This should handle all corner cases.

fixes #1785 