### PR TITLE
Aline online help for all 

### DIFF
--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -157,21 +157,21 @@ let names_all base bname fname =
 
 let speclist =
   [
-    ("-fn", Arg.Set fnames, "produce first names");
-    ("-sn", Arg.Set snames, "produce surnames");
-    ("-al", Arg.Set alias, "produce aliases");
-    ("-qu", Arg.Set qual, "produce qualifiers");
-    ("-pl", Arg.Set places, "produce places");
-    ("-all", Arg.Set all, "produce all");
-    ("-fna", Arg.Set fname_alias, "add first names aliases");
-    ("-prog", Arg.Set prog, "show progress bar");
+    ("-fn", Arg.Set fnames, " produce first names");
+    ("-sn", Arg.Set snames, " produce surnames");
+    ("-al", Arg.Set alias, " produce aliases");
+    ("-qu", Arg.Set qual, " produce qualifiers");
+    ("-pl", Arg.Set places, " produce places");
+    ("-all", Arg.Set all, " produce all");
+    ("-fna", Arg.Set fname_alias, " add first names aliases");
+    ("-prog", Arg.Set prog, " show progress bar");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun i = bname := i
 
 let usage =
-  "Usage: cache_files [-fn] [-sn] [-al] [-qu] [-pl] [-all] [-fna] [-prog] base\n\
-  \ cd bases; before running cache_files."
+  "Usage: cache_files [options] base\n cd bases; before running cache_files."
 
 let main () =
   Arg.parse speclist anonfun usage;

--- a/bin/connex/connex.ml
+++ b/bin/connex/connex.ml
@@ -240,29 +240,30 @@ let speclist =
   [
     ( "-gwd_p",
       Arg.Int (fun x -> gwd_port := x),
-      "<number>: Specify the port number of gwd (default = "
+      "<number> Specify the port number of gwd (default = "
       ^ string_of_int !gwd_port ^ "); > 1024 for normal users." );
     ( "-server",
       Arg.String (fun x -> server := x),
-      "<string>: Name of the server (default is 127.0.0.1)." );
-    ("-a", Arg.Set all, ": all connex components");
-    ("-s", Arg.Set statistics, ": produce statistics");
-    ("-d", Arg.Int (fun x -> detail := x), "<int> : detail for this length");
+      "<string> Name of the server (default is 127.0.0.1)." );
+    ("-a", Arg.Set all, " all connex components");
+    ("-s", Arg.Set statistics, " produce statistics");
+    ("-d", Arg.Int (fun x -> detail := x), "<int> detail for this length");
     ( "-i",
       Arg.String (fun x -> ignore := x :: !ignore),
-      "<file> : ignore this file" );
-    ("-bf", Arg.Clear ignore_files, ": by origin files");
+      "<file> ignore this file" );
+    ("-bf", Arg.Clear ignore_files, " by origin files");
     ( "-del",
       Arg.Int (fun i -> ask_for_delete := i),
-      "<int> : ask for deleting branches whose size <= that value" );
+      "<int> ask for deleting branches whose size <= that value" );
     ( "-cnt",
       Arg.Int (fun i -> cnt_for_delete := i),
-      "<int> : delete cnt branches whose size <= -del value" );
+      "<int> delete cnt branches whose size <= -del value" );
     ( "-exact",
       Arg.Set exact,
-      ": delete only branches whose size strictly = -del value" );
-    ("-o", Arg.String (fun x -> output := x), "<file> : output to this file");
+      " delete only branches whose size strictly = -del value" );
+    ("-o", Arg.String (fun x -> output := x), "<file> output to this file");
   ]
+  |> List.sort compare |> Arg.align
 
 let main () =
   Arg.parse speclist (fun s -> bname := s) usage;

--- a/bin/consang/consang.ml
+++ b/bin/consang/consang.ml
@@ -11,12 +11,13 @@ let speclist =
     ("-q", Arg.Unit (fun () -> verbosity := 1), " quiet mode");
     ("-qq", Arg.Unit (fun () -> verbosity := 0), " very quiet mode");
     ("-fast", Arg.Set fast, " faster, but use more memory");
-    ("-scratch", Arg.Set scratch, ": from scratch");
+    ("-scratch", Arg.Set scratch, " from scratch");
     ( "-mem",
       Arg.Set Outbase.save_mem,
-      ": Save memory, but slower when rewritting database" );
-    ("-nolock", Arg.Set Lock.no_lock_flag, ": do not lock database.");
+      " Save memory, but slower when rewritting database" );
+    ("-nolock", Arg.Set Lock.no_lock_flag, " do not lock database.");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun s =
   if !fname = "" then fname := s

--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -187,9 +187,10 @@ let speclist =
     ("-person-key", Arg.Set key, " missing doc");
     ( "-index",
       Arg.Set index,
-      " rebuild index. It is automatically enable by any other option." );
+      " rebuild index. It is automatically enabled by any other option." );
     ("-invalid-utf8", Arg.Set invalid_utf8, " missing doc");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun i = bname := i
 let usage = "Usage: " ^ Sys.argv.(0) ^ " [OPTION] base"

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3183,18 +3183,18 @@ let speclist =
   [ ( "-o", Arg.String (fun s -> out_file := s)
     , "<file> Output database (default: \"a\")." )
   ; ( "-f", Arg.Set force
-    , "Remove database if already existing" )
+    , " Remove database if already existing" )
   ; ( "-log", Arg.String (fun s -> log_oc := open_out s)
     , "<file> Redirect log trace to this file." )
   ; ( "-lf", Arg.Set lowercase_first_names
-    , "Convert first names to lowercase letters, with initials in uppercase." )
+    , " Convert first names to lowercase letters, with initials in uppercase." )
   ; ( "-trackid", Arg.Set track_ged2gw_id,
-      "Print gedcom id to gw id matches." )
+      " Print gedcom id to gw id matches." )
   ; ( "-ls", Arg.Unit (fun () -> case_surnames := LowerCase)
-    , "Convert surnames to lowercase letters, with initials in uppercase. \
+    , " Convert surnames to lowercase letters, with initials in uppercase. \
        Try to keep lowercase particles." )
   ; ( "-us", Arg.Unit (fun () -> case_surnames := UpperCase)
-    , "Convert surnames to uppercase letters." )
+    , " Convert surnames to uppercase letters." )
   ; ( "-fne"
     , Arg.String begin fun s ->
         if String.length s = 2
@@ -3206,29 +3206,30 @@ let speclist =
        is considered to be the usual first name: e.g. -fne '\"\"' or \
        -fne \"()\"." )
   ; ( "-efn", Arg.Set extract_first_names
-    , "When creating a person, if the GEDCOM first name part holds several \
+    , " When creating a person, if the GEDCOM first name part holds several \
        names, the first of this names becomes the person \"first name\" and \
        the complete GEDCOM first name part a \"first name alias\"." )
   ; ( "-no_efn", Arg.Clear extract_first_names,
-      "Cancels the previous option." )
+      " Cancels the previous option." )
   ; ( "-epn", Arg.Set extract_public_names
-    , "When creating a person, if the GEDCOM first name part looks like a \
-       public name, i.e. holds:\n\
-       * a number or a roman number, supposed to be a number of a nobility title,\n\
-       * one of the words: \"der\", \"den\", \"die\", \"el\", \"le\", \"la\", \"the\", \
+    , " When creating a person, if the GEDCOM first name part looks like a \
+       public name, i.e. holds either \
+       a number or a roman number, supposed to be a number of a nobility title, \
+       or one of the words: \
+       \"der\", \"den\", \"die\", \"el\", \"le\", \"la\", \"the\", \
        supposed to be the beginning of a qualifier, \
        then the GEDCOM first name part becomes the person \"public name\" \
        and its first word his \"first name\"." )
   ; ( "-no_epn", Arg.Clear extract_public_names
-    , "Cancels the previous option." )
+    , " Cancels the previous option." )
   ; ( "-no_pit", Arg.Set no_public_if_titles
-    , "Do not consider persons having titles as public")
+    , " Do not consider persons having titles as public")
   ; ( "-tnd", Arg.Set try_negative_dates
-    , "Set negative dates when inconsistency (e.g. birth after death)" )
+    , " Set negative dates when inconsistency (e.g. birth after death)" )
   ; ( "-no_nd", Arg.Set no_negative_dates
-    , "Don't interpret a year preceded by a minus sign as a negative year" )
-  ; ( "-nc", Arg.Clear do_check, "No consistency check" )
-  ; ( "-nopicture", Arg.Set no_picture, "Don't extract individual picture." )
+    , " Don't interpret a year preceded by a minus sign as a negative year" )
+  ; ( "-nc", Arg.Clear do_check, " No consistency check" )
+  ; ( "-nopicture", Arg.Set no_picture, " Don't extract individual picture." )
   ; ( "-udi"
     , Arg.String begin fun s ->
         match String.index_opt s '-' with
@@ -3241,21 +3242,22 @@ let speclist =
           dead_years := b ;
         | None -> raise (Arg.Bad "bad parameter for -udi")
       end
-    , "x-y Set the interval for persons whose death part is undefined:\n\
-       - if before x years, they are considered as alive\n\
-       - if after y year, they are considered as death\n\
-       - between x and y year, they are considered as \"don't know\"\n\
-       Default x is " ^ string_of_int !alive_years ^ " and y is " ^ string_of_int !dead_years)
+    , "x-y Set the interval for persons whose death part is undefined: \
+       If before x years, they are considered as alive. \
+       If after y year, they are considered as death. \
+       Between x and y year, they are considered as \"don't know\". \
+       Default x is " ^ string_of_int !alive_years ^ " \
+       Default y is " ^ string_of_int !dead_years)
   ; ( "-uin", Arg.Set untreated_in_notes
-    , "Put untreated GEDCOM tags in notes" )
+    , " Put untreated GEDCOM tags in notes" )
   ; ( "-ds", Arg.Set_string default_source
-    , "Set the source field for persons and families without source data" )
+    , " Set the source field for persons and families without source data" )
   ; ( "-dates_dm", Arg.Unit (fun () -> month_number_dates := DayMonthDates)
-    ,"Interpret months-numbered dates as day/month/year" )
+    ," Interpret months-numbered dates as day/month/year" )
   ; ( "-dates_md", Arg.Unit (fun () -> month_number_dates := MonthDayDates)
-    , "Interpret months-numbered dates as month/day/year" )
+    , " Interpret months-numbered dates as month/day/year" )
   ; ( "-rs_no_mention", Arg.Unit (fun () -> relation_status := NoMention)
-    , "Force relation status to NoMention (default is Married)" )
+    , " Force relation status to NoMention (default is Married)" )
   ; ( "-charset"
     , Arg.String begin function
         | "ANSEL" -> charset_option := Some Ansel
@@ -3263,7 +3265,7 @@ let speclist =
         | "MSDOS" -> charset_option := Some Msdos
         | _ -> raise (Arg.Bad "bad -charset value")
       end
-    , "[ANSEL|ASCII|MSDOS] Force given charset decoding, \
+    , " [ANSEL|ASCII|MSDOS] Force given charset decoding, \
        overriding the possible setting in GEDCOM" )
   ; ( "-particles"
     , Arg.String (fun s -> particles := Mutil.input_particles s)

--- a/bin/gwb2ged/gwb2ged.ml
+++ b/bin/gwb2ged/gwb2ged.ml
@@ -3,7 +3,7 @@ let with_indexes = ref false
 let speclist opts =
   ("-indexes", Arg.Set with_indexes, " export indexes in gedcom")
   :: Gwexport.speclist opts
-  |> Arg.align
+  |> List.sort compare |> Arg.align
 
 let main () =
   let opts = ref Gwexport.default_opts in

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -106,7 +106,7 @@ let speclist =
   [
     ( "-bnotes",
       Arg.Set_string bnotes,
-      "[drop|erase|first|merge] Behavior for base notes of the next file. \
+      " [drop|erase|first|merge] Behavior for base notes of the next file. \
        [drop]: dropped. [erase]: erase the current content. [first]: dropped \
        if current content is not empty. [merge]: concatenated to the current \
        content. Default: " ^ !bnotes ^ "" );

--- a/bin/gwdiff/gwdiff.ml
+++ b/bin/gwdiff/gwdiff.ml
@@ -540,23 +540,24 @@ let speclist =
         (fun s ->
           p1_fn := s;
           arg_state := ASwaitP1occ),
-      "<fn> <occ> <sn> : (mandatory) defines starting person in base1" );
+      "<fn> <occ> <sn> (mandatory) defines starting person in base1" );
     ( "-2",
       Arg.String
         (fun s ->
           p2_fn := s;
           arg_state := ASwaitP2occ),
-      "<fn> <occ> <sn> : (mandatory) defines starting person in base2" );
-    ("-ad", Arg.Set ad_mode, ": checks descendants of all ascendants ");
-    ("-d", Arg.Set d_mode, ": checks descendants (default)");
+      "<fn> <occ> <sn> (mandatory) defines starting person in base2" );
+    ("-ad", Arg.Set ad_mode, " checks descendants of all ascendants ");
+    ("-d", Arg.Set d_mode, " checks descendants (default)");
     ( "-html",
       Arg.String
         (fun s ->
           html := true;
           root := s),
-      "<root>: HTML format used for report" );
-    ("-mem", Arg.Set mem, ": save memory space, but slower");
+      "<root> HTML format used for report" );
+    ("-mem", Arg.Set mem, " save memory space, but slower");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun s =
   match !arg_state with

--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -66,7 +66,7 @@ let speclist c =
        multiple times. Key format is \"First Name.occ SURNAME\"" );
     ( "-c",
       Arg.Int (fun s -> c := { !c with censor = s }),
-      "<NUM>: when a person is born less than <num> years ago, it is not \
+      "<NUM> when a person is born less than <num> years ago, it is not \
        exported unless it is Public. All the spouses and descendants are also \
        censored." );
     ( "-charset",
@@ -83,7 +83,7 @@ let speclist c =
                 | "UTF-8" -> Utf8
                 | _ -> raise (Arg.Bad "bad -charset value"));
             }),
-      "[ASCII|ANSEL|ANSI|UTF-8] set charset; default is UTF-8" );
+      " [ASCII|ANSEL|ANSI|UTF-8] set charset; default is UTF-8" );
     ( "-d",
       Arg.Int (fun s -> c := { !c with desc = Some s }),
       "<N> maximum generation of the root's descendants." );

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -5,7 +5,7 @@ let isolated = ref false
 let speclist opts =
   ( "-odir",
     Arg.String (fun s -> GwuLib.out_dir := s),
-    "<dir>  create files from original name in directory (else on -o file)" )
+    "<dir> create files from original name in directory (else on -o file)" )
   :: ( "-isolated",
        Arg.Set isolated,
        " export isolated persons (work only if export all database)." )
@@ -18,7 +18,7 @@ let speclist opts =
        " raw output (without possible utf-8 conversion)" )
   :: ( "-sep",
        Arg.String (fun s -> GwuLib.separate_list := s :: !GwuLib.separate_list),
-       "<1st_name.num surname> To use together with the option \"-odir\": \
+       " <1st_name.num surname> To use together with the option \"-odir\": \
         separate this person and all his ancestors and descendants sharing the \
         same surname. All the concerned families are displayed on standard \
         output instead of their associated files. This option can be used \
@@ -36,7 +36,7 @@ let speclist opts =
        ^ string_of_int !GwuLib.sep_limit
        ^ ". The present option changes this limit." )
   :: Gwexport.speclist opts
-  |> Arg.align
+  |> List.sort compare |> Arg.align
 
 let main () =
   let opts = ref Gwexport.default_opts in

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -1943,20 +1943,23 @@ let usage =
   "Usage: " ^ Filename.basename Sys.argv.(0) ^ " [options] where options are:"
 let speclist =
   [("-bd", Arg.String (fun x -> base_dir := x),
-    "<dir>: Directory where the databases are installed.");
+    "<dir> Directory where the databases are installed.");
    ("-gwd_p", Arg.Int (fun x -> gwd_port := x),
-    "<number>: Specify the port number of gwd (default = " ^
+    "<number> Specify the port number of gwd (default = " ^
       string_of_int !gwd_port ^ "); > 1024 for normal users.");
-   ("-lang", Arg.String (fun x -> lang_param := x), "<string>: default lang");
-   ("-daemon", Arg.Set daemon, ": Unix daemon mode.");
+   ("-lang", Arg.String (fun x -> lang_param := x), "<string> default lang");
+   ("-daemon", Arg.Set daemon, " Unix daemon mode.");
    ("-p", Arg.Int (fun x -> port := x),
-    "<number>: Select a port number (default = " ^ string_of_int !port ^
+    "<number> Select a port number (default = " ^ string_of_int !port ^
     "); > 1024 for normal users.");
    ("-only", Arg.String (fun s -> only_file := s),
-    "<file>: File containing the only authorized address");
-   ("-gd", Arg.String (fun x -> setup_dir := x), "<string>: gwsetup directory");
+    "<file> File containing the only authorized address");
+   ("-gd", Arg.String (fun x -> setup_dir := x), "<string> gwsetup directory");
    ("-bindir", Arg.String (fun x -> bin_dir := x),
-    "<string>: binary directory (default = value of option -gd)")]
+    "<string> binary directory (default = value of option -gd)")
+  ]
+  |> List.sort compare |> Arg.align
+
 let anonfun s = raise (Arg.Bad ("don't know what to do with " ^ s))
 
 #ifdef UNIX


### PR DESCRIPTION
properly aline online help for commands: cache_files connex consang ged2gwb gwb2ged gwc gwdiff gwfixbase gwsetup gwu

with correct setting of doc strings in speclist variable.
* Need to be a one line string, not a multi-line.
* Add a space first character as per Arg.align.
    
Refer to Arg module documentation https://ocaml.org/manual/5.2/api/Arg.html

Note that the doc is now properly left aligned, but there is no way to justify long doc string.