### PR TITLE
correct big problem with cache_linked_pages…

### DIFF
--- a/lib/mergeInd.ml
+++ b/lib/mergeInd.ml
@@ -195,7 +195,7 @@ let effective_merge_ind conf base (warning : CheckItem.base_warning -> unit) p1
     let pgl = Notes.links_to_ind conf base db key in
     pgl
   in
-  Notes.update_cache_linked_pages conf Notes.Merge key key pgl
+  Notes.update_cache_linked_pages conf Notes.Merge key key (List.length pgl)
 
 exception Error_loop of person
 exception Same_person

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -276,9 +276,7 @@ let links_to_ind conf base db key =
   List.sort_uniq compare l
 
 type mode = Delete | Rename | Merge
-
-type cache_linked_pages_t =
-  (Def.NLDB.key, (Def.NLDB.key * Def.NLDB.ind) list) Hashtbl.t
+type cache_linked_pages_t = (Def.NLDB.key, int) Hashtbl.t
 
 let cache_linked_pages_name = "cache_linked_pages"
 
@@ -304,7 +302,7 @@ let write_cache_linked_pages conf cache_linked_pages =
   output_value oc cache_linked_pages;
   close_out oc
 
-let update_cache_linked_pages conf mode old_key new_key pgl =
+let update_cache_linked_pages conf mode old_key new_key nbr =
   let ht = read_cache_linked_pages conf in
   match mode with
   | Delete -> Hashtbl.remove ht old_key
@@ -314,7 +312,7 @@ let update_cache_linked_pages conf mode old_key new_key pgl =
       | Some _ -> Hashtbl.remove ht old_key
       | None ->
           ();
-          Hashtbl.add ht new_key pgl)
+          Hashtbl.add ht new_key nbr)
   | Rename ->
       (let entry =
          try Some (Hashtbl.find ht old_key) with Not_found -> None
@@ -322,7 +320,7 @@ let update_cache_linked_pages conf mode old_key new_key pgl =
        match entry with
        | Some pgl ->
            Hashtbl.remove ht old_key;
-           Hashtbl.add ht new_key pgl
+           Hashtbl.add ht new_key nbr
        | None -> ());
       write_cache_linked_pages conf ht
 
@@ -330,6 +328,6 @@ let linked_pages_nbr conf base ip =
   let key = Util.make_key base (Gwdb.gen_person_of_person (poi base ip)) in
   let ht = read_cache_linked_pages conf in
   let entry = try Some (Hashtbl.find ht key) with Not_found -> None in
-  match entry with Some pgl -> List.length pgl | None -> 0
+  match entry with Some nbr -> nbr | None -> 0
 
 let has_linked_pages conf base ip = linked_pages_nbr conf base ip <> 0

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -76,12 +76,7 @@ val linked_pages_nbr : Config.config -> Gwdb.base -> Gwdb.iper -> int
 val cache_linked_pages_name : string
 
 val update_cache_linked_pages :
-  Config.config ->
-  mode ->
-  Def.NLDB.key ->
-  Def.NLDB.key ->
-  (Def.NLDB.key * Def.NLDB.ind) list ->
-  unit
+  Config.config -> mode -> Def.NLDB.key -> Def.NLDB.key -> int -> unit
 
 val json_extract_img : Config.config -> string -> string * string
 val safe_gallery : Config.config -> string -> string

--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -153,13 +153,13 @@ let linked_page_rows conf base pg =
           (Format.sprintf
              {|
 <td class="align-middle">
-  <a href="%sm=MOD_FAM&i=%s&ip=%s#comments" title="%s %s %s">
+  <a href="%sm=MOD_FAM&i=%s&ip=%s#events" title="%s %s %s">
     <i class="fa fa-user fa-sm"></i><i class="fa fa-user fa-sm"></i></a></td>|}
              (commd conf :> string)
              (Gwdb.string_of_ifam ifam)
              (Gwdb.get_iper fath |> Gwdb.string_of_iper)
              (Utf8.capitalize_fst (transl conf "modify"))
-             (transl conf "comment")
+             (transl_nth conf "event/events" 0)
              (transl_nth conf "family/families" 0));
       Output.print_sstring conf
         (Format.sprintf

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -2901,10 +2901,20 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
           in
           VVbool r
       | _ -> raise Not_found)
+  (* TODO exclude TYPE gallery and album ?? *)
+  (* TODO fold link_to_ind and Notes.link_to_ind !! *)
   | [ "has_linked_pages" ] -> (
       match get_env "nldb" env with
-      | Vnldb _db -> VVbool (Notes.has_linked_pages conf base (get_iper p))
+      | Vnldb db ->
+          let key =
+            let fn = Name.lower (sou base (get_first_name p)) in
+            let sn = Name.lower (sou base (get_surname p)) in
+            (fn, sn, get_occ p)
+          in
+          VVbool (links_to_ind conf base db key None <> [])
       | _ -> raise Not_found)
+  | [ "has_linked_pages_2" ] ->
+      VVbool (Notes.linked_pages_nbr conf base (get_iper p) > 0)
   | [ "linked_pages_nbr" ] -> (
       match get_env "nldb" env with
       | Vnldb db ->
@@ -2920,6 +2930,8 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
           in
           str_val r
       | _ -> str_val "0")
+  | [ "linked_pages_nbr_2" ] ->
+      VVstring (string_of_int (Notes.linked_pages_nbr conf base (get_iper p)))
   | [ "nb_linked_pages_type"; s ] -> (
       match get_env "nldb" env with
       | Vnldb db ->
@@ -2957,12 +2969,6 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) loc = function
       match get_env "lev_cnt" env with
       | Vint i -> str_val (string_of_int i)
       | _ -> raise Not_found)
-  | [ "linked_pages_number" ] -> (
-      match get_env "nldb" env with
-      | Vnldb _db ->
-          Notes.linked_pages_nbr conf base (get_iper p)
-          |> string_of_int |> str_val
-      | _ -> str_val "0")
   | [ "linked_page"; s ] -> (
       match get_env "nldb" env with
       | Vnldb db ->

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -934,7 +934,7 @@ let effective_del_commit conf base op =
   let key =
     Util.make_key base (Gwdb.gen_person_of_person (poi base op.key_index))
   in
-  Notes.update_cache_linked_pages conf Notes.Delete key key [];
+  Notes.update_cache_linked_pages conf Notes.Delete key key 0;
   Util.commit_patches conf base;
   let changed = U_Delete_person op in
   History.record conf base changed "dp"
@@ -1185,7 +1185,7 @@ let print_mod ?prerr o_conf base =
     Notes.update_notes_links_db base (Def.NLDB.PgInd p.key_index) s;
     let new_key = Util.make_key base p in
     if old_key <> new_key then
-      Notes.update_cache_linked_pages conf Notes.Rename old_key new_key [];
+      Notes.update_cache_linked_pages conf Notes.Rename old_key new_key 0;
     let wl =
       let a = poi base p.key_index in
       let a = { parents = get_parents a; consang = get_consang a } in


### PR DESCRIPTION
cache_linked_pages was missing some pages, returning a 0 count sometimes.
Rewrote the creation process of cache_linked_pages to record only the number of pages.

Small edit of` | NotesLinks.WLperson (j, key, name, text) ->` (in update_nldb) handling both name and text if both present (-> name;text)

Small change in linked_pages presentation: for PgFam, m=MOD_FAM now points to #event rather that #comment