### PR TITLE
Automatic person references update in notes

### DIFF
--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -70,10 +70,7 @@ let compute base bdir =
        let file = files.(i) in
        if Filename.check_suffix file ".txt" then
          let wizid = Filename.chop_suffix file ".txt" in
-         let wfile =
-           List.fold_left Filename.concat bdir [ base_wiznotes_dir base; file ]
-         in
-         let list = notes_links (read_file_contents wfile) in
+         let list = notes_links (base_wiznotes_read base wizid) in
          if list = ([], []) then ()
          else (
            Printf.eprintf "%s... " wizid;

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -31,7 +31,7 @@ let notes_links s =
           in
           loop list_nt list_ind (pos + 1) j
       | NotesLinks.WLwizard (j, _, _) -> loop list_nt list_ind (pos + 1) j
-      | NotesLinks.WLnone -> loop list_nt list_ind pos (i + 1)
+      | NotesLinks.WLnone (j, _) -> loop list_nt list_ind pos j
   in
   loop [] [] 1 0
 

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -12386,11 +12386,11 @@ sl: ime %s že uporablja %tta oseba%t
 sv: namn %s används redan av %tdenna person%t
 tr: %s adı zaten %tbu kişi%t tarafından kullanılıyor
 
-    name changed. update linked pages
+    name changed. updated linked pages
 co: U nome, a casata, o un occurrenza di sta persona hà cambiatu. Ci vole à rinfrescà e pagine assuciate à l’anziana chjave inghjò.
 de: Vorname, Name oder Vorkommen dieser Person hat sich geändert. Bitte aktualisieren Sie die unten aufgeführten Seiten, die mit dem alten Schlüssel verknüpft sind.
-en: The first name, name or occurrence of this person has changed. Please update the pages linked to the old key listed below.
-fr: Le prénom, nom ou occurrence de cette personne a changé. Pensez à mettre à jour les pages liées à l’ancienne clé ci-dessous.
+en: The first name, name or occurrence of this person has changed. The pages linked to the old key listed below have been updated.
+fr: Le prénom, nom ou occurrence de cette personne a changé. Les pages ci-dessous liées à l’ancienne clé ont été mises à jour.
 pt: O primeiro nome, apelido ou ocorrência desta pessoa foi alterada. Por favor actualize as páginas ligadas à chave antiga abaixo.
 sv: Förnamn, efternamn eller förekomst av denna person har ändrats. Uppdatera sidorna som länkar till den gamla nyckeln som visas nedan.
 tr: Bu kişinin ilk adı, adı veya oluşumları değişmiştir. Lütfen aşağıda listelenen eski anahtara bağlı sayfaları güncelleyin.

--- a/hd/lang/missing-it.txt
+++ b/hd/lang/missing-it.txt
@@ -1800,9 +1800,9 @@ it:
 fr: En cas d’implexes, certains individus auront de multiples liens de parenté (chemins) avec l’individu racine. La parenté entre deux individus dépendra de tous les coefficients de leurs liens de parenté (chemins).
 it:
 
-    name changed. update linked pages
-en: The first name, name or occurrence of this person has changed. Please update the pages linked to the old key listed below.
-fr: Le prénom, nom ou occurrence de cette personne a changé. Pensez à mettre à jour les pages liées à l’ancienne clé ci-dessous.
+    name changed. updated linked pages
+en: The first name, name or occurrence of this person has changed. The pages linked to the old key listed below have been updated.
+fr: Le prénom, nom ou occurrence de cette personne a changé. Les pages ci-dessous liées à l’ancienne clé ont été mises à jour.
 it:
 
     navigate on tree

--- a/hd/lang/missing-pl.txt
+++ b/hd/lang/missing-pl.txt
@@ -2597,9 +2597,9 @@ pl:
 fr: En cas d’implexes, certains individus auront de multiples liens de parenté (chemins) avec l’individu racine. La parenté entre deux individus dépendra de tous les coefficients de leurs liens de parenté (chemins).
 pl:
 
-    name changed. update linked pages
-en: The first name, name or occurrence of this person has changed. Please update the pages linked to the old key listed below.
-fr: Le prénom, nom ou occurrence de cette personne a changé. Pensez à mettre à jour les pages liées à l’ancienne clé ci-dessous.
+    name changed. updated linked pages
+en: The first name, name or occurrence of this person has changed. The pages linked to the old key listed below have been updated.
+fr: Le prénom, nom ou occurrence de cette personne a changé. Les pages ci-dessous liées à l’ancienne clé ont été mises à jour.
 pl:
 
     naturalisation

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -456,6 +456,9 @@ module NLDB = struct
   type key = string * string * int
   type ind = { lnTxt : string option; lnPos : int }
   type ('a, 'b) t = (('a, 'b) page * (string list * (key * ind) list)) list
+
+  let equal_key (fn1, sn1, oc1) (fn2, sn2, oc2) =
+    oc1 = oc2 && String.equal fn1 fn2 && String.equal sn1 sn2
 end
 
 let ( ^^^ ) = Adef.( ^^^ )

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -409,6 +409,8 @@ type base_func = {
   commit_patches : unit -> unit;
   (* Update content (second arg) of the notes' file (first arg) if exists. *)
   commit_notes : string -> string -> unit;
+  (* Update content (second arg) of the notes' file (first arg) if exists. *)
+  commit_wiznotes : string -> string -> unit;
   (* Close every opened channel. *)
   cleanup : unit -> unit;
   (* Returns real number of persons inside the base (without empty persons).

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -249,10 +249,7 @@ let base_notes_origin_file base = base.data.bnotes.Def.norigin_file
 let base_notes_dir _base = "notes_d"
 let base_wiznotes_dir _base = "wiznotes"
 
-let base_notes_read_aux base fnotes mode =
-  let fname =
-    if fnotes = "" then "notes" else Filename.concat "notes_d" (fnotes ^ ".txt")
-  in
+let base_notes_read_file base fname mode =
   try
     let ic = Secure.open_in @@ Filename.concat base.data.bdir fname in
     let str =
@@ -264,6 +261,17 @@ let base_notes_read_aux base fnotes mode =
     close_in ic;
     str
   with Sys_error _ -> ""
+
+let base_notes_read_aux base fnotes mode =
+  let fname =
+    if fnotes = "" then "notes"
+    else Filename.concat (base_notes_dir base) (fnotes ^ ".txt")
+  in
+  base_notes_read_file base fname mode
+
+let base_wiznotes_read base fwnotes =
+  let fname = Filename.concat (base_wiznotes_dir base) (fwnotes ^ ".txt") in
+  base_notes_read_file base fname Def.RnAll
 
 let base_notes_read base fnotes = base_notes_read_aux base fnotes Def.RnAll
 

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -41,6 +41,7 @@ let insert_string base s =
 
 let commit_patches base = base.func.Dbdisk.commit_patches ()
 let commit_notes base s = base.func.Dbdisk.commit_notes s
+let commit_wiznotes base s = base.func.Dbdisk.commit_wiznotes s
 let person_of_key base = base.func.Dbdisk.person_of_key
 let persons_of_name base = base.func.Dbdisk.persons_of_name
 let persons_of_first_name base = base.func.Dbdisk.persons_of_first_name

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -373,6 +373,9 @@ val commit_patches : base -> unit
 val commit_notes : base -> string -> string -> unit
 (** [commit_notes fname s] Update content of the notes/extended page file [fname] if exists. *)
 
+val commit_wiznotes : base -> string -> string -> unit
+(** [commit_wiznotes fname s] Update content of the wizard notes page file [fname] if exists. *)
+
 val new_iper : base -> iper
 (** Retruns new unused person's id *)
 

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -521,6 +521,10 @@ val base_notes_read : base -> string -> string
 (** [base_notes_read base fname] read and return content of [fname] note
     (either database note either extended page). *)
 
+val base_wiznotes_read : base -> string -> string
+(** [base_wiznotes_read base fname] read and return content of [fname] note
+    (either database note either extended page). *)
+
 val base_notes_read_first_line : base -> string -> string
 (** [base_notes_read base fname] read and return first line of [fname] note *)
 

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -449,6 +449,11 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   let oocc1 = o_p1.occ in
   let key1 = (Name.lower ofn1, Name.lower osn1, oocc1) in
   let pgl1 = Notes.links_to_ind conf base db key1 in
+  let ofn2 = o_p2.first_name in
+  let osn2 = o_p2.surname in
+  let oocc2 = o_p2.occ in
+  let key2 = (Name.lower ofn2, Name.lower osn2, oocc2) in
+  let pgl2 = Notes.links_to_ind conf base db key2 in
   let warning _ = () in
   MergeInd.reparent_ind base warning sp.key_index o_p2.key_index;
   let p =
@@ -461,7 +466,11 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   UpdateIndOk.effective_del_no_commit base o_p2;
   patch_person base p.key_index p;
   let new_key = (sou base p.first_name, sou base p.surname, p.occ) in
-  Notes.update_ind_key conf base pgl1 key1 new_key;
+  if
+    (not (String.equal ofn1 sp.first_name && String.equal osn1 sp.surname))
+    || oocc1 <> sp.occ
+  then Notes.update_ind_key conf base pgl1 key1 new_key;
+  Notes.update_ind_key conf base pgl2 key2 new_key;
   let u = { family = Array.append p_family p2_family } in
   if p2_family <> [||] then patch_union base p.key_index u;
   Consang.check_noloop_for_person_list base
@@ -478,10 +487,4 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
     "fp";
   Notes.update_notes_links_db base (Def.NLDB.PgInd o_p2.key_index) "";
   Update.delete_topological_sort conf base;
-  let ofn2 = o_p2.first_name in
-  let osn2 = o_p2.surname in
-  let oocc2 = o_p2.occ in
-  let pgl2 =
-    Notes.links_to_ind conf base db (Name.lower ofn2, Name.lower osn2, oocc2)
-  in
   print_mod_merge_ok conf base wl p pgl1 ofn1 osn1 oocc1 pgl2 ofn2 osn2 oocc2

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -443,6 +443,12 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   let conf = Update.update_conf o_conf in
   let p_family = get_family (poi base sp.key_index) in
   let p2_family = get_family (poi base o_p2.key_index) in
+  let db = Gwdb.read_nldb base in
+  let ofn1 = o_p1.first_name in
+  let osn1 = o_p1.surname in
+  let oocc1 = o_p1.occ in
+  let key1 = (Name.lower ofn1, Name.lower osn1, oocc1) in
+  let pgl1 = Notes.links_to_ind conf base db key1 in
   let warning _ = () in
   MergeInd.reparent_ind base warning sp.key_index o_p2.key_index;
   let p =
@@ -454,6 +460,8 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   redirect_added_families base p o_p2.key_index p2_family;
   UpdateIndOk.effective_del_no_commit base o_p2;
   patch_person base p.key_index p;
+  let new_key = (sou base p.first_name, sou base p.surname, p.occ) in
+  Notes.update_ind_key base pgl1 key1 new_key;
   let u = { family = Array.append p_family p2_family } in
   if p2_family <> [||] then patch_union base p.key_index u;
   Consang.check_noloop_for_person_list base
@@ -470,13 +478,6 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
     "fp";
   Notes.update_notes_links_db base (Def.NLDB.PgInd o_p2.key_index) "";
   Update.delete_topological_sort conf base;
-  let db = Gwdb.read_nldb base in
-  let ofn1 = o_p1.first_name in
-  let osn1 = o_p1.surname in
-  let oocc1 = o_p1.occ in
-  let pgl1 =
-    Notes.links_to_ind conf base db (Name.lower ofn1, Name.lower osn1, oocc1)
-  in
   let ofn2 = o_p2.first_name in
   let osn2 = o_p2.surname in
   let oocc2 = o_p2.occ in

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -475,12 +475,12 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   let osn1 = o_p1.surname in
   let oocc1 = o_p1.occ in
   let pgl1 =
-    Perso.links_to_ind conf base db (Name.lower ofn1, Name.lower osn1, oocc1)
+    Notes.links_to_ind conf base db (Name.lower ofn1, Name.lower osn1, oocc1)
   in
   let ofn2 = o_p2.first_name in
   let osn2 = o_p2.surname in
   let oocc2 = o_p2.occ in
   let pgl2 =
-    Perso.links_to_ind conf base db (Name.lower ofn2, Name.lower osn2, oocc2)
+    Notes.links_to_ind conf base db (Name.lower ofn2, Name.lower osn2, oocc2)
   in
   print_mod_merge_ok conf base wl p pgl1 ofn1 osn1 oocc1 pgl2 ofn2 osn2 oocc2

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -461,7 +461,7 @@ let effective_mod_merge o_conf base o_p1 o_p2 sp print_mod_merge_ok =
   UpdateIndOk.effective_del_no_commit base o_p2;
   patch_person base p.key_index p;
   let new_key = (sou base p.first_name, sou base p.surname, p.occ) in
-  Notes.update_ind_key base pgl1 key1 new_key;
+  Notes.update_ind_key conf base pgl1 key1 new_key;
   let u = { family = Array.append p_family p2_family } in
   if p2_family <> [||] then patch_union base p.key_index u;
   Consang.check_noloop_for_person_list base

--- a/lib/mergeIndOkDisplay.ml
+++ b/lib/mergeIndOkDisplay.ml
@@ -38,7 +38,7 @@ let print_mod_merge_ok conf base wl p pgl1 ofn1 osn1 oocc1 pgl2 ofn2 osn2 oocc2
   then (
     Output.print_sstring conf
       {|<div class="alert alert-danger mx-auto mt-1" role="alert">|};
-    Output.printf conf (ftransl conf "name changed. update linked pages");
+    Output.printf conf (ftransl conf "name changed. updated linked pages");
     Output.print_sstring conf "</div>";
     let aux n txt ofn osn oocc =
       Output.print_sstring conf {|<span class="unselectable float-left">|};

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -75,7 +75,8 @@ let links_to_ind conf base db key =
         in
         if record_it then
           List.fold_left
-            (fun pgl (k, _) -> if k = key then pg :: pgl else pgl)
+            (fun pgl (k, _) ->
+              if Def.NLDB.equal_key k key then pg :: pgl else pgl)
             pgl il
         else pgl)
       [] db
@@ -172,6 +173,50 @@ let update_notes_links_db base fnotes s =
   in
   NotesLinks.update_db base fnotes (list_nt, list_ind)
 
+let update_notes_links_person base (p : _ Def.gen_person) =
+  let s =
+    let sl =
+      [
+        p.notes;
+        p.occupation;
+        p.birth_note;
+        p.birth_src;
+        p.baptism_note;
+        p.baptism_src;
+        p.death_note;
+        p.death_src;
+        p.burial_note;
+        p.burial_src;
+        p.psources;
+      ]
+    in
+    let sl =
+      let rec loop l accu =
+        match l with
+        | [] -> accu
+        | evt :: l -> loop l (evt.Def.epers_note :: evt.Def.epers_src :: accu)
+      in
+      loop p.pevents sl
+    in
+    String.concat " " (List.map (sou base) sl)
+  in
+  update_notes_links_db base (Def.NLDB.PgInd p.Def.key_index) s
+
+let update_notes_links_family base (f : _ Def.gen_family) =
+  let s =
+    let sl = [ f.marriage_note; f.marriage_src; f.comment; f.fsources ] in
+    let sl =
+      let rec loop l accu =
+        match l with
+        | [] -> accu
+        | evt :: l -> loop l (evt.Def.efam_note :: evt.Def.efam_src :: accu)
+      in
+      loop f.fevents sl
+    in
+    String.concat " " (List.map (sou base) sl)
+  in
+  update_notes_links_db base (Def.NLDB.PgFam f.Def.fam_index) s
+
 let commit_notes conf base fnotes s =
   let pg = if fnotes = "" then Def.NLDB.PgNotes else Def.NLDB.PgMisc fnotes in
   let fname = path_of_fnotes fnotes in
@@ -184,6 +229,122 @@ let commit_notes conf base fnotes s =
   Gwdb.commit_notes base fname s;
   History.record conf base (Def.U_Notes (p_getint conf.env "v", fnotes)) "mn";
   update_notes_links_db base pg s
+
+let rewrite_key s oldk newk =
+  let slen = String.length s in
+  let rec rebuild rs i =
+    if i >= slen then rs
+    else
+      match NotesLinks.misc_notes_link s i with
+      | WLpage (j, _, _, _, _) | WLwizard (j, _, _) | WLnone (j, _) ->
+          let ss = String.sub s i (j - i) in
+          rebuild (rs ^ ss) j
+      | WLperson (j, k, _name, text) ->
+          if Def.NLDB.equal_key k oldk then
+            let fn, sn, oc = newk in
+            let ss =
+              Printf.sprintf "[[%s/%s/%d/%s %s%s]]" fn sn oc fn sn
+                (Option.fold ~none:"" ~some:(fun txt -> ";" ^ txt) text)
+            in
+            rebuild (rs ^ ss) j
+          else
+            let ss = String.sub s i (j - i) in
+            rebuild (rs ^ ss) j
+  in
+  rebuild "" 0
+
+let replace_ind_key_in_str base is oldk newk =
+  let s = sou base is in
+  let s' = rewrite_key s oldk newk in
+  Gwdb.insert_string base s'
+
+let update_ind_key_pgind base p oldk newk =
+  let oldp = Gwdb.gen_person_of_person @@ poi base p in
+  let replace is = replace_ind_key_in_str base is oldk newk in
+  let notes = replace oldp.notes in
+  let occupation = replace oldp.occupation in
+  let birth_note = replace oldp.birth_note in
+  let birth_src = replace oldp.birth_src in
+  let baptism_note = replace oldp.baptism_note in
+  let baptism_src = replace oldp.baptism_src in
+  let death_note = replace oldp.death_note in
+  let death_src = replace oldp.death_src in
+  let burial_note = replace oldp.burial_note in
+  let burial_src = replace oldp.burial_src in
+  let psources = replace oldp.psources in
+  let pevents =
+    List.map
+      (fun (ev : _ Def.gen_pers_event) ->
+        {
+          ev with
+          epers_note = replace ev.epers_note;
+          epers_src = replace ev.epers_src;
+        })
+      oldp.pevents
+  in
+  let newp =
+    {
+      oldp with
+      notes;
+      occupation;
+      birth_note;
+      birth_src;
+      baptism_note;
+      baptism_src;
+      death_note;
+      death_src;
+      burial_note;
+      burial_src;
+      psources;
+      pevents;
+    }
+  in
+  Gwdb.patch_person base p newp;
+  update_notes_links_person base newp
+
+let update_ind_key_pgfam base f oldk newk =
+  let oldf = Gwdb.gen_family_of_family @@ foi base f in
+  let replace is = replace_ind_key_in_str base is oldk newk in
+  let marriage_note = replace oldf.marriage_note in
+  let marriage_src = replace oldf.marriage_src in
+  let comment = replace oldf.comment in
+  let fsources = replace oldf.fsources in
+  let fevents =
+    List.map
+      (fun (ev : _ Def.gen_fam_event) ->
+        {
+          ev with
+          efam_note = replace ev.efam_note;
+          efam_src = replace ev.efam_src;
+        })
+      oldf.fevents
+  in
+  let newf =
+    { oldf with marriage_note; marriage_src; comment; fsources; fevents }
+  in
+  Gwdb.patch_family base f newf;
+  update_notes_links_family base newf
+
+let update_ind_key_pgmisc base f oldk newk =
+  let oldn = base_notes_read base f in
+  let newn = rewrite_key oldn oldk newk in
+  Gwdb.commit_notes base f newn
+
+let update_ind_key_pgwiz base f oldk newk =
+  let oldn = base_wiznotes_read base f in
+  let newn = rewrite_key oldn oldk newk in
+  Gwdb.commit_notes base f newn
+
+let update_ind_key base link_pages oldk newk =
+  Printf.eprintf "updating %d note pages...\n%!" (List.length link_pages);
+  List.iter
+    (function
+      | Def.NLDB.PgInd p -> update_ind_key_pgind base p oldk newk
+      | PgFam f -> update_ind_key_pgfam base f oldk newk
+      | PgNotes -> update_ind_key_pgmisc base "" oldk newk
+      | PgMisc f -> update_ind_key_pgmisc base f oldk newk
+      | PgWizard f -> update_ind_key_pgwiz base f oldk newk)
+    link_pages
 
 let wiki_aux pp conf base env str =
   let s = Util.string_with_macros conf env str in

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -166,7 +166,7 @@ let update_notes_links_db base fnotes s =
             in
             loop list_nt list_ind (pos + 1) j
         | NotesLinks.WLwizard (j, _, _) -> loop list_nt list_ind pos j
-        | NotesLinks.WLnone -> loop list_nt list_ind pos (i + 1)
+        | NotesLinks.WLnone (j, _) -> loop list_nt list_ind pos j
     in
     loop [] [] 1 0
   in

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -17,6 +17,12 @@ val notes_links_db :
 val update_notes_links_db :
   Gwdb.base -> (Gwdb.iper, Gwdb.ifam) Def.NLDB.page -> string -> unit
 
+val update_notes_links_person :
+  Gwdb.base -> (Gwdb.iper, _, Gwdb.istr) Def.gen_person -> unit
+
+val update_notes_links_family :
+  Gwdb.base -> (_, Gwdb.ifam, Gwdb.istr) Def.gen_family -> unit
+
 val file_path : Config.config -> Gwdb.base -> string -> string
 val read_notes : Gwdb.base -> string -> (string * string) list * string
 
@@ -24,6 +30,13 @@ val merge_possible_aliases :
   Config.config ->
   (('a, 'b) Def.NLDB.page * (string list * 'c list)) list ->
   (('a, 'b) Def.NLDB.page * (string list * 'c list)) list
+
+val update_ind_key :
+  Gwdb.base ->
+  (Gwdb.iper, Gwdb.ifam) Def.NLDB.page list ->
+  Def.NLDB.key ->
+  string * string * int ->
+  unit
 
 val source : Config.config -> Gwdb.base -> string -> Adef.safe_string
 (** [source conf base str]

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -1,6 +1,13 @@
 val path_of_fnotes : string -> string
 val commit_notes : Config.config -> Gwdb.base -> string -> string -> unit
 
+val links_to_ind :
+  Config.config ->
+  Gwdb.base ->
+  (Gwdb.iper, Gwdb.ifam) Def.NLDB.t ->
+  string * string * int ->
+  (Gwdb.iper, Gwdb.ifam) Def.NLDB.page list
+
 val notes_links_db :
   Config.config ->
   Gwdb.base ->

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -32,6 +32,7 @@ val merge_possible_aliases :
   (('a, 'b) Def.NLDB.page * (string list * 'c list)) list
 
 val update_ind_key :
+  Config.config ->
   Gwdb.base ->
   (Gwdb.iper, Gwdb.ifam) Def.NLDB.page list ->
   Def.NLDB.key ->

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -24,7 +24,7 @@ let check_file_name s =
 
 type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
-  | WLperson of int * key * string * string option
+  | WLperson of int * key * string option * string option
   | WLwizard of int * string * string
   | WLnone of int * string
 
@@ -130,12 +130,10 @@ let misc_notes_link s i =
                 in
                 let oc1 = try int_of_string name with Failure _ -> -1 in
                 let oc = try int_of_string oc with Failure _ -> 0 in
-                if oc1 = -1 then (fn, sn, oc, name)
-                else (fn, sn, oc1, fn ^ " " ^ sn)
+                if oc1 = -1 then (fn, sn, oc, Some name) else (fn, sn, oc1, None)
               with Not_found ->
                 let sn = String.sub b k (String.length b - k) in
-                let name = fn ^ " " ^ sn in
-                (fn, sn, 0, name)
+                (fn, sn, 0, None)
             in
             let fn = Name.lower fn in
             let sn = Name.lower sn in

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -78,7 +78,7 @@ let misc_notes_link s i =
     else
       let j =
         let rec loop j =
-          if j = slen then i
+          if j = slen then j
           else if j <= slen - 2 && s.[j] = ']' && s.[j + 1] = ']' then j + 2
           else loop (j + 1)
         in
@@ -140,7 +140,7 @@ let misc_notes_link s i =
             WLperson (j, (fn, sn, oc), name, text)
           with Not_found -> wlnone j
       else wlnone j
-  else wlnone i
+  else wlnone (i+1)
 
 let add_in_db db who (list_nt, list_ind) =
   let db = List.remove_assoc who db in

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -26,10 +26,22 @@ type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
   | WLperson of int * key * string * string option
   | WLwizard of int * string * string
-  | WLnone
+  | WLnone of int * string
 
 let misc_notes_link s i =
   let slen = String.length s in
+  let cut j = String.sub s i (j - i) in
+  let rec wlnone j =
+    (* assume no link up to [j] and find next link position *)
+    if j < slen then
+      match s.[j] with
+      | '%' -> wlnone (j + 2)
+      | '[' ->
+          if j + 1 < slen && s.[j + 1] = '[' then WLnone (j, cut j)
+          else wlnone (j + 1)
+      | _ -> wlnone (j + 1)
+    else WLnone (slen, cut slen)
+  in
   if i < slen - 2 && s.[i] = '[' && s.[i + 1] = '[' then
     if s.[i + 2] = '[' then
       let j =
@@ -61,8 +73,8 @@ let misc_notes_link s i =
         in
         match check_file_name fname with
         | Some pg_path -> WLpage (j, pg_path, fname, anchor, text)
-        | None -> WLnone
-      else WLnone
+        | None -> wlnone j
+      else wlnone j
     else
       let j =
         let rec loop j =
@@ -129,9 +141,9 @@ let misc_notes_link s i =
             let fn = Name.lower fn in
             let sn = Name.lower sn in
             WLperson (j, (fn, sn, oc), name, text)
-          with Not_found -> WLnone
-      else WLnone
-  else WLnone
+          with Not_found -> wlnone j
+      else wlnone j
+  else wlnone i
 
 let add_in_db db who (list_nt, list_ind) =
   let db = List.remove_assoc who db in

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -131,7 +131,6 @@ let misc_notes_link s i =
                 let oc1 = try int_of_string name with Failure _ -> -1 in
                 let oc = try int_of_string oc with Failure _ -> 0 in
                 if oc1 = -1 then (fn, sn, oc, name)
-                  (* else if not Wiki.wi_person_exists (fn, sn, oc1) then (fn, sn, oc, fn ^ " " ^ sn) *)
                 else (fn, sn, oc1, fn ^ " " ^ sn)
               with Not_found ->
                 let sn = String.sub b k (String.length b - k) in

--- a/lib/notesLinks.mli
+++ b/lib/notesLinks.mli
@@ -2,7 +2,7 @@ type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
   | WLperson of int * Def.NLDB.key * string * string option
   | WLwizard of int * string * string
-  | WLnone
+  | WLnone of int * string
 
 val char_dir_sep : char
 val check_file_name : string -> (string list * string) option

--- a/lib/notesLinks.mli
+++ b/lib/notesLinks.mli
@@ -1,6 +1,6 @@
 type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
-  | WLperson of int * Def.NLDB.key * string * string option
+  | WLperson of int * Def.NLDB.key * string option * string option
   | WLwizard of int * string * string
   | WLnone of int * string
 

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1127,27 +1127,6 @@ let linked_page_text conf base p s key (str : Adef.safe_string) (pg, (_, il)) :
     ->
       str
 
-let links_to_ind conf base db key =
-  let l =
-    List.fold_left
-      (fun pgl (pg, (_, il)) ->
-        let record_it =
-          match pg with
-          | Def.NLDB.PgInd ip -> authorized_age conf base (pget conf base ip)
-          | Def.NLDB.PgFam ifam ->
-              authorized_age conf base
-                (pget conf base (get_father @@ foi base ifam))
-          | Def.NLDB.PgNotes | Def.NLDB.PgMisc _ | Def.NLDB.PgWizard _ -> true
-        in
-        if record_it then
-          List.fold_left
-            (fun pgl (k, _) -> if k = key then pg :: pgl else pgl)
-            pgl il
-        else pgl)
-      [] db
-  in
-  List.sort_uniq compare l
-
 (* Interpretation of template file *)
 
 let rec compare_ls sl1 sl2 =
@@ -2886,7 +2865,7 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
                 let sn = Name.lower (sou base (get_surname p)) in
                 (fn, sn, get_occ p)
               in
-              links_to_ind conf base db key <> []
+              Notes.links_to_ind conf base db key <> []
             else false
           in
           VVbool r
@@ -2901,7 +2880,7 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
                 let sn = Name.lower (sou base (get_surname p)) in
                 (fn, sn, get_occ p)
               in
-              string_of_int (List.length (links_to_ind conf base db key))
+              string_of_int (List.length (Notes.links_to_ind conf base db key))
             else "0"
           in
           str_val r
@@ -5541,7 +5520,7 @@ let print_what_links conf base p =
     in
     let db = Gwdb.read_nldb base in
     let db = Notes.merge_possible_aliases conf db in
-    let pgl = links_to_ind conf base db key in
+    let pgl = Notes.links_to_ind conf base db key in
     let title h =
       transl conf "linked pages" |> Utf8.capitalize_fst
       |> Output.print_sstring conf;

--- a/lib/perso.mli
+++ b/lib/perso.mli
@@ -27,13 +27,6 @@ val print : ?no_headers:bool -> config -> base -> person -> unit
 val print_what_links : config -> base -> person -> unit
 (** Displays links to pages associated to the person *)
 
-val links_to_ind :
-  Config.config ->
-  Gwdb.base ->
-  ((iper, ifam) Def.NLDB.page * ('a * ((string * string * int) * 'b) list)) list ->
-  string * string * int ->
-  (iper, ifam) Def.NLDB.page list
-
 val get_linked_page : config -> base -> person -> string -> Adef.safe_string
 val get_birth_text : config -> person -> bool -> Adef.safe_string
 val get_baptism_text : config -> person -> bool -> Adef.safe_string

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -1366,21 +1366,7 @@ let print_mod o_conf base =
     let ifam, fam, cpl, des = effective_mod conf base nsck sfam scpl sdes in
     let () = patch_parent_with_pevents base cpl in
     let () = patch_children_with_pevents base des in
-    let s =
-      let sl =
-        [ fam.comment; fam.fsources; fam.marriage_note; fam.marriage_src ]
-      in
-      let sl =
-        let rec loop l accu =
-          match l with
-          | [] -> accu
-          | evt :: l -> loop l (evt.efam_note :: evt.efam_src :: accu)
-        in
-        loop fam.fevents sl
-      in
-      String.concat " " (List.map (sou base) sl)
-    in
-    Notes.update_notes_links_db base (Def.NLDB.PgFam ifam) s;
+    Notes.update_notes_links_family base fam;
     let nfs = (Adef.parent_array cpl, des.children) in
     let onfs = Some (ofs, nfs) in
     let wl, ml =

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -986,7 +986,7 @@ let print_mod_ok conf base wl pgl p ofn osn oocc =
   if pgl <> [] && (ofn <> nfn || osn <> nsn || oocc <> nocc) then (
     Output.print_sstring conf
       {|<div class="alert alert-danger mx-auto mt-1" role="alert">|};
-    Output.print_sstring conf (transl conf "name changed. update linked pages");
+    Output.print_sstring conf (transl conf "name changed. updated linked pages");
     Output.print_sstring conf "</div>\n";
     let soocc = if oocc <> 0 then Printf.sprintf "/%d" oocc else "" in
     let snocc = if nocc <> 0 then Printf.sprintf "/%d" nocc else "" in

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -808,7 +808,10 @@ let effective_mod ?prerr ?skip_conflict conf base sp =
   let ofn = p_first_name base op in
   let osn = p_surname base op in
   let oocc = get_occ op in
-  (if ofn <> sp.first_name || osn <> sp.surname || oocc <> sp.occ then
+  (if
+   (not (String.equal ofn sp.first_name && String.equal osn sp.surname))
+   || oocc <> sp.occ
+  then
    match Gwdb.person_of_key base sp.first_name sp.surname sp.occ with
    | Some p' when p' <> pi && Some p' <> skip_conflict ->
        Update.print_create_conflict conf base (poi base p') ""
@@ -983,7 +986,10 @@ let print_mod_ok conf base wl pgl p ofn osn oocc =
   let nfn = p_first_name base np in
   let nsn = p_surname base np in
   let nocc = get_occ np in
-  if pgl <> [] && (ofn <> nfn || osn <> nsn || oocc <> nocc) then (
+  if
+    pgl <> []
+    && ((not (String.equal ofn nfn && String.equal osn nsn)) || oocc <> nocc)
+  then (
     Output.print_sstring conf
       {|<div class="alert alert-danger mx-auto mt-1" role="alert">|};
     Output.print_sstring conf (transl conf "name changed. updated linked pages");
@@ -1152,7 +1158,10 @@ let print_mod ?prerr o_conf base =
     let new_key = (sou base p.first_name, sou base p.surname, p.occ) in
     (* Needs the updates in this order in case of self-reference *)
     Notes.update_notes_links_person base p;
-    Notes.update_ind_key conf base pgl key new_key;
+    if
+      (not (String.equal ofn sp.first_name && String.equal osn sp.surname))
+      || oocc <> sp.occ
+    then Notes.update_ind_key conf base pgl key new_key;
     let wl =
       let a = poi base p.key_index in
       let a = { parents = get_parents a; consang = get_consang a } in

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -1149,33 +1149,9 @@ let print_mod ?prerr o_conf base =
     let op = poi base p.key_index in
     let u = { family = get_family op } in
     patch_person base p.key_index p;
-    let s =
-      let sl =
-        [
-          p.notes;
-          p.occupation;
-          p.birth_note;
-          p.birth_src;
-          p.baptism_note;
-          p.baptism_src;
-          p.death_note;
-          p.death_src;
-          p.burial_note;
-          p.burial_src;
-          p.psources;
-        ]
-      in
-      let sl =
-        let rec loop l accu =
-          match l with
-          | [] -> accu
-          | evt :: l -> loop l (evt.epers_note :: evt.epers_src :: accu)
-        in
-        loop p.pevents sl
-      in
-      String.concat " " (List.map (sou base) sl)
-    in
-    Notes.update_notes_links_db base (Def.NLDB.PgInd p.key_index) s;
+    let new_key = (sou base p.first_name, sou base p.surname, p.occ) in
+    Notes.update_ind_key base pgl key new_key;
+    Notes.update_notes_links_person base p;
     let wl =
       let a = poi base p.key_index in
       let a = { parents = get_parents a; consang = get_consang a } in

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -1142,7 +1142,7 @@ let print_mod ?prerr o_conf base =
   let pgl =
     let db = Gwdb.read_nldb base in
     let db = Notes.merge_possible_aliases conf db in
-    Perso.links_to_ind conf base db key
+    Notes.links_to_ind conf base db key
   in
   let callback sp =
     let p = effective_mod ?prerr conf base sp in

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -1150,8 +1150,9 @@ let print_mod ?prerr o_conf base =
     let u = { family = get_family op } in
     patch_person base p.key_index p;
     let new_key = (sou base p.first_name, sou base p.surname, p.occ) in
-    Notes.update_ind_key base pgl key new_key;
+    (* Needs the updates in this order in case of self-reference *)
     Notes.update_notes_links_person base p;
+    Notes.update_ind_key conf base pgl key new_key;
     let wl =
       let a = poi base p.key_index in
       let a = { parents = get_parents a; consang = get_consang a } in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1906,12 +1906,18 @@ let find_person_in_env_pref conf base pref =
     (pref ^ "oc")
 
 let person_exists conf base (fn, sn, oc) =
+  let auth, fn, sn =
+    match person_of_key base fn sn oc with
+    | Some ip ->
+        if authorized_age conf base (pget conf base ip) then
+          let p = poi base ip in
+          (true, sou base (get_first_name p), sou base (get_surname p))
+        else (false, "x", "x")
+    | None -> (false, fn, sn)
+  in
   match List.assoc_opt "red_if_not_exist" conf.base_env with
-  | Some "off" -> true
-  | Some _ | None -> (
-      match person_of_key base fn sn oc with
-      | Some ip -> authorized_age conf base (pget conf base ip)
-      | None -> false)
+  | Some "off" -> (true, fn, sn)
+  | Some _ | None -> (auth, fn, sn)
 
 let default_sosa_ref conf base =
   match List.assoc_opt "default_sosa_ref" conf.base_env with

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2299,7 +2299,7 @@ let rec in_text case_sens s m =
       | NotesLinks.WLperson (j, _, text, _)
       | NotesLinks.WLwizard (j, _, text) ->
           if in_text case_sens s text then true else loop false j
-      | NotesLinks.WLnone -> loop false (i + 1)
+      | NotesLinks.WLnone (j, _) -> loop false j
     else
       match start_equiv_with case_sens s m i with
       | Some _ -> true

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2302,9 +2302,11 @@ let rec in_text case_sens s m =
     else if m.[i] = '[' && i + 1 < String.length m && m.[i + 1] = '[' then
       match NotesLinks.misc_notes_link m i with
       | NotesLinks.WLpage (j, _, _, _, text)
-      | NotesLinks.WLperson (j, _, text, _)
+      | NotesLinks.WLperson (j, _, Some text, _)
       | NotesLinks.WLwizard (j, _, text) ->
           if in_text case_sens s text then true else loop false j
+      | NotesLinks.WLperson (j, (fn, sn, _), None, _) ->
+          if in_text case_sens s (fn ^ " " ^ sn) then true else loop false j
       | NotesLinks.WLnone (j, _) -> loop false j
     else
       match start_equiv_with case_sens s m i with

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -358,7 +358,10 @@ val string_of_witness_kind : config -> sex -> witness_kind -> Adef.safe_string
 
 val relation_txt : config -> sex -> family -> (('a -> 'b) -> 'b, 'a, 'b) format
 val string_of_decimal_num : config -> float -> string
-val person_exists : config -> base -> string * string * int -> bool
+
+val person_exists :
+  config -> base -> string * string * int -> bool * string * string
+
 val husband_wife : config -> base -> person -> bool -> Adef.safe_string
 
 val find_person_in_env : config -> base -> string -> person option

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -190,8 +190,7 @@ let syntax_links conf wi s =
       | NotesLinks.WLperson (j, (fn, sn, oc), name, _text) ->
           let exists, fn0, sn0 = wi.wi_person_exists (fn, sn, oc) in
           let name =
-            if name = Name.lower fn0 ^ " " ^ Name.lower sn0 then fn0 ^ " " ^ sn0
-            else name
+            match name with None -> fn0 ^ " " ^ sn0 | Some name -> name
           in
           let t =
             if exists then
@@ -303,11 +302,11 @@ let remove_links s =
       let len, i =
         match NotesLinks.misc_notes_link s i with
         | NotesLinks.WLpage (j, _, _, _, text) -> (Buff.mstore len text, j)
-        | NotesLinks.WLperson (j, _, name, text) ->
+        | NotesLinks.WLperson (j, (fn, sn, _), name, text) ->
             let text =
               match text with
-              | Some text -> if text = "" then name else text
-              | None -> name
+              | None | Some "" -> Option.value ~default:(fn ^ " " ^ sn) name
+              | Some text -> text
             in
             (Buff.mstore len text, j)
         | NotesLinks.WLwizard (j, _, text) -> (Buff.mstore len text, j)

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -91,7 +91,7 @@ let str_start_with str i x =
 type wiki_info = {
   wi_mode : string;
   wi_file_path : string -> string;
-  wi_person_exists : string * string * int -> bool;
+  wi_person_exists : string * string * int -> bool * string * string;
   wi_always_show_link : bool;
 }
 
@@ -187,9 +187,14 @@ let syntax_links conf wi s =
               (encode wi.wi_mode) (encode fname) anchor c text
           in
           loop quot_lev pos j (Buff.mstore len t)
-      | NotesLinks.WLperson (j, (fn, sn, oc), name, _) ->
+      | NotesLinks.WLperson (j, (fn, sn, oc), name, _text) ->
+          let exists, fn0, sn0 = wi.wi_person_exists (fn, sn, oc) in
+          let name =
+            if name = Name.lower fn0 ^ " " ^ Name.lower sn0 then fn0 ^ " " ^ sn0
+            else name
+          in
           let t =
-            if wi.wi_person_exists (fn, sn, oc) then
+            if exists then
               Printf.sprintf "<a id=\"p_%d\" href=\"%sp=%s&n=%s%s\">%s</a>" pos
                 (commd conf :> string)
                 (encode fn) (encode sn)

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -217,7 +217,8 @@ let syntax_links conf wi s =
               (encode wiz) s
           in
           loop quot_lev (pos + 1) j (Buff.mstore len t)
-      | NotesLinks.WLnone -> loop quot_lev pos (i + 1) (Buff.store len s.[i])
+      | NotesLinks.WLnone (j, none_s) ->
+          loop quot_lev pos j (Buff.mstore len none_s)
   in
   loop 0 1 0 0
 
@@ -305,7 +306,7 @@ let remove_links s =
             in
             (Buff.mstore len text, j)
         | NotesLinks.WLwizard (j, _, text) -> (Buff.mstore len text, j)
-        | NotesLinks.WLnone -> (Buff.store len s.[i], i + 1)
+        | NotesLinks.WLnone (j, none_s) -> (Buff.mstore len none_s, j)
       in
       loop len i
   in

--- a/lib/wiki.mli
+++ b/lib/wiki.mli
@@ -35,7 +35,7 @@ open Config
 type wiki_info = {
   wi_mode : string;
   wi_file_path : string -> string;
-  wi_person_exists : string * string * int -> bool;
+  wi_person_exists : string * string * int -> bool * string * string;
   wi_always_show_link : bool;
 }
 

--- a/test/wiki_test.ml
+++ b/test/wiki_test.ml
@@ -6,7 +6,7 @@ let pp_wiki_link = function
           (a, b, c, d, e)
   | WLperson (a, b, c, d) ->
       "WLperson"
-      ^ [%show: int * (string * string * int) * string * string option]
+      ^ [%show: int * (string * string * int) * string option * string option]
           (a, Obj.magic b, c, d)
   | WLwizard (a, b, c) -> "WLwizard" ^ [%show: int * string * string] (a, b, c)
   | WLnone (a, b)-> "WLnone" ^ [%show: int * string] (a, b)
@@ -34,18 +34,18 @@ let l =
     ( [
         WLpage (13, ([], "aaa"), "aaa", "", "bbb");
         WLnone (15, ", ");
-        WLperson (26, ("ccc", "ddd", 0), "ccc ddd", None);
+        WLperson (26, ("ccc", "ddd", 0), None, None);
         WLnone (51, ", http://site.com/eee#fff");
       ],
       "[[[aaa/bbb]]], [[ccc/ddd]], http://site.com/eee#fff" );
     ( [
         WLnone (1, "[");
-        WLperson (12, ("aaa", "bbb", 0), "aaa bbb", None);
+        WLperson (12, ("aaa", "bbb", 0), None, None);
         WLnone (14, ", ");
-        WLperson (25, ("ccc", "ddd", 0), "ccc ddd", None);
+        WLperson (25, ("ccc", "ddd", 0), Some "Ccc Ddd", None);
         WLnone (50, ", http://site.com/eee#fff");
       ],
-      "[[[aaa/bbb]], [[ccc/ddd]], http://site.com/eee#fff" );
+      "[[[aaa/bbb]], [[ccc/ddd/Ccc Ddd]], http://site.com/eee#fff" );
     ([ WLnone (7, "[[[aaa/") ], "[[[aaa/");
     ([ WLnone (6, "[[[]]]") ], "[[[]]]");
     ([ WLnone (4, "[[[w") ], "[[[w");

--- a/test/wiki_test.ml
+++ b/test/wiki_test.ml
@@ -9,7 +9,7 @@ let pp_wiki_link = function
       ^ [%show: int * (string * string * int) * string * string option]
           (a, Obj.magic b, c, d)
   | WLwizard (a, b, c) -> "WLwizard" ^ [%show: int * string * string] (a, b, c)
-  | WLnone -> "WLnone"
+  | WLnone (a, b)-> "WLnone" ^ [%show: int * string] (a, b)
   *)
 
 open Alcotest
@@ -25,12 +25,7 @@ let f s =
       | (WLpage (j, _, _, _, _) | WLperson (j, _, _, _) | WLwizard (j, _, _)) as
         x ->
           loop (x :: acc) j
-      | WLnone -> (
-          match acc with
-          | [] -> loop (WLnone :: acc) (i + 1)
-          | hd :: _ ->
-              if hd <> WLnone then loop (WLnone :: acc) (i + 1)
-              else loop acc (i + 1))
+      | WLnone (j, _text) as wn -> loop (wn :: acc) j
   in
   loop [] 0
 
@@ -38,24 +33,24 @@ let l =
   [
     ( [
         WLpage (13, ([], "aaa"), "aaa", "", "bbb");
-        WLnone;
+        WLnone (15, ", ");
         WLperson (26, ("ccc", "ddd", 0), "ccc ddd", None);
-        WLnone;
+        WLnone (51, ", http://site.com/eee#fff");
       ],
       "[[[aaa/bbb]]], [[ccc/ddd]], http://site.com/eee#fff" );
     ( [
-        WLnone;
+        WLnone (1, "[");
         WLperson (12, ("aaa", "bbb", 0), "aaa bbb", None);
-        WLnone;
+        WLnone (14, ", ");
         WLperson (25, ("ccc", "ddd", 0), "ccc ddd", None);
-        WLnone;
+        WLnone (50, ", http://site.com/eee#fff");
       ],
       "[[[aaa/bbb]], [[ccc/ddd]], http://site.com/eee#fff" );
-    ([ WLnone ], "[[[aaa/");
-    ([ WLnone ], "[[[]]]");
-    ([ WLnone ], "[[[w");
-    ([ WLnone ], "[[]]");
-    ([ WLnone ], "[[w");
+    ([ WLnone (7, "[[[aaa/") ], "[[[aaa/");
+    ([ WLnone (6, "[[[]]]") ], "[[[]]]");
+    ([ WLnone (4, "[[[w") ], "[[[w");
+    ([ WLnone (4, "[[]]") ], "[[]]");
+    ([ WLnone (3, "[[w") ], "[[w");
     ( [ WLpage (34, ([], "d_azincourt"), "d_azincourt", "", "d&#039;Azincourt") ],
       "[[[d_azincourt/d&#039;Azincourt]]]" );
   ]


### PR DESCRIPTION
This patch allows links to persons in the various texts field or files to be updated when the names or occurrence number of a person is changed. The subsequent changes pages are still listed in the update confirmation page for manual verification.

Some notes:
- I updated the warning message in the confirmation page in French and English, but it will need someone else to edit the other languages.
- Edits of notes should be reported through the `History` module, although I did not find a clear mechanized way to do this for wizard notes. If the current solution in unsatisfactory I may rework it with the help of some pointers.
- I noticed the equality test between pnocs was using the generic equality operator, which leads to observable bugs since it really shouldn't be used on strings. I patched the places I found but may have missed some.
- This is generally hard to test thoroughly so this might need some attention before we can completely rely on this.

cc @hgouraud  