### PR TITLE
[CI] test more ocaml-compiler versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,27 @@ on:
       - master
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-12
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4.14.x
+          - 4.08.x
         include:
-          - os: ubuntu-latest
-            ocaml-compiler: 4.08.0
+          - os: windows-latest
+            ocaml-compiler: 4.14.x
           - os: ubuntu-latest
             ocaml-compiler: 5.1.x
-    runs-on: ${{ matrix.os }}
+          - os: macos-latest
+            ocaml-compiler: 5.1.x
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Use Ocaml ${{ matrix.ocaml-compiler }}
+        uses: actions/checkout@v4
+      - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
@@ -42,3 +44,43 @@ jobs:
           opam exec -- make fmt distrib
       - name: Make CI tests
         run: opam exec -- make ci
+
+  build_nnp:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-12
+        ocaml-compiler:
+          - ocaml-variants.4.14.2+options,ocaml-option-nnp
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup OCaml ${{ matrix.ocaml-compiler }} with NNP
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Setup GeneWeb dependencies
+        run: |
+          opam install -y ancient calendars.1.0.0 camlp-streams camlp5 cppo dune jingoo markup ocamlformat.0.24.1 oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf
+
+      - name: build/distrib
+        run: |
+          opam exec -- ocaml ./configure.ml --release
+          opam exec -- make fmt distrib
+          
+      - name: Run gwd with cache-in-memory parameter and check output
+        run: |
+          output=$(distribution/gw/gwd -cache-in-memory testing 2>&1)
+          if echo "$output" | grep -q "Caching database testing in memory"; then
+            echo "Caching message found, test passed."
+            exit 0
+          else
+            echo "Caching message not found, test failed."
+            exit 1
+          fi


### PR DESCRIPTION
Here is a summary of various GeneWeb vs Github CI on May, 10th 2024. Note that Geneweb itself asks for an Ocaml-compiler above version 4.08. Using “latests OS”, macOS-14 fails the most, Windows is still failing with Ocaml > 5.0.
```markdown
| ocaml+opt. | linux | macos | mac14 |  win  | linux = linux-latest   (Ubuntu LTS 22.04)
|------------|-------|-------|-------|-------| macos = macos-11/12/13 (Big Sur/Monterey/Ventura)
| 4.08.x     |   ✅* |   ✅* |   ❌¹ |   ✅* |  mac14 = macos-latest   (Sonoma)
| 4.09.x     |   ✅  |   ✅  |   ❌¹ |   ✅  |    win = windows-latest (Windows Server 2022)⁵
| 4.10.x     |   ✅  |   ✅  |   ❌² |   ✅  |
| 4.11.x     |   ✅  |   ✅  |   ❌¹ |   ✅  |
| 4.12.x     |   ✅  |   ✅  |   ❌² |   ✅  |
| 4.13.x     |   ✅  |   ✅  |   ❌² |   ✅  |
| 4.14.x     |   ✅  |   ✅  |   ✅️  |   ✅* |
| 4.14.2+nnp |   ✅*³|   ✅³ |   ✅️*³|   ❌¹ |
| 5.0.x      |   ✅  |   ✅  |   ✅️  |   ❌¹ |
| 5.1.x      |   ✅* |   ✅  |   ✅️* |   ❌¹ |
| 5.2.x      |   ✅️⁴ |   ✅️⁴ |   ✅️⁴ |   ❌¹ |
```
`¹` Compiler not available for that OS.
`²` Build of unnf dep. is failing, see [this 4.13.1 macOS build job for example](https://github.com/geneweb/geneweb/actions/runs/9025767551/job/24801997648?pr=1794).
`³` Compiler variants with option no-naked-pointer installed (check that `-memory-in-cache` gwd parameter is working!).
`⁴` Building with Ocaml 5.2 without Ocamlformat (cf. [❌](https://github.com/geneweb/geneweb/actions/runs/9324750053/job/25670577665#step:3:456)>[✅️](https://github.com/geneweb/geneweb/actions/runs/9325473073)).
`⁵` [Github hosted runners](https://docs.github.com/fr/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).

`*` Suggested builds for CI embedded in this PR.




