### PR TITLE
use macOS-13, add camlpzip for nnp+ancient build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
@@ -53,7 +53,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - macos-12
+          - macos-13
         ocaml-compiler:
           - ocaml-variants.4.14.2+options,ocaml-option-nnp
     steps:
@@ -67,7 +67,7 @@ jobs:
 
       - name: Setup GeneWeb dependencies
         run: |
-          opam install -y ancient calendars.1.0.0 camlp-streams camlp5 cppo dune jingoo markup ocamlformat.0.24.1 oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf
+          opam install -y ancient calendars.1.0.0 camlp-streams camlp5 camlzip cppo dune jingoo markup ocamlformat.0.24.1 oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf
 
       - name: build/distrib
         run: |


### PR DESCRIPTION
bumping macOS version because macOS-12 is deprecated on GitHub Actions see https://github.com/actions/runner-images/issues/10721