### PR TITLE
Fix management of -odir  in gnt branch

### DIFF
--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -1175,7 +1175,7 @@ let read_family state ic fname = function
               divorce;
               fevents = [];
               comment = comm;
-              origin_file = fname;
+              origin_file = Filename.basename fname;
               fsources = fsrc;
               fam_index = Gwdb.dummy_ifam;
             }
@@ -1197,7 +1197,7 @@ let read_family state ic fname = function
               divorce;
               fevents = [];
               comment = comm;
-              origin_file = fname;
+              origin_file = Filename.basename fname;
               fsources = fsrc;
               fam_index = Gwdb.dummy_ifam;
             }

--- a/bin/setup/lang/gwu_ok.htm
+++ b/bin/setup/lang/gwu_ok.htm
@@ -21,17 +21,18 @@
 [The extraction of the %G source file is terminated.]
 
 <p>
-%Iodir;.;{
-[Files were reconstructed in the original sources directory.<br> Data created without origin file has been directed to the file %o or to comm.log. It is up to you to manage this new source file, or to merge this data into existing files.]
-%(
-Files were reconstructed in the original sources directory.<br> Data created wit
-hout origin file has been directed to the file %o or to comm.log. It is up to yo
-u to manage this new source file, or to merge this data into existing files.
-%)
+%Iodir;;{
+[This has built the file "%w%/%o".]
 |
-[This has built a file named "%o".]
-<p>
-[This file is in the directory "%w".]
+[Files were reconstructed in the designated directory.]
+<br>
+[Data created without origin file]
+%(Data created without origin file has been directed to the file %o
+or to comm.log.%)
+<br>
+[It is up to you to manage]
+%(It is up to you to manage this new source file,
+or to merge this data into existing files.%)
 }
 <p>
 Comm.log:

--- a/bin/setup/lang/lexicon.txt
+++ b/bin/setup/lang/lexicon.txt
@@ -1199,12 +1199,26 @@ de: fevents' Trauzeugen.
 en: fevents' witnesses.
 fr: fevents' witnesses.
 
-    Files were reconstructed in the original sources directory.<br> Data created without origin file has been directed to the file %o or to comm.log. It is up to you to manage this new source file, or to merge this data into existing files.
+    Files were reconstructed in the designated directory.
 aa: gwu_ok.htm
-co: I schedarii sò stati ricustituiti in u cartulare d’origine.<br> I novi dati senza schedariu d’origine sò stati inversiati ver di u schedariu %o o ver di comm.log. Tocca à voi d’amministrà stu novu schedariu .gw o d’aghjunghje sti dati à i schedarii esistente.
-de: Dateien wurden wiederhergestellt im Original Quellverzeichnis.<br>erstellte Daten ohne Originaldatei wurden in die Datei %o oder comm.log umgelenkt. Es liegt an Ihnen die neue Quelldatei zu verwalten, oder sie mit existierenden Dateien zusammenzuführen.
-en: Files were reconstructed in the original sources directory.<br> Data created without origin file has been directed to the file %o or to comm.log. It is up to you to manage this new source file, or to merge this data into existing files.
-fr: Les fichiers ont été reconstitués dans le dossier d'origine.<br> Les nouvelles données sans fichier d'origine ont été redirigées vers le fichier %o ou vers comm.log. Il vous revient la tâche de gérer ce nouveau fichier .gw ou d'ajouter ces  données aux fichiers existants.
+co: I schedarii sò stati ricustituiti in u -odir cartulare.
+de: Dateien wurden wiederhergestellt im -odir Quellverzeichnis .
+en: Files were reconstructed in the designated directory (-odir).
+fr: Les fichiers ont été reconstitués dans le dossier désigné (-odir).
+
+    Data created without origin file
+aa: gwu_ok.htm
+co: I novi dati senza schedariu d’origine sò stati inversiati ver di u schedariu %o o ver di comm.log.
+de: Erstellte Daten ohne Originaldatei wurden in die Datei %o oder comm.log umgelenkt.
+en: Data created without origin file has been directed to the file %o or to comm.log.
+fr: Les nouvelles données sans fichier d'origine ont été redirigées vers le fichier %o ou vers comm.log.
+
+    It is up to you to manage
+aa: gwu_ok.htm
+co: Tocca à voi d’amministrà stu novu schedariu .gw o d’aghjunghje sti dati à i schedarii esistente.
+de: Es liegt an Ihnen die neue Quelldatei zu verwalten, oder sie mit existierenden Dateien zusammenzuführen.
+en: It is up to you to manage this new source file, or to merge this data into existing files.
+fr: Il vous revient la tâche de gérer ce nouveau fichier .gw ou d'ajouter ces  données aux fichiers existants.
 
     First name
 aa: gwb2ged.htm
@@ -3321,6 +3335,10 @@ en: This file is in the directory "%w".
 es: Este fichero se encuentra en la carpeta "%w".
 fr: Ce fichier se trouve dans le répertoire "%w".
 it: Questo file si trova nella directory "%w".
+
+    This file is in the directory
+en: This file is in the directory:
+fr: Ce fichier est dans le dossier :
 
     This has built a file named "%o".
 aa: gw2gd_ok.htm

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -354,6 +354,7 @@ let macro conf =
   | 'q' -> Geneweb.Version.txt
   | 'u' -> Filename.dirname (abs_setup_dir ())
   | 'x' -> stringify !bin_dir
+  | 'v' -> strip_spaces (s_getenv conf.env "odir")
   | 'w' -> slashify (Sys.getcwd ())
   | 'y' -> Filename.basename (Lazy.force only_file_name)
   | 'z' -> string_of_int !port


### PR DESCRIPTION
Fix management of -odir  in gnt branch to be merged in gnt branch

This is cherry pick of cid ccd53b5 already merged in master branch to solve issue #1334  (PR #1543)
```
commit ccd53b5f7196244e7988869579f25657587855cf
Author: Henri83 <henri.gouraud@laposte.net>
Date:   Sat Aug 5 19:03:51 2023 +0200
    Fix management of -odir
```

Plus two specific changes:
* remove new_data.gw ref that is useless as about old code trials before last commit ccd53b5.

* Use Files.mkdir_p not Mutil to avoid build error in gnt branch.