### PR TITLE
Reraise exceptions with backtrace in gwd

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2127,4 +2127,9 @@ let () =
     GwdLog.syslog `LOG_CRIT (p ^ ": " ^ Dynlink.error_message e)
   | Register_plugin_failure (p, `string s) ->
     GwdLog.syslog `LOG_CRIT (p ^ ": " ^ s)
-  | e -> GwdLog.syslog `LOG_CRIT (Printexc.to_string e)
+  | exn -> (
+      let s = Printexc.get_backtrace () in
+      GwdLog.syslog `LOG_CRIT (Printexc.to_string exn);
+      if Printexc.backtrace_status () then
+        let s = Format.sprintf "Backtrace:@ %s" s in
+        GwdLog.syslog `LOG_CRIT s)

--- a/lib/wserver/wserver.ml
+++ b/lib/wserver/wserver.ml
@@ -278,7 +278,7 @@ let accept_connection tmout max_clients callback s =
         if !no_fork then client_connection tmout callback addr t
         else
           match Unix.fork () with
-          | exception exn ->
+          | exception _ ->
               eprintf "Fork failed\n";
               flush stderr
           | 0 -> (


### PR DESCRIPTION
As I noticed it previously, the webserver loses most of the backtrace while exception handling. Error handling in web servers is a well-known challenge. This commit focuses on preserving backtraces and logging them.

**I only tested the PR with gwd on Unix. I believe that we should test it with CGI too on both Linux and Windows.** 

Besides, is it correct that the web server only operates in CGI mode on Windows? 