### PR TITLE
Compatibility with camlp5 v8.03.00

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,12 +90,12 @@ BUILD = dune build -p geneweb --profile $(DUNE_PROFILE)
 UNPATCH = $(MAKE) --no-print-directory unpatch_files
 
 info:
-	@printf "Building \033[1;37mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n"
-	@printf "Repository \033[1;37m$(SOURCE)\033[0m. Branch \033[1;37m$(BRANCH)\033[0m. "
-	@printf "Last commit \033[1;37m$(COMMIT_ID)\033[0m message:\n\n"
-	@printf "\033[1;37m  %s\033[0m\n" '$(subst ','\'',$(COMMIT_TITLE))'
+	@printf "Building \033[1;1mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n"
+	@printf "Repository \033[1;1m$(SOURCE)\033[0m. Branch \033[1;1m$(BRANCH)\033[0m. "
+	@printf "Last commit \033[1;1m$(COMMIT_ID)\033[0m message:\n\n"
+	@printf "\033[1;1m  %s\033[0m\n" '$(subst ','\'',$(COMMIT_TITLE))'
 	@printf "  %s\n" '$(subst ','\'',$(COMMIT_COMMENT))' | fmt -w 80
-	@printf "\033[1;37mGenerating configuration files\033[0m\n"
+	@printf "\033[1;1mGenerating configuration files\033[0m\n"
 .PHONY: patch_files unpatch_files info
 
 GENERATED_FILES_DEP = \
@@ -131,19 +131,19 @@ fmt build gwd install uninstall: info patch_files generated
 
 fmt: ## Format Ocaml code
 ifneq ($(OS_TYPE),Win)
-	@printf "\n\033[1;37mOcamlformat\033[0m\n"
+	@printf "\n\033[1;1mOcamlformat\033[0m\n"
 	dune build @fmt --auto-promote ; $(UNPATCH)
 endif
 
 # [BEGIN] Installation / Distribution section
 
 build: ## Build the geneweb package (libraries and binaries)
-	@printf "\n\033[1;37mBuilding executables\033[0m\n"
+	@printf "\n\033[1;1mBuilding executables\033[0m\n"
 	@$(BUILD) ; $(UNPATCH)
 	@printf "Done."
 
 gwd: ## Build ondy gwd/gwc executables
-	@printf "\n\033[1;37mBuilding only gwd and gwc executables\033[0m\n"
+	@printf "\n\033[1;1mBuilding only gwd and gwc executables\033[0m\n"
 	@dune build bin/gwd bin/gwc --profile $(DUNE_PROFILE) ; $(UNPATCH)
 	@printf "Done."
 
@@ -157,11 +157,11 @@ uninstall: ## Uninstall geneweb using dune
 
 distrib: info ## Build the project and copy what is necessary for distribution
 	@$(MAKE) --no-print-directory patch_files generated
-	@printf "\n\033[1;37mBuilding executables.\n\033[0m"
+	@printf "\n\033[1;1mBuilding executables.\n\033[0m"
 	@$(BUILD) || { $(UNPATCH) && exit 1; }
 	@printf "Done."
 	@$(RM) -r $(DISTRIB_DIR)
-	@printf "\n\033[1;37mCreating distribution directory\033[0m\n"
+	@printf "\n\033[1;1mCreating distribution directory\033[0m\n"
 	mkdir $(DISTRIB_DIR)
 	mkdir -p $(DISTRIB_DIR)/bases
 	cp CHANGES $(DISTRIB_DIR)/CHANGES.txt
@@ -185,7 +185,7 @@ endif
 	mkdir $(DISTRIB_DIR)/gw
 	cp etc/a.gwf $(DISTRIB_DIR)/gw/.
 	echo "-setup_link" > $(DISTRIB_DIR)/gw/gwd.arg
-	@printf "\n\033[1;37m└ Copy binaries in $(DISTRIB_DIR)/gw/\033[0m\n"
+	@printf "\n\033[1;1m└ Copy binaries in $(DISTRIB_DIR)/gw/\033[0m\n"
 	cp $(BUILD_DISTRIB_DIR)connex/connex.exe $(DISTRIB_DIR)/gw/connex$(EXT)
 	cp $(BUILD_DISTRIB_DIR)consang/consang.exe $(DISTRIB_DIR)/gw/consang$(EXT)
 	cp $(BUILD_DISTRIB_DIR)fixbase/gwfixbase.exe $(DISTRIB_DIR)/gw/gwfixbase$(EXT)
@@ -202,7 +202,7 @@ endif
 	cp $(BUILD_DISTRIB_DIR)gwu/gwu.exe $(DISTRIB_DIR)/gw/gwu$(EXT)
 	cp $(BUILD_DISTRIB_DIR)setup/setup.exe $(DISTRIB_DIR)/gw/gwsetup$(EXT)
 	cp $(BUILD_DISTRIB_DIR)update_nldb/update_nldb.exe $(DISTRIB_DIR)/gw/update_nldb$(EXT)
-	@printf "\n\033[1;37m└ Copy templates in $(DISTRIB_DIR)/gw/\033[0m\n"
+	@printf "\n\033[1;1m└ Copy templates in $(DISTRIB_DIR)/gw/\033[0m\n"
 	cp -R hd/* $(DISTRIB_DIR)/gw/
 	mkdir $(DISTRIB_DIR)/gw/setup
 	cp bin/setup/intro.txt $(DISTRIB_DIR)/gw/setup/
@@ -212,7 +212,7 @@ endif
 	cp bin/setup/lang/*.htm $(DISTRIB_DIR)/gw/setup/lang/
 	cp bin/setup/lang/lexicon.txt $(DISTRIB_DIR)/gw/setup/lang/
 	cp bin/setup/lang/intro.txt $(DISTRIB_DIR)/gw/setup/lang/
-	@printf "\n\033[1;37m└ Copy plugins in $(DISTRIB_DIR)/gw/plugins\033[0m\n"
+	@printf "\n\033[1;1m└ Copy plugins in $(DISTRIB_DIR)/gw/plugins\033[0m\n"
 	mkdir $(DISTRIB_DIR)/gw/plugins
 	@for P in $(shell ls plugins); do \
 	  if [ -f $(BUILD_DIR)/plugins/$$P/plugin_$$P.cmxs ] ; then \
@@ -229,9 +229,9 @@ endif
 	    fi; \
 	  fi; \
 	done
-	@printf "Done.\n\n\033[1;37mDistribution complete.\033[0m\n"
+	@printf "Done.\n\n\033[1;1mDistribution complete.\033[0m\n"
 	@$(UNPATCH)
-	@printf "You can launch Geneweb with “\033[1;37mcd $(DISTRIB_DIR)\033[0m” followed by “\033[1;37mgw/gwd$(EXT)\033[0m”.\n"
+	@printf "You can launch Geneweb with “\033[1;1mcd $(DISTRIB_DIR)\033[0m” followed by “\033[1;1mgw/gwd$(EXT)\033[0m”.\n"
 .PHONY: fmt install uninstall distrib
 
 # [END] Installation / Distribution section

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,35 @@ lib/version.ml:
 	@printf "let commit_date = \"$(COMMIT_DATE)\"\n" >> $@
 	@printf "let compil_date = \"$(COMPIL_DATE)\"\n" >> $@
 	@printf "Generating $@… Done.\n"
-.PHONY: lib/version.ml
+
+# Patch/unpatch files for campl5 >= 8.03
+CAMLP5_VERSION := $(shell camlp5 -version 2>/dev/null || echo 0)
+CAMLP5_MAJOR := $(shell echo $(CAMLP5_VERSION) | cut -d '.' -f 1)
+CAMLP5_MINOR := $(shell echo $(CAMLP5_VERSION) | cut -d '.' -f 2)
+
+patch_files:
+	@if [ "$(CAMLP5_VERSION)" != 0 ] && [ $(CAMLP5_MAJOR) -eq 8 ] && [ $(CAMLP5_MINOR) -ge 3 ]; then \
+	  printf "\nPatching bin/ged2gwb/dune.in and ged2gwb.ml for camlp5 version $(CAMLP5_VERSION) (>= 8.03.00)… Done.\n"; \
+	  perl -pi.bak -e 's|\(preprocess \(action \(run camlp5o pr_o.cmo pa_extend.cmo q_MLast.cmo %\{input-file\}\)\)\)|\(preprocess \(action \(run not-ocamlfind preprocess -package camlp5.extend,camlp5.quotations,camlp5.pr_o -syntax camlp5o %\{input-file\}\)\)\)|' bin/ged2gwb/dune.in; \
+	  perl -0777 -pi.bak -e 's/(; Token\.tok_comm = None)(\n  \})/$$1\n  ; Token.kwds = Hashtbl.create 10$$2/' bin/ged2gwb/ged2gwb.ml; \
+	fi
+
+unpatch_files:
+	@if [ -f bin/ged2gwb/dune.in.bak ] && [ -f bin/ged2gwb/ged2gwb.ml.bak ]; then \
+	  printf "Restoring original patched files… Done.\n"; \
+	  mv bin/ged2gwb/dune.in.bak bin/ged2gwb/dune.in; \
+	  mv bin/ged2gwb/ged2gwb.ml.bak bin/ged2gwb/ged2gwb.ml; \
+	fi
+
+BUILD = dune build -p geneweb --profile $(DUNE_PROFILE)
+UNPATCH = $(MAKE) --no-print-directory unpatch_files
 
 info:
 	@printf "Building \033[1;37mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n"
 	@printf "Repository \033[1;37m$(SOURCE)\033[0m. Branch \033[1;37m$(BRANCH)\033[0m.\n\n"
 	@printf "Last commit \033[1;37m$(COMMIT_ID)\033[0m with message “\033[1;37m%s\033[0m”.\n" '$(subst ','\'',$(COMMIT_MSG))'
 	@printf "\n\033[1;37mGenerating configuration files\033[0m\n"
+.PHONY: patch_files unpatch_files info
 
 GENERATED_FILES_DEP = \
 	dune-workspace \
@@ -101,34 +123,33 @@ GENERATED_FILES_DEP = \
 
 generated: $(GENERATED_FILES_DEP)
 
-install uninstall fmt build distrib: info $(GENERATED_FILES_DEP)
+fmt build install uninstall: info patch_files $(GENERATED_FILES_DEP)
 
 fmt: ## Format Ocaml code
 ifneq ($(OS_TYPE),Win)
 	@printf "\n\033[1;37mOcamlformat\033[0m\n"
-	dune build @fmt --auto-promote
+	dune build @fmt --auto-promote ; $(UNPATCH)
 endif
 
 # [BEGIN] Installation / Distribution section
 
 build: ## Build the geneweb package (libraries and binaries)
-build:
 	@printf "\n\033[1;37mBuilding executables\033[0m\n"
-	dune build -p geneweb --profile $(DUNE_PROFILE)
+	@$(BUILD) ; $(UNPATCH)
 
 install: ## Install geneweb using dune
-install:
-	dune build @install --profile $(DUNE_PROFILE)
+	dune build @install --profile $(DUNE_PROFILE) ; $(UNPATCH)
 	dune install
 
 uninstall: ## Uninstall geneweb using dune
-uninstall:
-	dune build @install --profile $(DUNE_PROFILE)
+	dune build @install --profile $(DUNE_PROFILE) ; $(UNPATCH)
 	dune uninstall
 
-distrib: build ## Build the project and copy what is necessary for distribution
-distrib:
-	$(RM) -r $(DISTRIB_DIR)
+distrib: info ## Build the project and copy what is necessary for distribution
+	@$(MAKE) --no-print-directory patch_files generated
+	@printf "\n\033[1;37mBuilding executables.\n\033[0m"
+	@$(BUILD) || { $(UNPATCH) && exit 1; }
+	@$(RM) -r $(DISTRIB_DIR)
 	@printf "\n\033[1;37mCreating distribution directory\033[0m\n"
 	mkdir $(DISTRIB_DIR)
 	mkdir -p $(DISTRIB_DIR)/bases
@@ -192,8 +213,9 @@ endif
 		fi; \
 	done
 	@printf "\033[1;37mBuild complete.\033[0m\n"
+	@$(UNPATCH)
 	@printf "You can launch Geneweb with “\033[1;37mcd $(DISTRIB_DIR)\033[0m” followed by “\033[1;37mgw/gwd$(EXT)\033[0m”.\n"
-.PHONY: install uninstall distrib
+.PHONY: fmt install uninstall distrib
 
 # [END] Installation / Distribution section
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ dune-workspace: dune-workspace.in Makefile.config
 COMPIL_DATE := $(shell date +'%Y-%m-%d')
 COMMIT_DATE := $(shell git show -s --date=short --pretty=format:'%cd')
 COMMIT_ID := $(shell git rev-parse --short HEAD)
-COMMIT_MSG := $(shell git log -1 --pretty="%s%n%n%b" | sed 's/"/\\"/g')
+COMMIT_TITLE := $(shell git log -1 --no-merges --pretty="%s" | sed "s/\"/\\\"/g")
+COMMIT_COMMENT:= $(shell git log -1 --no-merges --pretty="%b" | sed "s/\"/\\\"/g")
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 VERSION := $(shell awk -F\" '/er =/ {print $$2}' lib/version.txt)
 SOURCE := $(shell git remote get-url origin | sed -n 's|^.*m/\([^/]\+/[^/.]\+\)\(.git\)\?|\1|p')
@@ -90,9 +91,11 @@ UNPATCH = $(MAKE) --no-print-directory unpatch_files
 
 info:
 	@printf "Building \033[1;37mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n"
-	@printf "Repository \033[1;37m$(SOURCE)\033[0m. Branch \033[1;37m$(BRANCH)\033[0m.\n\n"
-	@printf "Last commit \033[1;37m$(COMMIT_ID)\033[0m with message “\033[1;37m%s\033[0m”.\n" '$(subst ','\'',$(COMMIT_MSG))'
-	@printf "\n\033[1;37mGenerating configuration files\033[0m\n"
+	@printf "Repository \033[1;37m$(SOURCE)\033[0m. Branch \033[1;37m$(BRANCH)\033[0m. "
+	@printf "Last commit \033[1;37m$(COMMIT_ID)\033[0m message:\n\n"
+	@printf "\033[1;37m  %s\033[0m\n" '$(subst ','\'',$(COMMIT_TITLE))'
+	@printf "  %s\n" '$(subst ','\'',$(COMMIT_COMMENT))' | fmt -w 80
+	@printf "\033[1;37mGenerating configuration files\033[0m\n"
 .PHONY: patch_files unpatch_files info
 
 GENERATED_FILES_DEP = \
@@ -122,8 +125,9 @@ GENERATED_FILES_DEP = \
 	test/dune \
 
 generated: $(GENERATED_FILES_DEP)
+	@printf "Done.\n"
 
-fmt build install uninstall: info patch_files $(GENERATED_FILES_DEP)
+fmt build gwd install uninstall: info patch_files generated
 
 fmt: ## Format Ocaml code
 ifneq ($(OS_TYPE),Win)
@@ -136,6 +140,12 @@ endif
 build: ## Build the geneweb package (libraries and binaries)
 	@printf "\n\033[1;37mBuilding executables\033[0m\n"
 	@$(BUILD) ; $(UNPATCH)
+	@printf "Done."
+
+gwd: ## Build ondy gwd/gwc executables
+	@printf "\n\033[1;37mBuilding only gwd and gwc executables\033[0m\n"
+	@dune build bin/gwd bin/gwc --profile $(DUNE_PROFILE) ; $(UNPATCH)
+	@printf "Done."
 
 install: ## Install geneweb using dune
 	dune build @install --profile $(DUNE_PROFILE) ; $(UNPATCH)
@@ -149,6 +159,7 @@ distrib: info ## Build the project and copy what is necessary for distribution
 	@$(MAKE) --no-print-directory patch_files generated
 	@printf "\n\033[1;37mBuilding executables.\n\033[0m"
 	@$(BUILD) || { $(UNPATCH) && exit 1; }
+	@printf "Done."
 	@$(RM) -r $(DISTRIB_DIR)
 	@printf "\n\033[1;37mCreating distribution directory\033[0m\n"
 	mkdir $(DISTRIB_DIR)
@@ -184,7 +195,10 @@ endif
 	cp $(BUILD_DISTRIB_DIR)gwc/gwc.exe $(DISTRIB_DIR)/gw/gwc$(EXT)
 	cp $(BUILD_DISTRIB_DIR)gwd/gwd.exe $(DISTRIB_DIR)/gw/gwd$(EXT)
 	cp $(BUILD_DISTRIB_DIR)gwdiff/gwdiff.exe $(DISTRIB_DIR)/gw/gwdiff$(EXT)
-	if test -f $(BUILD_DISTRIB_DIR)gwrepl/gwrepl.bc ; then cp $(BUILD_DISTRIB_DIR)gwrepl/gwrepl.bc $(DISTRIB_DIR)/gw/gwrepl$(EXT); fi
+	@if test -f $(BUILD_DISTRIB_DIR)gwrepl/gwrepl.bc ; then \
+	  printf "cp %s %s\n" "$(BUILD_DISTRIB_DIR)gwrepl/gwrepl.bc" "$(DISTRIB_DIR)/gw/gwrepl$(EXT)"; \
+	  cp $(BUILD_DISTRIB_DIR)gwrepl/gwrepl.bc $(DISTRIB_DIR)/gw/gwrepl$(EXT); \
+	fi
 	cp $(BUILD_DISTRIB_DIR)gwu/gwu.exe $(DISTRIB_DIR)/gw/gwu$(EXT)
 	cp $(BUILD_DISTRIB_DIR)setup/setup.exe $(DISTRIB_DIR)/gw/gwsetup$(EXT)
 	cp $(BUILD_DISTRIB_DIR)update_nldb/update_nldb.exe $(DISTRIB_DIR)/gw/update_nldb$(EXT)
@@ -200,19 +214,22 @@ endif
 	cp bin/setup/lang/intro.txt $(DISTRIB_DIR)/gw/setup/lang/
 	@printf "\n\033[1;37m└ Copy plugins in $(DISTRIB_DIR)/gw/plugins\033[0m\n"
 	mkdir $(DISTRIB_DIR)/gw/plugins
-	for P in $(shell ls plugins); do \
-		if [ -f $(BUILD_DIR)/plugins/$$P/plugin_$$P.cmxs ] ; then \
-			mkdir $(DISTRIB_DIR)/gw/plugins/$$P; \
-			cp $(BUILD_DIR)/plugins/$$P/plugin_$$P.cmxs $(DISTRIB_DIR)/gw/plugins/$$P/; \
-			if [ -d plugins/$$P/assets ] ; then \
-				cp -R $(BUILD_DIR)/plugins/$$P/assets $(DISTRIB_DIR)/gw/plugins/$$P/; \
-			fi; \
-			if [ -f $(BUILD_DIR)/plugins/$$P/META ] ; then \
-				cp $(BUILD_DIR)/plugins/$$P/META $(DISTRIB_DIR)/gw/plugins/$$P/; \
-			fi; \
-		fi; \
+	@for P in $(shell ls plugins); do \
+	  if [ -f $(BUILD_DIR)/plugins/$$P/plugin_$$P.cmxs ] ; then \
+	    mkdir $(DISTRIB_DIR)/gw/plugins/$$P; \
+	    printf "cp %s %s\n" "$(BUILD_DIR)/plugins/$$P/plugin_$$P.cmxs" "$(DISTRIB_DIR)/gw/plugins/$$P/"; \
+	    cp $(BUILD_DIR)/plugins/$$P/plugin_$$P.cmxs $(DISTRIB_DIR)/gw/plugins/$$P/; \
+	    if [ -d plugins/$$P/assets ] ; then \
+	      printf "cp -R %s %s\n" "$(BUILD_DIR)/plugins/$$P/assets" "$(DISTRIB_DIR)/gw/plugins/$$P/"; \
+	      cp -R $(BUILD_DIR)/plugins/$$P/assets $(DISTRIB_DIR)/gw/plugins/$$P/; \
+	    fi; \
+	    if [ -f $(BUILD_DIR)/plugins/$$P/META ] ; then \
+	      printf "cp %s %s\n" "$(BUILD_DIR)/plugins/$$P/META" "$(DISTRIB_DIR)/gw/plugins/$$P/"; \
+	      cp $(BUILD_DIR)/plugins/$$P/META $(DISTRIB_DIR)/gw/plugins/$$P/; \
+	    fi; \
+	  fi; \
 	done
-	@printf "\033[1;37mBuild complete.\033[0m\n"
+	@printf "Done.\n\n\033[1;37mDistribution complete.\033[0m\n"
 	@$(UNPATCH)
 	@printf "You can launch Geneweb with “\033[1;37mcd $(DISTRIB_DIR)\033[0m” followed by “\033[1;37mgw/gwd$(EXT)\033[0m”.\n"
 .PHONY: fmt install uninstall distrib


### PR DESCRIPTION
So we have [failing CI jobs on linux/mac](https://github.com/geneweb/geneweb/actions/runs/9220821914/job/25368598942#step:5:51) since yesterday because of a change in camlp5 8.03, see issue https://github.com/camlp5/camlp5/issues/106.
Maintainer @chetmurthy pointed me a [fix on drjdn project](https://github.com/drjdn/p5scm/pull/4/files). I adapted the .opam file change to our `dune-project` quite easily. It was failing with:
```ocaml
File "bin/ged2gwb/ged2gwb.pp.ml", lines 533-539, characters 2-25:
533 | ..{Token.tok_func =
534 |     (fun s ->
535 |        make_date_lexing s,
536 |        {Plexing.Locations.locations = ref [| |]; overflow = ref true});
537 |    Token.tok_using = using_token; Token.tok_removing = (fun _ -> ());
538 |    Token.tok_match = tparse; Token.tok_text = (fun _ -> "<tok>");
539 |    Token.tok_comm = None}
Error: Some record fields are undefined: kwds
make: *** [Makefile:117: build] Error 1
```
I looked at the other modifications and tried a Token.kwds = something that was unbound! Mistral told me to set the field to a new empty hashtable `Hashtbl.create 10` (and that **we should replace it with an appropriate value for our use case!**).

Review heavily needed @ilankri @canonici please if you have time, it's important to fix and merge this as soon as possible. Thank you.

A warning remain since the beginning:
```ocaml
ocamlfind: [WARNING] Package `camlp5.extend': camlp5.extend SHOULD NOT be used with syntax camlp5o
```
Edit: removed § about “div Separated”… I did test on the wrong branch.. so waiting for CI here!