### PR TITLE
Avoid some odoc warnings while processing mli files

### DIFF
--- a/lib/GWPARAM.mli
+++ b/lib/GWPARAM.mli
@@ -79,7 +79,7 @@ module Default : sig
     Config.config ->
     Def.httpStatus ->
     unit
-  (** If [?content] is not set, sends page content from {/etc/<status-code>-<lang>.html}.
+  (** If [?content] is not set, sends page content from [/etc/<status-code>-<lang>.html].
       If the current lang is not available, use `en` *)
 
   val p_auth : Config.config -> Gwdb.base -> Gwdb.person -> bool

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -6,7 +6,7 @@ val carrousel_folder : config -> string
 val authorized_image_file_extension : string array
 
 val scale_to_fit : max_w:int -> max_h:int -> w:int -> h:int -> int * int
-(** [scale_to_fit ~max_w ~max_h ~w ~h] is the {(width, height)} of a proportionally scaled {(w, h)} rectangle so it can fit in a {(max_w, max_h)} rectangle *)
+(** [scale_to_fit ~max_w ~max_h ~w ~h] is the [width, height] of a proportionally scaled [w, h] rectangle so it can fit in a [max_w, max_h] rectangle *)
 
 val source_filename : config -> string -> string
 (** Returns path to the image file with the giving name in directory {i src/}. *)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -215,8 +215,8 @@ val person_title : config -> base -> person -> Adef.safe_string
 val child_of_parent : config -> base -> person -> Adef.safe_string
 
 val mod_ind_link : config -> person -> Adef.safe_string -> Adef.safe_string
-(** [mod_ind_link conf base p s] creates a hyperlink with the URL "?m=MOD_IND&i={iper}"
-    where {iper} is the index of the person [p], and the text [s]. If [s] is empty,
+(** [mod_ind_link conf base p s] creates a hyperlink with the URL "?m=MOD_IND&i=\{iper\}"
+    where '\{iper\}' is the index of the person [p], and the text [s]. If [s] is empty,
     it defaults to print a wrench icon. *)
 
 val reference : config -> base -> person -> Adef.safe_string -> Adef.safe_string

--- a/lib/wiki.mli
+++ b/lib/wiki.mli
@@ -58,7 +58,7 @@ val split_title_and_text : string -> (string * string) list * string
    This function calculates each Key/value pair and puts it in a list;
    except for the key TITLE, that is the second element of the returned tuple.
    If there is no title defined, checks if the first line is not empty and does
-   not start with '=' nor contains '<' nor '[', in which case it is choosen as a
+   not start with '=' nor contains '<' nor '\[', in which case it is choosen as a
    first line. Otherwise, the title is the empty string.
 *)
 


### PR DESCRIPTION
This is a step1 correction of issue #1852 as detailed in issue comments.