### PR TITLE
ged2gwb not to create base with invalid characters

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3181,7 +3181,7 @@ let out_file = ref "a"
 
 let speclist =
   [ ( "-o", Arg.String (fun s -> out_file := s)
-    , "<file> Output database (default: \"a\")." )
+    , "<file> Output database (default: \"a\"). Alphanumerics and -" )
   ; ( "-f", Arg.Set force
     , "Remove database if already existing" )
   ; ( "-log", Arg.String (fun s -> log_oc := open_out s)
@@ -3278,6 +3278,13 @@ let errmsg = "Usage: ged2gwb [<ged>] [options] where options are:"
 
 let main () =
   Arg.parse speclist anonfun errmsg;
+  if not (Mutil.good_name (Filename.basename !out_file)) then (
+    (* Util.transl conf not available !*)
+    Printf.eprintf "The database name \"%s\" contains a forbidden character.\n"
+      !out_file;
+    Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -\n";
+    flush stderr;
+    exit 2);
   Secure.set_base_dir (Filename.dirname !out_file);
   let arrays = make_arrays !in_file in
   Gc.compact ();

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -160,10 +160,10 @@ let main () =
   Arg.parse speclist anonfun errmsg;
   if not (Mutil.good_name (Filename.basename !out_file)) then (
     (* Util.transl conf not available !*)
-    Printf.eprintf "The database name \"%s\" contains a forbidden character./n"
+    Printf.eprintf "The database name \"%s\" contains a forbidden character.\n"
       !out_file;
-    Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -";
-    flush stdout;
+    Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -\n";
+    flush stderr;
     exit 2);
   Secure.set_base_dir (Filename.dirname !out_file);
   let gwo = ref [] in
@@ -188,7 +188,7 @@ let main () =
       Printf.eprintf
         "The database \"%s\" already exists. Use option -f to overwrite it."
         !out_file;
-      flush stdout;
+      flush stderr;
       exit 2);
     Lock.control (Mutil.lock_file !out_file)
       false ~onerror:Lock.print_error_and_exit (fun () ->
@@ -199,7 +199,6 @@ let main () =
         let next_family_fun = next_family_fun_templ (List.rev !gwo) in
         if Db1link.link next_family_fun bdir then ()
         else (
-          flush stderr;
           Printf.eprintf "*** database not created\n";
           flush stderr;
           exit 2)))


### PR DESCRIPTION
ged2gwb not to create base with invalid characters

Same correction as already done in gwc with PR #1443

Typo error about end line character and stderr flushing in gwc and ged2gwb.