### PR TITLE
ged2gwb: Prevent importing invalid dates

### DIFF
--- a/bin/ged2gwb/ged2gwb_lib.ml
+++ b/bin/ged2gwb/ged2gwb_lib.ml
@@ -542,13 +542,7 @@ let roman_int =
   Grammar.Entry.of_parser date_g "roman int" p
 
 let make_date n1 n2 n3 =
-  let n3 =
-    if !state.no_negative_dates then
-      match n3 with
-        Some n3 -> Some (abs n3)
-      | None -> None
-    else n3
-  in
+  let n3 = if !state.no_negative_dates then Option.map abs n3 else n3 in
   match n1, n2, n3 with
     Some d, Some m, Some y ->
       let (d, m) =

--- a/bin/ged2gwb/ged2gwb_lib.ml
+++ b/bin/ged2gwb/ged2gwb_lib.ml
@@ -577,7 +577,9 @@ let make_date n1 n2 n3 =
       {day = 0; month = 0; year = y; prec = Sure; delta = 0}
   | Some y, None, None ->
       {day = 0; month = 0; year = y; prec = Sure; delta = 0}
-  | _ -> raise (Stream.Error "bad date")
+  | Some _, None, Some _ | Some _, Some _, None | None, Some _, None |
+    None, None, None ->
+      raise (Stream.Error "bad date")
 
 let recover_date cal = function
   | Date.Dgreg (d, Dgregorian) ->

--- a/lib/util/date.ml
+++ b/lib/util/date.ml
@@ -277,6 +277,14 @@ let partial_date_upper_bound ~from ~day ~month ~year =
 
 let partial_date_lower_bound ~day ~month ~year = (max 1 day, max 1 month, year)
 
+let make_date_error_message ~prefix erroneous_date =
+  Printf.sprintf "%s: invalid %s: '%s'" prefix
+    (match erroneous_date.Calendars.kind with
+    | Calendars.Invalid_day -> "day"
+    | Calendars.Invalid_month -> "month"
+    | Calendars.Invalid_year -> "year")
+    (Calendars.Unsafe.to_string erroneous_date.Calendars.value)
+
 (* [to_sdn] does not work if day|month are unknown
    so we return sdn of partial_date_(lower|upper)_bound instead *)
 let to_sdn ~from ?(lower = true) d =
@@ -287,8 +295,9 @@ let to_sdn ~from ?(lower = true) d =
   let day, month, year = bound ~day ~month ~year in
   let make kind =
     match Calendars.make kind ~day ~month ~year ~delta with
-    | Error e ->
-        Printf.eprintf "Calendars.make error: %s" e;
+    | Error erroneous_date ->
+        prerr_string
+        @@ make_date_error_message ~prefix:"Date error" erroneous_date;
         -1
     | Ok d -> Calendars.to_sdn d
   in

--- a/lib/util/date.mli
+++ b/lib/util/date.mli
@@ -127,3 +127,9 @@ val french_of_sdn : prec:precision -> int -> dmy
 
 val hebrew_of_sdn : prec:precision -> int -> dmy
 (** Convert SDN to [dmy] in hebrew calendar *)
+
+val partial_date_lower_bound :
+  day:int -> month:int -> year:int -> int * int * int
+
+val make_date_error_message :
+  prefix:string -> 'a Calendars.erroneous_date -> string


### PR DESCRIPTION
Use partial dates instead if it is possible.

~Depends on https://github.com/geneweb/calendars/pull/1.~
