### PR TITLE
docker: fix launch script

### DIFF
--- a/docker/geneweb-launch.sh
+++ b/docker/geneweb-launch.sh
@@ -7,6 +7,8 @@ GENEWEB_ADMIN=${GENEWEB_ADMIN:=admin}
 GENEWEB_ADMIN_PASS=${GENEWEB_ADMIN_PASS:=$(openssl rand -hex 32)}
 GENEWEB_LANG=${GENEWEB_LANG:=en}
 
+[ -z "${GENEWEB_CUSTOM_ARGS}" ] && GENEWEB_CUSTOM_ARGS=" -cache-in-memory ${GENEWEB_DB}" 
+
 gwlaunch_log() {
 	echo "$(date +%Y-%m-%d_%H:%M:%S) geneweb-launch: $1"
 }
@@ -76,7 +78,7 @@ start() {
 	-trace_failed_passwd \
 	-bd ${GENEWEB_BASE_PATH} \
 	-hd ${GENEWEB_HOME}/share/dist/gw \
-	-cache-in-memory ${GENEWEB_DB} \
+	${GENEWEB_CUSTOM_ARGS} \
 	-log ${GENEWEB_HOME}/log/gwd.log \
 	$AUTH_ARG 2>&1
 	gwlaunch_log "-- Started gwd!"

--- a/docker/geneweb-launch.sh
+++ b/docker/geneweb-launch.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 GENEWEB_HOME="/usr/local/share/geneweb"
+GENEWEB_BASE_PATH=${GENEWEB_HOME}/share/data
 GENEWEB_DB=${GENEWEB_DB:=database}
-GENEWEB_DB_PATH=${GENEWEB_HOME}/share/data/${GENEWEB_DB}
+GENEWEB_DB_PATH=${GENEWEB_BASE_PATH}/${GENEWEB_DB}
 GENEWEB_ADMIN=${GENEWEB_ADMIN:=admin}
 GENEWEB_ADMIN_PASS=${GENEWEB_ADMIN_PASS:=$(openssl rand -hex 32)}
 GENEWEB_LANG=${GENEWEB_LANG:=en}
@@ -73,9 +74,9 @@ start() {
 	-daemon \
 	-plugins -unsafe ${GENEWEB_HOME}/share/dist/gw/plugins \
 	-trace_failed_passwd \
-	-bd ${GENEWEB_DATA_PATH} \
+	-bd ${GENEWEB_BASE_PATH} \
 	-hd ${GENEWEB_HOME}/share/dist/gw \
-	-cache-in-memory
+	-cache-in-memory ${GENEWEB_DB} \
 	-log ${GENEWEB_HOME}/log/gwd.log \
 	$AUTH_ARG 2>&1
 	gwlaunch_log "-- Started gwd!"


### PR DESCRIPTION
In eaa3eec63d the geneweb-launch script was adjusted, but the end-of-line backslash is missing after the "-cache-in-memory" argument.