### PR TITLE
Remove duplicated ending body tags for gwsetup htm files

### DIFF
--- a/bin/setup/lang/bsc.htm
+++ b/bin/setup/lang/bsc.htm
@@ -35,5 +35,3 @@ ome seconds or some minutes, depending on the case. Be patient.
      $ cd "%w"
      $ %x%/%d%p > comm.log
 </pre>
-</body>
-</html>

--- a/bin/setup/lang/bsi.htm
+++ b/bin/setup/lang/bsi.htm
@@ -40,5 +40,3 @@ ome seconds or some minutes, depending on the case. Be patient.
 <span style="color:#FF0000;">WARNING</span>: The content of file %o will be over
 written.
 %)
-</body>
-</html>

--- a/bin/setup/lang/bsi_connex.htm
+++ b/bin/setup/lang/bsi_connex.htm
@@ -39,5 +39,3 @@ some families. It may be prudent to have a backup archive.
 <pre>
      $ %x%/%d %Q
 </pre>
-</body>
-</html>

--- a/bin/setup/lang/bsi_diff.htm
+++ b/bin/setup/lang/bsi_diff.htm
@@ -39,5 +39,3 @@ some families. It may be prudent to have a backup archive.
 <pre>
      $ %x%/%d %R > comm.log
 </pre>
-</body>
-</html>

--- a/bin/setup/lang/bsi_err.htm
+++ b/bin/setup/lang/bsi_err.htm
@@ -39,5 +39,3 @@
 </dl>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/bsi_fix.htm
+++ b/bin/setup/lang/bsi_fix.htm
@@ -40,5 +40,3 @@ It may be prudent to have a backup archive.
 <pre>
      $ %x%/%d %p > comm.log
 </pre>
-</body>
-</html>

--- a/bin/setup/lang/bso.htm
+++ b/bin/setup/lang/bso.htm
@@ -59,5 +59,3 @@ ing on the cases. Be patient.
 </pre>
 [This builds a directory named "%o.gwb".]
 </ul>
-</body>
-</html>

--- a/bin/setup/lang/bso_ok.htm
+++ b/bin/setup/lang/bso_ok.htm
@@ -32,5 +32,3 @@ href="http://%m:%P/%o">http://%m:%P/%o</a>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
 <p>
 [Read the alert messages in the file "comm.log"] (<a href="gwsetup?lang=%l;v=bso_comm.htm">comm.log</a>)
-</body>
-</html>

--- a/bin/setup/lang/cache_files.htm
+++ b/bin/setup/lang/cache_files.htm
@@ -203,5 +203,3 @@
 </form>
 </ul>
 </div>
-</body>
-</html>

--- a/bin/setup/lang/cleanup1.htm
+++ b/bin/setup/lang/cleanup1.htm
@@ -43,6 +43,4 @@
         $ move %a.gwb old\.
      $ %x%/gwc tmp.gw -nofail -o %a > comm.log
 </pre>
-</body>
-</html>
 

--- a/bin/setup/lang/del_ok.htm
+++ b/bin/setup/lang/del_ok.htm
@@ -34,5 +34,3 @@
 </ul>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/delete.htm
+++ b/bin/setup/lang/delete.htm
@@ -40,5 +40,3 @@
   <input type="submit" value="[Check]">
   </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/delete_1.htm
+++ b/bin/setup/lang/delete_1.htm
@@ -34,5 +34,3 @@
 <dl><dt><dd><input type="submit" value="[Delete]"></dl>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/err_acc.htm
+++ b/bin/setup/lang/err_acc.htm
@@ -22,5 +22,3 @@
 [To change that, edit the file named "%y" and change the line holding: "<tt>%o</tt>" into "<tt>%a</tt>".]
 
 [Note that gwsetup has a -only file launch parameter]
-</body>
-</html>

--- a/bin/setup/lang/err_cnfl.htm
+++ b/bin/setup/lang/err_cnfl.htm
@@ -20,6 +20,4 @@
 [The name "%o" is used several times.]
 <p>
 [Go back to the previous page.] (<a href="%n">back</a>)
-</body>
-</html>
 

--- a/bin/setup/lang/err_miss.htm
+++ b/bin/setup/lang/err_miss.htm
@@ -20,5 +20,3 @@
 [It is not possible to execute your command. You did not give enough information.]
 <p >
 [Go back to the previous page.] (<a href="%n">back</a>)
-</body>
-</html>

--- a/bin/setup/lang/err_name.htm
+++ b/bin/setup/lang/err_name.htm
@@ -25,5 +25,3 @@ The name of a database is made of non accentuated letters (uppercase or lowercas
 e), digits and of the character "-". Other characters (particularly space) are f
 orbidden.
 %)
-</body>
-</html>

--- a/bin/setup/lang/err_ngw.htm
+++ b/bin/setup/lang/err_ngw.htm
@@ -36,5 +36,3 @@ If it is the case, rename the file "gwb2gw" into "gwu" in this directory and try
 %)
 <p>
 [Go back to the previous page.] (<a href="%n">back</a>)
-</body>
-</html>

--- a/bin/setup/lang/err_reco.htm
+++ b/bin/setup/lang/err_reco.htm
@@ -40,5 +40,3 @@ the %G program. Send him the traces of the command.
 %)
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/err_smdr.htm
+++ b/bin/setup/lang/err_smdr.htm
@@ -19,5 +19,3 @@
 </div>
 <p>
 [You selected the same directory than the one of this %G distribution.]
-</body>
-</html>

--- a/bin/setup/lang/ged2gwb.htm
+++ b/bin/setup/lang/ged2gwb.htm
@@ -334,5 +334,3 @@ May 2, 1912" or "February 5, 1912" according to the countries).
 <input type="submit" value="OK">
 </dl>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/gw2gd_ok.htm
+++ b/bin/setup/lang/gw2gd_ok.htm
@@ -25,5 +25,3 @@
 "%w".
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/gwb2ged.htm
+++ b/bin/setup/lang/gwb2ged.htm
@@ -207,5 +207,3 @@ is Public.<br>  All the spouses and descendants are also censored.
 <input type=submit value="[Extract]">
 </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/gwc.htm
+++ b/bin/setup/lang/gwc.htm
@@ -135,5 +135,3 @@ ectly in the url in your navigator.
 <input type=submit value="Ok">
 </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/gwd.htm
+++ b/bin/setup/lang/gwd.htm
@@ -151,5 +151,3 @@ can be found in the documentation.
 <input type=submit value="[Configure]">
 </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/gwd_info.htm
+++ b/bin/setup/lang/gwd_info.htm
@@ -53,6 +53,4 @@ automatically launched. If you stopped it and want to restart it, become root an
      $ /etc/rc.d/init.d/gwd stop
 </pre>
 </ul>
-</body>
-</html>
 

--- a/bin/setup/lang/gwd_ok.htm
+++ b/bin/setup/lang/gwd_ok.htm
@@ -37,5 +37,3 @@ directory "gw" of your %G distribution.
 </pre>
 </dl>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/gwdiff_ok.htm
+++ b/bin/setup/lang/gwdiff_ok.htm
@@ -24,5 +24,3 @@
 <p>
 [Read the alert messages in the file "comm.log"]
 (<a href="gwsetup?lang=%l;v=bso_comm.htm">comm.log</a>
-</body>
-</html>

--- a/bin/setup/lang/gwf.htm
+++ b/bin/setup/lang/gwf.htm
@@ -38,6 +38,4 @@
 <input type=submit value="[Configure]">
 </ul>
 </form>
-</body>
-</html>
 

--- a/bin/setup/lang/gwf_1.htm
+++ b/bin/setup/lang/gwf_1.htm
@@ -596,5 +596,3 @@ an use HTML tags.
 <input type=submit value="[Apply]">
 </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/gwf_ok.htm
+++ b/bin/setup/lang/gwf_ok.htm
@@ -37,5 +37,3 @@ the file named "%a.trl" in the subdirectory "lang" of the directory "%w".
 </ul>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/gwfix.htm
+++ b/bin/setup/lang/gwfix.htm
@@ -160,5 +160,3 @@
 <input type="submit" value="[Fix base]">
 </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/gwu.htm
+++ b/bin/setup/lang/gwu.htm
@@ -116,5 +116,3 @@ ame time</em> ancestors of the one and descendants of the other.
 <input type=submit value="[Extract]">
 </ul>
 </form>
-</body>
-</html>

--- a/bin/setup/lang/merge_1.htm
+++ b/bin/setup/lang/merge_1.htm
@@ -61,5 +61,3 @@ of seconds or some minutes, depending on the cases. Be patient.
      $ cd "%w"
 %s{     $ %x%/gwu %a -o %a.gw|}     $ %x%/gwc %s{-sep %a.gw |}\-f -o %o
 </pre>
-</body>
-</html>

--- a/bin/setup/lang/recover.htm
+++ b/bin/setup/lang/recover.htm
@@ -31,5 +31,3 @@ Select the name of the <em>directory</em> where your old version of %G is locate
 [Then click on this button][:]
 <input type=submit value="[Search]">
 </form>
-</body>
-</html>

--- a/bin/setup/lang/recover1.htm
+++ b/bin/setup/lang/recover1.htm
@@ -59,5 +59,3 @@ with the normal procedure, try this option.</td>
 <p>
 <input type=submit value="[Recover]">
 </form>
-</body>
-</html>

--- a/bin/setup/lang/recover2.htm
+++ b/bin/setup/lang/recover2.htm
@@ -62,5 +62,3 @@ Be patient.
      $ cd "%w"
      $ %x%Vsrc2new; %T -f -o %o > comm.log
 </pre>
-</body>
-</html>

--- a/bin/setup/lang/ren_ok.htm
+++ b/bin/setup/lang/ren_ok.htm
@@ -27,5 +27,3 @@
 </ul>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/update_nldb_ok.htm
+++ b/bin/setup/lang/update_nldb_ok.htm
@@ -24,5 +24,3 @@
 <ul><li><a href="http://%m:%P/%a">http://%m:%P/%a</a></ul>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)
-</body>
-</html>

--- a/bin/setup/lang/welcome.htm
+++ b/bin/setup/lang/welcome.htm
@@ -85,6 +85,3 @@
   <a href="lv">Latviesu</a>
   <a href="sv">Svenska</a>
 </div>
-<br>
-</body>
-</html>

--- a/bin/setup/setup.css
+++ b/bin/setup/setup.css
@@ -29,6 +29,6 @@ div.welcome {
   overflow: auto;
   margin-left: auto;
   margin-right: auto;
-  padding:5px;">
+  padding:5px;
 }
 </style>


### PR DESCRIPTION
Remove duplicated ending body tags for gwsetup htm files

also avoid browser warning caused by setup.css

details in two commit headers