### PR TITLE
Improve cache files performances

### DIFF
--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -205,7 +205,7 @@ let () =
   in
   let fds =
     if !all then `Fnames true :: fds
-    else if !snames then `Fnames !sname_aliases :: fds
+    else if !fnames then `Fnames !fname_aliases :: fds
     else fds
   in
 
@@ -229,6 +229,6 @@ let () =
   in
   let min, sec =
     let d = Float.to_int total_duration in
-    (d / 60, d mod 60)
+    (d / 60, mod_float total_duration 60.)
   in
-  Format.printf "Total duration: %dm %ds@." min sec
+  Format.printf "Total duration: %d min %6.2f s@." min sec

--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -198,8 +198,16 @@ let () =
   let fds = if !all || !estates then `Estates :: fds else fds in
   let fds = if !all || !pub_names then `Pub_names :: fds else fds in
   let fds = if !all || !aliases then `Aliases :: fds else fds in
-  let fds = if !all || !snames then `Snames !sname_aliases :: fds else fds in
-  let fds = if !all || !fnames then `Fnames !fname_aliases :: fds else fds in
+  let fds =
+    if !all then `Snames true :: fds
+    else if !snames then `Snames !sname_aliases :: fds
+    else fds
+  in
+  let fds =
+    if !all then `Fnames true :: fds
+    else if !snames then `Fnames !sname_aliases :: fds
+    else fds
+  in
 
   let total_duration =
     List.fold_left

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1742,7 +1742,7 @@ let connection (addr, request) script_name contents0 =
           let (contents, env) = build_env request contents0 in
           if not (image_request printer_conf script_name env)
           && not (misc_request printer_conf script_name)
-          then 
+          then
             conf_and_connection from request script_name contents env
         with Exit -> ()
     end
@@ -1796,7 +1796,7 @@ let geneweb_server () =
             null_reopen [Unix.O_WRONLY] Unix.stderr
           end
         else exit 0;
-        Mutil.mkdir_p ~perm:0o777 !GWPARAM.cnt_dir 
+        File.create_dir ~parent:true ~required_perm:0o755 !GWPARAM.cnt_dir
     end;
   Wserver.f GwdLog.syslog !selected_addr !selected_port !conn_timeout
     (if Sys.unix then !max_clients else None) connection
@@ -1883,7 +1883,7 @@ let slashify s =
   String.init (String.length s) conv_char
 
 let make_sock_dir x =
-  Mutil.mkdir_p x;
+  File.create_dir ~parent:true x;
   if Sys.unix then ()
   else
     begin

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -1541,7 +1541,8 @@ let rs_printf opts s =
   loop true 0
 
 let gwu opts isolated base in_dir out_dir src_oc_ht (per_sel, fam_sel) =
-  if out_dir <> "" && not (Sys.file_exists out_dir) then Mutil.mkdir_p out_dir;
+  if out_dir <> "" && not (Sys.file_exists out_dir) then
+    File.create_dir ~parent:true out_dir;
   let to_separate = separate base in
   let out_oc_first = ref true in
   let _ofile, oc, close = opts.oc in

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -17,6 +17,7 @@ let dummy_ifam = -1
 let empty_string = 0
 let quest_string = 1
 let eq_istr i1 i2 = i1 = i2
+let hash_istr i = i
 let eq_ifam i1 i2 = i1 = i2
 let eq_iper i1 i2 = i1 = i2
 let is_empty_string istr = istr = 0

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -310,7 +310,7 @@ let output base =
           (fun f ->
             let s = base.data.bnotes.Def.nread f Def.RnAll in
             let fname = Filename.concat tmp_notes_d (f ^ ".txt") in
-            Mutil.mkdir_p (Filename.dirname fname);
+            File.create_dir ~parent:true (Filename.dirname fname);
             let oc = open_out fname in
             output_string oc s;
             close_out oc)

--- a/lib/gwdb/gutil.mli
+++ b/lib/gwdb/gutil.mli
@@ -36,6 +36,7 @@ val designation : base -> person -> string
 val trim_trailing_spaces : string -> string
 (** Trim at the end of string *)
 
+(* TODO: This function is very slow and should be rewritten completely. *)
 val alphabetic_utf_8 : string -> string -> int
 (** Compare two UTF-8 encoded strings by alphabetic order *)
 

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -67,6 +67,12 @@ val dummy_ifam : ifam
 val eq_istr : istr -> istr -> bool
 (** [true] if strings with the giving ids are equal *)
 
+val hash_istr : istr -> int
+(** Compute a hash of a [istr] value. This function is just the identity
+    because a [istr] value is already a hash.
+
+    The hash should use only on strings from a common database. *)
+
 val eq_ifam : ifam -> ifam -> bool
 (** [true] if families with the giving ids are equal *)
 

--- a/lib/historyDiff.ml
+++ b/lib/historyDiff.ml
@@ -49,7 +49,7 @@ let create_history_dirs conf fname =
     let dirs =
       [ history_d conf; String.make 1 fname.[0]; String.make 1 fname.[1] ]
     in
-    Mutil.mkdir_p (List.fold_left Filename.concat "" dirs)
+    File.create_dir ~parent:true (List.fold_left Filename.concat "" dirs)
 
 (* ************************************************************************ *)
 (*  [Fonc] write_history_file : config -> string -> gen_record -> unit      *)

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -68,7 +68,7 @@ let move_file_to_save file dir =
   (* previous version iterated on file types *)
   try
     let save_dir = Filename.concat dir "saved" in
-    if not (Sys.file_exists save_dir) then Mutil.mkdir_p save_dir;
+    File.create_dir ~parent:true save_dir;
     let fname = Filename.basename file in
     let orig_file = Filename.concat dir fname in
     let saved_file = Filename.concat save_dir fname in
@@ -326,7 +326,7 @@ let effective_send_ok conf base p file =
   in
   let fname = Image.default_portrait_filename base p in
   let dir = !GWPARAM.images_d conf.bname in
-  if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
+  File.create_dir ~parent:true dir;
   let fname =
     Filename.concat dir
       (if mode = "portraits" then fname ^ extension_of_type typ else fname)
@@ -412,7 +412,7 @@ let effective_send_c_ok conf base p file file_name =
     if mode = "portraits" then !GWPARAM.portraits_d conf.bname
     else Filename.concat (!GWPARAM.images_d conf.bname) fname
   in
-  if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
+  File.create_dir ~parent:true dir;
   let fname =
     Filename.concat dir
       (if mode = "portraits" then fname ^ extension_of_type typ else file_name)
@@ -425,7 +425,7 @@ let effective_send_c_ok conf base p file file_name =
     | Some (`Url url) -> (
         let fname = Image.default_portrait_filename base p in
         let dir = Filename.concat dir "saved" in
-        if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
+        File.create_dir ~parent:true dir;
         let fname = Filename.concat dir fname ^ ".url" in
         try write_file fname url
         with _ ->
@@ -571,7 +571,7 @@ let effective_delete_c_ok conf base p =
     if mode = "portraits" then !GWPARAM.portraits_d conf.bname
     else Filename.concat (!GWPARAM.images_d conf.bname) fname
   in
-  if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
+  File.create_dir ~parent:true dir;
   (* TODO verify we dont destroy a saved image
       having the same name as portrait! *)
   if delete then

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -215,7 +215,7 @@ let commit_notes conf base fnotes s =
     String.concat Filename.dir_sep
       [ Util.bpath conf.bname; base_notes_dir base; fname ]
   in
-  Mutil.mkdir_p (Filename.dirname fpath);
+  File.create_dir ~parent:true (Filename.dirname fpath);
   try Gwdb.commit_notes base fname s
   with Sys_error m ->
     Hutil.incorrect_request conf ~comment:("explication todo: " ^ m);

--- a/lib/util/compat.ml
+++ b/lib/util/compat.ml
@@ -1,0 +1,44 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "-32-33"]
+
+module In_channel = struct
+  type t = in_channel
+
+  let with_open openfun s f =
+    let ic = openfun s in
+    Fun.protect ~finally:(fun () -> Stdlib.close_in_noerr ic) (fun () -> f ic)
+
+  let with_open_bin s f = with_open Stdlib.open_in_bin s f
+  let with_open_text s f = with_open Stdlib.open_in s f
+
+  let with_open_gen flags perm s f =
+    with_open (Stdlib.open_in_gen flags perm) s f
+end
+
+module Out_channel = struct
+  type t = out_channel
+
+  let with_open openfun s f =
+    let oc = openfun s in
+    Fun.protect ~finally:(fun () -> Stdlib.close_out_noerr oc) (fun () -> f oc)
+
+  let with_open_bin s f = with_open Stdlib.open_out_bin s f
+  let with_open_text s f = with_open Stdlib.open_out s f
+
+  let with_open_gen flags perm s f =
+    with_open (Stdlib.open_out_gen flags perm) s f
+end

--- a/lib/util/compat.mli
+++ b/lib/util/compat.mli
@@ -1,0 +1,62 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 2021 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module In_channel : sig
+  type t = in_channel
+  (** The type of input channel. *)
+
+  val with_open_bin : string -> (t -> 'a) -> 'a
+  (** [with_open_bin fn f] opens a channel [ic] on file [fn] and returns [f ic].
+      After [f] returns, either with a value or by raising an exception, [ic]
+      is guaranteed to be closed.
+
+      @since 4.14 *)
+
+  val with_open_text : string -> (t -> 'a) -> 'a
+  (** Like {!with_open_bin}, but the channel is opened in text mode (see
+      {!open_text}).
+
+      @since 4.14 *)
+
+  val with_open_gen : open_flag list -> int -> string -> (t -> 'a) -> 'a
+  (** Like {!with_open_bin}, but can specify the opening mode and file
+      permission, in case the file must be created (see {!open_gen}).
+
+      @since 4.14 *)
+end
+
+module Out_channel : sig
+  type t = out_channel
+  (** The type of output channel. *)
+
+  val with_open_bin : string -> (t -> 'a) -> 'a
+  (** [with_open_bin fn f] opens a channel [oc] on file [fn] and returns [f oc].
+      After [f] returns, either with a value or by raising an exception, [oc]
+      is guaranteed to be closed.
+
+      @since 4.14 *)
+
+  val with_open_text : string -> (t -> 'a) -> 'a
+  (** Like {!with_open_bin}, but the channel is opened in text mode (see
+      {!open_text}).
+
+      @since 4.14 *)
+
+  val with_open_gen : open_flag list -> int -> string -> (t -> 'a) -> 'a
+  (** Like {!with_open_bin}, but can specify the opening mode and file
+      permission, in case the file must be created (see {!open_gen}).
+
+      @since 4.14 *)
+end

--- a/lib/util/file.ml
+++ b/lib/util/file.ml
@@ -1,0 +1,88 @@
+exception File_error of string
+
+let raise_error ppf = Format.ksprintf (fun s -> raise (File_error s)) ppf
+
+let check_perm perm path =
+  let Unix.{ st_perm; _ } = Unix.stat path in
+  st_perm = perm
+
+let check_kind ~kind path =
+  let Unix.{ st_kind; _ } = Unix.stat path in
+  match kind with `File -> st_kind = Unix.S_REG | `Dir -> st_kind = Unix.S_DIR
+
+let create_file ?required_perm path =
+  let perm, check_perm =
+    match required_perm with
+    | Some perm -> (perm, check_perm perm)
+    | None -> (0o644, fun (_ : string) -> true)
+  in
+  let () =
+    if Sys.file_exists path then (
+      if not @@ check_kind ~kind:`File path then
+        raise_error "%s exists but it is not a regular file" path)
+    else Unix.openfile path [ Unix.O_CREAT ] perm |> Unix.close
+  in
+  if not @@ check_perm path then
+    raise_error "%s has not the required permissions %o" path perm
+
+let mkdir ~perm dir =
+  if Sys.file_exists dir then (
+    if not @@ check_kind ~kind:`Dir dir then
+      raise_error "%s exists but it is not a directory" dir)
+  else Unix.mkdir dir perm
+
+let ( // ) = Filename.concat
+
+let iter_path_entries f path =
+  let rec loop path =
+    match (Filename.dirname path, Filename.basename path) with
+    | ("." | "/"), base -> f base
+    | path, base ->
+        loop path;
+        f (path // base)
+  in
+  loop path
+
+let create_dir ?(parent = false) ?required_perm path =
+  if String.equal path "" then
+    (* The basename of an empty path is implemented-defined in POSIX.
+       We do not support this case to simplify the function. *)
+    invalid_arg "create_dir";
+  let perm, check_perm =
+    match required_perm with
+    | Some perm -> (perm, check_perm perm)
+    | None -> (0o755, fun (_ : string) -> true)
+  in
+  let () =
+    if parent then iter_path_entries (mkdir ~perm) path else mkdir ~perm path
+  in
+  if not @@ check_perm path then
+    raise_error "%s has not the required permissions %o" path perm
+
+let walk_folder ?(recursive = false) f path acc =
+  let rec walk_siblings dirs path handle acc =
+    match Unix.readdir handle with
+    | exception End_of_file -> (dirs, acc)
+    | "." | ".." -> walk_siblings dirs path handle acc
+    | s -> (
+        let fl = Filename.concat path s in
+        let stat = Unix.stat fl in
+        match stat.st_kind with
+        | Unix.S_REG -> walk_siblings dirs path handle (f (`File fl) acc)
+        | Unix.S_DIR ->
+            let dirs = if recursive then fl :: dirs else dirs in
+            walk_siblings dirs path handle (f (`Dir fl) acc)
+        | _ -> walk_siblings dirs path handle acc)
+  in
+  let rec traverse stack acc =
+    match stack with
+    | [] -> acc
+    | path :: stack ->
+        let stack, acc =
+          let handle = Unix.opendir path in
+          Fun.protect ~finally:(fun () -> Unix.closedir handle) @@ fun () ->
+          walk_siblings stack path handle acc
+        in
+        traverse stack acc
+  in
+  traverse [ path ] acc

--- a/lib/util/file.mli
+++ b/lib/util/file.mli
@@ -1,0 +1,49 @@
+exception File_error of string
+
+val create_file : ?required_perm:int -> string -> unit
+(** [create_file ?required_perm ~kind path] creates a file at [path] if the
+    target does not exist.
+
+    The default permissions are 0o644. In absence of required permissions,
+    we do not check the permissions of the target.
+
+    @raise File_error if the target exists but it is not a regular file or
+                      the target file does not fulfill the required
+                      permissions. *)
+
+val create_dir : ?parent:bool -> ?required_perm:int -> string -> unit
+(** [create_dir ?parent ?required_perm ~kind path] creates a directory at
+    [path] if the target does not exist.
+
+    The default permissions are 0o755. In absence of required permissions,
+    we do not check the permissions of the target.
+
+    If [parent] is [true], the function also creates all the intermediate
+    entries of the path that do not exist with the same permissions.
+    Notice that in this case the function does not behave exactly as the Unix
+    command `mkdir -p`. In particular it does not support relative paths which
+    involve dot-dot entries.
+
+    @raise File_error if one of the entry in the path exists but it is not
+                      a directory or the target directory does not fulfill the
+                      required permissions.
+
+    @raise Invalid_argument on empty path. *)
+
+val walk_folder :
+  ?recursive:bool ->
+  ([ `File of string | `Dir of string ] -> 'a -> 'a) ->
+  string ->
+  'a ->
+  'a
+(** [walk_folder ~recursive f dir] accumulates [f] on all the regular files or
+    directories of [dir].
+
+    The argument of [f] is the relative path of the file or subdirectory in
+    [dir].
+
+    If [recursive] is [true], the iterator also explores subdirectories. [false]
+    is the default.
+
+    @raise Unix.Unix_error if the function cannot open a file or a
+                           subdirectory in [dir]. *)

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -545,7 +545,7 @@ let input_lexicon lang ht open_fname =
           key ())
   in
   key () ;
-  Hashtbl.iter (fun k k2 -> 
+  Hashtbl.iter (fun k k2 ->
       match Hashtbl.find_opt ht k2 with
       | Some entry -> Hashtbl.replace ht k entry
       | None -> ()) tmp

--- a/lib/util/progrBar.mli
+++ b/lib/util/progrBar.mli
@@ -1,5 +1,33 @@
 (* $Id: progrBar.mli,v 5.3 2007-02-01 10:28:55 ddr Exp $ *)
 
+type t
+(** Type of a progress bar. *)
+
+val progress : t -> int -> int -> unit
+(** [progress t n max] changes the completion of the progress bar to be
+    [n / max] of its length.
+
+    This function can be used in moderately hot loops. *)
+
+val with_bar :
+  ?width:int ->
+  ?empty:char ->
+  ?full:char ->
+  ?disabled:bool ->
+  Format.formatter ->
+  (t -> 'a) ->
+  'a
+(** [with_bar ppf f] wraps the call to [f] with a progress
+    bar printed on the formatter [ppf]. The function [step] can be call to
+    change the progression of the bar in [f].
+
+    To work properly, one should not print anything on [ppf] in [f].
+
+    If [ppf] is the standard output or the error output, one should not print
+    anything of both of them. *)
+
+(* XXX: The below bar is deprecated and should not be used in new code. *)
+
 val empty : char ref
 (** Character that represents not passed part of progression bar *)
 
@@ -12,6 +40,9 @@ val start : unit -> unit
 val run : int -> int -> unit
 (** [run i len] modifies progression bar that is now filled proportionally to
     [i] by comparison with [len]. *)
+
+(* XXX: This function cannot be used in hot loops without impacting
+        performance. *)
 
 val finish : unit -> unit
 (** Stop printing progression bar and prints a new line. *)


### PR DESCRIPTION
My PR for the search engine is too large now so I start to split it in atomic ones. 

The main purpose of this PR is to improve the performance of the script `cache_files`. The new script is twice faster. The PR includes also:
1. A tiny library for file manipulations in `lib/util/file.mli`. 
2. A better progress bar. The previous one was buggy, can only be used on `stderr` and cannot be used in hot loops. 
3. A full rewrite of the script `cache_file`. Please, let me know if it works fine for you. 

Some general remarks:
1. The library `File` includes a new function `File.create_dir` which can be used to create new directories without raising an error if the directory already exists. The function can also create parents if they do not exists but it is not as good as `mkdir -p` in your terminal. For instance, `File.create_dir ~parent:true "foo/../bar"` will fail because of the dot-dot in the middle. I think that the correct way to implement it is to normalize the input path. On `Unix`, we can use `realpath` of the libc but the OCaml Unix library do not expose it. I think that this function is also useful for security purposes. For instance, I believe that `Secure.check` is a real sieve because of it is implementation of `Secure.decompose` (I didn't check it, I may be wrong).
2. In plenty of locations of the codebase, the backtrace of OCaml is destroyed by the following anti-pattern:
```ocaml 
(* Get some resource *)
let resource = open () in
try 
  (* do something that can raise exceptions *)
  close (); 
with 
| exn -> 
   close (); 
   raise exn
```
The OCaml runtime cannot understand that the exception have been raised in the try block and you will only got the end of the backtrace (which is, most of the times, the least interesting part of it). It is error-prone to maintain this pattern by hand, and actually I found places in `gwd` where resources are not freed for all the exceptions. If you want to save the backtrace, you have to it by hand: 
```ocaml 
(* Get some resource *)
let resource = open () in
try 
  (* do something that can raise exceptions *)
  close (); 
with 
| exn -> 
   close (); 
   let bt = Printexc.get_raw_backtrace () in
   Printexc.raise_with_backtrace exn bt
```
 Unfortunately, OCaml has no `finally` blocks like Java or Python, so you have to it yourself. Since OCaml 4.08, there is a new function `Fun.protect` which essentially do the right thing for you. The previous code can be rewrite like this:
```ocaml 
(* Get some resource *)
let resource = open () in
Fun.protect ~finally:close @@ fun () -> 
  (* do something that can raise exceptions *)
 ```

The `File` module contains two specialized functions of `Fun.protect` for files and directories. I recommend that you use them.
  