### PR TITLE
Add a tool to check common typographic errors for dictionaries

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -495,6 +495,8 @@ let treat_request =
           w_base @@ AdvSearchOkDisplay.print
         | "C" ->
           w_base @@ w_person @@ CousinsDisplay.print
+        | "CHK_DATA" ->
+          w_base @@ CheckDataDisplay.print
         | "CAL" -> w_base @@ Hutil.print_calendar
         | "CHG_CHN" when conf.wizard ->
           w_wizard @@ w_base @@ ChangeChildrenDisplay.print

--- a/hd/etc/css/css.css
+++ b/hd/etc/css/css.css
@@ -66,6 +66,23 @@
   word-wrap: break-word;
 }
 
+/* Check data */
+.hl-check-data {
+  background-color: #FFEB3B;
+  border-radius: 2px;
+  white-space: pre;
+}
+
+.hl-check-data.narrow-nbsp {
+  background-color: #ffb300;
+}
+
+.zero-width-char {
+  display: inline-block;
+  min-width: 0.5em;
+  border: 1px dashed #FF5722;
+}
+
 /* Toolbar and characters panel */
 /* Light grey background color highlight for the toolbar characters.txt */
 .ch .hl {

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -425,6 +425,9 @@ fr: Mon compte associatif
         %apply;book_button("src","source/sources","box-archive")
         %apply;book_button("title","title/titles","crown")
         %apply;book_button("domain","domain/domains","chess-rook")
+        <a href="%prefix;m=CHK_DATA" class="btn btn-outline-success ml-2"
+          title="[*data typographic checker]"><i class="fas fa-spell-check"></i>
+        </a>
       </div>
     </div>
   </div>

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -4393,6 +4393,26 @@ ru: порядок личных событий был изменён
 sv: ändrade ordningen för personhändelser
 tr: bireysel etkinliklerin sırasını değiştir
 
+    chk_data invisible characters
+en: Invisible characters
+fr: Caractères invisibles
+
+    chk_data bad capitalization
+en: Bad capitalization
+fr: Capitalisation erronée
+
+    chk_data multiple spaces
+en: Multiple spaces
+fr: Espaces multiples
+
+    chk_data mutiples characters
+en: Multiple characters
+fr: Caractères multiples
+
+    chk_data non-breaking spaces
+en: Non-breaking spaces
+fr: Espaces insécables
+
     child/children
 af: kind/kinders
 ar: طفلة/أطفال
@@ -19242,6 +19262,10 @@ ru: попытайтесь изменить тип связи
 sv: försök ett annat beräkningssätt
 tr: başka bir hesaplama seçeneği deneyin
 
+    data typographic checker
+en: Data typographic checker
+fr: Vérificateur typographique des données
+
     uncheck
 co: diselezziunà
 de: Abwählen
@@ -20373,4 +20397,6 @@ sk: tvoja správa čaká na potvrdenie
 sv: ditt meddelande väntar på godkännande
 tr: mesajınız doğrulama için bekliyor
 
-
+    zero-width character
+en: this zero-width character has been widened to be visible
+fr: ce caractère sans chasse a été élargi pour être visible

--- a/lib/checkData.ml
+++ b/lib/checkData.ml
@@ -1,0 +1,551 @@
+open Gwdb
+open Def
+
+(* Basic types *)
+type dict_type =
+  | Fnames
+  | Snames
+  | Places
+  | PubNames
+  | Qualifiers
+  | Aliases
+  | Occupation
+  | Estates
+  | Titles
+  | Sources
+
+type error_type =
+  | InvisibleCharacters
+  | BadCapitalization
+  | MultipleSpaces
+  | NonBreakingSpace
+
+type highlight_style = {
+  make_class : string -> string;
+  make_title : ?code:string -> ?name:string -> Config.config -> string option;
+}
+
+let first_word s =
+  try
+    let i = String.index s ' ' in
+    if i = String.length s then if i > 6 then String.sub s 0 6 else s
+    else String.sub s 0 i
+  with Not_found -> if String.length s > 6 then String.sub s 0 6 else s
+
+(* Split a string into its words, filtering out empty strings *)
+let split_words s =
+  let words = String.split_on_char ' ' s in
+  List.filter (fun w -> w <> "") words
+
+(* Detect if a word is a Roman numeral with various notations:
+   - Basic roman numerals: I, II, III, IV, V, etc.
+   - French ordinals: Ier, Ire
+   - English/German style: I., II., III., etc. *)
+let is_roman_numeral s =
+  let roman = Str.regexp "^[IVX]+[.]?$" in
+  let first_ordinal = Str.regexp "^I\\(ᵉʳ\\|ʳᵉ\\|er\\|re\\)$" in
+  try Str.string_match roman s 0 || Str.string_match first_ordinal s 0
+  with _ -> false
+
+(* Multiple Spaces functions *)
+let has_multiple_spaces s =
+  let rec aux i =
+    if i >= String.length s - 1 then false
+    else if s.[i] = ' ' && s.[i + 1] = ' ' then true
+    else aux (i + 1)
+  in
+  aux 0
+
+(* Check if the character following nbsp is part of a roman numeral *)
+let has_roman_after_nbsp s i =
+  if i + 2 >= String.length s then false
+  else
+    let rest = String.sub s (i + 2) (String.length s - (i + 2)) in
+    let next_word =
+      try String.sub rest 0 (String.index rest ' ') with Not_found -> rest
+    in
+    is_roman_numeral next_word
+
+let find_multiple_spaces_positions s =
+  let rec aux acc i =
+    if i >= String.length s then List.rev acc
+    else if s.[i] = ' ' then
+      let rec count_spaces pos positions =
+        if pos >= String.length s || s.[pos] <> ' ' then (pos, positions)
+        else count_spaces (pos + 1) (pos :: positions)
+      in
+      let next_pos, spaces = count_spaces i [] in
+      if List.length spaces > 1 then aux (spaces @ acc) next_pos
+      else aux acc (i + 1)
+    else aux acc (i + 1)
+  in
+  aux [] 0
+
+let fix_multiple_spaces s =
+  let rec aux acc i =
+    if i >= String.length s then String.concat "" (List.rev acc)
+    else if s.[i] = ' ' then
+      let rec skip_spaces j =
+        if j >= String.length s || s.[j] != ' ' then j else skip_spaces (j + 1)
+      in
+      let next = skip_spaces (i + 1) in
+      aux (" " :: acc) next
+    else aux (String.make 1 s.[i] :: acc) (i + 1)
+  in
+  aux [] 0
+
+(* Non-breaking spaces functions *)
+let has_regular_nbsp s i =
+  i + 1 < String.length s && s.[i] = '\xC2' && s.[i + 1] = '\xA0'
+
+let has_narrow_nbsp s i =
+  i + 2 < String.length s
+  && s.[i] = '\xE2'
+  && s.[i + 1] = '\x80'
+  && s.[i + 2] = '\xAF'
+
+let has_non_breaking_space s =
+  let rec aux i =
+    if i >= String.length s - 1 then false
+    else if has_regular_nbsp s i then
+      if has_roman_after_nbsp s i then false else true
+    else if has_narrow_nbsp s i then
+      if has_roman_after_nbsp s i then false else true
+    else aux (i + 1)
+  in
+  aux 0
+
+let find_non_breaking_space_positions s =
+  let rec aux acc i =
+    if i >= String.length s - 1 then List.rev acc
+    else if has_regular_nbsp s i then
+      if has_roman_after_nbsp s i then aux acc (i + 2)
+      else aux (i :: (i + 1) :: acc) (i + 2)
+    else if has_narrow_nbsp s i then
+      if has_roman_after_nbsp s i then aux acc (i + 3)
+      else aux (i :: (i + 1) :: (i + 2) :: acc) (i + 3)
+    else aux acc (i + 1)
+  in
+  aux [] 0
+
+(* Detect if a word starts with Irish name prefixes Mac/Mc/Fitz *)
+let is_irish_prefix s =
+  let prefixes = [ "Mac"; "Mc"; "Fitz" ] in
+  List.exists
+    (fun prefix ->
+      String.length s >= String.length prefix
+      && String.sub s 0 (String.length prefix) = prefix)
+    prefixes
+
+(* Check if a word is either a Roman numeral or starts with an Irish prefix
+   Examples of valid words:
+   - Roman numerals: "XIV", "III", "IX"
+   - Irish prefixes: "MacDonald", "McLeod", "FitzGerald" *)
+let is_allowed_word s = is_roman_numeral s || is_irish_prefix s
+
+(* Detect invalid capitalization patterns:
+   - Multiple uppercase letters in sequence
+   - Lowercase followed by uppercase
+   - Uppercase, lowercase, uppercase sequence *)
+
+(* Bad Capitalization functions *)
+let has_bad_capitalization_pattern s =
+  let re = Str.regexp "\\([A-Z]\\{2,\\}\\|[a-z][A-Z]\\|[A-Z][a-z][A-Z]\\)" in
+  try
+    let _ = Str.search_forward re s 0 in
+    true
+  with Not_found -> false
+
+(* Capitalization check function
+   Examines each word for valid patterns for some books
+   For other types, just checks for invalid capitalization patterns *)
+let has_legitimate_mixed_case dict s =
+  let words = split_words s in
+  match dict with
+  | Fnames | Snames | PubNames | Aliases | Places ->
+      (* For these types, we check if each word is either:
+         - A Roman numeral (e.g. "MacDonald III")
+         - An Irish prefix name (e.g. "MacArthur", "FitzGerald") *)
+      let rec check_words = function
+        | [] -> true (* All words are valid *)
+        | word :: rest ->
+            if has_bad_capitalization_pattern word && not (is_allowed_word word)
+            then false
+            else check_words rest
+      in
+      check_words words
+  | _ -> false
+
+let has_bad_capitalization dict s =
+  has_bad_capitalization_pattern s && not (has_legitimate_mixed_case dict s)
+
+let find_bad_capitalization_positions s =
+  let re = Str.regexp "\\([A-Z]\\{2,\\}\\|[a-z][A-Z]\\|[A-Z][a-z][A-Z]\\)" in
+  let rec aux acc pos =
+    try
+      let pos' = Str.search_forward re s pos in
+      let len = String.length (Str.matched_string s) in
+      let new_pos = pos' + len in
+      let positions = List.init len (fun i -> pos' + i) in
+      aux (positions @ acc) new_pos
+    with Not_found -> List.rev acc
+  in
+  aux [] 0
+
+(* Table des caractères invisibles indésirables
+   Association code point héxadécimaux -> nom officiel Unicode *)
+(* Table des caractères invisibles indésirables *)
+let invisible_chars =
+  [|
+    ("00AD", "SOFT HYPHEN");
+    ("034F", "COMBINING GRAPHEME JOINER");
+    ("0600", "ARABIC NUMBER SIGN");
+    ("0601", "ARABIC SIGN SANAH");
+    ("0602", "ARABIC FOOTNOTE MARKER");
+    ("0603", "ARABIC SIGN SAFHA");
+    ("06DD", "ARABIC END OF AYAH");
+    ("070F", "SYRIAC ABBREVIATION MARK");
+    ("0F0C", "TIBETAN MARK DELIMITER");
+    ("115F", "HANGUL CHOSEONG FILLER");
+    ("1160", "HANGUL JUNGSEONG FILLER");
+    ("1680", "OGHAM SPACE MARK");
+    ("180E", "MONGOLIAN VOWEL SEPARATOR");
+    ("2000", "EN QUAD");
+    ("2001", "EM QUAD");
+    ("2002", "EN SPACE");
+    ("2003", "EM SPACE");
+    ("2004", "THREE-PER-EM SPACE");
+    ("2005", "FOUR-PER-EM SPACE");
+    ("2006", "SIX-PER-EM SPACE");
+    ("2007", "FIGURE SPACE");
+    ("2008", "PUNCTUATION SPACE");
+    ("2009", "THIN SPACE");
+    ("200A", "HAIR SPACE");
+    ("200B", "ZERO WIDTH SPACE");
+    ("200C", "ZERO WIDTH NON-JOINER");
+    ("200D", "ZERO WIDTH JOINER");
+    ("200E", "LEFT-TO-RIGHT MARK");
+    ("200F", "RIGHT-TO-LEFT MARK");
+    ("205F", "MEDIUM MATHEMATICAL SPACE");
+    ("2060", "WORD JOINER");
+    ("2061", "FUNCTION APPLICATION");
+    ("2062", "INVISIBLE TIMES");
+    ("2063", "INVISIBLE SEPARATOR");
+    ("2064", "INVISIBLE PLUS");
+    ("206A", "INHIBIT SYMMETRIC SWAPPING");
+    ("206B", "ACTIVATE SYMMETRIC SWAPPING");
+    ("206C", "INHIBIT ARABIC FORM SHAPING");
+    ("206D", "ACTIVATE ARABIC FORM SHAPING");
+    ("206E", "NATIONAL DIGIT SHAPES");
+    ("206F", "NOMINAL DIGIT SHAPES");
+    ("3000", "IDEOGRAPHIC SPACE");
+    ("FEFF", "ZERO WIDTH NO-BREAK SPACE");
+  |]
+
+let is_zero_width hex =
+  match hex with "200B" | "200C" | "200D" | "FEFF" -> true | _ -> false
+
+let get_unicode_info code =
+  let hex = Printf.sprintf "%04X" code in
+  let rec find_in_array i =
+    if i >= Array.length invisible_chars then
+      (hex, "UNKNOWN INVISIBLE CHARACTER")
+    else
+      let h, name = invisible_chars.(i) in
+      if h = hex then (hex, name) else find_in_array (i + 1)
+  in
+  find_in_array 0
+
+let get_unicode_point s i =
+  let n = Char.code (String.get s i) in
+  if n < 0x80 then (n, 1)
+  else if n <= 0xdf && i + 1 < String.length s then
+    (((n - 0xc0) lsl 6) lor (0x7f land Char.code (String.get s (i + 1))), 2)
+  else if n <= 0xef && i + 2 < String.length s then
+    let n' = n - 0xe0 in
+    let m = Char.code (String.get s (i + 1)) in
+    let n' = (n' lsl 6) lor (0x7f land m) in
+    let m = Char.code (String.get s (i + 2)) in
+    ((n' lsl 6) lor (0x7f land m), 3)
+  else if i + 3 < String.length s then
+    let n' = n - 0xf0 in
+    let m = Char.code (String.get s (i + 1)) in
+    let n' = (n' lsl 6) lor (0x7f land m) in
+    let m = Char.code (String.get s (i + 2)) in
+    let n' = (n' lsl 6) lor (0x7f land m) in
+    let m = Char.code (String.get s (i + 3)) in
+    ((n' lsl 6) lor (0x7f land m), 4)
+  else (n, 1)
+
+let hex_to_int hex = int_of_string ("0x" ^ hex)
+
+let has_invisible_chars s =
+  let len = String.length s in
+  let rec aux i =
+    if i >= len then false
+    else
+      let code, size = get_unicode_point s i in
+      if Array.exists (fun (h, _) -> hex_to_int h = code) invisible_chars then
+        true
+      else aux (i + size)
+  in
+  aux 0
+
+let find_invisible_positions s =
+  let len = String.length s in
+  let rec aux acc i =
+    if i >= len then List.rev acc
+    else
+      let code, size = get_unicode_point s i in
+      if Array.exists (fun (h, _) -> hex_to_int h = code) invisible_chars then
+        aux (i :: acc) (i + size)
+      else aux acc (i + size)
+  in
+  aux [] 0
+
+let fix_invisible_chars s =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec aux i =
+    if i >= len then Buffer.contents buf
+    else
+      let code, size = get_unicode_point s i in
+      if Array.exists (fun (h, _) -> hex_to_int h = code) invisible_chars then (
+        Buffer.add_char buf ' ';
+        aux (i + size))
+      else (
+        Buffer.add_char buf s.[i];
+        aux (i + 1))
+  in
+  aux 0
+
+(* Generic error handling *)
+let find_error_positions error_type s =
+  match error_type with
+  | InvisibleCharacters -> find_invisible_positions s
+  | BadCapitalization -> find_bad_capitalization_positions s
+  | MultipleSpaces -> find_multiple_spaces_positions s
+  | NonBreakingSpace -> find_non_breaking_space_positions s
+
+let fix_error error_type s =
+  match error_type with
+  | InvisibleCharacters -> fix_invisible_chars s
+  | BadCapitalization -> s (* Return original string *)
+  | MultipleSpaces -> fix_multiple_spaces s
+  | NonBreakingSpace -> s
+
+(* Define style and tooltip of error types *)
+let get_highlight_style error_type conf =
+  match error_type with
+  | NonBreakingSpace ->
+      {
+        make_class =
+          (fun s ->
+            let is_narrow =
+              String.length s >= 3
+              && s.[0] = '\xE2'
+              && s.[1] = '\x80'
+              && s.[2] = '\xAF'
+            in
+            if is_narrow then " narrow-nbsp" else "");
+        make_title =
+          (fun ?code ?name:_ _ ->
+            match code with
+            | Some "00A0" -> Some "U+00A0 NON-BREAKING SPACE"
+            | Some "202F" -> Some "U+202F NARROW NON-BREAKING SPACE"
+            | _ -> None);
+      }
+  | InvisibleCharacters ->
+      {
+        make_class =
+          (fun hex -> if is_zero_width hex then " zero-width-char" else "");
+        make_title =
+          (fun ?code ?name _ ->
+            let base =
+              Printf.sprintf "U+%s %s"
+                (Option.value code ~default:"")
+                (Option.value name ~default:"")
+            in
+            let () =
+              Printf.printf "code: %s\n" (Option.value code ~default:"")
+            in
+            if is_zero_width (Option.value code ~default:"") then
+              Some
+                (Printf.sprintf "%s (%s)" base
+                   (Util.transl conf "zero-width character"))
+            else Some base);
+      }
+  | _ ->
+      {
+        make_class = (fun _ -> "");
+        make_title = (fun ?code:_ ?name:_ _ -> None);
+      }
+
+(* HTML Generation *)
+
+let make_highlight_html s positions error_type conf =
+  let buf = Buffer.create (String.length s * 2) in
+  let style = get_highlight_style error_type conf in
+
+  let rec process_char i in_span =
+    if i >= String.length s then (
+      if in_span then Buffer.add_string buf "</span>";
+      Buffer.contents buf)
+    else
+      let is_highlight = List.mem i positions in
+      if is_highlight then (
+        let code, size = get_unicode_point s i in
+        let hex, name = get_unicode_info code in
+        let title_attr =
+          match style.make_title ~code:hex ~name conf with
+          | Some t -> Printf.sprintf " title=\"%s\"" t
+          | None -> ""
+        in
+        let original = String.sub s i size in
+        Printf.bprintf buf "<span class=\"hl-check-data%s\"%s>%s</span>"
+          (style.make_class original)
+          title_attr original;
+        process_char (i + size) false)
+      else (
+        Buffer.add_char buf s.[i];
+        process_char (i + 1) false)
+  in
+  process_char 0 false
+
+let make_error_html conf data entry error_type =
+  let s = first_word entry in
+  let s1 = entry in
+  let s2 = fix_error error_type entry in
+  let positions = find_error_positions error_type entry in
+  let highlighted = make_highlight_html entry positions error_type conf in
+
+  let url =
+    Printf.sprintf "?m=MOD_DATA&data=%s&s=%s&s1=%s&s2=%s" data
+      (Mutil.encode s :> string)
+      (Mutil.encode s1 :> string)
+      (Mutil.encode s2 :> string)
+  in
+  Printf.sprintf "<a href=\"%s\">%s</a>" url highlighted
+
+(* Error collection *)
+(* Event accessors *)
+let get_epers_place evt = evt.epers_place
+let get_epers_src evt = evt.epers_src
+let get_efam_place evt = evt.efam_place
+let get_efam_src evt = evt.efam_src
+
+(* Basic getters returning lists *)
+let get_birth_place_x p = [ get_birth_place p ]
+let get_baptism_place_x p = [ get_baptism_place p ]
+let get_death_place_x p = [ get_death_place p ]
+let get_burial_place_x p = [ get_burial_place p ]
+let get_birth_src_x p = [ get_birth_src p ]
+let get_baptism_src_x p = [ get_baptism_src p ]
+let get_death_src_x p = [ get_death_src p ]
+let get_burial_src_x p = [ get_burial_src p ]
+let get_psources_x p = [ get_psources p ]
+let get_marriage_place_x fam = [ get_marriage_place fam ]
+let get_marriage_src_x fam = [ get_marriage_src fam ]
+let get_fsources_x fam = [ get_fsources fam ]
+
+(* Generic collector for attributes - places or sources *)
+let collect_attributes base p
+    ~std_attrs (* list of standard attribute collectors *)
+    ~epers_attr_get (* personal event attribute getter *)
+    ~marriage_attr (* marriage attribute collector *)
+    ~efam_attr_get (* family event attribute getter *) =
+  let attrs = ref [] in
+  List.iter
+    (fun getter -> List.iter (fun x -> attrs := x :: !attrs) (getter p))
+    std_attrs;
+  List.iter (fun evt -> attrs := epers_attr_get evt :: !attrs) (get_pevents p);
+  Array.iter
+    (fun ifam ->
+      let fam = foi base ifam in
+      List.iter (fun x -> attrs := x :: !attrs) (marriage_attr fam);
+      List.iter
+        (fun evt -> attrs := efam_attr_get evt :: !attrs)
+        (get_fevents fam))
+    (get_family p);
+  !attrs
+  |> List.filter (fun i -> not (is_empty_string i))
+  |> List.sort_uniq compare
+
+let collect_places base p =
+  collect_attributes base p
+    ~std_attrs:
+      [
+        get_birth_place_x;
+        get_baptism_place_x;
+        get_death_place_x;
+        get_burial_place_x;
+      ]
+    ~epers_attr_get:get_epers_place ~marriage_attr:get_marriage_place_x
+    ~efam_attr_get:get_efam_place
+
+let collect_sources base p =
+  let sources =
+    collect_attributes base p
+      ~std_attrs:
+        [
+          get_birth_src_x;
+          get_baptism_src_x;
+          get_death_src_x;
+          get_burial_src_x;
+          get_psources_x;
+        ]
+      ~epers_attr_get:get_epers_src ~marriage_attr:get_marriage_src_x
+      ~efam_attr_get:get_efam_src
+  in
+  let sources = ref sources in
+  Array.iter
+    (fun ifam ->
+      let fam = foi base ifam in
+      List.iter (fun x -> sources := x :: !sources) (get_fsources_x fam))
+    (get_family p);
+  List.sort_uniq compare !sources
+
+let collect_dict_strings base = function
+  | Fnames -> fun p -> [ get_first_name p ]
+  | Snames -> fun p -> [ get_surname p ]
+  | Places -> collect_places base
+  | PubNames -> fun p -> [ get_public_name p ]
+  | Qualifiers -> get_qualifiers
+  | Aliases -> get_aliases
+  | Occupation -> fun p -> [ get_occupation p ]
+  | Titles -> fun p -> List.map (fun t -> t.t_ident) (get_titles p)
+  | Estates -> fun p -> List.map (fun t -> t.t_place) (get_titles p)
+  | Sources -> collect_sources base
+
+let collect_all_errors base dict =
+  let strings_with_errors = Hashtbl.create 1024 in
+  let add_error s err =
+    match Hashtbl.find_opt strings_with_errors s with
+    | Some errs -> Hashtbl.replace strings_with_errors s (err :: errs)
+    | None -> Hashtbl.add strings_with_errors s [ err ]
+  in
+
+  let check_string s =
+    if has_invisible_chars s then add_error s InvisibleCharacters;
+    if has_bad_capitalization dict s then add_error s BadCapitalization;
+    if has_multiple_spaces s then add_error s MultipleSpaces;
+    if has_non_breaking_space s then add_error s NonBreakingSpace
+  in
+
+  let collect_strings = collect_dict_strings base dict in
+
+  Collection.iter
+    (fun i ->
+      let p = poi base i in
+      List.iter
+        (fun istr ->
+          let s = sou base istr in
+          if s <> "" then check_string s)
+        (collect_strings p))
+    (ipers base);
+
+  let result = ref [] in
+  Hashtbl.iter
+    (fun s errs -> result := (s, errs) :: !result)
+    strings_with_errors;
+  !result

--- a/lib/checkData.mli
+++ b/lib/checkData.mli
@@ -1,0 +1,24 @@
+type dict_type =
+  | Fnames
+  | Snames
+  | Places
+  | PubNames
+  | Qualifiers
+  | Aliases
+  | Occupation
+  | Estates
+  | Titles
+  | Sources
+
+type error_type =
+  | InvisibleCharacters
+  | BadCapitalization
+  | MultipleSpaces
+  | NonBreakingSpace
+
+val find_error_positions : error_type -> string -> int list
+val fix_error : error_type -> string -> string
+val make_error_html : Config.config -> string -> string -> error_type -> string
+
+val collect_all_errors :
+  Gwdb.base -> dict_type -> (string * error_type list) list

--- a/lib/checkDataDisplay.ml
+++ b/lib/checkDataDisplay.ml
@@ -1,0 +1,89 @@
+open Config
+
+let print_nav_button conf current_data data icon title =
+  let href = Printf.sprintf "?m=CHK_DATA&data=%s" data in
+  let active = if current_data = data then "active" else "" in
+  Output.printf conf
+    {|<a href="%s" class="btn btn-outline-primary %s">
+       <i class="fa fa-%s mr-1"></i>%s
+     </a>|}
+    href active icon
+    (Utf8.capitalize_fst (Util.transl_nth conf title 1))
+
+let print_nav_buttons conf current_data =
+  Output.printf conf "<div class=\"d-flex btn-group mt-3\" role=\"group\">\n";
+  print_nav_button conf current_data "fn" "child" "first name/first names";
+  print_nav_button conf current_data "sn" "signature" "surname/surnames";
+  print_nav_button conf current_data "place" "map-location-dot" "place/places";
+  print_nav_button conf current_data "pubn" "pen" "public name/public names";
+  print_nav_button conf current_data "qual" "comment" "qualifier/qualifiers";
+  print_nav_button conf current_data "alias" "mask" "alias/aliases";
+  print_nav_button conf current_data "occu" "user-doctor"
+    "occupation/occupations";
+  print_nav_button conf current_data "title" "crown" "title/titles";
+  print_nav_button conf current_data "domain" "chess-rook" "domain/domains";
+  print_nav_button conf current_data "src" "box-archive" "source/sources";
+  Output.printf conf "</div>\n"
+
+let display_error_section conf data entries error_type error_title =
+  let filtered_entries =
+    List.filter_map
+      (fun (entry, errors) ->
+        if List.mem error_type errors then
+          Some (CheckData.make_error_html conf data entry error_type)
+        else None)
+      entries
+  in
+  if filtered_entries <> [] then (
+    Output.printf conf "<h3 class=\"mt-3\">%s</h3>" error_title;
+    Output.print_sstring conf "<ul class=\"list-group\">";
+    List.iter
+      (fun html ->
+        Output.printf conf "<li class=\"list-group-item\">%s</li>" html)
+      filtered_entries;
+    Output.print_sstring conf "</ul>")
+
+let print conf base =
+  let data = Util.p_getenv conf.env "data" |> Option.value ~default:"" in
+
+  let dict =
+    match data with
+    | "fn" -> Some CheckData.Fnames
+    | "sn" -> Some CheckData.Snames
+    | "place" -> Some CheckData.Places
+    | "pubn" -> Some CheckData.PubNames
+    | "qual" -> Some CheckData.Qualifiers
+    | "alias" -> Some CheckData.Aliases
+    | "occu" -> Some CheckData.Occupation
+    | "title" -> Some CheckData.Titles
+    | "domain" -> Some CheckData.Estates
+    | "src" -> Some CheckData.Sources
+    | _ -> None
+  in
+
+  let entries =
+    match dict with
+    | Some dict_type -> CheckData.collect_all_errors base dict_type
+    | None -> []
+  in
+
+  let title _ =
+    Output.print_sstring conf (Util.transl conf "data typographic checker")
+  in
+  Hutil.header conf title;
+
+  print_nav_buttons conf data;
+
+  display_error_section conf data entries CheckData.InvisibleCharacters
+    (Util.transl conf "chk_data invisible characters");
+
+  display_error_section conf data entries CheckData.BadCapitalization
+    (Util.transl conf "chk_data bad capitalization");
+
+  display_error_section conf data entries CheckData.MultipleSpaces
+    (Util.transl conf "chk_data multiple spaces");
+
+  display_error_section conf data entries CheckData.NonBreakingSpace
+    (Util.transl conf "chk_data non-breaking spaces");
+
+  Hutil.trailer conf

--- a/lib/checkDataDisplay.mli
+++ b/lib/checkDataDisplay.mli
@@ -1,0 +1,2 @@
+val print : Config.config -> Gwdb.base -> unit
+(** Display the list of potential typographic errors in the database. *)


### PR DESCRIPTION
Add new system to detect typographic errors in dictonaries (books):
- Invisible characters
- Bad capitalization (with special rules for Roman numerals and Irish name prefixes)
- Multiple spaces
- Non-breaking spaces (detects both regular and narrow forms)

Implemented for all dictionaries (first names, surnames, places, public names, qualifiers,
  aliases, occupations, titles, domains and sources) with specific rules:
- First names/surnames/public names: exclude Roman numerals (e.g., "Louis XIV") and Irish prefixes (Mac-/Mc-/Fitz-)
- Places: detect space variations that could affect location matching
- Other dictionaries: standard typographic rules

Features:
- Navigation bar between dictionaries
- Visual highlighting of detected issues
- Error categorization with explanatory tooltips for invisible characters
- Direct link to correction interface (upddata) for each entry
- Structure designed for easy addition of new dictionaries and error types