### PR TITLE
Add buffered `input_line` for Camlzip in_channel

### DIFF
--- a/lib/util/dune.in
+++ b/lib/util/dune.in
@@ -5,6 +5,7 @@
  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% -V OCAML:%{ocaml_version} %{input-file})))
  (libraries
    calendars
+   camlzip
    stdlib-shims
    unidecode
    geneweb.def

--- a/lib/util/my_gzip.ml
+++ b/lib/util/my_gzip.ml
@@ -1,0 +1,81 @@
+type in_channel = {
+  gic : Gzip.in_channel;
+  (* Underlying input channel of camlzip. *)
+  lines : string Queue.t;
+  (* Queue of complete lines not yet returned by [input_line]. *)
+  tail : Buffer.t; (* Last incomplete line. *)
+}
+
+let open_in path =
+  {
+    gic = Gzip.open_in path;
+    lines = Queue.create ();
+    tail = Buffer.create 2_048;
+  }
+
+let close_in ic = Gzip.close_in ic.gic
+let close_in_noerr ic = try Gzip.close_in ic.gic with _ -> ()
+
+let with_open path f =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () -> f ic
+
+let contains_newline b r =
+  let rec loop i =
+    if i >= r then false
+    else if Char.equal (Bytes.get b i) '\n' then true
+    else loop (i + 1)
+  in
+  loop 0
+
+(* Search the end of the next line in the buffer [b] starting at [s]. *)
+let find_nextline b s =
+  let len = Buffer.length b in
+  let rec loop i =
+    if i >= len then raise Not_found
+    else if Char.equal (Buffer.nth b i) '\n' then i
+    else loop (i + 1)
+  in
+  loop s
+
+(* Read from the input channel [ic] until a new line is found in the
+   buffer. Return the number of read characters. *)
+let read_until_newline ic =
+  let b = Bytes.create 500 in
+  let rec loop acc =
+    let r = Gzip.input ic.gic b 0 500 in
+    Buffer.add_subbytes ic.tail b 0 r;
+    if contains_newline b r || r = 0 then acc + r else loop (acc + r)
+  in
+  loop 0
+
+(* Feed the queue with all the complete lines in the buffer.
+   The eventual last incomplete line is returned. The buffer tail
+   is empty after calling this function.
+
+   Return the incomplete line remaining in the buffer. *)
+let flush_tail ic =
+  let len = Buffer.length ic.tail in
+  let rec loop s =
+    match find_nextline ic.tail s with
+    | exception Not_found ->
+        let b = Bytes.create (len - s) in
+        Buffer.blit ic.tail s b 0 (len - s);
+        Buffer.clear ic.tail;
+        b
+    | e ->
+        Queue.push (Buffer.sub ic.tail s (e - s)) ic.lines;
+        loop (e + 1)
+  in
+  loop 0
+
+let rec input_line ic =
+  if not @@ Queue.is_empty ic.lines then Queue.pop ic.lines
+  else
+    let r = read_until_newline ic in
+    let b = flush_tail ic in
+    if r = 0 && Bytes.length b = 0 then raise End_of_file
+    else if r = 0 then Bytes.to_string b
+    else (
+      Buffer.add_bytes ic.tail b;
+      input_line ic)

--- a/lib/util/my_gzip.mli
+++ b/lib/util/my_gzip.mli
@@ -1,0 +1,23 @@
+type in_channel
+(** Abstract type representing a channel opened for reading from
+    compressed file. *)
+
+val open_in : string -> in_channel
+(** [open_in path] open a compressed file [path]. *)
+
+val with_open : string -> (in_channel -> 'a) -> 'a
+(** [with_open path f] open the compressed file [path] and call [f] on
+    the input channel. The input channel is properly closed even if
+    [f] raises exceptions. *)
+
+val close_in : in_channel -> unit
+(** [close_in ic] closes the input channel. *)
+
+val close_in_noerr : in_channel -> unit
+(** [close_in_noerr ic] closes the input channel without raising exception. *)
+
+val input_line : in_channel -> string
+(** [input_line ic] reads the next line on the channel [ic]. The last line will 
+    be produce even if it does not end with a line feed.
+
+    @raise End_of_file if it reaches the end of the file. *)


### PR DESCRIPTION
The input_channel type exposed by Camlzip does not provide a convenient API as stdlib's in_channel. In particular, there is no `input_line` function to read a gzip file line by line.

For small gzip file, a simple workaround is to read the entire file in one pass and store it in an OCaml string. However, this approach as two drawbacks:
1. On 32-bits architecture, the size of OCaml string is really limited (around 16MB), which means we cannot read large gzip file.
2. The entire file must be stored in memory, even if only a single line in memory is needed to perform a task.

This PR addresses this issue by implementing a small wrapper around the Camlzip in_channel type. The `My_gzip.input_line` function limits memory usage to the length of the next line.

NB: This PR is a part of the fuzzy search feature.