### PR TITLE
test: Exit with non-zero status when a test fails

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -8,5 +8,4 @@ let () =
   let filter ~name ~index:_ =
     if is_ci && Array.mem name known_failures then `Skip else `Run
   in
-  try Alcotest.run ~and_exit:false "Geneweb" ~filter test_suite
-  with Alcotest.Test_error -> ()
+  Alcotest.run "Geneweb" ~filter test_suite


### PR DESCRIPTION
It fixes an error introduced while porting the tests to Alcotest (see ca4d5994f8506f69299e55dda5aeb0ce50f1bf14).