### PR TITLE
Fix create_dir for absolute path

### DIFF
--- a/lib/util/file.ml
+++ b/lib/util/file.ml
@@ -38,7 +38,7 @@ let ( // ) = Filename.concat
 let iter_path_entries f path =
   let rec loop path =
     match (Filename.dirname path, Filename.basename path) with
-    | ("." | "/"), base -> f base
+    | ("." | "/"), _ -> f path
     | path, base ->
         loop path;
         f (path // base)


### PR DESCRIPTION
The previous version contains a bug reported by michelmno in https://github.com/geneweb/geneweb/issues/1987

The base case of the iterator on path entries was wrong for absolute path. This commit addresses the issue.