### PR TITLE
CI: Restore tests for versions 4.08.0 and 5.1.x after a faulty renaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
           - 4.14.x
         include:
           - os: ubuntu-latest
-            ocaml-version: 4.08.0
+            ocaml-compiler: 4.08.0
           - os: ubuntu-latest
-            ocaml-version: 5.1.x
+            ocaml-compiler: 5.1.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Bug introduced in 5e146940c411dd12462417776faf7c3d894c1d8c.