### PR TITLE
gwexport: Always skip the too deep descendants of the root persons

### DIFF
--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -472,7 +472,18 @@ let select opts ips =
             match opts.ascdesc with
             | Some ascdesc ->
                 let ips = List.map (fun i -> (i, asc)) ips in
-                Geneweb.Util.select_mascdesc conf base ips ascdesc
+                let skip_descendants ~ancestors ~generation _ =
+                  let is_descendant_of_root_person () =
+                    let root_persons =
+                      ips |> List.map fst |> Geneweb.Util.IperSet.of_list
+                    in
+                    not @@ Geneweb.Util.IperSet.is_empty
+                    @@ Geneweb.Util.IperSet.inter ancestors root_persons
+                  in
+                  generation <= desc && is_descendant_of_root_person ()
+                in
+                Geneweb.Util.select_mascdesc ~skip_descendants conf base ips
+                  ascdesc
             | None ->
                 let ht = Hashtbl.create 0 in
                 Geneweb.Util.IperSet.iter

--- a/lib/gwdb/gwdb.ml
+++ b/lib/gwdb/gwdb.ml
@@ -246,3 +246,8 @@ let children_of_p base p =
   Array.fold_right
     (fun ifam -> Array.fold_right List.cons (get_children @@ foi base ifam))
     (get_family p) []
+
+let parents_of_person base person =
+  person |> get_parents
+  |> Option.map (foi base)
+  |> Option.map gen_couple_of_family

--- a/lib/gwdb/gwdb.mli
+++ b/lib/gwdb/gwdb.mli
@@ -22,3 +22,4 @@ val nobtitles :
   base -> string list lazy_t -> string list lazy_t -> person -> title list
 
 val children_of_p : base -> person -> iper list
+val parents_of_person : base -> person -> iper Adef.gen_couple option

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -522,6 +522,7 @@ val select_masc :
 *)
 
 val select_desc :
+  ?skip_descendants:(ancestors:IperSet.t -> generation:int -> Gwdb.iper -> bool) ->
   Config.config ->
   Gwdb.base ->
   int ->
@@ -533,6 +534,7 @@ val select_desc :
 *)
 
 val select_mascdesc :
+  ?skip_descendants:(ancestors:IperSet.t -> generation:int -> Gwdb.iper -> bool) ->
   Config.config ->
   Gwdb.base ->
   (Gwdb.iper * int) list ->


### PR DESCRIPTION
Including when computing the collateral relatives.
