### PR TITLE
new reorg structure; GWPARAM handles folder access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ uninstall: ## Uninstall geneweb using dune
 distrib: info ## Build the project and copy what is necessary for distribution
 	@$(MAKE) --no-print-directory patch_files generated
 	@printf "\n\033[1;1mBuilding executables.\n\033[0m"
-	@$(BUILD) || { $(UNPATCH) && exit 1; }
+	@$(call unpatch_after, $(BUILD))
 	@printf "Done."
 	@$(RM) -r $(DISTRIB_DIR)
 	@printf "\n\033[1;1mCreating distribution directory\033[0m\n"

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ unpatch_files:
 BUILD = dune build -p geneweb --profile $(DUNE_PROFILE)
 UNPATCH = $(MAKE) --no-print-directory unpatch_files
 
+unpatch_after = (($(1) && $(UNPATCH)) || ($(UNPATCH) && false))
+
 info:
 	@printf "Building \033[1;1mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n"
 	@printf "Repository \033[1;1m$(SOURCE)\033[0m. Branch \033[1;1m$(BRANCH)\033[0m. "
@@ -132,27 +134,27 @@ fmt build gwd install uninstall: info patch_files generated
 fmt: ## Format Ocaml code
 ifneq ($(OS_TYPE),Win)
 	@printf "\n\033[1;1mOcamlformat\033[0m\n"
-	dune build @fmt --auto-promote ; $(UNPATCH)
+	$(call unpatch_after, dune build @fmt --auto-promote)
 endif
 
 # [BEGIN] Installation / Distribution section
 
 build: ## Build the geneweb package (libraries and binaries)
 	@printf "\n\033[1;1mBuilding executables\033[0m\n"
-	@$(BUILD) ; $(UNPATCH)
+	@$(call unpatch_after, $(BUILD))
 	@printf "Done."
 
 gwd: ## Build ondy gwd/gwc executables
 	@printf "\n\033[1;1mBuilding only gwd and gwc executables\033[0m\n"
-	@dune build bin/gwd bin/gwc --profile $(DUNE_PROFILE) ; $(UNPATCH)
+	@$(call unpatch_after, dune build bin/gwd bin/gwc --profile $(DUNE_PROFILE))
 	@printf "Done."
 
 install: ## Install geneweb using dune
-	dune build @install --profile $(DUNE_PROFILE) ; $(UNPATCH)
+	$(call unpatch_after, dune build @install --profile $(DUNE_PROFILE))
 	dune install
 
 uninstall: ## Uninstall geneweb using dune
-	dune build @install --profile $(DUNE_PROFILE) ; $(UNPATCH)
+	$(call unpatch_after, dune build @install --profile $(DUNE_PROFILE))
 	dune uninstall
 
 distrib: info ## Build the project and copy what is necessary for distribution

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,6 @@ endif
 	  fi; \
 	done
 	@printf "Done.\n\n\033[1;1mDistribution complete.\033[0m\n"
-	@$(UNPATCH)
 	@printf "You can launch Geneweb with “\033[1;1mcd $(DISTRIB_DIR)\033[0m” followed by “\033[1;1mgw/gwd$(EXT)\033[0m”.\n"
 .PHONY: fmt install uninstall distrib
 

--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -1,4 +1,3 @@
-open Geneweb
 open Gwdb
 
 let bname = ref ""
@@ -19,7 +18,7 @@ let write_cache_file bname fname list =
   in
   let fname =
     Filename.concat
-      (Util.base_path [] (bname ^ ".gwb"))
+      (!Geneweb.GWPARAM.bpath bname)
       (bname ^ "_" ^ fname ^ "_cache.txt")
   in
   Printf.printf "Write to : %s\n" fname;

--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -157,21 +157,21 @@ let names_all base bname fname =
 
 let speclist =
   [
-    ("-fn", Arg.Set fnames, "produce first names");
-    ("-sn", Arg.Set snames, "produce surnames");
-    ("-al", Arg.Set alias, "produce aliases");
-    ("-qu", Arg.Set qual, "produce qualifiers");
-    ("-pl", Arg.Set places, "produce places");
-    ("-all", Arg.Set all, "produce all");
-    ("-fna", Arg.Set fname_alias, "add first names aliases");
-    ("-prog", Arg.Set prog, "show progress bar");
+    ("-fn", Arg.Set fnames, " produce first names");
+    ("-sn", Arg.Set snames, " produce surnames");
+    ("-al", Arg.Set alias, " produce aliases");
+    ("-qu", Arg.Set qual, " produce qualifiers");
+    ("-pl", Arg.Set places, " produce places");
+    ("-all", Arg.Set all, " produce all");
+    ("-fna", Arg.Set fname_alias, " add first names aliases");
+    ("-prog", Arg.Set prog, " show progress bar");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun i = bname := i
 
 let usage =
-  "Usage: cache_files [-fn] [-sn] [-al] [-qu] [-pl] [-all] [-fna] [-prog] base\n\
-  \ cd bases; before running cache_files."
+  "Usage: cache_files [options] base\n cd bases; before running cache_files."
 
 let main () =
   Arg.parse speclist anonfun usage;

--- a/bin/connex/connex.ml
+++ b/bin/connex/connex.ml
@@ -240,29 +240,30 @@ let speclist =
   [
     ( "-gwd_p",
       Arg.Int (fun x -> gwd_port := x),
-      "<number>: Specify the port number of gwd (default = "
+      "<number> Specify the port number of gwd (default = "
       ^ string_of_int !gwd_port ^ "); > 1024 for normal users." );
     ( "-server",
       Arg.String (fun x -> server := x),
-      "<string>: Name of the server (default is 127.0.0.1)." );
-    ("-a", Arg.Set all, ": all connex components");
-    ("-s", Arg.Set statistics, ": produce statistics");
-    ("-d", Arg.Int (fun x -> detail := x), "<int> : detail for this length");
+      "<string> Name of the server (default is 127.0.0.1)." );
+    ("-a", Arg.Set all, " all connex components");
+    ("-s", Arg.Set statistics, " produce statistics");
+    ("-d", Arg.Int (fun x -> detail := x), "<int> detail for this length");
     ( "-i",
       Arg.String (fun x -> ignore := x :: !ignore),
-      "<file> : ignore this file" );
-    ("-bf", Arg.Clear ignore_files, ": by origin files");
+      "<file> ignore this file" );
+    ("-bf", Arg.Clear ignore_files, " by origin files");
     ( "-del",
       Arg.Int (fun i -> ask_for_delete := i),
-      "<int> : ask for deleting branches whose size <= that value" );
+      "<int> ask for deleting branches whose size <= that value" );
     ( "-cnt",
       Arg.Int (fun i -> cnt_for_delete := i),
-      "<int> : delete cnt branches whose size <= -del value" );
+      "<int> delete cnt branches whose size <= -del value" );
     ( "-exact",
       Arg.Set exact,
-      ": delete only branches whose size strictly = -del value" );
-    ("-o", Arg.String (fun x -> output := x), "<file> : output to this file");
+      " delete only branches whose size strictly = -del value" );
+    ("-o", Arg.String (fun x -> output := x), "<file> output to this file");
   ]
+  |> List.sort compare |> Arg.align
 
 let main () =
   Arg.parse speclist (fun s -> bname := s) usage;

--- a/bin/consang/consang.ml
+++ b/bin/consang/consang.ml
@@ -11,12 +11,13 @@ let speclist =
     ("-q", Arg.Unit (fun () -> verbosity := 1), " quiet mode");
     ("-qq", Arg.Unit (fun () -> verbosity := 0), " very quiet mode");
     ("-fast", Arg.Set fast, " faster, but use more memory");
-    ("-scratch", Arg.Set scratch, ": from scratch");
+    ("-scratch", Arg.Set scratch, " from scratch");
     ( "-mem",
       Arg.Set Outbase.save_mem,
-      ": Save memory, but slower when rewritting database" );
-    ("-nolock", Arg.Set Lock.no_lock_flag, ": do not lock database.");
+      " Save memory, but slower when rewritting database" );
+    ("-nolock", Arg.Set Lock.no_lock_flag, " do not lock database.");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun s =
   if !fname = "" then fname := s

--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -187,9 +187,10 @@ let speclist =
     ("-person-key", Arg.Set key, " missing doc");
     ( "-index",
       Arg.Set index,
-      " rebuild index. It is automatically enable by any other option." );
+      " rebuild index. It is automatically enabled by any other option." );
     ("-invalid-utf8", Arg.Set invalid_utf8, " missing doc");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun i = bname := i
 let usage = "Usage: " ^ Sys.argv.(0) ^ " [OPTION] base"

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3181,7 +3181,7 @@ let out_file = ref "a"
 
 let speclist =
   [ ( "-o", Arg.String (fun s -> out_file := s)
-    , "<file> Output database (default: \"a\")." )
+    , "<file> Output database (default: \"a\"). Alphanumerics and -" )
   ; ( "-f", Arg.Set force
     , " Remove database if already existing" )
   ; ( "-log", Arg.String (fun s -> log_oc := open_out s)
@@ -3280,6 +3280,13 @@ let errmsg = "Usage: ged2gwb [<ged>] [options] where options are:"
 
 let main () =
   Arg.parse speclist anonfun errmsg;
+  if not (Mutil.good_name (Filename.basename !out_file)) then (
+    (* Util.transl conf not available !*)
+    Printf.eprintf "The database name \"%s\" contains a forbidden character.\n"
+      !out_file;
+    Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -\n";
+    flush stderr;
+    exit 2);
   Secure.set_base_dir (Filename.dirname !out_file);
   let arrays = make_arrays !in_file in
   Gc.compact ();

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3183,18 +3183,18 @@ let speclist =
   [ ( "-o", Arg.String (fun s -> out_file := s)
     , "<file> Output database (default: \"a\")." )
   ; ( "-f", Arg.Set force
-    , "Remove database if already existing" )
+    , " Remove database if already existing" )
   ; ( "-log", Arg.String (fun s -> log_oc := open_out s)
     , "<file> Redirect log trace to this file." )
   ; ( "-lf", Arg.Set lowercase_first_names
-    , "Convert first names to lowercase letters, with initials in uppercase." )
+    , " Convert first names to lowercase letters, with initials in uppercase." )
   ; ( "-trackid", Arg.Set track_ged2gw_id,
-      "Print gedcom id to gw id matches." )
+      " Print gedcom id to gw id matches." )
   ; ( "-ls", Arg.Unit (fun () -> case_surnames := LowerCase)
-    , "Convert surnames to lowercase letters, with initials in uppercase. \
+    , " Convert surnames to lowercase letters, with initials in uppercase. \
        Try to keep lowercase particles." )
   ; ( "-us", Arg.Unit (fun () -> case_surnames := UpperCase)
-    , "Convert surnames to uppercase letters." )
+    , " Convert surnames to uppercase letters." )
   ; ( "-fne"
     , Arg.String begin fun s ->
         if String.length s = 2
@@ -3206,29 +3206,30 @@ let speclist =
        is considered to be the usual first name: e.g. -fne '\"\"' or \
        -fne \"()\"." )
   ; ( "-efn", Arg.Set extract_first_names
-    , "When creating a person, if the GEDCOM first name part holds several \
+    , " When creating a person, if the GEDCOM first name part holds several \
        names, the first of this names becomes the person \"first name\" and \
        the complete GEDCOM first name part a \"first name alias\"." )
   ; ( "-no_efn", Arg.Clear extract_first_names,
-      "Cancels the previous option." )
+      " Cancels the previous option." )
   ; ( "-epn", Arg.Set extract_public_names
-    , "When creating a person, if the GEDCOM first name part looks like a \
-       public name, i.e. holds:\n\
-       * a number or a roman number, supposed to be a number of a nobility title,\n\
-       * one of the words: \"der\", \"den\", \"die\", \"el\", \"le\", \"la\", \"the\", \
+    , " When creating a person, if the GEDCOM first name part looks like a \
+       public name, i.e. holds either \
+       a number or a roman number, supposed to be a number of a nobility title, \
+       or one of the words: \
+       \"der\", \"den\", \"die\", \"el\", \"le\", \"la\", \"the\", \
        supposed to be the beginning of a qualifier, \
        then the GEDCOM first name part becomes the person \"public name\" \
        and its first word his \"first name\"." )
   ; ( "-no_epn", Arg.Clear extract_public_names
-    , "Cancels the previous option." )
+    , " Cancels the previous option." )
   ; ( "-no_pit", Arg.Set no_public_if_titles
-    , "Do not consider persons having titles as public")
+    , " Do not consider persons having titles as public")
   ; ( "-tnd", Arg.Set try_negative_dates
-    , "Set negative dates when inconsistency (e.g. birth after death)" )
+    , " Set negative dates when inconsistency (e.g. birth after death)" )
   ; ( "-no_nd", Arg.Set no_negative_dates
-    , "Don't interpret a year preceded by a minus sign as a negative year" )
-  ; ( "-nc", Arg.Clear do_check, "No consistency check" )
-  ; ( "-nopicture", Arg.Set no_picture, "Don't extract individual picture." )
+    , " Don't interpret a year preceded by a minus sign as a negative year" )
+  ; ( "-nc", Arg.Clear do_check, " No consistency check" )
+  ; ( "-nopicture", Arg.Set no_picture, " Don't extract individual picture." )
   ; ( "-udi"
     , Arg.String begin fun s ->
         match String.index_opt s '-' with
@@ -3241,21 +3242,22 @@ let speclist =
           dead_years := b ;
         | None -> raise (Arg.Bad "bad parameter for -udi")
       end
-    , "x-y Set the interval for persons whose death part is undefined:\n\
-       - if before x years, they are considered as alive\n\
-       - if after y year, they are considered as death\n\
-       - between x and y year, they are considered as \"don't know\"\n\
-       Default x is " ^ string_of_int !alive_years ^ " and y is " ^ string_of_int !dead_years)
+    , "x-y Set the interval for persons whose death part is undefined: \
+       If before x years, they are considered as alive. \
+       If after y year, they are considered as death. \
+       Between x and y year, they are considered as \"don't know\". \
+       Default x is " ^ string_of_int !alive_years ^ " \
+       Default y is " ^ string_of_int !dead_years)
   ; ( "-uin", Arg.Set untreated_in_notes
-    , "Put untreated GEDCOM tags in notes" )
+    , " Put untreated GEDCOM tags in notes" )
   ; ( "-ds", Arg.Set_string default_source
-    , "Set the source field for persons and families without source data" )
+    , " Set the source field for persons and families without source data" )
   ; ( "-dates_dm", Arg.Unit (fun () -> month_number_dates := DayMonthDates)
-    ,"Interpret months-numbered dates as day/month/year" )
+    ," Interpret months-numbered dates as day/month/year" )
   ; ( "-dates_md", Arg.Unit (fun () -> month_number_dates := MonthDayDates)
-    , "Interpret months-numbered dates as month/day/year" )
+    , " Interpret months-numbered dates as month/day/year" )
   ; ( "-rs_no_mention", Arg.Unit (fun () -> relation_status := NoMention)
-    , "Force relation status to NoMention (default is Married)" )
+    , " Force relation status to NoMention (default is Married)" )
   ; ( "-charset"
     , Arg.String begin function
         | "ANSEL" -> charset_option := Some Ansel
@@ -3263,7 +3265,7 @@ let speclist =
         | "MSDOS" -> charset_option := Some Msdos
         | _ -> raise (Arg.Bad "bad -charset value")
       end
-    , "[ANSEL|ASCII|MSDOS] Force given charset decoding, \
+    , " [ANSEL|ASCII|MSDOS] Force given charset decoding, \
        overriding the possible setting in GEDCOM" )
   ; ( "-particles"
     , Arg.String (fun s -> particles := Mutil.input_particles s)

--- a/bin/gwb2ged/gwb2ged.ml
+++ b/bin/gwb2ged/gwb2ged.ml
@@ -3,7 +3,7 @@ let with_indexes = ref false
 let speclist opts =
   ("-indexes", Arg.Set with_indexes, " export indexes in gedcom")
   :: Gwexport.speclist opts
-  |> Arg.align
+  |> List.sort compare |> Arg.align
 
 let main () =
   let opts = ref Gwexport.default_opts in

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -160,10 +160,10 @@ let main () =
   Arg.parse speclist anonfun errmsg;
   if not (Mutil.good_name (Filename.basename !out_file)) then (
     (* Util.transl conf not available !*)
-    Printf.eprintf "The database name \"%s\" contains a forbidden character./n"
+    Printf.eprintf "The database name \"%s\" contains a forbidden character.\n"
       !out_file;
-    Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -";
-    flush stdout;
+    Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -\n";
+    flush stderr;
     exit 2);
   Secure.set_base_dir (Filename.dirname !out_file);
   let gwo = ref [] in
@@ -188,7 +188,7 @@ let main () =
       Printf.eprintf
         "The database \"%s\" already exists. Use option -f to overwrite it."
         !out_file;
-      flush stdout;
+      flush stderr;
       exit 2);
     Lock.control (Mutil.lock_file !out_file)
       false ~onerror:Lock.print_error_and_exit (fun () ->
@@ -199,7 +199,6 @@ let main () =
         let next_family_fun = next_family_fun_templ (List.rev !gwo) in
         if Db1link.link next_family_fun bdir then ()
         else (
-          flush stderr;
           Printf.eprintf "*** database not created\n";
           flush stderr;
           exit 2)))

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -221,7 +221,7 @@ let main () =
       (fun () ->
         let next_family_fun = next_family_fun_templ (List.rev !gwo) in
         if Db1link.link next_family_fun bdir then (
-          (*Geneweb.Util.print_default_gwf_file bname;*)
+          Geneweb.Util.print_default_gwf_file bname;
           if !kill_gwo then
             List.iter
               (fun (x, _separate, _bnotes, _shift) ->

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -106,7 +106,7 @@ let speclist =
   [
     ( "-bnotes",
       Arg.Set_string bnotes,
-      "[drop|erase|first|merge] Behavior for base notes of the next file. \
+      " [drop|erase|first|merge] Behavior for base notes of the next file. \
        [drop]: dropped. [erase]: erase the current content. [first]: dropped \
        if current content is not empty. [merge]: concatenated to the current \
        content. Default: " ^ !bnotes ^ "" );

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2092,7 +2092,7 @@ let main () =
   in
   Geneweb.GWPARAM.gwd_cmd := gwd_cmd;
   List.iter register_plugin !plugins ;
-  !GWPARAM.init () ;
+  GWPARAM.init "" ;
   cache_lexicon () ;
   List.iter
     (fun dbn ->

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1503,7 +1503,7 @@ let image_request conf script_name env =
         if fname.[0] = '/' then String.sub fname 1 (String.length fname - 1)
         else fname
       in
-      let `Path fname = Image.path_of_filename fname in
+      let `Path fname = Image.path_of_filename conf fname in
       let _ = ImageDisplay.print_image_file conf fname in true
   | _ ->
       let s = script_name in
@@ -1514,7 +1514,7 @@ let image_request conf script_name env =
         (* empeche d'avoir des images qui se trouvent dans le dossier   *)
         (* image. Si on ne fait pas de basename, alors ça marche.       *)
         (* let fname = Filename.basename fname in *)
-        let `Path fname = Image.path_of_filename fname in
+        let `Path fname = Image.path_of_filename conf fname in
         let _ = ImageDisplay.print_image_file conf fname in true
       else false
 

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -314,7 +314,7 @@ let try_plugin list conf base_name m =
   List.exists fn (Hashtbl.find_all GwdPlugin.ht m)
 
 let w_lock ~onerror fn conf (base_name : string option) =
-  let bfile = Util.bpath (conf.bname ^ ".gwb") in
+  let bfile = !GWPARAM.bpath conf.bname in
   Lock.control
     (Mutil.lock_file bfile) true
     ~onerror:(fun () -> onerror conf base_name)
@@ -370,11 +370,11 @@ let treat_request =
   fun conf ->
   let bfile =
     if conf.bname = "" then None
-    else
-      let bfile = Util.bpath (conf.bname ^ ".gwb") in
+    else (
+      let bfile = Filename.concat (Secure.base_dir ()) (conf.bname ^ ".gwb") in
       if Sys.file_exists bfile
       then Some bfile
-      else None
+      else None)
   in
   let process () =
   if conf.wizard
@@ -828,4 +828,9 @@ let treat_request =
   else process ()
 
 let treat_request conf =
+  GWPARAM.init conf.bname ;
+  (* TODO verify if we need init_etc here *)
+  let conf = { conf with
+    base_env = Util.read_base_env conf.bname conf.gw_prefix conf.debug }
+  in
   try treat_request conf with Update.ModErr _ -> Output.flush conf

--- a/bin/gwd/robot.ml
+++ b/bin/gwd/robot.ml
@@ -66,7 +66,7 @@ let output_excl oc xcl =
   output_value oc (xcl : excl)
 
 let robot_excl () =
-  let fname = SrcfileDisplay.adm_file "robot" in
+  let fname = !GWPARAM.adm_file "robot" in
   let xcl =
     match try Some (Secure.open_in_bin fname) with _ -> None with
     | Some ic ->

--- a/bin/gwdiff/gwdiff.ml
+++ b/bin/gwdiff/gwdiff.ml
@@ -540,23 +540,24 @@ let speclist =
         (fun s ->
           p1_fn := s;
           arg_state := ASwaitP1occ),
-      "<fn> <occ> <sn> : (mandatory) defines starting person in base1" );
+      "<fn> <occ> <sn> (mandatory) defines starting person in base1" );
     ( "-2",
       Arg.String
         (fun s ->
           p2_fn := s;
           arg_state := ASwaitP2occ),
-      "<fn> <occ> <sn> : (mandatory) defines starting person in base2" );
-    ("-ad", Arg.Set ad_mode, ": checks descendants of all ascendants ");
-    ("-d", Arg.Set d_mode, ": checks descendants (default)");
+      "<fn> <occ> <sn> (mandatory) defines starting person in base2" );
+    ("-ad", Arg.Set ad_mode, " checks descendants of all ascendants ");
+    ("-d", Arg.Set d_mode, " checks descendants (default)");
     ( "-html",
       Arg.String
         (fun s ->
           html := true;
           root := s),
-      "<root>: HTML format used for report" );
-    ("-mem", Arg.Set mem, ": save memory space, but slower");
+      "<root> HTML format used for report" );
+    ("-mem", Arg.Set mem, " save memory space, but slower");
   ]
+  |> List.sort compare |> Arg.align
 
 let anonfun s =
   match !arg_state with

--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -66,7 +66,7 @@ let speclist c =
        multiple times. Key format is \"First Name.occ SURNAME\"" );
     ( "-c",
       Arg.Int (fun s -> c := { !c with censor = s }),
-      "<NUM>: when a person is born less than <num> years ago, it is not \
+      "<NUM> when a person is born less than <num> years ago, it is not \
        exported unless it is Public. All the spouses and descendants are also \
        censored." );
     ( "-charset",
@@ -83,7 +83,7 @@ let speclist c =
                 | "UTF-8" -> Utf8
                 | _ -> raise (Arg.Bad "bad -charset value"));
             }),
-      "[ASCII|ANSEL|ANSI|UTF-8] set charset; default is UTF-8" );
+      " [ASCII|ANSEL|ANSI|UTF-8] set charset; default is UTF-8" );
     ( "-d",
       Arg.Int (fun s -> c := { !c with desc = Some s }),
       "<N> maximum generation of the root's descendants." );

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -5,7 +5,7 @@ let isolated = ref false
 let speclist opts =
   ( "-odir",
     Arg.String (fun s -> GwuLib.out_dir := s),
-    "<dir>  create files from original name in directory (else on -o file)" )
+    "<dir> create files from original name in directory (else on -o file)" )
   :: ( "-isolated",
        Arg.Set isolated,
        " export isolated persons (work only if export all database)." )
@@ -18,7 +18,7 @@ let speclist opts =
        " raw output (without possible utf-8 conversion)" )
   :: ( "-sep",
        Arg.String (fun s -> GwuLib.separate_list := s :: !GwuLib.separate_list),
-       "<1st_name.num surname> To use together with the option \"-odir\": \
+       " <1st_name.num surname> To use together with the option \"-odir\": \
         separate this person and all his ancestors and descendants sharing the \
         same surname. All the concerned families are displayed on standard \
         output instead of their associated files. This option can be used \
@@ -36,7 +36,7 @@ let speclist opts =
        ^ string_of_int !GwuLib.sep_limit
        ^ ". The present option changes this limit." )
   :: Gwexport.speclist opts
-  |> Arg.align
+  |> List.sort compare |> Arg.align
 
 let main () =
   let opts = ref Gwexport.default_opts in

--- a/bin/setup/lang/gwc.htm
+++ b/bin/setup/lang/gwc.htm
@@ -6,14 +6,11 @@
   <meta charset="utf-8">
   <meta name="robots" content="none">
   <link rel="shortcut icon" href="images/favicon_gwsetup.png">
-
   <title>[Import a GeneWeb file]
 </title>
 %fsetup.css;
 </head>
-
 <body %Vbody_prop;>
-
 <div style="background:url('images/gwlogo.png') no-repeat left top; text-align:center; height:95px; line-height:95px; color:#2f6400;">
 <h1 style="margin:0;">[Import a GeneWeb file]</h1>
 </div>
@@ -55,6 +52,20 @@ l be insufficient to change the drive letter (C: -> D:), but you can do this dir
 ectly in the url in your navigator.
 %)
 </td></tr>
+
+</table>
+</span>
+<p>
+<li>
+[Enter the name of the folder holding databases.]
+<p>
+<span style="font-size:80%%">
+<table class="setup">
+<tr align=left><td>
+<input name=bd size=30 placeholder="." value=".">
+[If you write nothing, it will be taken as "."]
+</td></tr>
+</table>
 </table>
 </span>
 <p>
@@ -102,6 +113,23 @@ ectly in the url in your navigator.
 </tr>
 </table>
 <p>
+<p>
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=gwo value="on">   </td>
+<td>[Kill .gwo files after base creation.]
+</td>
+</tr>
+</table>
+<p>
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=reorg value="on">   </td>
+<td>[Reorg mode.]
+</td>
+</tr>
+</table>
+<p>
 <li>
 [Then click on this button][:]
 <input type=submit value="Ok">
@@ -109,4 +137,3 @@ ectly in the url in your navigator.
 </form>
 </body>
 </html>
-

--- a/bin/setup/lang/gwf_1.htm
+++ b/bin/setup/lang/gwf_1.htm
@@ -66,7 +66,8 @@ database.
 %)
 </td>
 </tr>
-<tr align=left><td align=center>
+<tr align=left>
+<td align=left>
 <p>
 <table style="border:1px solid">
 <tr align=left>
@@ -236,7 +237,7 @@ value='style="background-color:#CC0000; text:#FFFFFF; link:#FFFF00; vlink:#00FFF
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <select name=default_lang>
 <option value=""%Edefault_lang=;>-
 <option value="af"%Edefault_lang=af;>%Laf;
@@ -286,7 +287,7 @@ ult, it is 8 generations, but you can indicate a different value here.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_anc_level value="%Vmax_anc_level;"
+<td align=left><input name=max_anc_level value="%Vmax_anc_level;"
 size=5></td>
 </tr>
 </table>
@@ -304,7 +305,7 @@ fault, it is 12 generations, but you can indicate a different value here.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_desc_level value="%Vmax_desc_level;"
+<td align=left><input name=max_desc_level value="%Vmax_desc_level;"
 size=5></td>
 </tr>
 </table>
@@ -322,7 +323,7 @@ When ancestors are displayed by tree, limit the number of displayed generations.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_anc_tree value="%Vmax_anc_tree;"
+<td align=left><input name=max_anc_tree value="%Vmax_anc_tree;"
 size=5></td>
 </tr>
 </table>
@@ -340,7 +341,7 @@ s. By default, it is 4 generations, but you can indicate a different value here.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_desc_tree value="%Vmax_desc_tree;"
+<td align=left><input name=max_desc_tree value="%Vmax_desc_tree;"
 size=5></td>
 </tr>
 </table>
@@ -360,7 +361,7 @@ start empty.
 %)
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=history value="yes"%Chistory=yes;>[yes|no]0
 <input type=radio name=history value="no"%Chistory=no;>[yes|no]1
 </tr>
@@ -383,7 +384,7 @@ send image" which are installed as a standard name in a standard place.
 %)
 </tr>
 <tr align=left>
-<td align=center><input name=images_path value="%Vimages_path;"
+<td align=left><input name=images_path value="%Vimages_path;"
 size=50></td>
 </tr>
 </table>
@@ -399,7 +400,7 @@ The advanced request allows to make researches in the data base. As it is very i
 ncomplete, it is hidden by default. Select "no" below to set it.
 %)
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=hide_advanced_request
 value="yes"%Chide_advanced_request=yes;>[yes|no]0
 <input type=radio name=hide_advanced_request
@@ -429,7 +430,7 @@ If this area is empty, everybody is a "friend". You can leave this area empty if
 </td>
 </tr>
 <tr align=left>
-<td align=center><input name=friend_passwd value="%Vfriend_passwd;"
+<td align=left><input name=friend_passwd value="%Vfriend_passwd;"
 size=30></td>
 </tr>
 </table>
@@ -451,7 +452,7 @@ If this area is empty, everybody is a "wizard". You can leave this area empty if
 </td>
 </tr>
 <tr align=left>
-<td align=center><input name=wizard_passwd value="%Vwizard_passwd;"
+<td align=left><input name=wizard_passwd value="%Vwizard_passwd;"
 size=30></td>
 </tr>
 </table>
@@ -474,7 +475,7 @@ t is accessible to Internet, to avoid that "wizards" make changes which would be
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=wizard_just_friend
  value="yes"%Cwizard_just_friend=yes;>[yes|no]0
 <input type=radio name=wizard_just_friend
@@ -498,7 +499,7 @@ actly, the persons of less than one century.
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=hide_private_names
  value="yes"%Chide_private_names=yes;>[yes|no]0
 <input type=radio name=hide_private_names
@@ -525,7 +526,7 @@ ropriate file name.
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=can_send_image
  value="yes"%Ccan_send_image=yes;>[yes|no]0
 <input type=radio name=can_send_image
@@ -554,7 +555,7 @@ w name to use with the same clickable request.
 </td>
 </tr>
 <tr align=left>
-<td align=center><input name=renamed value="%Vrenamed;" size=30></td>
+<td align=left><input name=renamed value="%Vrenamed;" size=30></td>
 </tr>
 </table>
 <p>
@@ -574,6 +575,20 @@ an use HTML tags.
 </td>
 </tr>
 </table>
+<p>
+<table style="border:1px solid" width="100%%">
+<tr align=left>
+<td>
+[check this box if creating a config file in reorg mode]
+</td>
+</tr>
+<tr align=left>
+<td>
+<input type="checkbox" name="reorg" id="reorg">[Reorg mode]
+</td>
+</tr>
+</table>
+
 </table></dl>
 <p>
 <li>

--- a/bin/setup/lang/lexicon.txt
+++ b/bin/setup/lang/lexicon.txt
@@ -56,6 +56,21 @@ sv: af=afrikaans|bg=bulgariska|br=bretonska|ca=katalanska|co=korsikanska|cs=tjec
 tr: af=Afrikaans|bg=Bulgarca|br=Bretonca|ca=Katalanca|co=Korsikaca|cs=Çekçe|da=Danca|de=Almanca|en=İngilizce|eo=Esperanto|es=İspanyolca|et=Estonca|fi=Fince|fr=Fransızca|he=İbranice|is=İzlandaca|it=İtalyanca|lv=Letonca|nl=Hollandaca|no=Norveççe|oc=Oksitanca|pl=Lehçe|pt=Portekizce|pt-br=Brezilya Portekizcesi|ro=Romence|ru=Rusça|sk=Slovakça|sl=Slovence|sv=İsveççe|tr=Türkçe|zh=Çince
 zh: af=南非語|bg=保加利亚语|br=布列塔尼语|ca=加泰罗尼亚语|co=科西嘉岛|cs=捷克语|da=丹麦语|de=德语|en=英语|eo=世界语|es=西班牙语|et=爱沙尼亚语|fi=芬兰语|fr=法语|he=希伯来语|is=冰岛语|it=意大利语|lv=拉脱维亚语|nl=荷蘭語|no=挪威语|oc=奥克语|pl=波兰语|pt=葡萄牙語|pt-br= 巴西葡萄牙语|ro=羅馬尼亞語|ru=俄语|sk=斯洛伐克语|sl=斯洛文尼亚语|sv= 瑞典語|tr=土耳其|zh=中文
 
+    Enter the name of the folder holding databases.
+en: Enter the name of the folder holding databases.
+fr: Entrez le nom du dossier contenant les bases.
+
+    If you write nothing, it will be taken as "."
+en: If you write nothing, it will be taken as "."
+fr: Si vous mettez rien, la valeur par défaut sera "."
+
+    Reorg mode.
+en: Reorg mode
+fr: Mode reorg
+
+    Kill .gwo files after base creation.
+en: Kill .gwo files after base creation.
+fr: Détruire les fichiers .gwo après création de la base
     "first names enclosed": the -fne option must be followed by a two characters string "be". When creating a person, if the GEDCOM first name part holds a part between 'b' (any character) and 'e' (any character), it is considered to be the usual first name: e.g. -fne "\\" or -fne "()".
 aa: ged2gwb.htm
 co: L’ozzione « first names enclosed » deve esse seguitata da una catena di dui caratteri di u furmatu "pf". Durante a creazione d’una persona, s’è una parte di a catena <i>nome</i> di u schedariu GEDCOM <b>p</b>rincipia da u caratteru 'p' è si <b>f</b>inisce da u caratteru 'f', sta parte serà impiegata per u nome usuale. Esempii : <span  style="font-family: monospace">-fne "\\"</span> o <span style="font-family: monospace"> -fne "()"</span>.

--- a/bin/setup/lang/simple.htm
+++ b/bin/setup/lang/simple.htm
@@ -25,6 +25,14 @@
 <p>
 <input name="o" size="30" value="base">
 <p>
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=reorg value="on">   </td>
+<td>[Reorg mode.]
+</td>
+</tr>
+</table>
+<p>
 <li>
 [Then click on this button][:]
 <p>

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -901,30 +901,6 @@ let setup_gen conf =
     Some fname -> print_file conf (basename fname)
   | _ -> error conf "request needs \"v\" parameter"
 
-let print_default_gwf_file conf =
-  let gwf =
-    ["access_by_key=yes"; "disable_forum=yes"; "hide_private_names=no";
-     "use_restrict=no"; "show_consang=yes"; "display_sosa=yes";
-     "place_surname_link_to_ind=yes"; "max_anc_level=8"; "max_anc_tree=7";
-     "max_desc_level=12"; "max_desc_tree=4"; "max_cousins=2000";
-     "max_cousins_level=5"; "latest_event=20"; "template=*"; "long_date=no";
-     "counter=no"; "full_siblings=yes"; "hide_advanced_request=no";
-     "perso_module_i=individu"; "perso_module_p=parents";
-     "perso_module_g=gr_parents"; "perso_module_u=unions";
-     "perso_module_f=fratrie"; "perso_module_r=relations";
-     "perso_module_c=chronologie"; "perso_module_n=notes";
-     "perso_module_s=sources"; "perso_module_a=arbres";
-     "perso_module_h=htrees"; "perso_module_d=data_3col";
-     "perso_module_l=ligne"; "p_mod="]
-  in
-  let bname = try List.assoc "o" conf.env with Not_found -> "" in
-  let dir = Sys.getcwd () in
-  let fname = Filename.concat dir (bname ^ ".gwf") in
-  if Sys.file_exists fname then ()
-  else
-    let oc = open_out fname in
-    List.iter (fun s -> Printf.fprintf oc "%s\n" s) gwf; close_out oc
-
 let simple conf =
   let ged =
     match p_getenv conf.env "anon" with
@@ -1022,7 +998,7 @@ let gwc conf =
   Printf.eprintf "\n";
   flush stderr;
   if rc > 1 then print_file conf "bso_err.htm"
-  else begin print_default_gwf_file conf; print_file conf "bso_ok.htm" end
+  else begin print_file conf "bso_ok.htm" end
 
 let gwdiff_check conf =
   print_file conf "bsi_diff.htm"
@@ -1624,7 +1600,7 @@ let ged2gwb conf =
   Printf.eprintf "\n";
   flush stderr;
   if rc > 1 then print_file conf "bso_err.htm"
-  else begin print_default_gwf_file conf; print_file conf "bso_ok.htm" end
+  else print_file conf "bso_ok.htm"
 
 let consang conf ok_file =
   let rc =

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -1943,20 +1943,23 @@ let usage =
   "Usage: " ^ Filename.basename Sys.argv.(0) ^ " [options] where options are:"
 let speclist =
   [("-bd", Arg.String (fun x -> base_dir := x),
-    "<dir>: Directory where the databases are installed.");
+    "<dir> Directory where the databases are installed.");
    ("-gwd_p", Arg.Int (fun x -> gwd_port := x),
-    "<number>: Specify the port number of gwd (default = " ^
+    "<number> Specify the port number of gwd (default = " ^
       string_of_int !gwd_port ^ "); > 1024 for normal users.");
-   ("-lang", Arg.String (fun x -> lang_param := x), "<string>: default lang");
-   ("-daemon", Arg.Set daemon, ": Unix daemon mode.");
+   ("-lang", Arg.String (fun x -> lang_param := x), "<string> default lang");
+   ("-daemon", Arg.Set daemon, " Unix daemon mode.");
    ("-p", Arg.Int (fun x -> port := x),
-    "<number>: Select a port number (default = " ^ string_of_int !port ^
+    "<number> Select a port number (default = " ^ string_of_int !port ^
     "); > 1024 for normal users.");
    ("-only", Arg.String (fun s -> only_file := s),
-    "<file>: File containing the only authorized address");
-   ("-gd", Arg.String (fun x -> setup_dir := x), "<string>: gwsetup directory");
+    "<file> File containing the only authorized address");
+   ("-gd", Arg.String (fun x -> setup_dir := x), "<string> gwsetup directory");
    ("-bindir", Arg.String (fun x -> bin_dir := x),
-    "<string>: binary directory (default = value of option -gd)")]
+    "<string> binary directory (default = value of option -gd)")
+  ]
+  |> List.sort compare |> Arg.align
+
 let anonfun s = raise (Arg.Bad ("don't know what to do with " ^ s))
 
 #ifdef UNIX

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -62,17 +62,17 @@
 %end;
 
 %let;portraits_store;
-  %if;(bvar.reorg="on")%base.name;.gwb%X;documents%X;portraits%nn;
+  %if;reorg;%base.name;.gwb%X;documents%X;portraits%nn;
   %else;images%X;%base.name;%nn;
   %end;%nn;
 %in;
 %let;saved_portraits_store;
-  %if;(bvar.reorg="on")%base.name;.gwb%X;documents%X;portraits%nn;
+  %if;reorg;%base.name;.gwb%X;documents%X;portraits%X;old%nn;
   %else;images%X;%base.name;%X;old%nn;
   %end;%nn;
 %in;
 %let;images_store;
-  %if;(bvar.reorg="on")%base.name;.gwb%X;documents%X;images%nn;
+  %if;reorg;%base.name;.gwb%X;documents%X;images%nn;
   %else;src%X;%base.name;%X;images%nn;
   %end;%nn;
 %in;

--- a/hd/etc/conf.txt
+++ b/hd/etc/conf.txt
@@ -56,7 +56,8 @@
 <section id="bvar-list" class="mt-3 mx-3">
   <h2>[*configuration parameters]</h2>
   <div>
-    <tt>%base.name;.gwf</tt><br>
+     Mode: <b>%if;reorg;Reorg%else;Classic%end;</b>[:]%sp;
+    <tt>%if;reorg;%base.name;.gwb%/etc%/%base.name;%else;%base.name;%end;.gwf</tt><br>
     %bvar.list;
   </div>
 </section>

--- a/hd/etc/css.txt
+++ b/hd/etc/css.txt
@@ -7,7 +7,7 @@
   li.parent { list-style-type: disc; list-style-image: url('%images_prefix;left.png'); }
 </style>
 %end;
-%if;(evar.templ="")
+%if;(e.templ!="templ")
   %if;(bvar.use_cdn="yes")
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"

--- a/hd/etc/modules/test.txt
+++ b/hd/etc/modules/test.txt
@@ -1,0 +1,3 @@
+<!-- test.txt 06/07/202 -->
+
+module gw/etc/modules/test.txt

--- a/hd/etc/perso_utils.txt
+++ b/hd/etc/perso_utils.txt
@@ -819,6 +819,8 @@
 %let;o13;%apply;nth_c%with;%p_mod;%and;%expr(27)%end;%in;
 %let;m14;%apply;nth_c%with;%p_mod;%and;%expr(28)%end;%in;
 %let;o14;%apply;nth_c%with;%p_mod;%and;%expr(29)%end;%in;
+%let;m15;%apply;nth_c%with;%p_mod;%and;%expr(30)%end;%in;
+%let;o15;%apply;nth_c%with;%p_mod;%and;%expr(31)%end;%in;
 
 %let;perso_module_a;arbres%in;
 %let;perso_module_c;chronologie%in;
@@ -833,11 +835,12 @@
 %let;perso_module_r;relations%in;
 %let;perso_module_s;sources%in;
 %let;perso_module_u;unions%in;
+%let;perso_module_t;test%in;
 
-%let;abc;acdfghilnprsu%in;
+%let;abc;acdfghilnprsut%in;
 %( compute nbr of entries in p_mod %)
 %reset_count;
-%for;i;0;14;
+%for;i;0;15;
   %let;mnb;%apply;mm(i)%in;
   %if;(mnb!="")%incr_count;%end;
 %end;

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -1712,6 +1712,7 @@ sv: aktivera/undertrycka
 tr: etkinleştir/kaldır
 
     suppress this path
+de: diesen Pfad verbergen
 en: suppress this path
 fr: supprimer ce chemin
 
@@ -2196,6 +2197,7 @@ tr: takma ad
 
 
     search type
+de: Suchmodus
 en: search type
 fr: mode de recherche
 
@@ -9254,10 +9256,12 @@ tr: hiyerarşik gezinmede bir giriş seçin
 zh: 在层次导航中选择一个条目
 
     high generation levels
+de: die Generationen höher als 12
 en: the generation levels higher then 12
 fr: les générations supérieures à 12
 
     high generation caution
+de: Vorsicht! Bei Auswahl höherer Generationen kann die Erzeugung mehrere Minuten dauern und zu Server-Timeouts führen.
 en: be carefull! Selecting high generation level may take minutes to generate and that can lead to server timeouts.
 fr: attention ! Sélectionner un nombre de génération élevé peut prendre plusieurs minutes à générer et entraîner des délais d'attente dépassé du serveur.
 
@@ -10047,7 +10051,7 @@ tr: eşler dizini (nesil yok)
 
     individual notes
 co: note individuale
-de: Hinweis zur Person
+de: Hinweise zur Person
 en: individual notes
 es: nota individual
 fi: merkintöjä henkilöstä
@@ -13098,14 +13102,17 @@ sv: summering av noteringar
 tr: notlar
 
     notes sources show help
+de: den Hintergrund zum Anzeigen der
 en: the background to show the
 fr: sur l’arrière-plan pour afficher les
 
     notes sources edit on date
+de: auf das Datum links zum Ändern dieses Ereignisses
 en: on the date on the left to modify this event
 fr: sur la date à gauche pour modifier cet événement
 
     note without title
+de: Notiz ohne Titel
 en: note without title
 fr: note sans titre
 

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -9256,7 +9256,7 @@ tr: hiyerarşik gezinmede bir giriş seçin
 zh: 在层次导航中选择一个条目
 
     high generation levels
-de: die Generationen höher als 12
+de: der Generationen höher als 12
 en: the generation levels higher then 12
 fr: les générations supérieures à 12
 

--- a/lib/GWPARAM.mli
+++ b/lib/GWPARAM.mli
@@ -3,6 +3,30 @@ val errors_undef : string list ref
 val errors_other : string list ref
 val set_vars : string list ref
 val gwd_cmd : string ref
+val cnt_dir : string ref
+val sock_dir : string ref
+val bases : string ref
+val reorg : bool ref
+val force : bool ref
+
+type init_s = { status : bool; bname : string }
+
+val init_done : init_s ref
+val config_reorg : string -> string
+
+type my_fun_2 = string -> string
+type my_fun_3 = string -> string -> string
+
+val config : my_fun_2 ref
+val cnt_d : my_fun_2 ref
+val adm_file : my_fun_2 ref
+val src_d : my_fun_2 ref
+val etc_d : my_fun_2 ref
+val config_d : my_fun_2 ref
+val lang_d : my_fun_3 ref
+val bpath : my_fun_2 ref
+val portraits_d : my_fun_2 ref
+val images_d : my_fun_2 ref
 
 type syslog_level =
   [ `LOG_EMERG  (** A panic condition. *)
@@ -24,19 +48,13 @@ type syslog_level =
 
 (* S: Move it to gwd_lib?  *)
 
-val init : (unit -> unit) ref
+val init : string -> unit
 (** Function called before gwd starts
     e.g. inititialise assets folders in Secure module. *)
 
-val base_path : (string list -> string -> string) ref
-(** [!base_path pref fname] function that returns a path to a file identified by [pref] [fname]
-    related to bases. [pref] is like a category for file [fname].
-
-    See {!val:GWPARAM.Default.base_path} for a concrete example.
-*)
-
-val bpath : (string -> string) ref
-(** Same as {!val:base_path}, but without the prefix (avoid unecessary empty list). *)
+val init_etc : string -> unit
+(** Function called before gwd starts
+    e.g. inititialise etc folders in reorg mode. *)
 
 val output_error :
   (?headers:string list ->
@@ -61,14 +79,34 @@ val wrap_output :
     Wrap the display of [title] and [content] in a defined template.
 *)
 
-module Default : sig
-  val init : unit -> unit
-  (** Inititialise assets directories for gwd server:
-      * current directory
-      *)
+val is_reorg_base : string -> bool
+val test_reorg : string -> unit
 
-  val base_path : string list -> string -> string
-  (** Use concatenation of [Secure.base_dir ()], [pref] and [fname] *)
+module Reorg : sig
+  val config : string -> string
+  val cnt_d : string -> string
+  val adm_file : string -> string
+  val portraits_d : string -> string
+  val src_d : string -> string
+  val etc_d : string -> string
+  val config_d : string -> string
+  val lang_d : string -> string -> string
+  val images_d : string -> string
+
+  val bpath : string -> string
+  (** [Filename.concat (Secure.base_dir ())] *)
+end
+
+module Default : sig
+  val config : string -> string
+  val cnt_d : string -> string
+  val adm_file : string -> string
+  val portraits_d : string -> string
+  val src_d : string -> string
+  val etc_d : string -> string
+  val config_d : string -> string
+  val lang_d : string -> string -> string
+  val images_d : string -> string
 
   val bpath : string -> string
   (** [Filename.concat (Secure.base_dir ())] *)

--- a/lib/cousins.ml
+++ b/lib/cousins.ml
@@ -333,26 +333,29 @@ let init_cousins_cnt conf base p =
   | Some t, Some d_t -> (t, d_t)
   | _, _ ->
       let _pnoc, _v1, t', d_t' =
+        let cous_cache_fname =
+          Filename.concat (!GWPARAM.bpath conf.bname) "cousins_cache"
+        in
         match List.assoc_opt "cache_cousins_tool" conf.Config.base_env with
         | Some "yes" -> (
             flush stderr;
             let pnoc, v1, t', d_t' =
-              Mutil.read_or_create_value "cousins_cache" (fun () ->
+              Mutil.read_or_create_value cous_cache_fname (fun () ->
                   build_tables key)
             in
             match (pnoc, v1) with
             | pnoc, v1 when pnoc = key && max_a_l <= v1 -> (pnoc, v1, t', d_t')
             | pnoc, v1 when pnoc = key ->
                 let _pnoc, _v1, t', d_t' =
-                  Mutil.read_or_create_value "cousins_cache" (fun () ->
+                  Mutil.read_or_create_value cous_cache_fname (fun () ->
                       build_tables key)
                 in
-                Sys.remove "cousins_cache";
-                Mutil.read_or_create_value "cousins_cache" ~magic:key (fun () ->
+                Sys.remove cous_cache_fname;
+                Mutil.read_or_create_value cous_cache_fname ~magic:key (fun () ->
                     expand_tables key v1 max_a_l t' d_t')
             | _ ->
-                Sys.remove "cousins_cache";
-                Mutil.read_or_create_value "cousins_cache" (fun () ->
+                Sys.remove cous_cache_fname;
+                Mutil.read_or_create_value cous_cache_fname (fun () ->
                     build_tables key))
         | _ ->
             flush stderr;

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -349,7 +349,7 @@ let output base =
      Mutil.rm tmp_names_inx;
      Mutil.rm tmp_names_acc;
      Mutil.rm tmp_strings_inx;
-     Mutil.remove_dir tmp_notes_d;
+     Mutil.rm_rf tmp_notes_d;
      raise e);
   close_base base;
   Mutil.rm (Filename.concat bname "base");
@@ -376,8 +376,14 @@ let output base =
     Sys.rename tmp_notes (Filename.concat bname "notes");
   if Sys.file_exists tmp_notes_d then (
     let notes_d = Filename.concat bname "notes_d" in
-    Mutil.remove_dir notes_d;
-    Sys.rename tmp_notes_d notes_d);
+    if Sys.file_exists notes_d then Mutil.rm_rf notes_d;
+    try Sys.rename tmp_notes_d notes_d
+    with e ->
+      trace
+        (Printf.sprintf "Error renaming %s to %s: %s. Retrying once."
+           tmp_notes_d notes_d (Printexc.to_string e));
+      Unix.sleepf 0.5;
+      Sys.rename tmp_notes_d notes_d);
   Mutil.rm (Filename.concat bname "patches");
   Mutil.rm (Filename.concat bname "patches~");
   Mutil.rm (Filename.concat bname "synchro_patches");

--- a/lib/history.ml
+++ b/lib/history.ml
@@ -8,12 +8,7 @@ open TemplAst
 open Util
 
 (* S: Fail if conf.bname is undefined? *)
-let file_name conf =
-  let bname =
-    if Filename.check_suffix conf.bname ".gwb" then conf.bname
-    else conf.bname ^ ".gwb"
-  in
-  Filename.concat (Util.bpath bname) "history"
+let file_name conf = Filename.concat (Util.bpath conf.bname) "history"
 
 (* Record history when committing updates *)
 

--- a/lib/image.ml
+++ b/lib/image.ml
@@ -1,10 +1,9 @@
 open Config
 open Gwdb
 
-let portrait_folder conf = Util.base_path [ "images" ] conf.bname
+let portrait_folder conf = !GWPARAM.portraits_d conf.bname
 
-let carrousel_folder conf =
-  Filename.concat (Util.base_path [ "src" ] conf.bname) "images"
+let carrousel_folder conf = !GWPARAM.images_d conf.bname
 
 (** [default_portrait_filename_of_key fn sn occ] is the default filename
  of the corresponding person's portrait. WITHOUT its file extenssion.
@@ -51,18 +50,10 @@ let full_portrait_path conf base p =
   | None ->
       None
 
-let source_filename conf src =
-  let fname1 = Filename.concat (carrousel_folder conf) src in
-  if Sys.file_exists fname1 then fname1
-  else
-    List.fold_right Filename.concat [ Secure.base_dir (); "src"; "images" ] src
-
-let path_of_filename src =
-  let fname1 =
-    List.fold_right Filename.concat [ Secure.base_dir (); "images" ] src
-  in
+let path_of_filename conf fname =
+  let fname1 = Filename.concat (!GWPARAM.images_d conf.bname) fname in
   if Sys.file_exists fname1 then `Path fname1
-  else `Path (Util.search_in_assets (Filename.concat "images" src))
+  else `Path (Util.search_in_assets (Filename.concat "images" fname))
 
 let png_size ic =
   let magic = really_input_string ic 4 in

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -8,9 +8,6 @@ val authorized_image_file_extension : string array
 val scale_to_fit : max_w:int -> max_h:int -> w:int -> h:int -> int * int
 (** [scale_to_fit ~max_w ~max_h ~w ~h] is the {(width, height)} of a proportionally scaled {(w, h)} rectangle so it can fit in a {(max_w, max_h)} rectangle *)
 
-val source_filename : config -> string -> string
-(** Returns path to the image file with the giving name in directory {i src/}. *)
-
 (* TODO this should be removed *)
 val default_portrait_filename : base -> person -> string
 (** [default_portrait_filename base p] is the default filename of [p]'s portrait. Without it's file extension.
@@ -23,7 +20,7 @@ val size_from_path : [ `Path of string ] -> (int * int, unit) result
     - Ok (width, height) of the file.
 It works by opening the file and reading magic numbers *)
 
-val path_of_filename : string -> [> `Path of string ]
+val path_of_filename : config -> string -> [> `Path of string ]
 (** [path_of_filename fname] search for image {i images/fname} inside the base and assets directories.
     Return the path to found file or [fname] if file isn't found.  *)
 

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -175,10 +175,8 @@ let get_extension conf saved fname =
   let f =
     if saved then
       String.concat Filename.dir_sep
-        [ Util.base_path [ "images" ] conf.bname; "old"; fname ]
-    else
-      String.concat Filename.dir_sep
-        [ Util.base_path [ "images" ] conf.bname; fname ]
+        [ !GWPARAM.images_d conf.bname; "old"; fname ]
+    else String.concat Filename.dir_sep [ !GWPARAM.images_d conf.bname; fname ]
   in
   if Sys.file_exists (f ^ ".jpg") then ".jpg"
   else if Sys.file_exists (f ^ ".jpeg") then ".jpeg"
@@ -249,10 +247,7 @@ let print_send_image conf base p =
       Output.print_string conf (Util.escape_html (p_surname base p)))
   in
   let digest = Image.default_portrait_filename base p in
-  Perso.interp_notempl_with_menu title "perso_header" conf base p;
-  Output.print_sstring conf "<h2>\n";
-  title false;
-  Output.print_sstring conf "</h2>\n";
+  Hutil.header conf title;
   Output.printf conf
     "<form method=\"post\" action=\"%s\" enctype=\"multipart/form-data\">\n"
     conf.command;
@@ -329,7 +324,7 @@ let effective_send_ok conf base p file =
         | _ -> (typ, content))
   in
   let fname = Image.default_portrait_filename base p in
-  let dir = Util.base_path [ "images" ] conf.bname in
+  let dir = !GWPARAM.images_d conf.bname in
   if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
   let fname =
     Filename.concat dir
@@ -413,11 +408,8 @@ let effective_send_c_ok conf base p file file_name =
   in
   let fname = Image.default_portrait_filename base p in
   let dir =
-    if mode = "portraits" then
-      String.concat Filename.dir_sep [ Util.base_path [ "images" ] conf.bname ]
-    else
-      String.concat Filename.dir_sep
-        [ Util.base_path [ "src" ] conf.bname; "images"; fname ]
+    if mode = "portraits" then !GWPARAM.portraits_d conf.bname
+    else Filename.concat (!GWPARAM.images_d conf.bname) fname
   in
   if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
   let fname =
@@ -530,7 +522,7 @@ let print_deleted conf base p =
 let effective_delete_ok conf base p =
   let fname = Image.default_portrait_filename base p in
   let ext = get_extension conf false fname in
-  let dir = Util.base_path [ "images" ] conf.bname in
+  let dir = !GWPARAM.portraits_d conf.bname in
   if move_file_to_save (fname ^ ext) dir = 0 then
     incorrect conf "effective delete";
   let changed =
@@ -575,10 +567,8 @@ let effective_delete_c_ok conf base p =
   let ext = get_extension conf delete fname in
   let file = if file_name = "" then fname ^ ext else file_name in
   let dir =
-    if mode = "portraits" then Util.base_path [ "images" ] conf.bname
-    else
-      String.concat Filename.dir_sep
-        [ Util.base_path [ "src" ] conf.bname; "images"; fname ]
+    if mode = "portraits" then !GWPARAM.portraits_d conf.bname
+    else Filename.concat (!GWPARAM.images_d conf.bname) fname
   in
   if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
   (* TODO verify we dont destroy a saved image
@@ -598,12 +588,12 @@ let effective_reset_c_ok conf base p =
   let mode =
     try (List.assoc "mode" conf.env :> string) with Not_found -> "portraits"
   in
-  let carrousel = Image.default_portrait_filename base p in
+  let keydir = Image.default_portrait_filename base p in
   let file_name =
     try List.assoc "file_name" conf.env with Not_found -> Adef.encoded ""
   in
   let file_name = (Mutil.decode file_name :> string) in
-  let file_name = if mode = "portraits" then carrousel else file_name in
+  let file_name = if mode = "portraits" then keydir else file_name in
   let ext = get_extension conf false file_name in
   let old_ext = get_extension conf true file_name in
   let ext =
@@ -615,11 +605,10 @@ let effective_reset_c_ok conf base p =
   in
   let file_in_new =
     if mode = "portraits" then
-      String.concat Filename.dir_sep
-        [ Util.base_path [ "images" ] conf.bname; file_name ^ ext ]
+      Filename.concat (!GWPARAM.portraits_d conf.bname) (file_name ^ ext)
     else
       String.concat Filename.dir_sep
-        [ Util.base_path [ "src" ] conf.bname; "images"; carrousel; file_name ]
+        [ !GWPARAM.images_d conf.bname; keydir; file_name ]
   in
   (if Sys.file_exists file_in_new then ()
   else

--- a/lib/imageDisplay.ml
+++ b/lib/imageDisplay.ml
@@ -116,7 +116,7 @@ let print_portrait conf base p =
 
 let print_source conf f =
   let fname = if f.[0] = '/' then String.sub f 1 (String.length f - 1) else f in
-  let fname = Image.source_filename conf fname in
+  let fname = Filename.concat (!GWPARAM.images_d conf.bname) fname in
   if (conf.wizard || conf.friend) || Image.is_not_private_img conf fname then
     Result.fold ~ok:ignore
       ~error:(fun _ -> Hutil.incorrect_request conf)

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -6,9 +6,8 @@ open Util
 module StrSet = Mutil.StrSet
 
 let file_path conf base fname =
-  Util.bpath
-    (List.fold_left Filename.concat (conf.bname ^ ".gwb")
-       [ base_notes_dir base; fname ^ ".txt" ])
+  String.concat Filename.dir_sep
+    [ Util.bpath conf.bname; base_notes_dir base; fname ^ ".txt" ]
 
 let path_of_fnotes fnotes =
   match NotesLinks.check_file_name fnotes with
@@ -155,9 +154,8 @@ let commit_notes conf base fnotes s =
   let pg = if fnotes = "" then Def.NLDB.PgNotes else Def.NLDB.PgMisc fnotes in
   let fname = path_of_fnotes fnotes in
   let fpath =
-    List.fold_left Filename.concat
-      (Util.bpath (conf.bname ^ ".gwb"))
-      [ base_notes_dir base; fname ]
+    String.concat Filename.dir_sep
+      [ Util.bpath conf.bname; base_notes_dir base; fname ]
   in
   Mutil.mkdir_p (Filename.dirname fpath);
   Gwdb.commit_notes base fname s;

--- a/lib/srcfileDisplay.mli
+++ b/lib/srcfileDisplay.mli
@@ -11,9 +11,5 @@ val print_source : config -> base -> string -> unit
 val print_start : config -> base -> unit
 val incr_welcome_counter : config -> (int * int * string) option
 val incr_request_counter : config -> (int * int * string) option
-
-val adm_file : string -> string
-(** Compute administration file path with giving name (search inside {i cnt} directory) *)
-
 val source_file_name : config -> string -> string
 val copy_from_stream : config -> base -> char Stream.t -> src_mode -> unit

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -306,7 +306,7 @@ let rec eval_variable conf = function
           acc
           ^ Format.sprintf "<b%s>%s</b>=%s<br>\n" duplicate k
               (Util.escape_html v :> string))
-        "" l
+        "" conf.base_env
   | [ "gwd"; "arglist" ] -> !GWPARAM.gwd_cmd
   | [ "bvar"; v ] | [ "b"; v ] -> (
       try List.assoc v conf.base_env with Not_found -> "")
@@ -1100,6 +1100,7 @@ let rgb_of_str_hsv h s v =
 let eval_var conf ifun env ep loc sl =
   try
     match sl with
+    | [ "reorg" ] -> VVbool !GWPARAM.reorg
     | [ "env"; "key" ] -> (
         match ifun.get_vother (List.assoc "binding" env) with
         | Some (Vbind (k, _)) -> VVstring k
@@ -1134,7 +1135,7 @@ let print_foreach conf ifun print_ast eval_expr env ep loc s sl el al =
     templ_print_foreach conf print_ast ifun.set_vother env ep loc s sl el al
 
 let print_wid_hei conf fname =
-  match Image.size_from_path (Image.path_of_filename fname) with
+  match Image.size_from_path (Image.path_of_filename conf fname) with
   | Ok (wid, hei) -> Output.printf conf " width=\"%d\" height=\"%d\"" wid hei
   | Error () -> ()
 

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -353,7 +353,7 @@ let print_err_unknown conf (f, s, o) =
   print_return conf
 
 let delete_topological_sort_v conf _base =
-  let bfile = Util.bpath (conf.bname ^ ".gwb") in
+  let bfile = Util.bpath conf.bname in
   let tstab_file = Filename.concat bfile "tstab_visitor" in
   Mutil.rm tstab_file;
   let tstab_file = Filename.concat bfile "restrict" in
@@ -361,7 +361,7 @@ let delete_topological_sort_v conf _base =
 
 let delete_topological_sort conf base =
   let _ = delete_topological_sort_v conf base in
-  let bfile = Util.bpath (conf.bname ^ ".gwb") in
+  let bfile = Util.bpath conf.bname in
   let tstab_file = Filename.concat bfile "tstab" in
   Mutil.rm tstab_file
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1137,7 +1137,8 @@ let string_of_witness_kind conf sex witness_kind =
   in
   Adef.safe @@ transl_nth conf s n
 
-let base_path pref bname = !GWPARAM.base_path pref bname
+let base_path pref bname =
+  List.fold_right Filename.concat (Secure.base_dir () :: pref) bname
 let bpath bname = !GWPARAM.bpath bname
 let copy_from_templ_ref = ref (fun _ _ _ -> assert false)
 let copy_from_templ conf env ic = !copy_from_templ_ref conf env ic

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -4,10 +4,17 @@ open Config
 open Def
 open Gwdb
 
+val print_default_gwf_file : string -> unit
+(** print default config file bname.gwf or bname.gwb/etc/mybase.gwf *)
+
+val read_base_env : string -> string -> bool -> (string * string) list
+(** read base environment bname.gwf or bname.gwb/etc/bname.gwf *)
+
 val time_debug :
   config -> float -> int -> string list -> string list -> string list -> unit
 (** prints the query duration and reports it in the "home" section *)
 
+(* REORG *)
 val cnt_dir : string ref
 (** The directory where counters (e.g. number page displayed) are stored. *)
 
@@ -439,7 +446,7 @@ val short_f_month : int -> string
 type auth_user = { au_user : string; au_passwd : string; au_info : string }
 (** Authenticated user from from authorization file. *)
 
-val read_gen_auth_file : string -> auth_user list
+val read_gen_auth_file : string -> string -> auth_user list
 (** Read all authenticated users with their passwords from authorization file (associated to {i "wizard_passwd_file"} in [conf.base_env]) *)
 
 val is_that_user_and_password : auth_scheme_kind -> string -> string -> bool
@@ -606,3 +613,6 @@ val designation : base -> person -> Adef.escaped_string
 
 val has_children : base -> person -> bool
 val get_bases_list : ?format_fun:(string -> string) -> unit -> string list
+
+val test_cnt_d : config -> string
+(** tests if cnt_d exists and creaets it if needed *)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -14,13 +14,6 @@ val time_debug :
   config -> float -> int -> string list -> string list -> string list -> unit
 (** prints the query duration and reports it in the "home" section *)
 
-(* REORG *)
-val cnt_dir : string ref
-(** The directory where counters (e.g. number page displayed) are stored. *)
-
-val base_path : string list -> string -> string
-(** Alias for !GWPARAM.base_path *)
-
 val bpath : string -> string
 (** Alias for !GWPARAM.bpath *)
 

--- a/lib/util/lock.ml
+++ b/lib/util/lock.ml
@@ -12,7 +12,7 @@ let print_try_again () =
   flush stdout
 
 let control ~onerror lname wait f =
-  if !no_lock_flag then f ()
+  if !no_lock_flag || Filename.basename lname = ".lck" then f ()
   else
     try
       let fd = Unix.openfile lname [ Unix.O_RDWR; Unix.O_CREAT ] 0o666 in

--- a/lib/util/mutil.mli
+++ b/lib/util/mutil.mli
@@ -34,9 +34,6 @@ val mkdir_p : ?perm:int -> string -> unit
     No error if existing, make parent directories as needed.
 *)
 
-val remove_dir : string -> unit
-(** Remove every file in the directory and then remove the directory itself *)
-
 val lock_file : string -> string
 (** Returns the name of a lock file (with extension .lck). Result is generally used as an
     argument for [Lock.control] function. *)

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -51,8 +51,8 @@ let section_level s len =
 let notes_aliases conf =
   let fname =
     match List.assoc_opt "notes_alias_file" conf.base_env with
-    | Some f -> Util.bpath f
-    | None -> Filename.concat (Util.bpath (conf.bname ^ ".gwb")) "notes.alias"
+    | Some f -> f
+    | None -> Filename.concat (Util.bpath conf.bname) "notes.alias"
   in
   match try Some (Secure.open_in fname) with Sys_error _ -> None with
   | Some ic ->

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -5,9 +5,7 @@ open Def
 open Util
 
 let dir conf base =
-  Filename.concat
-    (Util.bpath (conf.bname ^ ".gwb"))
-    (Gwdb.base_wiznotes_dir base)
+  Filename.concat (Util.bpath conf.bname) (Gwdb.base_wiznotes_dir base)
 
 let wzfile wddir wz = Filename.concat wddir (wz ^ ".txt")
 

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -11,8 +11,8 @@ let dir conf base =
 
 let wzfile wddir wz = Filename.concat wddir (wz ^ ".txt")
 
-let read_auth_file fname =
-  let data = read_gen_auth_file fname in
+let read_auth_file fname bname =
+  let data = read_gen_auth_file fname bname in
   List.map
     (fun au ->
       let wizname =
@@ -264,7 +264,7 @@ let print_main conf base auth_file =
   in
   let by_alphab_order = p_getenv conf.env "o" <> Some "H" in
   let wizdata =
-    let list = read_auth_file auth_file in
+    let list = read_auth_file auth_file conf.bname in
     if by_alphab_order then
       List.sort
         (fun (_, (_, (o1, _))) (_, (_, (o2, _))) ->
@@ -320,7 +320,7 @@ let wizard_page_title conf wizname _ = Output.print_string conf wizname
 
 let print_whole_wiznote conf base auth_file wz wfile (s, date) ho =
   let wizname =
-    let wizdata = read_auth_file auth_file in
+    let wizdata = read_auth_file auth_file conf.bname in
     try fst (List.assoc wz wizdata) with Not_found -> wz
   in
   let edit_opt =

--- a/plugins/fixbase/plugin_fixbase.ml
+++ b/plugins/fixbase/plugin_fixbase.ml
@@ -119,7 +119,7 @@ let fixbase_ok conf base =
   let process () =
     ignore @@ Unix.alarm 0;
     (* cancel timeout *)
-    let base' = Gwdb.open_base @@ Util.base_path [] (bname base ^ ".gwb") in
+    let base' = Gwdb.open_base @@ !GWPARAM.bpath conf.bname in
     let ipers = ref [] in
     let ifams = ref [] in
     let istrs = ref [] in
@@ -378,7 +378,7 @@ let fixbase_ok conf base =
     in
     let tstab () =
       if UI.enabled conf "tstab" then (
-        let bname = Util.base_path [] (bname base ^ ".gwb") in
+        let bname = !GWPARAM.bpath conf.bname in
         Mutil.rm (Filename.concat bname "tstab_visitor");
         Mutil.rm (Filename.concat bname "tstab");
         Output.print_sstring conf {|<p>|};
@@ -418,7 +418,7 @@ let fixbase_ok conf base =
   if dry_run then process ()
   else
     Lock.control
-      (Mutil.lock_file @@ Util.base_path [] (conf.bname ^ ".gwb"))
+      (Mutil.lock_file @@ !GWPARAM.bpath conf.bname)
       false
       ~onerror:(fun () -> !GWPARAM.output_error conf Def.Service_Unavailable)
       process

--- a/plugins/forum/forum.ml
+++ b/plugins/forum/forum.ml
@@ -171,7 +171,7 @@ module MF : MF = struct
 end
 
 let forum_file conf =
-  let fn = Filename.concat (bpath (conf.bname ^ ".gwb")) "forum" in
+  let fn = Filename.concat (Util.bpath conf.bname) "forum" in
   MF.filename_of_string fn
 
 (* Black list *)

--- a/test/run-GW-test.sh
+++ b/test/run-GW-test.sh
@@ -373,7 +373,7 @@ done
 if test -f "$GWDLOG"; then
 echo "$GWDLOG reported traces (empty if no failure):"
 grep -E "$WARNING_CONDITIONS" $GWDLOG
-grep -E "$FAILING_CONDITIONS" $GWDLOG && RC=$(($RC+1))
+grep -B1 -E "$FAILING_CONDITIONS" $GWDLOG && RC=$(($RC+1))
 fi
 if test "$RC" != 0; then
     echo "at least $RC detected error(s)."

--- a/test/test-gwu.sh
+++ b/test/test-gwu.sh
@@ -14,6 +14,7 @@ exit 1
 
 setenv_file="./test-gw-vars.txt"
 
+REFTESTGW='testgalichet' # reference gw file
 #=== hardcoded vars (start) ===
 # assumes we are running in the repo folder
 # ./test/testgwu.sh
@@ -42,12 +43,20 @@ shift $(($OPTIND - 1))
 # overwrite above hardcoded vars by an input file.
 test -f "$setenv_file" && . $setenv_file
 
+if test ! -d $BASES_DIR/ ; then
+    echo "$BASES_DIR/ not accessible, change your default parms."
+    exit 1
+fi
 if test ! -f $BASES_DIR/$TESTGW.gw ; then
     if test -f test/$TESTGW.gw ; then
         cp -f  test/$TESTGW.gw $BASES_DIR/
     else
         echo "$TESTGW.gw not found in $BASES_DIR or test/"
         exit 1
+    fi
+else
+    if test "$TESTGW" = "$REFTESTGW"; then
+        rsync -a test/$TESTGW.gw $BASES_DIR/
     fi
 fi
 

--- a/test/testgalichet.gw
+++ b/test/testgalichet.gw
@@ -109,7 +109,7 @@ pevt Marty Florence
 #deat 1875
 end pevt
 
-fam Galichet lolo +1840 #ms inventé -1844 femme1 prenom1 #src inventé 1818 od
+fam Galichet lolo +1840 #ms inventé femme1 prenom1 #src inventé 1818 od
 fevt
 #marr 1840 #s inventé
 #div 1844 #s inventé


### PR DESCRIPTION


This PR (which replaces PR 1871) proposes a new organisation where all data associated with a base, in particular images and portraits, are stored inside the main mybase.gwb folder.
The new “reorg” mode is automatically detected by the existence of the file mybase.gwb/config/mybase.gwf, or is forced by a new -reorg option in gwc.
The default organisation is the classical one.
The proposed new organisation is as follows:

```
mybase.gwb
    config
        mybase.gwf
        wiz.auth 	# wizard auth file, as named in .gwf
        fr.auth	        # idem friends
        cnt
            various counters and log files (robot, .lck, mybase.txt, mybase_w.txt, …)
    etc
        base specific template files
        cache
            some browser related cache files
    lang
        base specific language files
    documents
        portraits 	# the classical images/mybase folder (no sub-folders)
        images 	        # the classical src/mybase/images folder with sub-folders possibility
        src 		# the classical src/mybase folder (without images, with sub-folders possibility)

    base		# and the other classical files and folders

```
Implementation:
this feature is implemented through a set of access functions to the various folders defined in GWPARAM
