### PR TITLE
Fix several bugs

### DIFF
--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -1352,7 +1352,7 @@ let connected_families base fam_sel ifam cpl =
   loop [ ifam ] [] [ get_father cpl ]
 
 let read_file_contents fname =
-  match try Some (open_in fname) with Sys_error _ -> None with
+  match try Some (Secure.open_in fname) with Sys_error _ -> None with
   | Some ic -> (
       let len = ref 0 in
       try
@@ -1361,7 +1361,9 @@ let read_file_contents fname =
           loop ()
         in
         loop ()
-      with End_of_file -> Buff.get !len)
+      with End_of_file ->
+        close_in ic;
+        Buff.get !len)
   | None -> ""
 
 type separate = ToSeparate | NotScanned | BeingScanned | Scanned

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -41,7 +41,7 @@ let notes_links s =
   loop [] [] 1 0
 
 let read_file_contents fname =
-  match try Some (open_in fname) with Sys_error _ -> None with
+  match try Some (Secure.open_in fname) with Sys_error _ -> None with
   | Some ic -> (
       let len = ref 0 in
       try
@@ -50,7 +50,9 @@ let read_file_contents fname =
           loop ()
         in
         loop ()
-      with End_of_file -> Buff.get !len)
+      with End_of_file ->
+        close_in ic;
+        Buff.get !len)
   | None -> ""
 
 type cache_linked_pages_t = (Def.NLDB.key, int) Hashtbl.t

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -306,15 +306,20 @@ let url_set_aux conf evar_l str_l =
 
 let substr_start_aux n s =
   let len = String.length s in
-  let rec loop i n str =
-    if n = 0 || i >= len then str
+  let buffer = Buffer.create (min len (n * 4)) in
+  let rec loop i count =
+    if count = 0 || i >= len then Buffer.contents buffer
     else
-      (* Attention aux caractères utf-8 !! *)
-      let nbc = Utf8.nbc s.[i] in
-      let car = String.sub s i nbc in
-      loop (i + nbc) (n - 1) (str ^ car)
+      try
+        let nbc = Utf8.nbc s.[i] in
+        if i + nbc <= len then (
+          let car = String.sub s i nbc in
+          Buffer.add_string buffer car;
+          loop (i + nbc) (count - 1))
+        else Buffer.contents buffer
+      with _ -> Buffer.contents buffer
   in
-  loop 0 n ""
+  loop 0 n
 
 let rec eval_variable conf = function
   | [ "base"; "name" ] -> conf.bname

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -1086,9 +1086,9 @@ let rev_input_line ic pos (rbuff, rpos) =
     Bytes.unsafe_to_string s
   in
   let rev_input_line pos =
-    seek_in ic pos;
     if pos <= 0 then raise End_of_file
     else
+      let _ = seek_in ic pos in
       let rec loop pos =
         if pos <= 0 then get_n_reset (), pos
         else

--- a/lib/util/utf8.ml
+++ b/lib/util/utf8.ml
@@ -61,7 +61,23 @@ let cmap_utf_8 cmap s =
 let lowercase s = cmap_utf_8 Uucp.Case.Map.to_lower s
 let uppercase s = cmap_utf_8 Uucp.Case.Map.to_upper s
 
+let skip_html_tags s =
+  let rec loop i s =
+    if s.[i] = ' ' then loop (i + 1) s
+    else if s.[i] = '<' then
+      let j = try String.index_from s i '>' with Not_found -> -1 in
+      if j = -1 then (
+        Printf.eprintf "WARNING: badly formed string %s\n" s;
+        0)
+      else loop (j + 1) s
+    else i
+  in
+  loop 0 s
+
 let capitalize_fst s =
+  let i = skip_html_tags s in
+  let head = String.sub s 0 i in
+  let tail = String.sub s i (String.length s - i) in
   let first = ref true in
   let cmap u =
     if !first then (
@@ -69,7 +85,8 @@ let capitalize_fst s =
       Uucp.Case.Map.to_upper u)
     else `Self
   in
-  cmap_utf_8 cmap s
+  let tail = cmap_utf_8 cmap tail in
+  head ^ tail
 
 let capitalize s =
   let first = ref true in

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -241,8 +241,8 @@ let syntax_links conf wi s =
               (encode wiz) s
           in
           loop quot_lev (pos + 1) j (Buff.mstore len t)
-      | NotesLinks.WLnone (j, none_s) ->
-          loop quot_lev pos j (Buff.mstore len none_s)
+      | NotesLinks.WLnone (_j, _none_s) ->
+          loop quot_lev pos (i + 1) (Buff.store len s.[i])
   in
   loop 0 1 0 0
 

--- a/test/util_test.ml
+++ b/test/util_test.ml
@@ -152,6 +152,15 @@ let util_string_with_macros _ =
     {|<a href="mailto:jean@dupond.net">jean@dupond.net</a> - le 1 &amp; 2|}
     (Util.string_with_macros conf [] {|jean@dupond.net - le 1 &amp; 2|})
 
+let utf8_capitalize_fst _ =
+  let test a r = (check string) a r (Utf8.capitalize_fst a) in
+  test "abcdef" "Abcdef";
+  test " ghiljl" " Ghiljl";
+  test "<i>mnopqr1" "<i>Mnopqr1";
+  test "<i><b>mnopqr2" "<i><b>Mnopqr2";
+  test "<i> <b>mnopqr3" "<i> <b>Mnopqr3";
+  test "<i>, <b>mnopqr4" "<i>, <b>mnopqr4"
+
 let util_escape_html _ =
   (check string) ""
     {|&#60;a href=&#34;mailto:jean@dupond.net&#34;&#62;jean@dupond.net&#60;/a&#62; - le 1 &#38;amp; 2|}
@@ -222,6 +231,7 @@ let v =
         test_case "Utf8.sub" `Quick utf8_sub;
         test_case "Utf8.name_with_roman_number" `Quick
           util_name_with_roman_number;
+        test_case "Utf8.capitalize_fst" `Quick utf8_capitalize_fst;
       ] );
     ( "util",
       [


### PR DESCRIPTION
Several bugs detected while staging roglo-7:

* when displaying history of modification `seek_in ic pos` had a negative argument 
* gwu failed to close wizard files at export time (reached the limit of opened files in Linux with Roglo)
* fix and rewrite substr_start_aux (was triggering `Invalid_argument("String.sub / Bytes.sub")`) for some Utf8 chars
* Utf8.capitalize_fst ineffective if text was decorated by html tags!
* Broken italic and bold in wiki format


