### PR TITLE
use precompiled Ocaml, add update_nldb and fix home for Colab

### DIFF
--- a/geneweb_colab.ipynb
+++ b/geneweb_colab.ipynb
@@ -70,13 +70,12 @@
       },
       "outputs": [],
       "source": [
-        "#Installing Ocaml environnement needed to build Geneweb (takes 15-20 min, be patient!)\n",
-        "!add-apt-repository -y ppa:avsm/ppa\n",
-        "!apt update\n",
+        "#Installing Ocaml environnement needed to build Geneweb (takes 10 min, be patient!)\n",
         "!apt install opam libgmp-dev xdot\n",
-        "!opam -y init --compiler=4.14.2\n",
-        "!eval $(opam env)\n",
-        "!opam install -y calendars.1.0.0 camlp-streams camlp5 cppo dune jingoo markup oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf"
+        "!opam -y init --bare --shell-setup\n",
+        "!opam switch create 4.13.1\n",
+        "!eval $(opam env --switch=4.13.1)\n",
+        "!opam install -y calendars.1.0.0 camlp-streams camlp5 camlzip cppo dune jingoo markup oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf yojson"
       ]
     },
     {
@@ -124,7 +123,7 @@
       "outputs": [],
       "source": [
         "#Import your Geneweb database. Log file stored in /bases/ if needed.\n",
-        "!cd geneweb/distribution/bases/ && ../gw/gwc -f ../../../$basefile -stats -cg > import.log"
+        "!cd geneweb/distribution/bases/ && ../gw/gwc -f ../../../$basefile -o mybase -stats -cg > import.log && ../gw/update_nldb mybase"
       ]
     },
     {
@@ -146,7 +145,9 @@
       "source": [
         "# Show the URL of Geneweb server on this Colab environnement. Don’t click before the gwd server is launched (next step).\n",
         "from google.colab.output import eval_js\n",
-        "print(eval_js(\"google.colab.kernel.proxyPort(2317)\"))"
+        "print(f\"{eval_js('google.colab.kernel.proxyPort(2317)')}mybase?m=H&v=welcome\")\n",
+        "#KNOWN BUG: blank query for welcome page is broken in Colab, using m=H&v=welcome as home instead\n",
+        "!perl -i -pe 's|;(\" title=\"\\[\\*home)|;m=H&v=welcome$1|' /content/geneweb/distribution/gw/etc/home.txt"
       ]
     },
     {


### PR DESCRIPTION
Using precompiled Ocaml 4.13.1 on Colab saves about 5 min of build. The welcome page with an empty query “…/mybase?” is broken on Colab because it is adding ?auth=0 automaticaly and this parameter is not interpreted by gwd. To avoid failure we target “?m=H&v=welcome” at start and also hack the first hyperlink button of home template with a perl regexp.