### PR TITLE
Cache lnked pages info

### DIFF
--- a/lib/mergeFamOk.ml
+++ b/lib/mergeFamOk.ml
@@ -259,6 +259,7 @@ let effective_mod_merge conf base o_f1 o_f2 sfam scpl sdes =
         String.concat " " (List.map (sou base) sl)
       in
       Notes.update_notes_links_db base (Def.NLDB.PgFam ifam) s;
+      (* TODO update_cache_linked_pages *)
       let changed =
         let gen_p =
           let p =

--- a/lib/mergeInd.ml
+++ b/lib/mergeInd.ml
@@ -187,7 +187,19 @@ let effective_merge_ind conf base (warning : CheckItem.base_warning -> unit) p1
     in
     String.concat " " (List.map (sou base) sl)
   in
-  Notes.update_notes_links_db base (Def.NLDB.PgInd p1.key_index) s
+  Notes.update_notes_links_db base (Def.NLDB.PgInd p1.key_index) s;
+  let key =
+    ( Name.lower (sou base p1.first_name),
+      Name.lower (sou base p1.surname),
+      p1.occ )
+  in
+  let pgl =
+    let db = Gwdb.read_nldb base in
+    let db = Notes.merge_possible_aliases conf db in
+    let pgl = Notes.links_to_ind conf base db key in
+    pgl
+  in
+  Notes.update_cache_linked_pages conf Notes.Merge key key pgl
 
 exception Error_loop of person
 exception Same_person

--- a/lib/mergeInd.ml
+++ b/lib/mergeInd.ml
@@ -188,11 +188,7 @@ let effective_merge_ind conf base (warning : CheckItem.base_warning -> unit) p1
     String.concat " " (List.map (sou base) sl)
   in
   Notes.update_notes_links_db base (Def.NLDB.PgInd p1.key_index) s;
-  let key =
-    ( Name.lower (sou base p1.first_name),
-      Name.lower (sou base p1.surname),
-      p1.occ )
-  in
+  let key = Util.make_key base p1 in
   let pgl =
     let db = Gwdb.read_nldb base in
     let db = Notes.merge_possible_aliases conf db in

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -469,6 +469,7 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
     (U_Merge_person (o_p1, o_p2, Util.string_gen_person base p))
     "fp";
   Notes.update_notes_links_db base (Def.NLDB.PgInd o_p2.key_index) "";
+  (* TODO update_cache_linked_pages *)
   Update.delete_topological_sort conf base;
   let db = Gwdb.read_nldb base in
   let ofn1 = o_p1.first_name in

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -269,23 +269,9 @@ let update_cache_linked_pages conf mode old_key new_key pgl =
       write_cache_linked_pages conf ht
 
 let linked_pages_nbr conf base ip =
-  let p = poi base ip in
-  let key =
-    ( sou base (get_first_name p) |> Name.lower,
-      sou base (get_surname p) |> Name.lower,
-      get_occ p )
-  in
+  let key = Util.make_key base (Gwdb.gen_person_of_person (poi base ip)) in
   let ht = read_cache_linked_pages conf in
   let entry = try Some (Hashtbl.find ht key) with Not_found -> None in
   match entry with Some pgl -> List.length pgl | None -> 0
 
-let has_linked_pages conf base ip =
-  let p = poi base ip in
-  let key =
-    ( sou base (get_first_name p) |> Name.lower,
-      sou base (get_surname p) |> Name.lower,
-      get_occ p )
-  in
-  let ht = read_cache_linked_pages conf in
-  let entry = try Some (Hashtbl.find ht key) with Not_found -> None in
-  match entry with Some pgl when List.length pgl <> 0 -> true | _ -> false
+let has_linked_pages conf base ip = linked_pages_nbr conf base ip <> 0

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -60,6 +60,25 @@ val source_note_with_env :
     Interprets wiki syntax in a "source" context with a predefined env.
 *)
 
-val has_linked_pages : Config.config -> Gwdb.iper -> bool
-val linked_pages_nbr : Config.config -> Gwdb.iper -> int
+type mode = Delete | Rename | Merge
+
+val links_to_ind :
+  Config.config ->
+  Gwdb.base ->
+  ((Gwdb.iper, Gwdb.ifam) Def.NLDB.page
+  * (string list * (Def.NLDB.key * Def.NLDB.ind) list))
+  list ->
+  Def.NLDB.key ->
+  (Def.NLDB.key * Def.NLDB.ind) list
+
+val has_linked_pages : Config.config -> Gwdb.base -> Gwdb.iper -> bool
+val linked_pages_nbr : Config.config -> Gwdb.base -> Gwdb.iper -> int
 val cache_linked_pages_name : string
+
+val update_cache_linked_pages :
+  Config.config ->
+  mode ->
+  Def.NLDB.key ->
+  Def.NLDB.key ->
+  (Def.NLDB.key * Def.NLDB.ind) list ->
+  unit

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -59,3 +59,7 @@ val source_note_with_env :
 (** [source_note_with_env conf base env str]
     Interprets wiki syntax in a "source" context with a predefined env.
 *)
+
+val has_linked_pages : Config.config -> Gwdb.iper -> bool
+val linked_pages_nbr : Config.config -> Gwdb.iper -> int
+val cache_linked_pages_name : string

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -2892,18 +2892,8 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
       | _ -> raise Not_found)
   | [ "has_linked_pages" ] -> (
       match get_env "nldb" env with
-      | Vnldb db ->
-          let r =
-            if p_auth then
-              let key =
-                let fn = Name.lower (sou base (get_first_name p)) in
-                let sn = Name.lower (sou base (get_surname p)) in
-                (fn, sn, get_occ p)
-              in
-              links_to_ind conf base db key <> []
-            else false
-          in
-          VVbool r
+      | Vnldb _db ->
+          VVbool (Notes.has_linked_pages conf (get_iper p))
       | _ -> raise Not_found)
   | [ "linked_pages_nbr" ] -> (
       match get_env "nldb" env with
@@ -2942,6 +2932,13 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
       match get_env "lev_cnt" env with
       | Vint i -> str_val (string_of_int i)
       | _ -> raise Not_found)
+  | [ "linked_pages_number" ] -> (
+      match get_env "nldb" env with
+      | Vnldb _db ->
+          Notes.linked_pages_nbr conf (get_iper p)
+          |> string_of_int
+          |> str_val
+      | _ -> str_val "0")
   | [ "linked_page"; s ] -> (
       match get_env "nldb" env with
       | Vnldb db ->

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -2892,8 +2892,7 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
       | _ -> raise Not_found)
   | [ "has_linked_pages" ] -> (
       match get_env "nldb" env with
-      | Vnldb _db ->
-          VVbool (Notes.has_linked_pages conf (get_iper p))
+      | Vnldb _db -> VVbool (Notes.has_linked_pages conf base (get_iper p))
       | _ -> raise Not_found)
   | [ "linked_pages_nbr" ] -> (
       match get_env "nldb" env with
@@ -2935,9 +2934,8 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
   | [ "linked_pages_number" ] -> (
       match get_env "nldb" env with
       | Vnldb _db ->
-          Notes.linked_pages_nbr conf (get_iper p)
-          |> string_of_int
-          |> str_val
+          Notes.linked_pages_nbr conf base (get_iper p)
+          |> string_of_int |> str_val
       | _ -> str_val "0")
   | [ "linked_page"; s ] -> (
       match get_env "nldb" env with

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -1381,6 +1381,7 @@ let print_mod o_conf base =
       String.concat " " (List.map (sou base) sl)
     in
     Notes.update_notes_links_db base (Def.NLDB.PgFam ifam) s;
+    (* TODO update_cache_linked_pages *)
     let nfs = (Adef.parent_array cpl, des.children) in
     let onfs = Some (ofs, nfs) in
     let wl, ml =

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -930,7 +930,9 @@ let effective_del_no_commit base op =
 
 let effective_del_commit conf base op =
   Notes.update_notes_links_db base (Def.NLDB.PgInd op.key_index) "";
-  let key = (Name.lower op.first_name, Name.lower op.surname, op.occ) in
+  let key =
+    Util.make_key base (Gwdb.gen_person_of_person (poi base op.key_index))
+  in
   Notes.update_cache_linked_pages conf Notes.Delete key key [];
   Util.commit_patches conf base;
   let changed = U_Delete_person op in
@@ -1139,7 +1141,9 @@ let print_mod ?prerr o_conf base =
   let ofn = o_p.first_name in
   let osn = o_p.surname in
   let oocc = o_p.occ in
-  let old_key = (Name.lower ofn, Name.lower osn, oocc) in
+  let old_key =
+    Util.make_key base (Gwdb.gen_person_of_person (poi base o_p.key_index))
+  in
   let conf = Update.update_conf o_conf in
   let pgl =
     let db = Gwdb.read_nldb base in
@@ -1178,11 +1182,7 @@ let print_mod ?prerr o_conf base =
       String.concat " " (List.map (sou base) sl)
     in
     Notes.update_notes_links_db base (Def.NLDB.PgInd p.key_index) s;
-    let new_key =
-      ( Name.lower (sou base p.first_name),
-        Name.lower (sou base p.surname),
-        p.occ )
-    in
+    let new_key = Util.make_key base p in
     if old_key <> new_key then
       Notes.update_cache_linked_pages conf Notes.Rename old_key new_key [];
     let wl =

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1007,6 +1007,9 @@ let person_title conf base p =
     | None -> Adef.safe ""
   else Adef.safe ""
 
+let make_key base p =
+  (Name.lower (sou base p.first_name), Name.lower (sou base p.surname), p.occ)
+
 let name_key base s =
   let part = Mutil.get_particle (Gwdb.base_particles base) s in
   if part = "" then s

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -499,6 +499,10 @@ val array_mem_witn :
     and returns corresponding [string_of_witness_kind] if so.
 *)
 
+val make_key :
+  Gwdb.base -> (iper, iper, istr) Def.gen_person -> string * string * int
+(** make a tuple (first_name, surname, occ) apply Name.lower *)
+
 val name_key : Gwdb.base -> string -> string
 (** [name_key base name] is [name],
     with particles put at the end of the string instead of the beginning.


### PR DESCRIPTION
linked pages computation is potentially expensive.
performing this computation once at the same time as update_nldb, and caching the result is proposed in this PR.
Update of the cache, similar to update_nldb is proposed when pnoc is changed.
This work is a DRAFT proposed for review
