### PR TITLE
new reorg structure; GWPARAM handles folder access

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -48,7 +48,6 @@ let month_number_dates = ref NoMonthNumberDates
 let no_public_if_titles = ref false
 let first_names_brackets = ref None
 let untreated_in_notes = ref false
-let force = ref false
 let default_source = ref ""
 let relation_status = ref Married
 let no_picture = ref false
@@ -3179,12 +3178,18 @@ let finish_base (persons, families, strings, _) =
 
 (* Main *)
 
+let in_file = ref ""
 let out_file = ref "a"
 
 let speclist =
-  [ ( "-o", Arg.String (fun s -> out_file := s)
-    , "<file> Output database (default: \"a\"). Alphanumerics and -" )
-  ; ( "-f", Arg.Set force
+  [ ( "-bd",
+      Arg.String Secure.set_base_dir,
+      "<DIR> Specify where the “bases” directory with databases is installed \
+       (default if empty is “.”)." )
+  ; ( "-o", Arg.Set_string out_file,
+      "<file> Output database (default: <input file name>.gwb, a.gwb if not \
+       available). Alphanumerics and -" )
+  ; ( "-f", Arg.Set Geneweb.GWPARAM.force
     , " Remove database if already existing" )
   ; ( "-log", Arg.String (fun s -> log_oc := open_out s)
     , "<file> Redirect log trace to this file." )
@@ -3272,6 +3277,7 @@ let speclist =
   ; ( "-particles"
     , Arg.String (fun s -> particles := Mutil.input_particles s)
     , "<FILE> Use the given file as list of particles" )
+  ; ("-reorg", Arg.Set Geneweb.GWPARAM.reorg, " Mode reorg");
   ] |> List.sort compare |> Arg.align
 
 let anonfun s =
@@ -3282,6 +3288,12 @@ let errmsg = "Usage: ged2gwb [<ged>] [options] where options are:"
 
 let main () =
   Arg.parse speclist anonfun errmsg;
+  if not (Array.mem "-bd" Sys.argv) then Secure.set_base_dir ".";
+  in_file :=
+    if !in_file <> "" then
+      Filename.remove_extension (Filename.basename !in_file)
+    else !in_file;
+  if !in_file <> "" && (not (Array.mem "-o" Sys.argv)) then out_file := !in_file;
   if not (Mutil.good_name (Filename.basename !out_file)) then (
     (* Util.transl conf not available !*)
     Printf.eprintf "The database name \"%s\" contains a forbidden character.\n"
@@ -3289,7 +3301,10 @@ let main () =
     Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -\n";
     flush stderr;
     exit 2);
+  let bname = Filename.remove_extension (Filename.basename !out_file) in
+  Geneweb.GWPARAM.init bname;
   Secure.set_base_dir (Filename.dirname !out_file);
+  Geneweb.GWPARAM.test_base bname;
   let arrays = make_arrays !in_file in
   Gc.compact ();
   let arrays = make_subarrays arrays in

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -1621,6 +1621,7 @@ let output_wizard_notes bdir wiznotes =
   let wizdir = Filename.concat bdir "wiznotes" in
   if wiznotes <> [] then (
     (* FIXME ad hoc solution. wiznotes should be handled same as notes_d *)
+    (* not necessarily true! notes_d is part of base, wiznotes is not *)
     if not @@ Sys.file_exists wizdir then Unix.mkdir wizdir 0o755;
     List.iter
       (fun (wizid, text) ->
@@ -1682,19 +1683,15 @@ let link next_family_fun bdir =
   let istr_quest = unique_string gen "?" in
   assert (istr_empty = 0);
   assert (istr_quest = 1);
-  if Sys.unix then Sys.remove tmp_per_index;
-  if Sys.unix then Sys.remove tmp_per;
-  if Sys.unix then Sys.remove tmp_fam_index;
-  if Sys.unix then Sys.remove tmp_fam;
   let next_family = next_family_fun fi in
-  (let rec loop () =
-     match next_family () with
-     | Some fam ->
-         insert_syntax fi.f_curr_src_file gen fam;
-         loop ()
-     | None -> ()
-   in
-   loop ());
+  let rec loop () =
+    match next_family () with
+    | Some fam ->
+        insert_syntax fi.f_curr_src_file gen fam;
+        loop ()
+    | None -> ()
+  in
+  loop ();
   close_out gen.g_per_index;
   close_out gen.g_per;
   close_out gen.g_fam_index;
@@ -1702,13 +1699,14 @@ let link next_family_fun bdir =
   Hashtbl.clear gen.g_strings;
   Hashtbl.clear gen.g_names;
   Hashtbl.clear fi.f_local_names;
-  Gc.compact ();
   let base = make_base bdir gen per_index_ic per_ic in
   Hashtbl.clear gen.g_patch_p;
+  Gc.full_major ();
+  close_in per_index_ic;
+  close_in per_ic;
   if !do_check && gen.g_pcnt > 0 then (
     Check.check_base base (set_error base gen) (set_warning base) ignore;
     if !pr_stats then Stats.(print_stats base @@ stat_base base));
-  Mutil.remove_dir tmp_dir;
   if not gen.g_errored then (
     if !do_consang then ignore @@ ConsangAll.compute base true;
     Gwdb.sync base;
@@ -1716,5 +1714,5 @@ let link next_family_fun bdir =
     output_command_line bdir;
     true)
   else (
-    Mutil.remove_dir bdir;
+    Mutil.rm_rf bdir;
     false)

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -96,14 +96,19 @@ let next_family_fun_templ gwo_list fi =
 
 let just_comp = ref false
 let out_file = ref (Filename.concat Filename.current_dir_name "a")
-let force = ref false
+let in_file = ref ""
 let separate = ref false
 let bnotes = ref "merge"
 let shift = ref 0
 let files = ref []
+let kill_gwo = ref false
 
 let speclist =
   [
+    ( "-bd",
+      Arg.String Secure.set_base_dir,
+      "<DIR> Specify where the “bases” directory with databases is installed \
+       (default if empty is “.”)." );
     ( "-bnotes",
       Arg.Set_string bnotes,
       " [drop|erase|first|merge] Behavior for base notes of the next file. \
@@ -116,7 +121,8 @@ let speclist =
       Arg.Set_string Db1link.default_source,
       "<str> Set the source field for persons and families without source data"
     );
-    ("-f", Arg.Set force, " Remove database if already existing");
+    ("-f", Arg.Set Geneweb.GWPARAM.force, " Remove database if already existing");
+    ("-gwo", Arg.Set kill_gwo, " Suppress .gwo files after base creation");
     ("-mem", Arg.Set Outbase.save_mem, " Save memory, but slower");
     ("-nc", Arg.Clear Db1link.do_check, " No consistency check");
     ("-nofail", Arg.Set Gwcomp.no_fail, " No failure in case of error");
@@ -126,11 +132,13 @@ let speclist =
       " Do not create associative pictures" );
     ( "-o",
       Arg.Set_string out_file,
-      "<file> Output database (default: a.gwb). Alphanumerics and -" );
+      "<file> Output database (default: <input file name>.gwb, a.gwb if not \
+       available). Alphanumerics and -" );
     ( "-particles",
       Arg.Set_string Db1link.particules_file,
       "<file> Particles file (default = predefined particles)" );
     ("-q", Arg.Clear Mutil.verbose, " Quiet");
+    ("-reorg", Arg.Set Geneweb.GWPARAM.reorg, " Mode reorg");
     ("-sep", Arg.Set separate, " Separate all persons in next file");
     ("-sh", Arg.Set_int shift, "<int> Shift all persons numbers in next files");
     ("-stats", Arg.Set Db1link.pr_stats, " Print statistics");
@@ -141,8 +149,8 @@ let speclist =
 let anonfun x =
   let bn = !bnotes in
   let sep = !separate in
-  if Filename.check_suffix x ".gw" then ()
-  else if Filename.check_suffix x ".gwo" then ()
+  if Filename.check_suffix x ".gw" then in_file := x
+  else if Filename.check_suffix x ".gwo" then in_file := x
   else raise (Arg.Bad ("Don't know what to do with \"" ^ x ^ "\""));
   separate := false;
   bnotes := "merge";
@@ -158,6 +166,16 @@ let errmsg =
 let main () =
   Mutil.verbose := false;
   Arg.parse speclist anonfun errmsg;
+  if not (Array.mem "-bd" Sys.argv) then Secure.set_base_dir ".";
+  in_file :=
+    if !in_file <> "" then
+      Filename.remove_extension (Filename.basename !in_file)
+    else !in_file;
+  if List.length !files > 1 && not (Array.mem "-o" Sys.argv) then (
+    Printf.eprintf "The database name must be specified with -o\n";
+    flush stdout;
+    exit 2);
+  if !in_file <> "" && not (Array.mem "-o" Sys.argv) then out_file := !in_file;
   if not (Mutil.good_name (Filename.basename !out_file)) then (
     (* Util.transl conf not available !*)
     Printf.eprintf "The database name \"%s\" contains a forbidden character.\n"
@@ -165,7 +183,11 @@ let main () =
     Printf.eprintf "Allowed characters: a..z, A..Z, 0..9, -\n";
     flush stderr;
     exit 2);
-  Secure.set_base_dir (Filename.dirname !out_file);
+  let bname = Filename.remove_extension (Filename.basename !out_file) in
+  Geneweb.GWPARAM.init bname;
+  let dist_etc_d = Filename.concat (Filename.dirname Sys.argv.(0)) "etc" in
+  if !Db1link.particules_file = "" then
+    Db1link.particules_file := Filename.concat dist_etc_d "particles.txt";
   let gwo = ref [] in
   List.iter
     (fun (x, separate, bnotes, shift) ->
@@ -180,27 +202,24 @@ let main () =
       else raise (Arg.Bad ("Don't know what to do with \"" ^ x ^ "\"")))
     (List.rev !files);
   if not !just_comp then (
-    let bdir =
-      if Filename.check_suffix !out_file ".gwb" then !out_file
-      else !out_file ^ ".gwb"
-    in
-    if (not !force) && Sys.file_exists bdir then (
-      Printf.eprintf
-        "The database \"%s\" already exists. Use option -f to overwrite it."
-        !out_file;
-      flush stderr;
-      exit 2);
-    Lock.control (Mutil.lock_file !out_file)
-      false ~onerror:Lock.print_error_and_exit (fun () ->
-        let bdir =
-          if Filename.check_suffix !out_file ".gwb" then !out_file
-          else !out_file ^ ".gwb"
-        in
+    let bdir = !Geneweb.GWPARAM.bpath bname in
+    Geneweb.GWPARAM.test_base bname;
+    Geneweb.GWPARAM.init_etc bname;
+    Lock.control (Mutil.lock_file bdir) false ~onerror:Lock.print_error_and_exit
+      (fun () ->
         let next_family_fun = next_family_fun_templ (List.rev !gwo) in
-        if Db1link.link next_family_fun bdir then ()
+        if Db1link.link next_family_fun bdir then (
+          Geneweb.Util.print_default_gwf_file bname;
+          if !kill_gwo then
+            List.iter
+              (fun (x, _separate, _bnotes, _shift) ->
+                if Sys.file_exists (x ^ "o") then Mutil.rm (x ^ "o"))
+              (List.rev !files))
         else (
           Printf.eprintf "*** database not created\n";
           flush stderr;
-          exit 2)))
+          exit 2));
+    let tmp_file = Filename.concat Filename.current_dir_name "gw_tmp" in
+    Mutil.rm_rf tmp_file)
 
 let _ = main ()

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -265,64 +265,6 @@ let alias_lang lang =
       close_in ic ; lang
     with Sys_error _ -> lang
 
-let rec cut_at_equal i s =
-  if i = String.length s then s, ""
-  else if s.[i] = '=' then
-    String.sub s 0 i, String.sub s (succ i) (String.length s - succ i)
-  else cut_at_equal (succ i) s
-
-let strip_trailing_spaces s =
-  let len =
-    let rec loop len =
-      if len = 0 then 0
-      else
-        match s.[len-1] with
-          ' ' | '\n' | '\r' | '\t' -> loop (len - 1)
-        | _ -> len
-    in
-    loop (String.length s)
-  in
-  String.sub s 0 len
-
-let read_base_env bname =
-  let load_file fname =
-    try
-      let ic = Secure.open_in fname in
-      let env =
-        let rec loop env =
-          match input_line ic with
-          | s ->
-            let s = strip_trailing_spaces s in
-            if s = "" || s.[0] = '#' then loop env
-            else loop (cut_at_equal 0 s :: env)
-          | exception End_of_file -> env
-        in
-        loop []
-      in
-      close_in ic;
-      env
-    with Sys_error error ->
-      GwdLog.log (fun oc ->
-          Printf.fprintf oc "Error %s while loading %s, using empty config\n%!"
-            error fname);
-      []
-  in
-  let fname1 = Util.bpath (bname ^ ".gwf") in
-  if Sys.file_exists fname1 then
-    load_file fname1
-  else
-    let fname2 = Filename.concat !gw_prefix "etc/a.gwf" in
-    if Sys.file_exists fname2 then begin
-      if !debug then GwdLog.log (fun oc ->
-          Printf.fprintf oc "Using configuration from %s\n%!" fname2);
-      load_file fname2
-    end else begin
-      if !debug then GwdLog.log (fun oc ->
-          Printf.fprintf oc "No config file found in either %s or %s\n%!"
-            fname1 fname2);
-      []
-    end
-
 let print_renamed conf new_n =
   let link =
     let req = Util.get_request_string conf in
@@ -350,7 +292,7 @@ let print_renamed conf new_n =
       Hutil.trailer conf)
 
 let log_redirect from request req =
-  Lock.control (SrcfileDisplay.adm_file "gwd.lck") true
+  Lock.control (!GWPARAM.adm_file "gwd.lck") true
     ~onerror:(fun () -> ()) begin fun () ->
     let referer = Mutil.extract_param "referer: " '\n' request in
     GwdLog.syslog `LOG_NOTICE @@
@@ -373,8 +315,7 @@ let print_redirected conf from request new_addr =
 let nonce_private_key =
   Lazy.from_fun
     (fun () ->
-       let cnt_dir = Filename.concat !(Util.cnt_dir) "cnt" in
-       let fname = Filename.concat cnt_dir "gwd_private.txt" in
+       let fname = Filename.concat !GWPARAM.cnt_dir "gwd_private.txt" in
        let k =
          try
            let ic = open_in fname in
@@ -478,10 +419,10 @@ let unauth_server conf ar =
   Output.print_sstring conf "</dl>\n";
   Hutil.trailer conf
 
-let gen_match_auth_file test_user_and_password auth_file =
+let gen_match_auth_file test_user_and_password auth_file base_file =
   if auth_file = "" then None
   else
-    let aul = read_gen_auth_file auth_file in
+    let aul = read_gen_auth_file auth_file base_file in
     let rec loop =
       function
         au :: aul ->
@@ -505,12 +446,12 @@ let gen_match_auth_file test_user_and_password auth_file =
     in
     loop aul
 
-let basic_match_auth_file uauth =
-  gen_match_auth_file (fun au -> au.au_user ^ ":" ^ au.au_passwd = uauth)
+let basic_match_auth_file uauth base_file =
+  gen_match_auth_file (fun au -> au.au_user ^ ":" ^ au.au_passwd = uauth) base_file
 
-let digest_match_auth_file asch =
+let digest_match_auth_file asch base_file =
   gen_match_auth_file
-    (fun au -> is_that_user_and_password asch au.au_user au.au_passwd)
+    (fun au -> is_that_user_and_password asch au.au_user au.au_passwd) base_file
 
 let match_simple_passwd sauth uauth =
   match String.index_opt sauth ':' with
@@ -521,9 +462,9 @@ let match_simple_passwd sauth uauth =
           sauth = String.sub uauth (i + 1) (String.length uauth - i - 1)
       | None -> sauth = uauth
 
-let basic_match_auth passwd auth_file uauth =
+let basic_match_auth passwd auth_file uauth base_file =
   if passwd <> "" && match_simple_passwd passwd uauth then Some ""
-  else basic_match_auth_file uauth auth_file
+  else basic_match_auth_file uauth auth_file base_file
 
 type access_type =
     ATwizard of string * string
@@ -536,7 +477,10 @@ let compatible_tokens check_from (addr1, base1_pw1) (addr2, base2_pw2) =
   (not check_from || addr1 = addr2) && base1_pw1 = base2_pw2
 
 let get_actlog check_from utm from_addr base_password =
-  let fname = SrcfileDisplay.adm_file "actlog" in
+  let fname = !GWPARAM.adm_file "actlog" in
+  if not (Sys.file_exists fname) then (
+    let oc = Secure.open_out fname in
+    close_out oc);
   try
     let ic = Secure.open_in fname in
       let tmout = float_of_int !login_timeout in
@@ -583,11 +527,11 @@ let get_actlog check_from utm from_addr base_password =
       in
       loop false ATnormal []
   with Sys_error e -> (
-      GwdLog.syslog `LOG_WARNING ("Error opening actlog: " ^ e);
+      GwdLog.syslog `LOG_WARNING ("Error opening (get) actlog: " ^ e);
     [], ATnormal, false)
 
 let set_actlog list =
-  let fname = SrcfileDisplay.adm_file "actlog" in
+  let fname = !GWPARAM.adm_file "actlog" in
   try
     let oc = Secure.open_out fname in
     List.iter
@@ -602,7 +546,7 @@ let set_actlog list =
     ())
 
 let get_token check_from utm from_addr base_password =
-  Lock.control (SrcfileDisplay.adm_file "gwd.lck") true
+  Lock.control (!GWPARAM.adm_file "gwd.lck") true
     ~onerror:(fun () -> ATnormal)
     (fun () ->
        let (list, r, changed) =
@@ -624,7 +568,7 @@ let random_self_init () =
   Random.init seed
 
 let set_token utm from_addr base_file acc user username =
-  Lock.control (SrcfileDisplay.adm_file "gwd.lck") true
+  Lock.control (!GWPARAM.adm_file "gwd.lck") true
     ~onerror:(fun () -> "")
     (fun () ->
        random_self_init ();
@@ -886,27 +830,27 @@ let basic_authorization from_addr request base_env passwd access_type utm
         if wizard_passwd = "" && wizard_passwd_file = "" then
           true, true, friend_passwd = "", ""
         else
-          match basic_match_auth wizard_passwd wizard_passwd_file uauth with
+          match basic_match_auth wizard_passwd wizard_passwd_file uauth base_file with
             Some username -> true, true, false, username
           | None -> false, false, false, ""
       else if passwd = "f" then
         if friend_passwd = "" && friend_passwd_file = "" then
           true, false, true, ""
         else
-          match basic_match_auth friend_passwd friend_passwd_file uauth with
+          match basic_match_auth friend_passwd friend_passwd_file uauth base_file with
             Some username -> true, false, true, username
           | None -> false, false, false, ""
       else assert false
     else if wizard_passwd = "" && wizard_passwd_file = "" then
       true, true, friend_passwd = "", ""
     else
-      match basic_match_auth wizard_passwd wizard_passwd_file uauth with
+      match basic_match_auth wizard_passwd wizard_passwd_file uauth base_file with
         Some username -> true, true, false, username
       | _ ->
           if friend_passwd = "" && friend_passwd_file = "" then
             true, false, true, ""
           else
-            match basic_match_auth friend_passwd friend_passwd_file uauth with
+            match basic_match_auth friend_passwd friend_passwd_file uauth base_file with
               Some username -> true, false, true, username
             | None -> true, false, false, ""
   in
@@ -965,7 +909,7 @@ let bad_nonce_report command passwd_char =
    ar_scheme = NoAuth; ar_user = ""; ar_name = ""; ar_wizard = false;
    ar_friend = false; ar_uauth = ""; ar_can_stale = true}
 
-let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz =
+let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz base_file =
   let asch = HttpAuth (Digest ds) in
   if wf_passwd <> "" &&
      is_that_user_and_password asch ds.ds_username wf_passwd
@@ -977,7 +921,7 @@ let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz =
        ar_name = ""; ar_wizard = wiz; ar_friend = not wiz; ar_uauth = "";
        ar_can_stale = false}
   else
-    match digest_match_auth_file asch wf_passwd_file with
+    match digest_match_auth_file asch wf_passwd_file base_file with
       Some username ->
         if ds.ds_nonce <> nonce then bad_nonce_report command passwd_char
         else
@@ -1041,10 +985,10 @@ let digest_authorization request base_env passwd utm base_file command =
                passwd nonce ds.ds_meth ds.ds_uri)
       in
       if passwd = "w" then
-        test_passwd ds nonce command wizard_passwd wizard_passwd_file "w" true
+        test_passwd ds nonce command wizard_passwd wizard_passwd_file "w" true base_file
       else if passwd = "f" then
         test_passwd ds nonce command friend_passwd friend_passwd_file "f"
-          false
+          false base_file
       else failwith (Printf.sprintf "not impl (2) %s %s" auth meth)
     else
       {ar_ok = false; ar_command = command; ar_passwd = passwd;
@@ -1160,7 +1104,8 @@ let make_conf from_addr request script_name env =
   let (threshold_test, env) = extract_assoc "threshold" env in
   if threshold_test <> ""
   then RelationLink.threshold := int_of_string threshold_test;
-  let base_env = read_base_env base_file in
+  GWPARAM.test_reorg base_file;
+  let base_env = Util.read_base_env base_file !gw_prefix !debug in
   let default_lang =
     try
       let x = List.assoc "default_lang" base_env in
@@ -1300,7 +1245,7 @@ let make_conf from_addr request script_name env =
          begin try List.assoc "no_note_for_visitor" base_env = "yes" with
            Not_found -> false
          end;
-     bname = base_file;
+     bname = Filename.remove_extension base_file;
      nb_of_persons = -1;
      nb_of_families = -1;
      env = env; senv = [];
@@ -1321,7 +1266,7 @@ let make_conf from_addr request script_name env =
      auth_file =
        begin try
          let x = List.assoc "auth_file" base_env in
-         if x = "" then !auth_file else Util.bpath x
+         if x = "" then !auth_file else Filename.concat (!GWPARAM.bpath base_file) x
        with Not_found -> !auth_file
        end;
      border =
@@ -1356,6 +1301,7 @@ let make_conf from_addr request script_name env =
      plugins = !plugins;
     }
   in
+  GWPARAM.cnt_dir := !GWPARAM.cnt_d conf.bname;
   conf, ar
 
 let log tm conf from gauth request script_name contents =
@@ -1384,7 +1330,7 @@ let log tm conf from gauth request script_name contents =
     end
 
 let is_robot from =
-  Lock.control (SrcfileDisplay.adm_file "gwd.lck") true
+  Lock.control (!GWPARAM.adm_file "gwd.lck") true
     ~onerror:(fun () -> false)
     (fun () ->
        let (robxcl, _) = Robot.robot_excl () in
@@ -1431,7 +1377,7 @@ let log_and_robot_check conf auth from request script_name contents =
   if !robot_xcl = None
   then log (Unix.time ()) conf from auth request script_name contents
   else
-    Lock.control (SrcfileDisplay.adm_file "gwd.lck") true ~onerror:ignore
+    Lock.control (!GWPARAM.adm_file "gwd.lck") true ~onerror:ignore
       begin fun () ->
         let tm = Unix.time () in
         begin match !robot_xcl with
@@ -1490,7 +1436,7 @@ let conf_and_connection =
           if is_robot from then Robot.robot_error conf 0 0
           else
             let tm = Unix.time () in
-            Lock.control (SrcfileDisplay.adm_file "gwd.lck") true
+            Lock.control (!GWPARAM.adm_file "gwd.lck") true
               ~onerror:(fun () -> ())
               (fun () -> log_passwd_failed ar tm from request conf.bname) ;
             unauth_server conf ar
@@ -1560,7 +1506,7 @@ let image_request conf script_name env =
         if fname.[0] = '/' then String.sub fname 1 (String.length fname - 1)
         else fname
       in
-      let `Path fname = Image.path_of_filename fname in
+      let `Path fname = Image.path_of_filename conf fname in
       let _ = ImageDisplay.print_image_file conf fname in true
   | _ ->
       let s = script_name in
@@ -1571,7 +1517,7 @@ let image_request conf script_name env =
         (* empeche d'avoir des images qui se trouvent dans le dossier   *)
         (* image. Si on ne fait pas de basename, alors ça marche.       *)
         (* let fname = Filename.basename fname in *)
-        let `Path fname = Image.path_of_filename fname in
+        let `Path fname = Image.path_of_filename conf fname in
         let _ = ImageDisplay.print_image_file conf fname in true
       else false
 
@@ -1616,12 +1562,12 @@ let content_misc conf len misc_fname =
   Output.header conf "Cache-control: private, max-age=%d" (60 * 60 * 24 * 365);
   Output.flush conf
 
-let find_misc_file name =
+let find_misc_file conf name =
   if Sys.file_exists name
   && List.exists (fun p -> Mutil.start_with (Filename.concat p "assets") 0 name) !plugins
   then name
   else
-    let name' = Filename.concat (base_path ["etc"] "") name in
+    let name' = Filename.concat (!GWPARAM.etc_d conf.bname) name in
     if Sys.file_exists name' then name'
     else
       let name' = Util.search_in_assets @@ Filename.concat "etc" name in
@@ -1670,7 +1616,7 @@ let print_misc_file conf misc_fname =
     true
 
 let misc_request conf fname =
-  let fname = find_misc_file fname in
+  let fname = find_misc_file conf fname in
   if fname <> "" then
     let misc_fname =
       if Filename.check_suffix fname ".css" then Css fname
@@ -1786,8 +1732,9 @@ let connection (addr, request) script_name contents0 =
   if script_name = "robots.txt" then robots_txt printer_conf
   else if excluded from then refuse_log printer_conf from
   else
-    begin let accept =
-      if !only_addresses = [] then true else List.mem from !only_addresses
+    begin
+      let accept =
+        if !only_addresses = [] then true else List.mem from !only_addresses
     in
       if not accept then only_log printer_conf from
       else
@@ -1795,7 +1742,8 @@ let connection (addr, request) script_name contents0 =
           let (contents, env) = build_env request contents0 in
           if not (image_request printer_conf script_name env)
           && not (misc_request printer_conf script_name)
-          then conf_and_connection from request script_name contents env
+          then 
+            conf_and_connection from request script_name contents env
         with Exit -> ()
     end
 
@@ -1848,7 +1796,7 @@ let geneweb_server () =
             null_reopen [Unix.O_WRONLY] Unix.stderr
           end
         else exit 0;
-       Mutil.mkdir_p ~perm:0o777 (Filename.concat !Util.cnt_dir "cnt")
+        Mutil.mkdir_p ~perm:0o777 !GWPARAM.cnt_dir 
     end;
   Wserver.f GwdLog.syslog !selected_addr !selected_port !conn_timeout
     (if Sys.unix then !max_clients else None) connection
@@ -1869,7 +1817,7 @@ let manage_cgi_timeout tmout =
 
 let geneweb_cgi addr script_name contents =
   if Sys.unix then manage_cgi_timeout !conn_timeout;
-  begin try Unix.mkdir (Filename.concat !(Util.cnt_dir) "cnt") 0o755 with
+  begin try Unix.mkdir !GWPARAM.cnt_dir 0o755 with
     Unix.Unix_error (_, _, _) -> ()
   end;
   let add k x request =
@@ -1934,7 +1882,7 @@ let slashify s =
   in
   String.init (String.length s) conv_char
 
-let make_cnt_dir x =
+let make_sock_dir x =
   Mutil.mkdir_p x;
   if Sys.unix then ()
   else
@@ -1942,7 +1890,7 @@ let make_cnt_dir x =
       Wserver.sock_in := Filename.concat x "gwd.sin";
       Wserver.sock_out := Filename.concat x "gwd.sou"
     end;
-  Util.cnt_dir := x
+  GWPARAM.sock_dir := x
 
 let arg_plugin_doc opt doc =
   doc ^ " Combine with -force to enable for every base. \
@@ -2024,7 +1972,7 @@ let main () =
     [
       ("-hd", Arg.String (fun x -> gw_prefix := x; Secure.add_assets x), "<DIR> Specify where the “etc”, “images” and “lang” directories are installed (default if empty is “gw”).")
     ; ("-bd", Arg.String Secure.set_base_dir, "<DIR> Specify where the “bases” directory with databases is installed (default if empty is “bases”).")
-    ; ("-wd", Arg.String make_cnt_dir, "<DIR> Directory for socket communication (Windows) and access count.")
+    ; ("-wd", Arg.String make_sock_dir, "<DIR> Directory for socket communication (Windows) and access count.")
     ; ("-cache_langs", Arg.String (fun s -> List.iter (Mutil.list_ref_append cache_langs) @@ String.split_on_char ',' s), " Lexicon languages to be cached.")
     ; ("-cgi", Arg.Set force_cgi, " Force CGI mode.")
     ; ("-etc_prefix", Arg.String (fun x -> etc_prefix := x; Secure.add_assets x), "<DIR> Specify where the “etc” directory is installed (default if empty is [-hd value]/etc).")
@@ -2095,12 +2043,12 @@ let main () =
   in
   Geneweb.GWPARAM.gwd_cmd := gwd_cmd;
   List.iter register_plugin !plugins ;
-  !GWPARAM.init () ;
+  GWPARAM.init "" ;
   cache_lexicon () ;
   List.iter
     (fun dbn ->
        Printf.eprintf "Caching database %s in memory… %!" dbn;
-       let dbn = Util.bpath (dbn ^ ".gwb") in
+       let dbn = !GWPARAM.bpath dbn in
        ignore (Gwdb.open_base ~keep_in_memory:true dbn);
        Printf.eprintf "Done.\n%!"
     )
@@ -2120,10 +2068,9 @@ let main () =
     in
       images_prefix := "file://" ^ slashify abs_dir
     end;
-  if !(Util.cnt_dir) = Filename.current_dir_name then
-    Util.cnt_dir := Secure.base_dir ();
+  GWPARAM.cnt_dir := !GWPARAM.cnt_d "";
   Wserver.stop_server :=
-    List.fold_left Filename.concat !(Util.cnt_dir) ["cnt"; "STOP_SERVER"];
+    List.fold_left Filename.concat !GWPARAM.cnt_dir ["STOP_SERVER"];
   let (query, cgi) =
     try Sys.getenv "QUERY_STRING" |> Adef.encoded, true
     with Not_found -> "" |> Adef.encoded, !force_cgi

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -314,7 +314,7 @@ let try_plugin list conf base_name m =
   List.exists fn (Hashtbl.find_all GwdPlugin.ht m)
 
 let w_lock ~onerror fn conf (base_name : string option) =
-  let bfile = Util.bpath (conf.bname ^ ".gwb") in
+  let bfile = !GWPARAM.bpath conf.bname in
   Lock.control
     (Mutil.lock_file bfile) true
     ~onerror:(fun () -> onerror conf base_name)
@@ -370,11 +370,11 @@ let treat_request =
   fun conf ->
   let bfile =
     if conf.bname = "" then None
-    else
-      let bfile = Util.bpath (conf.bname ^ ".gwb") in
+    else (
+      let bfile = Filename.concat (Secure.base_dir ()) (conf.bname ^ ".gwb") in
       if Sys.file_exists bfile
       then Some bfile
-      else None
+      else None)
   in
   let process () =
   if conf.wizard
@@ -828,4 +828,9 @@ let treat_request =
   else process ()
 
 let treat_request conf =
+  GWPARAM.init conf.bname ;
+  (* TODO verify if we need init_etc here *)
+  let conf = { conf with
+    base_env = Util.read_base_env conf.bname conf.gw_prefix conf.debug }
+  in
   try treat_request conf with Update.ModErr _ -> Output.flush conf

--- a/bin/gwd/robot.ml
+++ b/bin/gwd/robot.ml
@@ -66,7 +66,7 @@ let output_excl oc xcl =
   output_value oc (xcl : excl)
 
 let robot_excl () =
-  let fname = SrcfileDisplay.adm_file "robot" in
+  let fname = !GWPARAM.adm_file "robot" in
   let xcl =
     match try Some (Secure.open_in_bin fname) with _ -> None with
     | Some ic ->

--- a/bin/setup/lang/ged2gwb.htm
+++ b/bin/setup/lang/ged2gwb.htm
@@ -50,10 +50,25 @@ ectly in the url in your navigator.
 </table>
 </span>
 <p>
+
 <li>
-[Enter The name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.]
+[Enter the name of the folder holding databases.]
+<p>
+<table class="setup">
+<tr><td>
+<span style="font-family: monospace">
+   -bd          </span>
+<input name="bd" size="30" style="padding-left:4px"
+placeholder=".">
+[If you write nothing, it will be taken as "."]
+</td></tr>
+</table>
+<p>
+
+<li>
+[Enter the name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.]
 %(
-Enter The name you want to give to your %G database.
+Enter the name you want to give to your %G database.
 If omitted, it will be deducted from the name of the GEDCOM file.
 %)
 <p>
@@ -70,6 +85,14 @@ placeholder="[name]
 <li>
 [Select the options you want][:]
 
+<p>
+<table class="setup">
+<tr align="left">
+<td><input type="checkbox" name="f" id="f" value="on" />
+<label for="f" style="font-family: monospace">-f            | </label>[Delete database if already existing.]
+</td>
+</tr>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
@@ -203,6 +226,16 @@ e year.
 </td>
 </tr>
 </table>
+
+<p>
+<table class="setup">
+<tr align=left>
+<td><input type="checkbox" name="reorg" id="reorg" value="on">
+<label for="reorg" style="font-family: monospace">-org           | </label>[Reorg mode.]
+</td>
+</tr>
+</table>
+
 <p>
 <table class="setup">
 <tr align=left><td>   
@@ -293,6 +326,7 @@ May 2, 1912" or "February 5, 1912" according to the countries).
 <label for="MSDOS">[The accentuated characters are in MSDOS encoding.]
 </label></td>
 </tr>
+
 </table>
 <p>
 <li>

--- a/bin/setup/lang/gwc.htm
+++ b/bin/setup/lang/gwc.htm
@@ -6,14 +6,11 @@
   <meta charset="utf-8">
   <meta name="robots" content="none">
   <link rel="shortcut icon" href="images/favicon_gwsetup.png">
-
   <title>[Import a GeneWeb file]
 </title>
 %fsetup.css;
 </head>
-
 <body %Vbody_prop;>
-
 <div style="background:url('images/gwlogo.png') no-repeat left top; text-align:center; height:95px; line-height:95px; color:#2f6400;">
 <h1 style="margin:0;">[Import a GeneWeb file]</h1>
 </div>
@@ -55,6 +52,20 @@ l be insufficient to change the drive letter (C: -> D:), but you can do this dir
 ectly in the url in your navigator.
 %)
 </td></tr>
+
+</table>
+</span>
+<p>
+<li>
+[Enter the name of the folder holding databases.]
+<p>
+<span style="font-size:80%%">
+<table class="setup">
+<tr align=left><td>
+<input name=bd size=30 placeholder="." value=".">
+[If you write nothing, it will be taken as "."]
+</td></tr>
+</table>
 </table>
 </span>
 <p>
@@ -102,6 +113,23 @@ ectly in the url in your navigator.
 </tr>
 </table>
 <p>
+<p>
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=gwo value="on">   </td>
+<td>[Kill .gwo files after base creation.]
+</td>
+</tr>
+</table>
+<p>
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=reorg value="on">   </td>
+<td>[Reorg mode.]
+</td>
+</tr>
+</table>
+<p>
 <li>
 [Then click on this button][:]
 <input type=submit value="Ok">
@@ -109,4 +137,3 @@ ectly in the url in your navigator.
 </form>
 </body>
 </html>
-

--- a/bin/setup/lang/gwf_1.htm
+++ b/bin/setup/lang/gwf_1.htm
@@ -66,7 +66,8 @@ database.
 %)
 </td>
 </tr>
-<tr align=left><td align=center>
+<tr align=left>
+<td align=left>
 <p>
 <table style="border:1px solid">
 <tr align=left>
@@ -236,7 +237,7 @@ value='style="background-color:#CC0000; text:#FFFFFF; link:#FFFF00; vlink:#00FFF
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <select name=default_lang>
 <option value=""%Edefault_lang=;>-
 <option value="af"%Edefault_lang=af;>%Laf;
@@ -286,7 +287,7 @@ ult, it is 8 generations, but you can indicate a different value here.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_anc_level value="%Vmax_anc_level;"
+<td align=left><input name=max_anc_level value="%Vmax_anc_level;"
 size=5></td>
 </tr>
 </table>
@@ -304,7 +305,7 @@ fault, it is 12 generations, but you can indicate a different value here.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_desc_level value="%Vmax_desc_level;"
+<td align=left><input name=max_desc_level value="%Vmax_desc_level;"
 size=5></td>
 </tr>
 </table>
@@ -322,7 +323,7 @@ When ancestors are displayed by tree, limit the number of displayed generations.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_anc_tree value="%Vmax_anc_tree;"
+<td align=left><input name=max_anc_tree value="%Vmax_anc_tree;"
 size=5></td>
 </tr>
 </table>
@@ -340,7 +341,7 @@ s. By default, it is 4 generations, but you can indicate a different value here.
 </tr>
 </tr>
 <tr align=left>
-<td align=center><input name=max_desc_tree value="%Vmax_desc_tree;"
+<td align=left><input name=max_desc_tree value="%Vmax_desc_tree;"
 size=5></td>
 </tr>
 </table>
@@ -360,7 +361,7 @@ start empty.
 %)
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=history value="yes"%Chistory=yes;>[yes|no]0
 <input type=radio name=history value="no"%Chistory=no;>[yes|no]1
 </tr>
@@ -383,7 +384,7 @@ send image" which are installed as a standard name in a standard place.
 %)
 </tr>
 <tr align=left>
-<td align=center><input name=images_path value="%Vimages_path;"
+<td align=left><input name=images_path value="%Vimages_path;"
 size=50></td>
 </tr>
 </table>
@@ -399,7 +400,7 @@ The advanced request allows to make researches in the data base. As it is very i
 ncomplete, it is hidden by default. Select "no" below to set it.
 %)
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=hide_advanced_request
 value="yes"%Chide_advanced_request=yes;>[yes|no]0
 <input type=radio name=hide_advanced_request
@@ -429,7 +430,7 @@ If this area is empty, everybody is a "friend". You can leave this area empty if
 </td>
 </tr>
 <tr align=left>
-<td align=center><input name=friend_passwd value="%Vfriend_passwd;"
+<td align=left><input name=friend_passwd value="%Vfriend_passwd;"
 size=30></td>
 </tr>
 </table>
@@ -451,7 +452,7 @@ If this area is empty, everybody is a "wizard". You can leave this area empty if
 </td>
 </tr>
 <tr align=left>
-<td align=center><input name=wizard_passwd value="%Vwizard_passwd;"
+<td align=left><input name=wizard_passwd value="%Vwizard_passwd;"
 size=30></td>
 </tr>
 </table>
@@ -474,7 +475,7 @@ t is accessible to Internet, to avoid that "wizards" make changes which would be
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=wizard_just_friend
  value="yes"%Cwizard_just_friend=yes;>[yes|no]0
 <input type=radio name=wizard_just_friend
@@ -498,7 +499,7 @@ actly, the persons of less than one century.
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=hide_private_names
  value="yes"%Chide_private_names=yes;>[yes|no]0
 <input type=radio name=hide_private_names
@@ -525,7 +526,7 @@ ropriate file name.
 </td>
 </tr>
 <tr align=left>
-<td align=center>
+<td align=left>
 <input type=radio name=can_send_image
  value="yes"%Ccan_send_image=yes;>[yes|no]0
 <input type=radio name=can_send_image
@@ -554,7 +555,7 @@ w name to use with the same clickable request.
 </td>
 </tr>
 <tr align=left>
-<td align=center><input name=renamed value="%Vrenamed;" size=30></td>
+<td align=left><input name=renamed value="%Vrenamed;" size=30></td>
 </tr>
 </table>
 <p>
@@ -574,6 +575,20 @@ an use HTML tags.
 </td>
 </tr>
 </table>
+<p>
+<table style="border:1px solid" width="100%%">
+<tr align=left>
+<td>
+[check this box if creating a config file in reorg mode]
+</td>
+</tr>
+<tr align=left>
+<td>
+<input type="checkbox" name="reorg" id="reorg">[Reorg mode]
+</td>
+</tr>
+</table>
+
 </table></dl>
 <p>
 <li>

--- a/bin/setup/lang/lexicon.txt
+++ b/bin/setup/lang/lexicon.txt
@@ -92,6 +92,13 @@ fr: Sources
 en: Cache files computed
 fr: Fichiers cache calculés
 
+    Reorg mode.
+en: Reorg mode
+fr: Mode reorg
+
+    Kill .gwo files after base creation.
+en: Kill .gwo files after base creation.
+fr: Détruire les fichiers .gwo après création de la base
 
     "first names enclosed": the -fne option must be followed by a two characters string "be". When creating a person, if the GEDCOM first name part holds a part between 'b' (any character) and 'e' (any character), it is considered to be the usual first name: e.g. -fne "\\" or -fne "()".
 aa: ged2gwb.htm
@@ -1213,11 +1220,11 @@ it: Digitate il nome che volete dare alla vostra base di dati%G.
 lv: Ierakstiet nosaukumu, kâdâ Jûs  vçlaties nosaukt savu %G datu bâzi.
 sv: Namnet du vill kalla din %G databas.
 
-    Enter The name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.
+    Enter the name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.
 aa: ged2gwb.htm
 co: Scrivite u nome chì vò vulete dà à a vostra basa di dati %G. S’ellu hè omessu, serà deduttu secondu u nome di u schedariu GEDCOM.
 de: Name, den du deiner %G-Datenbank geben möchtest. Wenn du hier nichts eingibst, wird der Datenbankname aus dem Namen der GEDCOM-Datei abgeleitet.
-en: Enter The name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.
+en: Enter the name you want to give to your %G database. If omitted, it will be deducted from the name of the GEDCOM file.
 es: El nombre que Ud. desea dar a su base de datos %G. Si Ud. no mete ningún nombre, él será deducido del nombre del fichero GEDCOM.
 fr: Entrez le nom que vous voulez donner à votre base de données %G. Si vous ne mettez rien, il sera déduit du nom du fichier GEDCOM.
 it: Digitate il nome che volete dare alla vostra base di dati %G. Se non mettete niente il nome sarà dedotto da quello del file GEDCOM.

--- a/bin/setup/lang/simple.htm
+++ b/bin/setup/lang/simple.htm
@@ -25,6 +25,14 @@
 <p>
 <input name="o" size="30" value="base">
 <p>
+<table class="setup">
+<tr align=left>
+<td><input type=checkbox name=reorg value="on">   </td>
+<td>[Reorg mode.]
+</td>
+</tr>
+</table>
+<p>
 <li>
 [Then click on this button][:]
 <p>

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -39,15 +39,15 @@
   %if;("http" in portrait or "http" in portrait_saved)
     Update image field with <a href="%prefix;m=MOD_IND;i=%index;">MOD_IND</a>
   %elseif;(evar.mode="others" or evar.mode="note")
-    <samp>%if;(evar.em="RESET_IMAGE_C_OK")images%X;%carrousel;%X;old%X;%evar.file_name; <strong>></strong> %end;images%X;%carrousel;%if;(evar.delete="on")%X;old%end;%X;%nn;
+    <samp>%if;(evar.em="RESET_IMAGE_C_OK")images%X;%carrousel;%X;saved%X;%evar.file_name; <strong>></strong> %end;images%X;%carrousel;%if;(evar.delete="on")%X;saved%end;%X;%nn;
     %if;(evar.notes!="")%evar.file_name_2;.txt%else;%evar.file_name;%end;</samp>
   %else;
     %if;(evar.em="SND_IMAGE_C_OK" or evar.em="RESET_IMAGE_C_OK")
-      <samp>%evar.file_name;</samp> %if;(evar.em="RESET_IMAGE_C_OK")<samp>%portraits_store;%X;old%X;%portrait_saved;</samp>
+      <samp>%evar.file_name;</samp> %if;(evar.em="RESET_IMAGE_C_OK")<samp>%portraits_store;%X;saved%X;%portrait_saved;</samp>
       <strong> <</strong>%end;<strong>> </strong><samp>%portraits_store;%X;%portrait;</samp>%nn;
       %(%if;(evar.em="DEL IMAGE_C_OK" or evar.em="RESET_IMAGE_C_OK")%portrait;%else;%evar.file_name;%end;</samp>%)
     %elseif;(evar.em="DEL_IMAGE_C_OK")
-      %if;(evar.delete!="on")<samp>portrait%X;%portrait_saved;</samp> <strong>></strong> <samp>portraits%X;old%X;%portrait_saved;</samp>
+      %if;(evar.delete!="on")<samp>portrait%X;%portrait_saved;</samp> <strong>></strong> <samp>portraits%X;saved%X;%portrait_saved;</samp>
       %else;<samp>portraits%X;saved%X;%carrousel;(.gif/jpg/png)</samp>%end;
     %end;
   %end;
@@ -62,17 +62,17 @@
 %end;
 
 %let;portraits_store;
-  %if;(bvar.reorg="on")%base.name;.gwb%X;documents%X;portraits%nn;
+  %if;reorg;%base.name;.gwb%X;documents%X;portraits%nn;
   %else;images%X;%base.name;%nn;
   %end;%nn;
 %in;
 %let;saved_portraits_store;
-  %if;(bvar.reorg="on")%base.name;.gwb%X;documents%X;portraits%nn;
-  %else;images%X;%base.name;%X;old%nn;
+  %if;reorg;%base.name;.gwb%X;documents%X;portraits%X;saved%nn;
+  %else;images%X;%base.name;%X;saved%nn;
   %end;%nn;
 %in;
 %let;images_store;
-  %if;(bvar.reorg="on")%base.name;.gwb%X;documents%X;images%nn;
+  %if;reorg;%base.name;.gwb%X;documents%X;images%nn;
   %else;src%X;%base.name;%X;images%nn;
   %end;%nn;
 %in;
@@ -101,7 +101,9 @@
           type="submit" disabled>[*send]</button>
       </form>
       <div class="small mt-2">%nn;
-        %if;(has_portrait and has_old_portrait)[*previous portrait]%end;
+        %if;has_portrait_url;[*must use MOD_IND]%else;
+          %if;(has_portrait and has_old_portrait)[*previous portrait]%end;
+        %end;
       </div>
       <h1 class="display-4">
       %(<i class="far fa-file-image fa-fw mr-1"></i>%)[*add image]</h1>
@@ -165,37 +167,39 @@
         %if;has_portrait;
           <div class="d-flex mt-1">
             <a role="button" 
-              href=%if;has_portrait_url;"%portrait;"%else;"%prefix;kch=%random.bits;&m=IM_C&i=%index;"%end;%sp;
+              href="%if;has_portrait_url;%portrait;%else;%prefix;kch=%random.bits;&m=IM_C&i=%index;%end;"%sp;
               target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong>[*see portrait]</strong><br><span class="small">%portrait;</span>
                    <br><img class="rounded my-1"
-              src=%if;has_portrait_url;"%portrait;"%else;"%prefix;kch=%random.bits;&m=IM_C&i=%index;"%end;%sp;
+              src="%if;has_portrait_url;%portrait;%else;%prefix;kch=%random.bits;&m=IM_C&i=%index;%end;"%sp;
                    width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
           <span class="invisible"><i class="fas fa-retweet fa-rotate-90 fa-fw text-primary"></i></span>
-          <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%nn;
-          %if;has_portrait_url;%carrousel;.url%else;%portrait_name;%end;</samp>
-          <a role="button" class="ml-auto col-1"  href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&idigest=%idigest;"
-             data-toggle="tooltip" data-html="true" data-placement="left"
-             title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete portrait]</strong><br><span class="small">%portrait;</span>
-                    <br><img class="rounded my-1" src="%prefix;m=IM_C&i=%index;"
-                    width="185px">'>
-            <i class="far fa-trash-can text-warning"></i>%nn;</a>
+          %if;has_portrait_url;%portrait;%else;
+            <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong>%nn;
+            <samp>%portrait_name;</samp>
+            <a role="button" class="ml-auto col-1"  href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&idigest=%idigest;"
+               data-toggle="tooltip" data-html="true" data-placement="left"
+               title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete portrait]</strong><br><span class="small">%portrait;</span>
+                      <br><img class="rounded my-1" src="%prefix;m=IM_C&i=%index;"
+                      width="185px">'>
+              <i class="far fa-trash-can text-warning"></i>%nn;</a>
+          %end;
           </div>
         %end;
         %if;has_old_portrait;
           <div class="d-flex mt-1">
             <a role="button" 
-              href=%if;has_old_portrait_url;"%portrait;"%else;"%prefix;kch=%random.bits;&m=IM_C_S&i=%index;"%end;
+              href="%if;has_old_portrait_url;%portrait;%else;%prefix;kch=%random.bits;&m=IM_C_S&i=%index;%end;"
               target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong>[*see portrait]</strong><br><span class="small">%portrait_saved</span>
                    <br><img class="rounded my-1"
-              src=%if;has_old_portrait_url;"%portrait_saved;"%else;"%prefix;kch=%random.bits;&m=IM_C_S&i=%index;"%end;
+              src="%if;has_old_portrait_url;%portrait_saved;%else;%prefix;kch=%random.bits;&m=IM_C_S&i=%index;%end;"
                    width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait;&idigest=%idigest;"
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait_name;&idigest=%idigest;"
                title="[*restore portrait saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
             <strong><samp class="text-truncate">%saved_portraits_store;%X;</samp></strong><samp>
@@ -225,12 +229,12 @@
         %foreach;img_in_carrousel;
           <div class="d-flex mt-1">
             <a role="button"
-              href=%if;(url_in_env!="")"%url_in_env;"%else;"%prefix;m=IM_C&i=%index;&s=%carrousel_img;"%end;
+              href="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
               target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [image/images]0</strong>
                      <br><span class="small">%carrousel_img_raw;</span>
                      <br><img class="rounded my-1"
-              src=%if;(url_in_env!="")"%url_in_env;"%else;"%prefix;m=IM_C&i=%index;&s=%carrousel_img;"%end;
+              src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
                      width="185px">
                      '>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
@@ -256,7 +260,7 @@
                 title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete image]</strong>
                        <br><span class="small">%carrousel_img_raw;</span>
                        <br><img class="rounded my-1"
-                src=%if;(url_in_env!="")"%url_in_env;"%else;"%prefix;m=IM_C&i=%index;&s=%carrousel_img;"%end;
+                src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
                 width="185px">'>
                 <i class="far fa-trash-can text-warning"></i></a>
             </div>
@@ -267,25 +271,25 @@
         <h1 class="display-4">[*saved images]1</h1>
         <div class="d-flex align-items-center">
           <i class="fa fa-folder-open fa-lg text-warning mx-2" aria-hidden="true"></i>
-          <strong><samp class="text-truncate" title="%images_store;%X;%carrousel;%X;old%X;">%images_store%X;%carrousel;%X;old%X;</samp></strong>
+          <strong><samp class="text-truncate" title="%images_store;%X;%carrousel;%X;saved%X;">%images_store%X;%carrousel;%X;saved%X;</samp></strong>
           <div class="ml-auto">(%carrousel_old_img_nbr; %if;(carrousel_old_img_nbr>1)[image/images]1%else;[image/images]0%end;)</div>
         </div>
         %foreach;img_in_carrousel_old;
           <div class="d-flex mt-1">
             <a role="button"
-              href=%if;(url_in_env!="")"%url_in_env;"%else;"%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;"%end;
+              href="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
               target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [saved images]0</strong>
                      <br><span class="small">%carrousel_img_raw;</span>
                      <br><img class="rounded my-1"
-              src=%if;(url_in_env!="")"%url_in_env;"%else;"%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;"%end;
+              src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
               width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
             <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=others&file_name=%carrousel_img;&idigest=%idigest;"
                %if;(url_in_env!="")%else;data-toggle="tooltip" data-html="true" data-placement="top"%end;
                title="[*restore image saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i></a>
-            <samp class="text-truncate ml-1" title="%images_store;%X;old%X;%carrousel_img;">%carrousel_img_raw;</samp>
+            <samp class="text-truncate ml-1" title="%images_store;%X;saved%X;%carrousel_img;">%carrousel_img_raw;</samp>
             <div class="ml-auto col-1">
               <a role="button"
                 href="%prefix;m=DEL_IMAGE_C_OK&i=%index%nn;
@@ -295,7 +299,7 @@
                 title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete image saved]</strong>
                          <br><span class="small">%carrousel_img_raw;</span>
                          <br><img class="rounded my-1"
-                src=%if;(url_in_env!="")"%url_in_env;"%else;"%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;"%end;
+                src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
                 width="185px">'>
                 <i class="far fa-trash-can text-danger fa-fw text-primary"></i></a>
             </div>

--- a/hd/etc/conf.txt
+++ b/hd/etc/conf.txt
@@ -56,7 +56,8 @@
 <section id="bvar-list" class="mt-3 mx-3">
   <h2>[*configuration parameters]</h2>
   <div>
-    <tt>%base.name;.gwf</tt><br>
+     Mode: <b>%if;reorg;Reorg%else;Classic%end;</b>[:]%sp;
+    <tt>%if;reorg;%base.name;.gwb%/etc%/%base.name;%else;%base.name;%end;.gwf</tt><br>
     %bvar.list;
   </div>
 </section>

--- a/hd/etc/css.txt
+++ b/hd/etc/css.txt
@@ -7,7 +7,7 @@
   li.parent { list-style-type: disc; list-style-image: url('%images_prefix;left.png'); }
 </style>
 %end;
-%if;(evar.templ="")
+%if;(e.templ!="templ")
   %if;(bvar.use_cdn="yes")
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"

--- a/hd/etc/modules/test.txt
+++ b/hd/etc/modules/test.txt
@@ -1,0 +1,3 @@
+<!-- test.txt 06/07/202 -->
+
+module gw/etc/modules/test.txt

--- a/hd/etc/perso_utils.txt
+++ b/hd/etc/perso_utils.txt
@@ -836,6 +836,8 @@
 %let;o13;%apply;nth_c%with;%p_mod;%and;%expr(27)%end;%in;
 %let;m14;%apply;nth_c%with;%p_mod;%and;%expr(28)%end;%in;
 %let;o14;%apply;nth_c%with;%p_mod;%and;%expr(29)%end;%in;
+%let;m15;%apply;nth_c%with;%p_mod;%and;%expr(30)%end;%in;
+%let;o15;%apply;nth_c%with;%p_mod;%and;%expr(31)%end;%in;
 
 %let;perso_module_a;arbres%in;
 %let;perso_module_c;chronologie%in;
@@ -850,11 +852,12 @@
 %let;perso_module_r;relations%in;
 %let;perso_module_s;sources%in;
 %let;perso_module_u;unions%in;
+%let;perso_module_t;test%in;
 
-%let;abc;acdfghilnprsu%in;
+%let;abc;acdfghilnprsut%in;
 %( compute nbr of entries in p_mod %)
 %reset_count;
-%for;i;0;14;
+%for;i;0;15;
   %let;mnb;%apply;mm(i)%in;
   %if;(mnb!="")%incr_count;%end;
 %end;

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -1827,6 +1827,10 @@ sl: dodaj slika
 sv: lägg till bild
 tr: resim ekle
 
+    must use MOD_IND
+en: portrait is a url. Use MOD_IND to delete or update.
+fr: le portrait est une Url. Utiliser MOD_IND pour le corriger ou le supprimer.
+
     add portrait
 co: aghjunghje un ritrattu
 de: Porträt hinzufügen
@@ -14678,8 +14682,8 @@ fr: si une image du même nom existe déjà dans le sous-répertoire de sauvegar
     previous portrait
 co: un arregistramentu precedente di u ritrattu, s’ellu esiste, serà squassatu.
 de: wenn schon ein gespeichertes Porträt mit dem gleichen Namen existiert, wird es gelöscht.
-en: a possible previous version of the saved portrait will be deleted.
-fr: une sauvegarde pré-existante du portrait sera supprimée.
+en: a possible previous version of the saved portrait will be deleted. Using MOD_IND does not save the portrait.
+fr: une sauvegarde pré-existante du portrait sera supprimée.<br> Utiliser MOD_IND ne sauvegarde pas le portrait.
 
     previous sibling
 af: vorige broer/vorige suster/vorige broer of suster

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -9,6 +9,20 @@ let errors_undef = ref []
 let errors_other = ref []
 let set_vars = ref []
 let gwd_cmd = ref ""
+let reorg = ref false
+let force = ref false
+let cnt_dir = ref ""
+let sock_dir = ref ""
+let bases = ref (Secure.base_dir ())
+
+type init_s = { status : bool; bname : string }
+
+let init_done : init_s ref = ref { status = false; bname = "" }
+
+(** allows testing of reorg config in classic mode *)
+let config_reorg bname =
+  String.concat Filename.dir_sep
+    [ Secure.base_dir (); bname ^ ".gwb"; "config"; bname ^ ".gwf" ]
 
 type syslog_level =
   [ `LOG_ALERT
@@ -21,12 +35,108 @@ type syslog_level =
   | `LOG_WARNING ]
 
 module Default = struct
-  let init () = Secure.add_assets Filename.current_dir_name
+  (* Attention, ajuster is_reorg_base en conséquence *)
+  let config bname =
+    let bname = Filename.remove_extension bname in
+    config_reorg bname
 
-  let base_path pref bname =
-    List.fold_right Filename.concat (Secure.base_dir () :: pref) bname
+  let cnt_d bname =
+    let bname = Filename.remove_extension bname in
+    if !sock_dir = "" then
+      cnt_dir :=
+        if bname <> "" then
+          String.concat Filename.dir_sep
+            [ Secure.base_dir (); bname ^ ".gwb"; "config"; "cnt" ]
+        else String.concat Filename.dir_sep [ Secure.base_dir (); "cnt" ]
+    else cnt_dir := !sock_dir;
+    !cnt_dir
 
-  let bpath bname = Filename.concat (Secure.base_dir ()) bname
+  let adm_file file = Filename.concat !cnt_dir file
+
+  let portraits_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep
+      [ Secure.base_dir (); bname ^ ".gwb"; "documents"; "portraits" ]
+
+  let src_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep
+      [ Secure.base_dir (); bname ^ ".gwb"; "documents"; "src" ]
+
+  let etc_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep [ Secure.base_dir (); bname ^ ".gwb"; "etc" ]
+
+  let config_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep
+      [ Secure.base_dir (); bname ^ ".gwb"; "config" ]
+
+  let lang_d bname lang =
+    let bname = Filename.remove_extension bname in
+    if lang = "" then
+      String.concat Filename.dir_sep
+        [ Secure.base_dir (); bname ^ ".gwb"; "etc"; "lang" ]
+    else
+      String.concat Filename.dir_sep
+        [ Secure.base_dir (); bname ^ ".gwb"; "etc"; "lang"; lang ]
+
+  let images_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep
+      [ Secure.base_dir (); bname ^ ".gwb"; "documents"; "images" ]
+
+  let bpath bname =
+    let bname = Filename.remove_extension bname in
+    if bname = "" then Secure.base_dir ()
+    else Filename.concat (Secure.base_dir ()) (bname ^ ".gwb")
+end
+
+module Legacy = struct
+  (* Attention, ajuster is_reorg_base en conséquence *)
+  let config bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep [ Secure.base_dir (); bname ^ ".gwf" ]
+
+  let cnt_d _bname =
+    if !cnt_dir = "" then (
+      let str = String.concat Filename.dir_sep [ Secure.base_dir (); "cnt" ] in
+      cnt_dir := str;
+      str)
+    else !cnt_dir
+
+  let adm_file file = Filename.concat !cnt_dir file
+
+  let portraits_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep [ Secure.base_dir (); "images"; bname ]
+
+  let src_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep [ Secure.base_dir (); "src"; bname ]
+
+  let etc_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep [ Secure.base_dir (); "etc"; bname ]
+
+  let config_d _bname = Secure.base_dir ()
+
+  let lang_d bname lang =
+    let bname = Filename.remove_extension bname in
+    if lang = "" then
+      String.concat Filename.dir_sep [ Secure.base_dir (); "lang"; bname ]
+    else
+      String.concat Filename.dir_sep [ Secure.base_dir (); "lang"; lang; bname ]
+
+  let images_d bname =
+    let bname = Filename.remove_extension bname in
+    String.concat Filename.dir_sep
+      [ Secure.base_dir (); "src"; bname; "images" ]
+
+  let bpath bname =
+    let bname = Filename.remove_extension bname in
+    if bname = "" then Secure.base_dir ()
+    else Filename.concat (Secure.base_dir ()) (bname ^ ".gwb")
 
   (** [output_error ?headers ?content conf code]
       Send the http status [code], [headers] and
@@ -167,15 +277,141 @@ module Default = struct
     Output.print_sstring conf {|</body></html>|}
 end
 
-let init = ref Default.init
-let base_path = ref Default.base_path
-let bpath = ref Default.bpath
-let output_error = ref Default.output_error
-let p_auth = ref Default.p_auth
-let syslog = ref Default.syslog
+type my_fun_2 = string -> string
+type my_fun_3 = string -> string -> string
+
+let config = ref (Legacy.config : my_fun_2)
+let cnt_d = ref (Legacy.cnt_d : my_fun_2)
+let adm_file = ref (Legacy.adm_file : my_fun_2)
+let src_d = ref (Legacy.src_d : my_fun_2)
+let etc_d = ref (Legacy.etc_d : my_fun_2)
+let config_d = ref (Legacy.config_d : my_fun_2)
+let lang_d = ref (Legacy.lang_d : my_fun_3)
+let bpath = ref (Legacy.bpath : my_fun_2)
+let portraits_d = ref (Legacy.portraits_d : my_fun_2)
+let images_d = ref (Legacy.images_d : my_fun_2)
+
+(* attention; ne pas utiliser !config! *)
+let is_reorg_base bname =
+  let bname = Filename.remove_extension bname in
+  Sys.file_exists
+    (String.concat Filename.dir_sep
+       [ Secure.base_dir (); bname ^ ".gwb"; "config"; bname ^ ".gwf" ])
+
+let output_error = ref Legacy.output_error
+let p_auth = ref Legacy.p_auth
+let syslog = ref Legacy.syslog
+
+let init bname =
+  Secure.add_assets Filename.current_dir_name;
+
+  reorg := !reorg || is_reorg_base bname;
+  if !reorg then (
+    config := Default.config;
+    cnt_d := Default.cnt_d;
+    adm_file := Default.adm_file;
+    src_d := Default.src_d;
+    etc_d := Default.etc_d;
+    config_d := Default.config_d;
+    lang_d := Default.lang_d;
+    bpath := Default.bpath;
+    portraits_d := Default.portraits_d;
+    images_d := Default.images_d)
+  else (
+    config := Legacy.config;
+    cnt_d := Legacy.cnt_d;
+    adm_file := Legacy.adm_file;
+    src_d := Legacy.src_d;
+    etc_d := Legacy.etc_d;
+    config_d := Legacy.config_d;
+    lang_d := Legacy.lang_d;
+    bpath := Legacy.bpath;
+    portraits_d := Legacy.portraits_d;
+    images_d := Legacy.images_d)
+
+let init_etc bname =
+  if !init_done.status && bname = !init_done.bname then ()
+  else init_done := { status = true; bname };
+  if !reorg then (
+    (if not (Sys.file_exists (!bpath bname)) then
+     try
+       Unix.mkdir (!bpath bname) 0o755;
+       force := true
+     with Unix.Unix_error (_, _, _) ->
+       !syslog `LOG_WARNING
+         (Printf.sprintf "Failure when creating base_dir: %s" (!bpath bname)));
+
+    (if not (Sys.file_exists (!etc_d bname)) then
+     try Unix.mkdir (!etc_d bname) 0o755
+     with Unix.Unix_error (_, _, _) ->
+       !syslog `LOG_WARNING
+         (Printf.sprintf "Failure when creating etc_dir: %s" (!etc_d bname)));
+
+    (if not (Sys.file_exists (!config_d bname)) then
+     try Unix.mkdir (!config_d bname) 0o755
+     with Unix.Unix_error (_, _, _) ->
+       !syslog `LOG_WARNING
+         (Printf.sprintf "Failure when creating config_dir: %s"
+            (!config_d bname)));
+
+    if not (Sys.file_exists (!cnt_d bname)) then
+      try Unix.mkdir (!cnt_d bname) 0o755
+      with Unix.Unix_error (_, _, _) ->
+        !syslog `LOG_WARNING
+          (Printf.sprintf "Failure when creating cnt_dir: %s" (!cnt_d bname)))
+  else (
+    (if not (Sys.file_exists "etc") then
+     try
+       Unix.mkdir "etc" 0o755;
+       force := true
+     with Unix.Unix_error (_, _, _) ->
+       !syslog `LOG_WARNING (Printf.sprintf "Failure when creating etc"));
+
+    (if not (Sys.file_exists "lang") then
+     try
+       Unix.mkdir "lang" 0o755;
+       force := true
+     with Unix.Unix_error (_, _, _) ->
+       !syslog `LOG_WARNING (Printf.sprintf "Failure when creating lang"));
+
+    (if not (Sys.file_exists "cnt") then
+     try
+       Unix.mkdir "etc" 0o755;
+       force := true
+     with Unix.Unix_error (_, _, _) ->
+       !syslog `LOG_WARNING (Printf.sprintf "Failure when creating cnt"));
+
+    if not (Sys.file_exists (!etc_d bname)) then
+      try
+        Unix.mkdir (!etc_d bname) 0o755;
+        force := true
+      with Unix.Unix_error (_, _, _) ->
+        !syslog `LOG_WARNING
+          (Printf.sprintf "Failure when creating etc_dir: %s" (!etc_d bname)))
+
+let test_reorg bname =
+  if !reorg || is_reorg_base bname then (
+    reorg := true;
+    init bname)
+
+let test_base bname =
+  let bdir = !bpath bname in
+  if Sys.file_exists (config_reorg bname) && !force then (
+    reorg := true;
+    init_done := { status = false; bname };
+    init bname);
+  Printf.eprintf "Mode: %s, for base %s\n"
+    (if !reorg then "reorg" else "classic")
+    (Filename.concat (!bpath "") (bname ^ ".gwb"));
+  if (not !force) && Sys.file_exists bdir then (
+    Printf.eprintf
+      "The database \"%s\" already exists. Use option -f to overwrite it." bname;
+    flush stderr;
+    exit 2);
+  init_etc bname
 
 (** [wrap_output conf title content]
     Plugins defining a page content but not a complete UI
     may want to wrap their page using [wrap_output].
 *)
-let wrap_output = ref Default.wrap_output
+let wrap_output = ref Legacy.wrap_output

--- a/lib/GWPARAM.mli
+++ b/lib/GWPARAM.mli
@@ -3,6 +3,30 @@ val errors_undef : string list ref
 val errors_other : string list ref
 val set_vars : string list ref
 val gwd_cmd : string ref
+val cnt_dir : string ref
+val sock_dir : string ref
+val bases : string ref
+val reorg : bool ref
+val force : bool ref
+
+type init_s = { status : bool; bname : string }
+
+val init_done : init_s ref
+val config_reorg : string -> string
+
+type my_fun_2 = string -> string
+type my_fun_3 = string -> string -> string
+
+val config : my_fun_2 ref
+val cnt_d : my_fun_2 ref
+val adm_file : my_fun_2 ref
+val src_d : my_fun_2 ref
+val etc_d : my_fun_2 ref
+val config_d : my_fun_2 ref
+val lang_d : my_fun_3 ref
+val bpath : my_fun_2 ref
+val portraits_d : my_fun_2 ref
+val images_d : my_fun_2 ref
 
 type syslog_level =
   [ `LOG_EMERG  (** A panic condition. *)
@@ -23,20 +47,6 @@ type syslog_level =
 (** The level of log gravity. See SYSLOG(3) *)
 
 (* S: Move it to gwd_lib?  *)
-
-val init : (unit -> unit) ref
-(** Function called before gwd starts
-    e.g. inititialise assets folders in Secure module. *)
-
-val base_path : (string list -> string -> string) ref
-(** [!base_path pref fname] function that returns a path to a file identified by [pref] [fname]
-    related to bases. [pref] is like a category for file [fname].
-
-    See {!val:GWPARAM.Default.base_path} for a concrete example.
-*)
-
-val bpath : (string -> string) ref
-(** Same as {!val:base_path}, but without the prefix (avoid unecessary empty list). *)
 
 val output_error :
   (?headers:string list ->
@@ -61,14 +71,48 @@ val wrap_output :
     Wrap the display of [title] and [content] in a defined template.
 *)
 
-module Default : sig
-  val init : unit -> unit
-  (** Inititialise assets directories for gwd server:
-      * current directory
-      *)
+val init : string -> unit
+(** Function called before gwd starts
+    e.g. inititialise assets folders in Secure module. *)
 
-  val base_path : string list -> string -> string
-  (** Use concatenation of [Secure.base_dir ()], [pref] and [fname] *)
+val init_etc : string -> unit
+(** Function called before gwd starts
+    e.g. inititialise etc folders in reorg mode. *)
+
+val is_reorg_base : string -> bool
+(** returns true if mybase.gwb/config/mybase.gwf exists *)
+
+val test_reorg : string -> unit
+(** set reorg to true if !reorg of is_reorg_base; then calls init *)
+
+val test_base : string -> unit
+(** for gwc and ged2gwb, test_reorg, alert if base exists and force is not set *)
+
+module Default : sig
+  val config : string -> string
+  val cnt_d : string -> string
+  val adm_file : string -> string
+  val portraits_d : string -> string
+  val src_d : string -> string
+  val etc_d : string -> string
+  val config_d : string -> string
+  val lang_d : string -> string -> string
+  val images_d : string -> string
+
+  val bpath : string -> string
+  (** [Filename.concat (Secure.base_dir ())] *)
+end
+
+module Legacy : sig
+  val config : string -> string
+  val cnt_d : string -> string
+  val adm_file : string -> string
+  val portraits_d : string -> string
+  val src_d : string -> string
+  val etc_d : string -> string
+  val config_d : string -> string
+  val lang_d : string -> string -> string
+  val images_d : string -> string
 
   val bpath : string -> string
   (** [Filename.concat (Secure.base_dir ())] *)

--- a/lib/cousins.ml
+++ b/lib/cousins.ml
@@ -333,26 +333,29 @@ let init_cousins_cnt conf base p =
   | Some t, Some d_t -> (t, d_t)
   | _, _ ->
       let _pnoc, _v1, t', d_t' =
+        let cous_cache_fname =
+          Filename.concat (!GWPARAM.bpath conf.bname) "cousins_cache"
+        in
         match List.assoc_opt "cache_cousins_tool" conf.Config.base_env with
         | Some "yes" -> (
             flush stderr;
             let pnoc, v1, t', d_t' =
-              Mutil.read_or_create_value "cousins_cache" (fun () ->
+              Mutil.read_or_create_value cous_cache_fname (fun () ->
                   build_tables key)
             in
             match (pnoc, v1) with
             | pnoc, v1 when pnoc = key && max_a_l <= v1 -> (pnoc, v1, t', d_t')
             | pnoc, v1 when pnoc = key ->
                 let _pnoc, _v1, t', d_t' =
-                  Mutil.read_or_create_value "cousins_cache" (fun () ->
+                  Mutil.read_or_create_value cous_cache_fname (fun () ->
                       build_tables key)
                 in
-                Sys.remove "cousins_cache";
-                Mutil.read_or_create_value "cousins_cache" ~magic:key (fun () ->
-                    expand_tables key v1 max_a_l t' d_t')
+                Sys.remove cous_cache_fname;
+                Mutil.read_or_create_value cous_cache_fname ~magic:key
+                  (fun () -> expand_tables key v1 max_a_l t' d_t')
             | _ ->
-                Sys.remove "cousins_cache";
-                Mutil.read_or_create_value "cousins_cache" (fun () ->
+                Sys.remove cous_cache_fname;
+                Mutil.read_or_create_value cous_cache_fname (fun () ->
                     build_tables key))
         | _ ->
             flush stderr;

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -349,7 +349,7 @@ let output base =
      Mutil.rm tmp_names_inx;
      Mutil.rm tmp_names_acc;
      Mutil.rm tmp_strings_inx;
-     Mutil.remove_dir tmp_notes_d;
+     Mutil.rm_rf tmp_notes_d;
      raise e);
   close_base base;
   Mutil.rm (Filename.concat bname "base");
@@ -376,8 +376,14 @@ let output base =
     Sys.rename tmp_notes (Filename.concat bname "notes");
   if Sys.file_exists tmp_notes_d then (
     let notes_d = Filename.concat bname "notes_d" in
-    Mutil.remove_dir notes_d;
-    Sys.rename tmp_notes_d notes_d);
+    if Sys.file_exists notes_d then Mutil.rm_rf notes_d;
+    try Sys.rename tmp_notes_d notes_d
+    with e ->
+      trace
+        (Printf.sprintf "Error renaming %s to %s: %s. Retrying once."
+           tmp_notes_d notes_d (Printexc.to_string e));
+      Unix.sleepf 0.5;
+      Sys.rename tmp_notes_d notes_d);
   Mutil.rm (Filename.concat bname "patches");
   Mutil.rm (Filename.concat bname "patches~");
   Mutil.rm (Filename.concat bname "synchro_patches");

--- a/lib/history.ml
+++ b/lib/history.ml
@@ -8,12 +8,7 @@ open TemplAst
 open Util
 
 (* S: Fail if conf.bname is undefined? *)
-let file_name conf =
-  let bname =
-    if Filename.check_suffix conf.bname ".gwb" then conf.bname
-    else conf.bname ^ ".gwb"
-  in
-  Filename.concat (Util.bpath bname) "history"
+let file_name conf = Filename.concat (Util.bpath conf.bname) "history"
 
 (* Record history when committing updates *)
 

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -8,9 +8,6 @@ val authorized_image_file_extension : string array
 val scale_to_fit : max_w:int -> max_h:int -> w:int -> h:int -> int * int
 (** [scale_to_fit ~max_w ~max_h ~w ~h] is the [width, height] of a proportionally scaled [w, h] rectangle so it can fit in a [max_w, max_h] rectangle *)
 
-val source_filename : config -> string -> string
-(** Returns path to the image file with the giving name in directory {i src/}. *)
-
 (* TODO this should be removed *)
 val default_portrait_filename : base -> person -> string
 (** [default_portrait_filename base p] is the default filename of [p]'s portrait. Without it's file extension.
@@ -23,7 +20,7 @@ val size_from_path : [ `Path of string ] -> (int * int, unit) result
     - Ok (width, height) of the file.
 It works by opening the file and reading magic numbers *)
 
-val path_of_filename : string -> [> `Path of string ]
+val path_of_filename : config -> string -> [> `Path of string ]
 (** [path_of_filename fname] search for image {i images/fname} inside the base and assets directories.
     Return the path to found file or [fname] if file isn't found.  *)
 
@@ -34,7 +31,8 @@ val src_to_string : [< `Path of string | `Url of string ] -> string
 (** [src_to_string src] is [src] as a string *)
 
 (* TODO this should be removed *)
-val get_portrait_path : config -> base -> person -> [> `Path of string ] option
+val get_portrait_path :
+  config -> base -> person -> [> `Path of string | `Url of string ] option
 (** [get_portrait_path conf base p] is
     - [None] if we don't have access to [p]'s portrait or it doesn't exist.
     - [Some path] with [path] the full path with extension of [p]'s portrait.

--- a/lib/imageDisplay.ml
+++ b/lib/imageDisplay.ml
@@ -116,7 +116,7 @@ let print_portrait conf base p =
 
 let print_source conf f =
   let fname = if f.[0] = '/' then String.sub f 1 (String.length f - 1) else f in
-  let fname = Image.source_filename conf fname in
+  let fname = Filename.concat (!GWPARAM.images_d conf.bname) fname in
   if (conf.wizard || conf.friend) || Image.is_not_private_img conf fname then
     Result.fold ~ok:ignore
       ~error:(fun _ -> Hutil.incorrect_request conf)

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -6,9 +6,8 @@ open Util
 module StrSet = Mutil.StrSet
 
 let file_path conf base fname =
-  Util.bpath
-    (List.fold_left Filename.concat (conf.bname ^ ".gwb")
-       [ base_notes_dir base; fname ^ ".txt" ])
+  String.concat Filename.dir_sep
+    [ Util.bpath conf.bname; base_notes_dir base; fname ^ ".txt" ]
 
 let path_of_fnotes fnotes =
   match NotesLinks.check_file_name fnotes with
@@ -155,9 +154,8 @@ let commit_notes conf base fnotes s =
   let pg = if fnotes = "" then Def.NLDB.PgNotes else Def.NLDB.PgMisc fnotes in
   let fname = path_of_fnotes fnotes in
   let fpath =
-    List.fold_left Filename.concat
-      (Util.bpath (conf.bname ^ ".gwb"))
-      [ base_notes_dir base; fname ]
+    String.concat Filename.dir_sep
+      [ Util.bpath conf.bname; base_notes_dir base; fname ]
   in
   Mutil.mkdir_p (Filename.dirname fpath);
   Gwdb.commit_notes base fname s;
@@ -225,7 +223,7 @@ type cache_linked_pages_t =
 let cache_linked_pages_name = "cache_linked_pages"
 
 let get_linked_pages_fname conf =
-  Filename.concat (base_path [] (conf.bname ^ ".gwb")) cache_linked_pages_name
+  Filename.concat (!GWPARAM.bpath conf.bname) cache_linked_pages_name
 
 let read_cache_linked_pages conf =
   let fname = get_linked_pages_fname conf in

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3599,6 +3599,7 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
       (* TODO what do we want here? can we remove this? *)
       match Image.get_portrait_path conf base p with
       | Some (`Path s) -> str_val s
+      | Some (`Url u) -> str_val u
       | None -> null_val)
   | "birth_place" ->
       if p_auth then

--- a/lib/srcfileDisplay.mli
+++ b/lib/srcfileDisplay.mli
@@ -11,9 +11,5 @@ val print_source : config -> base -> string -> unit
 val print_start : config -> base -> unit
 val incr_welcome_counter : config -> (int * int * string) option
 val incr_request_counter : config -> (int * int * string) option
-
-val adm_file : string -> string
-(** Compute administration file path with giving name (search inside {i cnt} directory) *)
-
 val source_file_name : config -> string -> string
 val copy_from_stream : config -> base -> char Stream.t -> src_mode -> unit

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -346,7 +346,7 @@ let rec eval_variable conf = function
           acc
           ^ Format.sprintf "<b%s>%s</b>=%s<br>\n" duplicate k
               (Util.escape_html v :> string))
-        "" l
+        "" conf.base_env
   | [ "gwd"; "arglist" ] -> !GWPARAM.gwd_cmd
   | [ "bvar"; v ] | [ "b"; v ] -> (
       try List.assoc v conf.base_env with Not_found -> "")
@@ -1140,6 +1140,7 @@ let rgb_of_str_hsv h s v =
 let eval_var conf ifun env ep loc sl =
   try
     match sl with
+    | [ "reorg" ] -> VVbool !GWPARAM.reorg
     | [ "env"; "key" ] -> (
         match ifun.get_vother (List.assoc "binding" env) with
         | Some (Vbind (k, _)) -> VVstring k
@@ -1174,7 +1175,7 @@ let print_foreach conf ifun print_ast eval_expr env ep loc s sl el al =
     templ_print_foreach conf print_ast ifun.set_vother env ep loc s sl el al
 
 let print_wid_hei conf fname =
-  match Image.size_from_path (Image.path_of_filename fname) with
+  match Image.size_from_path (Image.path_of_filename conf fname) with
   | Ok (wid, hei) -> Output.printf conf " width=\"%d\" height=\"%d\"" wid hei
   | Error () -> ()
 

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -353,7 +353,7 @@ let print_err_unknown conf (f, s, o) =
   print_return conf
 
 let delete_topological_sort_v conf _base =
-  let bfile = Util.bpath (conf.bname ^ ".gwb") in
+  let bfile = Util.bpath conf.bname in
   let tstab_file = Filename.concat bfile "tstab_visitor" in
   Mutil.rm tstab_file;
   let tstab_file = Filename.concat bfile "restrict" in
@@ -361,7 +361,7 @@ let delete_topological_sort_v conf _base =
 
 let delete_topological_sort conf base =
   let _ = delete_topological_sort_v conf base in
-  let bfile = Util.bpath (conf.bname ^ ".gwb") in
+  let bfile = Util.bpath conf.bname in
   let tstab_file = Filename.concat bfile "tstab" in
   Mutil.rm tstab_file
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -4,15 +4,15 @@ open Config
 open Def
 open Gwdb
 
+val print_default_gwf_file : string -> unit
+(** print default config file bname.gwf or bname.gwb/etc/mybase.gwf *)
+
+val read_base_env : string -> string -> bool -> (string * string) list
+(** read base environment bname.gwf or bname.gwb/etc/bname.gwf *)
+
 val time_debug :
   config -> float -> int -> string list -> string list -> string list -> unit
 (** prints the query duration and reports it in the "home" section *)
-
-val cnt_dir : string ref
-(** The directory where counters (e.g. number page displayed) are stored. *)
-
-val base_path : string list -> string -> string
-(** Alias for !GWPARAM.base_path *)
 
 val bpath : string -> string
 (** Alias for !GWPARAM.bpath *)
@@ -447,7 +447,7 @@ val short_f_month : int -> string
 type auth_user = { au_user : string; au_passwd : string; au_info : string }
 (** Authenticated user from from authorization file. *)
 
-val read_gen_auth_file : string -> auth_user list
+val read_gen_auth_file : string -> string -> auth_user list
 (** Read all authenticated users with their passwords from authorization file (associated to {i "wizard_passwd_file"} in [conf.base_env]) *)
 
 val is_that_user_and_password : auth_scheme_kind -> string -> string -> bool
@@ -618,3 +618,6 @@ val designation : base -> person -> Adef.escaped_string
 
 val has_children : base -> person -> bool
 val get_bases_list : ?format_fun:(string -> string) -> unit -> string list
+
+val test_cnt_d : config -> string
+(** tests if cnt_d exists and creaets it if needed *)

--- a/lib/util/lock.ml
+++ b/lib/util/lock.ml
@@ -12,7 +12,7 @@ let print_try_again () =
   flush stdout
 
 let control ~onerror lname wait f =
-  if !no_lock_flag then f ()
+  if !no_lock_flag || Filename.basename lname = ".lck" then f ()
   else
     try
       let fd = Unix.openfile lname [ Unix.O_RDWR; Unix.O_CREAT ] 0o666 in

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -189,24 +189,7 @@ let mkdir_p ?(perm = 0o755) d =
   in
   loop d
 
-let rec remove_dir d =
-  begin try
-    let files = Sys.readdir d in
-    for i = 0 to Array.length files - 1 do
-      remove_dir (Filename.concat d files.(i));
-      rm (Filename.concat d files.(i))
-    done
-  with Sys_error _ -> ()
-  end;
-  try Unix.rmdir d with Unix.Unix_error (_, _, _) -> ()
-
-let lock_file bname =
-  let bname =
-    if Filename.check_suffix bname ".gwb" then
-      Filename.chop_suffix bname ".gwb"
-    else bname
-  in
-  bname ^ ".lck"
+let lock_file bname = (Filename.remove_extension bname) ^ ".lck"
 
 let initial n =
   let rec loop i =
@@ -217,6 +200,13 @@ let initial n =
       | _ -> loop (succ i)
   in
   loop 0
+
+let default_particles =
+  let upper =
+    [ "AF " ; "D'" ; "D’" ; "DAL " ; "DE " ; "DES " ; "DI " ; "DU " ; "OF "
+    ; "VAN " ; "VON UND ZU " ; "VON " ; "Y " ; "ZU " ; "ZUR " ]
+  in
+  List.rev_append (List.rev_map String.lowercase_ascii upper) upper
 
 let input_particles fname =
   try
@@ -232,7 +222,7 @@ let input_particles fname =
         List.rev (if len = 0 then list else Buff.get len :: list)
     in
     loop [] 0
-  with Sys_error _ -> []
+  with Sys_error _ -> default_particles
 
 let saints = ["saint"; "sainte"]
 
@@ -660,13 +650,6 @@ let array_except v a =
     else loop (i + 1)
   in
   loop 0
-
-let default_particles =
-  let upper =
-    [ "AF " ; "D'" ; "D’" ; "DAL " ; "DE " ; "DES " ; "DI " ; "DU " ; "OF "
-    ; "VAN " ; "VON UND ZU " ; "VON " ; "Y " ; "ZU " ; "ZUR " ]
-  in
-  List.rev_append (List.rev_map String.lowercase_ascii upper) upper
 
 let array_forall2 f a1 a2 =
   if Array.length a1 <> Array.length a2 then invalid_arg "array_forall2"
@@ -1136,23 +1119,56 @@ let eq_key (fn1, sn1, oc1) (fn2, sn2, oc2) =
   s fn1 = s fn2 && s sn1 = s sn2 && oc1 = oc2
 
 let ls_r dirs =
-  let rec loop result = function
-    | f :: fs when Sys.is_directory f ->
-      Sys.readdir f
-      |> Array.to_list
-      |> List.rev_map (Filename.concat f)
-      |> List.rev_append fs
-      |> loop (f :: result)
-    | f :: fs -> loop (f :: result) fs
-    | [] -> result
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | dir :: rest ->
+        if Sys.file_exists dir then
+          if Sys.is_directory dir then
+            let contents =
+              try Sys.readdir dir |> Array.to_list |> List.map (Filename.concat dir)
+              with e ->
+                Printf.eprintf "Error reading directory %s: %s\n" dir (Printexc.to_string e);
+                []
+            in
+            loop (dir :: acc) (contents @ rest)
+          else loop (dir :: acc) rest
+        else
+          (Printf.eprintf "Path does not exist: %s\n" dir; loop acc rest)
   in
   loop [] dirs
 
+let check_permissions path =
+  try
+    let stats = Unix.stat path in
+    let perms = stats.Unix.st_perm in
+    if perms land 0o200 = 0 then
+      Printf.eprintf "File is not writable: %s\n" path;
+    (try Unix.access path [Unix.W_OK]
+     with Unix.Unix_error _ ->
+       Printf.eprintf "Current process does not have write permission: %s\n" path)
+  with e ->
+    Printf.eprintf "Error checking permissions for %s: %s\n" path (Printexc.to_string e)
+
 let rm_rf f =
   if Sys.file_exists f then
-    let (directories, files) = ls_r [f] |> List.partition Sys.is_directory in
-    List.iter Unix.unlink files ;
-    List.iter Unix.rmdir directories
+    let all_paths = ls_r [f] in
+    List.iter check_permissions all_paths;
+    let (directories, files) = List.partition Sys.is_directory all_paths in
+    List.iter (fun file ->
+      try
+        let ic = open_in_bin file in
+        close_in ic;
+        Sys.remove file
+      with e ->
+        Printf.eprintf "Error handling file %s: %s\n" file (Printexc.to_string e)
+    ) files;
+    List.iter (fun dir ->
+      try Unix.rmdir dir
+      with e ->
+        Printf.eprintf "Error deleting directory %s: %s\n" dir (Printexc.to_string e)
+    ) (List.rev directories)
+  else
+    Printf.eprintf "Path does not exist: %s\n" f
 
 let rec filter_map fn = function
   | [] -> []

--- a/lib/util/mutil.mli
+++ b/lib/util/mutil.mli
@@ -34,9 +34,6 @@ val mkdir_p : ?perm:int -> string -> unit
     No error if existing, make parent directories as needed.
 *)
 
-val remove_dir : string -> unit
-(** Remove every file in the directory and then remove the directory itself *)
-
 val lock_file : string -> string
 (** Returns the name of a lock file (with extension .lck). Result is generally used as an
     argument for [Lock.control] function. *)

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -51,8 +51,8 @@ let section_level s len =
 let notes_aliases conf =
   let fname =
     match List.assoc_opt "notes_alias_file" conf.base_env with
-    | Some f -> Util.bpath f
-    | None -> Filename.concat (Util.bpath (conf.bname ^ ".gwb")) "notes.alias"
+    | Some f -> f
+    | None -> Filename.concat (Util.bpath conf.bname) "notes.alias"
   in
   match try Some (Secure.open_in fname) with Sys_error _ -> None with
   | Some ic ->

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -5,14 +5,12 @@ open Def
 open Util
 
 let dir conf base =
-  Filename.concat
-    (Util.bpath (conf.bname ^ ".gwb"))
-    (Gwdb.base_wiznotes_dir base)
+  Filename.concat (Util.bpath conf.bname) (Gwdb.base_wiznotes_dir base)
 
 let wzfile wddir wz = Filename.concat wddir (wz ^ ".txt")
 
-let read_auth_file fname =
-  let data = read_gen_auth_file fname in
+let read_auth_file fname bname =
+  let data = read_gen_auth_file fname bname in
   List.map
     (fun au ->
       let wizname =
@@ -264,7 +262,7 @@ let print_main conf base auth_file =
   in
   let by_alphab_order = p_getenv conf.env "o" <> Some "H" in
   let wizdata =
-    let list = read_auth_file auth_file in
+    let list = read_auth_file auth_file conf.bname in
     if by_alphab_order then
       List.sort
         (fun (_, (_, (o1, _))) (_, (_, (o2, _))) ->
@@ -320,7 +318,7 @@ let wizard_page_title conf wizname _ = Output.print_string conf wizname
 
 let print_whole_wiznote conf base auth_file wz wfile (s, date) ho =
   let wizname =
-    let wizdata = read_auth_file auth_file in
+    let wizdata = read_auth_file auth_file conf.bname in
     try fst (List.assoc wz wizdata) with Not_found -> wz
   in
   let edit_opt =

--- a/plugins/fixbase/plugin_fixbase.ml
+++ b/plugins/fixbase/plugin_fixbase.ml
@@ -119,7 +119,7 @@ let fixbase_ok conf base =
   let process () =
     ignore @@ Unix.alarm 0;
     (* cancel timeout *)
-    let base' = Gwdb.open_base @@ Util.base_path [] (bname base ^ ".gwb") in
+    let base' = Gwdb.open_base @@ !GWPARAM.bpath conf.bname in
     let ipers = ref [] in
     let ifams = ref [] in
     let istrs = ref [] in
@@ -378,7 +378,7 @@ let fixbase_ok conf base =
     in
     let tstab () =
       if UI.enabled conf "tstab" then (
-        let bname = Util.base_path [] (bname base ^ ".gwb") in
+        let bname = !GWPARAM.bpath conf.bname in
         Mutil.rm (Filename.concat bname "tstab_visitor");
         Mutil.rm (Filename.concat bname "tstab");
         Output.print_sstring conf {|<p>|};
@@ -418,7 +418,7 @@ let fixbase_ok conf base =
   if dry_run then process ()
   else
     Lock.control
-      (Mutil.lock_file @@ Util.base_path [] (conf.bname ^ ".gwb"))
+      (Mutil.lock_file @@ !GWPARAM.bpath conf.bname)
       false
       ~onerror:(fun () -> !GWPARAM.output_error conf Def.Service_Unavailable)
       process

--- a/plugins/forum/forum.ml
+++ b/plugins/forum/forum.ml
@@ -171,7 +171,7 @@ module MF : MF = struct
 end
 
 let forum_file conf =
-  let fn = Filename.concat (bpath (conf.bname ^ ".gwb")) "forum" in
+  let fn = Filename.concat (Util.bpath conf.bname) "forum" in
   MF.filename_of_string fn
 
 (* Black list *)


### PR DESCRIPTION
This PR proposes a new organisation where all data associated with a base, in particular images and portraits, are stored inside the main mybase.gwb folder.
The new “reorg” mode is automatically detected by the existence of the file mybase.gwb/config/mybase.gwf, or is forced by a new -reorg option in gwc.
The default organisation is the classical one.
The proposed new organisation is as follows:
```

mybase.gwb
    config
        mybase.gwf
        wiz.auth 	# wizard auth file, as named in .gwf
        fr.auth	        # idem friends
        cnt
            various counters and log files (robot, .lck, mybase.txt, mybase_w.txt, …)
    etc
        base specific template files
        cache
            some browser related cache files
    lang
        base specific language files
    documents
        portraits 	# the classical images/mybase folder (no sub-folders)
        images 	        # the classical src/mybase/images folder with sub-folders possibility
        src 		# the classical src/mybase folder (without images, with sub-folders possibility)

    base		# and the other classical files and folders
```

Implementation:
this feature is implemented through a set of access functions to the various folders defined in GWPARAM
