### PR TITLE
Fix1162  to properly export in gw the multilines family comment (comm flag)

### DIFF
--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -225,7 +225,7 @@ let ged_header opts base ifile ofile =
   | Gwexport.Ansi -> Printf.ksprintf (oc opts) "1 CHAR ANSI\n"
   | Gwexport.Ascii -> Printf.ksprintf (oc opts) "1 CHAR ASCII\n"
   | Gwexport.Utf8 -> Printf.ksprintf (oc opts) "1 CHAR UTF-8\n");
-  if opts.Gwexport.no_notes = `none then
+  if opts.Gwexport.base_notes then
     match base_notes_read base "" with "" -> () | s -> display_note opts 1 s
 
 let sub_string_index s t =
@@ -348,7 +348,7 @@ let ged_ev_detail opts n typ d pl note src =
       Printf.ksprintf (oc opts) "\n"
   | None -> ());
   if pl <> "" then Printf.ksprintf (oc opts) "%d PLAC %s\n" n (encode opts pl);
-  if opts.Gwexport.no_notes <> `nnn && note <> "" then display_note opts n note;
+  if opts.Gwexport.notes && note <> "" then display_note opts n note;
   if opts.Gwexport.source = None && src <> "" then
     print_sour opts n (encode opts src)
 
@@ -585,7 +585,7 @@ let ged_multimedia_link opts base per =
         Printf.ksprintf (oc opts) "2 FILE %s\n" s)
 
 let ged_note opts base per =
-  if opts.Gwexport.no_notes <> `nnn then
+  if opts.Gwexport.notes then
     match sou base (get_notes per) with "" -> () | s -> display_note opts 1 s
 
 let ged_tag_fevent base evt =
@@ -648,7 +648,7 @@ let ged_fsource opts base fam =
       | s -> print_sour opts 1 (encode opts s))
 
 let ged_comment opts base fam =
-  if opts.Gwexport.no_notes <> `nnn then
+  if opts.Gwexport.notes then
     match sou base (get_comment fam) with
     | "" -> ()
     | s -> display_note opts 1 s

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -1102,6 +1102,9 @@ let aux_loop_note tag line ic =
 (** Parse note (succesive lines starting with "note") *)
 let loop_note = aux_loop_note "note"
 
+(** Parse comment (succesive lines starting with "comm") *)
+let loop_comment = aux_loop_note "comm"
+
 (** Parse witnesses across the lines and returns list of [(wit,wsex,wk)]
     where wit is a witness definition/reference, [wsex] is a sex of witness
     and [wk] is a kind of witness relationship to the family. *)
@@ -1188,8 +1191,16 @@ let read_family ic fname = function
       let comm, line =
         match line with
         | Some (str, "comm" :: _) ->
-            let comm = String.sub str 5 (String.length str - 5) in
-            (comm, read_line ic)
+            let comm, next_line = loop_comment str ic in
+
+            (* duplicate of input_real_line but starting with line [s] *)
+            let rec get_next_real_line s =
+              if s = "" || s.[0] = '#' then get_next_real_line (input_a_line ic)
+              else s
+            in
+
+            let next_line = get_next_real_line next_line in
+            (comm, Some (next_line, fields next_line))
         | _ -> ("", line)
       in
       (* read family events *)

--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -12,7 +12,8 @@ type gwexport_opts = {
   img_base_path : string;
   keys : string list;
   mem : bool;
-  no_notes : [ `none | `nn | `nnn ];
+  notes : bool;
+  base_notes : bool;
   no_picture : bool;
   oc : string * (string -> unit) * (unit -> unit);
   parentship : bool;
@@ -32,7 +33,8 @@ let default_opts =
     img_base_path = "";
     keys = [];
     mem = false;
-    no_notes = `none;
+    notes = true;
+    base_notes = true;
     no_picture = false;
     oc = ("", prerr_string, fun () -> close_out stderr);
     parentship = false;
@@ -83,11 +85,10 @@ let speclist c =
       Arg.Unit (fun () -> c := { !c with mem = true }),
       " save memory space, but slower." );
     ( "-nn",
-      Arg.Unit
-        (fun () -> if !c.no_notes = `none then c := { !c with no_notes = `nn }),
-      " no (database) notes." );
+      Arg.Unit (fun () -> c := { !c with base_notes = false }),
+      " no database notes." );
     ( "-nnn",
-      Arg.Unit (fun () -> c := { !c with no_notes = `nnn }),
+      Arg.Unit (fun () -> c := { !c with notes = false; base_notes = false }),
       " no notes (implies -nn)." );
     ( "-nopicture",
       Arg.Unit (fun () -> c := { !c with no_picture = true }),

--- a/bin/gwexport/gwexport.mli
+++ b/bin/gwexport/gwexport.mli
@@ -10,9 +10,8 @@ type gwexport_opts = {
   img_base_path : string; (* Unused by this module (and not set by options) *)
   keys : string list; (* Key reference of additional persons to select *)
   mem : bool; (* Unused by this module *)
-  no_notes : [ `nn | `nnn | `none ];
-      (* Unused by this module
-         S: Consider simple ADTs *)
+  notes : bool; (* true if we export notes *)
+  base_notes : bool; (* true if we export base_notes *)
   no_picture : bool; (* Unused by this module *)
   oc : string * (string -> unit) * (unit -> unit); (* Unused by this module *)
   parentship : bool;

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -591,9 +591,12 @@ let print_pevent opts base gen e =
   | Epers_VenteBien -> Printf.ksprintf (oc opts) "#vteb"
   | Epers_Will -> Printf.ksprintf (oc opts) "#will"
   | Epers_Name s -> Printf.ksprintf (oc opts) "#%s" (correct_string base s));
-  Printf.ksprintf (oc opts) " ";
   let epers_date = Date.od_of_cdate e.epers_date in
-  print_date_option opts epers_date;
+  (match epers_date with
+  | None -> ()
+  | Some _d ->
+      Printf.ksprintf (oc opts) " ";
+      print_date_option opts epers_date);
   print_if_no_empty opts base "#p" e.epers_place;
   (* TODO *)
   (*print_if_no_empty opts base "#c" e.epers_cause;*)
@@ -685,9 +688,12 @@ let print_fevent opts base gen in_comment e =
   | Efam_PACS -> Printf.ksprintf (oc opts) "#pacs"
   | Efam_Residence -> Printf.ksprintf (oc opts) "#resi"
   | Efam_Name n -> Printf.ksprintf (oc opts) "#%s" (correct_string base n));
-  Printf.ksprintf (oc opts) " ";
   let efam_date = Date.od_of_cdate e.efam_date in
-  print_date_option opts efam_date;
+  (match efam_date with
+  | None -> ()
+  | Some _d ->
+      Printf.ksprintf (oc opts) " ";
+      print_date_option opts efam_date);
   print_if_no_empty opts base "#p" e.efam_place;
   (*print_if_no_empty opts base "#c" e.efam_cause;*)
   if opts.source = None then print_if_no_empty opts base "#s" e.efam_src;

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -621,7 +621,7 @@ let print_pevent opts base gen e =
         print_witness opts base gen p;
         Printf.ksprintf (oc opts) "\n"))
     e.epers_witnesses;
-  let note = if opts.no_notes <> `nnn then sou base e.epers_note else "" in
+  let note = if opts.notes then sou base e.epers_note else "" in
   if note <> "" then
     List.iter
       (fun line -> Printf.ksprintf (oc opts) "note %s\n" line)
@@ -717,7 +717,7 @@ let print_fevent opts base gen in_comment e =
         print_witness opts base gen p;
         print_sep ()))
     e.efam_witnesses;
-  let note = if opts.no_notes <> `nnn then sou base e.efam_note else "" in
+  let note = if opts.notes then sou base e.efam_note else "" in
   if note <> "" then
     List.iter
       (fun line ->
@@ -726,7 +726,7 @@ let print_fevent opts base gen in_comment e =
       (lines_list_of_string note)
 
 let print_comment_for_family opts base gen fam =
-  let comm = if opts.no_notes <> `nnn then sou base (get_comment fam) else "" in
+  let comm = if opts.notes then sou base (get_comment fam) else "" in
   (* Si on est en mode old_gw, on mets tous les évènements dans les notes. *)
   (* On supprime les 2 évènements principaux. *)
   let fevents =
@@ -955,7 +955,7 @@ let print_notes_for_person opts base gen p =
     | Epers_Cremation -> "cremation"
     | _ -> ""
   in
-  let notes = if opts.no_notes <> `nnn then sou base (get_notes p) else "" in
+  let notes = if opts.notes then sou base (get_notes p) else "" in
   let surn = s_correct_string (p_surname base p) in
   let fnam = s_correct_string (p_first_name base p) in
   (* Si on n'est en mode old_gw, on mets tous les évènements dans les notes. *)
@@ -975,9 +975,7 @@ let print_notes_for_person opts base gen p =
            | Epers_Birth | Epers_Baptism | Epers_Death | Epers_Burial
            | Epers_Cremation ->
                let name = epers_name_to_string evt in
-               let notes =
-                 if opts.no_notes <> `nnn then sou base evt.epers_note else ""
-               in
+               let notes = if opts.notes then sou base evt.epers_note else "" in
                if notes <> "" then
                  Printf.ksprintf (oc opts) "%s: %s\n" name notes;
                print_witness_in_notes evt.epers_witnesses;
@@ -995,7 +993,7 @@ let print_notes_for_person opts base gen p =
   let s =
     let aux g = sou base (g p) in
     let sl =
-      if opts.no_notes <> `nnn then
+      if opts.notes then
         [
           aux get_notes;
           aux get_birth_note;
@@ -1016,9 +1014,7 @@ let print_notes_for_person opts base gen p =
     if (not !old_gw) && opts.source = None then
       List.fold_left
         (fun acc e ->
-          let acc =
-            if opts.no_notes <> `nnn then sou base e.epers_note :: acc else acc
-          in
+          let acc = if opts.notes then sou base e.epers_note :: acc else acc in
           let acc =
             if opts.source = None then sou base e.epers_src :: acc else acc
           in
@@ -1675,7 +1671,7 @@ let gwu opts isolated base in_dir out_dir src_oc_ht (per_sel, fam_sel) =
                 print_isolated_relations opts base gen p)
       (Gwdb.ipers base);
   if !Mutil.verbose then ProgrBar.finish ();
-  if opts.no_notes = `none then (
+  if opts.base_notes then (
     let s = base_notes_read base "" in
     let oc, first, _ = origin_file (base_notes_origin_file base) in
     let f, _ooc, c = opts.oc in

--- a/hd/etc/modules/notes.txt
+++ b/hd/etc/modules/notes.txt
@@ -47,7 +47,10 @@
             %else;^
             %end;
             %if;(nb_families>1)%apply;nth([nth (generation)], count) [marriage with]%else;[*marriage with]%end; %spouse.first_name; %spouse.surname;
-            [:] %comment;
+            [:]
+            %if;has_comment;%comment;%end;
+            %if;(has_comment and has_marriage_note)%nl;%end;
+            %if;has_marriage_note;%marriage_note;%end;
           </li>
         </ul>
       %end;
@@ -75,7 +78,7 @@
     %end;
     %foreach;family;
       %if;(has_comment or has_marriage_note)
-        <h3>[*marriage notes/marriages notes]1%sp;
+        <h3>[*marriage notes/marriages notes]0%sp;
         [with] %spouse.first_name; %spouse.surname;</h3>
       %end;
       <blockquote>%nn;

--- a/plugins/export/plugin_export.ml
+++ b/plugins/export/plugin_export.ml
@@ -114,12 +114,11 @@ let export conf base =
               (get_family (poi base iper)))
           ipers IFS.empty
       in
-      let no_notes =
+      let notes, base_notes =
         match getenv_opt "notes" conf.env with
-        | None -> `none
-        | Some "nn" -> `nn
-        | Some "nnn" -> `nnn
-        | Some _ -> `none
+        | Some "nn" -> (true, false)
+        | Some "nnn" -> (false, false)
+        | Some _ | None -> (true, true)
       in
       let source = getenv_opt "source" conf.env in
       let isolated = getenv_opt "isolated" conf.env <> Some "off" in
@@ -127,7 +126,8 @@ let export conf base =
         {
           Gwexport.default_opts with
           oc = (fname, Output.print_sstring conf, Wserver.close_connection);
-          no_notes;
+          notes;
+          base_notes;
           no_picture = getenv_opt "pictures" conf.env = Some "off";
           source;
         }

--- a/test/galichet.gw
+++ b/test/galichet.gw
@@ -4,8 +4,14 @@ gwplus
 fam Galichet Jean_Pierre #occu Marchand_de_bois #src déjà_décédés_au_mariage_de_sa_fille_Thérèse_Eugénie 0 <1849 + Loche Marie_Elisabeth #src déjà_décédés_au_mariage_de_sa_fille_Thérèse_Eugénie 0 <1849
 src déjà_décédés_au_mariage_de_sa_fille_Thérèse_Eugénie
 csrc rajout_de_2_enfants_pour_test
+comm few words comment for family, with successive wiki bullets started in first column
+comm * bullet one
+comm ** sub 1.1
+comm ** sub 1.2
+comm ** sub 1.3
+comm * bullet two
 fevt
-#marr 
+#marr
 note Rajout de notes avec retour à la ligne avec des tag html
 note <br>1880 - Habitent Yzernay naissance d'une fille
 note <br>1886 - Habitent la Verdelière (6 enfants) - Recensement Moulins: - Vue 23
@@ -14,7 +20,7 @@ end fevt
 beg
 - h Jean_Charles #occu Négociant #src témoin_au_mariage_de_sa_soeur_Thérèse_Eugénie 1813 #bs 1849-36ans od
 - h Pierre 1814 1/1/1835
-- h Paul 1816 1/1/1886
+- h Paul 1816 1/1/1886 #buri
 - h lolo #src inventé 1818 od
 - f Thérèse_Eugénie #src inscription_des_hypothèques_du_23_février_1874_au_profit_de_dame_thérèse_eugènie_Galichet;_voir_ses_ascendants_dans_la_base_<a_href="https://gw.geneanet.org/mout?lang=fr&p=therese+eugenie&n=galichet">mout</a> 7/9/1830 #bp _[Châlons-sur-Marne]_-_Châlons-en-Champagne,51,Marne,Champagne-Ardenne,France #bs acte_de_mariage od
 end
@@ -23,6 +29,18 @@ notes Galichet Jean_Charles
 beg
 What about [[[Chantal]]]  notes,
 and [[[Andre]]] as second creation ?
+end notes
+
+notes Galichet Paul
+beg
+je rajoute une note sur chacun des événements par défaut, pour contrôler comment elles apparaissent sur la page de cet individu, cela soulève plusieurs problèmes:
+* test fait avec l'affichage par défaut (p_mod=)
+* notes ajoutées sur: naissance, baptême, décès, inhumation
+* ces notes n'apparaissent que sous forme d'info-bulle quand la souris passe sur l'évènement correspondant.
+* sauf pour le baptême qui n'est pas affiché car ni date, ni lieu
+* par contre pour l'inhumation qui est ajouté bien que sans date ni lieu
+(le traitement des deux cas n'est pas cohérent).
+* ces notes devraient apparaitre aussi explicitement dans la fiche par défaut, ce qui correspond à hd/etc/modules/notes.txt  avec op_m=1
 end notes
 
 notes Galichet lolo
@@ -60,7 +78,7 @@ end notes
 
 pevt Galichet Jean_Charles
 #birt 1813 #s 1849-36ans
-#deat 
+#deat
 end pevt
 
 pevt Galichet Pierre
@@ -70,17 +88,23 @@ end pevt
 
 pevt Galichet Paul
 #birt 1816
+note ma note de naissance avec que l'info de l'année
+#bapt
+note ma note de baptême sans aucun détail
 #deat 1/1/1886
+note ma note de mariage sans le lieu
+#buri
+note ma note d'inhumation sans aucun détail non plus
 end pevt
 
 pevt Galichet lolo
 #birt 1818
-#deat 
+#deat
 end pevt
 
 pevt Galichet Thérèse_Eugénie
 #birt 7/9/1830 #p _[Châlons-sur-Marne]_-_Châlons-en-Champagne,51,Marne,Champagne-Ardenne,France #s acte_de_mariage
-#deat 
+#deat
 end pevt
 
 pevt Loche Marie_Elisabeth
@@ -94,8 +118,10 @@ end pevt
 fam Galichet Paul +3/3/1835 Marty Florence #src archives 1/1/1815 1875
 src archives
 csrc archives
+comm * un commentaire de famille sur une seule ligne
 fevt
 #marr 3/3/1835
+note * une note de mariage sur une seule ligne (avec tag wiki)
 end fevt
 beg
 - h Jean-Paul 2/2/1836 od
@@ -116,13 +142,22 @@ pevt Marty Florence
 end pevt
 
 fam Galichet lolo +1840 #mp Brisbane,Queensland,Australie #ms inventé femme1 prenom1 #src inventé 1818 od
+comm un commentaire de famille sur une seule ligne
 fevt
 #marr 1840 #p Brisbane,Queensland,Australie #s inventé
+note note de mariage sur plusieurs lignes avec tag wiki
+note * un bullet
+note * un 2eme bullet
 #div 1844 #s inventé
 end fevt
 fam Galichet lolo +1845 #mp Sydney,Nouvelle-Galles\_du\_Sud,Australie #ms inventé femme2 prenom2 #src inventé 1825 od
+comm une commentaire sur la 2eme famille,
+comm * sur plusieurs lignes
+comm * avec marqueurs wiki
+comm * devant démarrer en 1ere colonne.
 fevt
 #marr 1845 #p Sydney,Nouvelle-Galles\_du\_Sud,Australie #s inventé
+note un commentaire pour le 2eme mariage, sur une seule ligne, et sans tag.
 end fevt
 
 pevt femme1 prenom1
@@ -134,6 +169,7 @@ pevt femme2 prenom2
 end pevt
 
 fam Sutaine Louis.1 0 +1570 #mp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France Galichet Nicole 0
+comm le champ commentaire de famille sur une seule ligne, et pas de note de mariage.
 fevt
 #marr 1570 #p _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France
 end fevt
@@ -148,12 +184,13 @@ end notes
 
 pevt Sutaine Louis
 #birt 1575
-#deat 
+#deat
 end pevt
 
 fam Sutaine Louis + #mp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France Petizon Claude 0
 fevt
-#marr  #p _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France
+#marr #p _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France
+note une note de mariage, sur une seule ligne; et pas de commentaire de famille.
 end fevt
 beg
 - f Perrette 1600 11/4/1684 #dp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France
@@ -165,8 +202,11 @@ pevt Sutaine Perrette
 end pevt
 
 fam Jayot Jean 1604 8/11/1674 #dp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France + Sutaine Perrette
+comm * un commentaire de famille
+comm * sur plusieurs lignes
+comm * mais pas de note de mariage
 fevt
-#marr 
+#marr
 end fevt
 beg
 - f Claude 27/6/1633 11/4/1697 #dp _[Saint-Hilaire]_-_Reims,51,Marne,Champagne-Ardenne,France
@@ -184,7 +224,10 @@ end pevt
 
 fam Boizot Jean.1234 #occu Menuisier 1618 22/3/1702 #dp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France + Jayot Claude
 fevt
-#marr 
+#marr
+note note de mariage (avec des marqueurs wiki)
+note * sur plusieurs lignes
+note * mais pas de commentaire de famille
 end fevt
 beg
 - f Jeanne.1 27/2/1671 #bp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France 22/4/1748 #dp _[Saint-Hilaire]_-_Reims,51,Marne,Champagne-Ardenne,France
@@ -202,7 +245,7 @@ end pevt
 
 fam Geruzet Anthoine.1 #occu Menuisier_à_Paris_(Paroisse_St_Roch) 1640 17/1/1709 #dp _[Saint-Hilaire]_-_Reims,51,Marne,Champagne-Ardenne,France + Bouquet Louise 0
 fevt
-#marr 
+#marr
 end fevt
 beg
 - h Anthoine #occu Maître_Menuisier_reçu_le_25.01.1695_à_Reims 1667 #bp _[Saint-Roch]_-_Paris,75,Ville-de-Paris,Ile-de-France,France 16/2/1755 #dp _[Saint-Symphorien]_-_Reims,51,Marne,Champagne-Ardenne,France
@@ -221,6 +264,10 @@ end pevt
 fam Geruzet Anthoine +17/1/1695 #mp _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France Boizot Jeanne.1
 fevt
 #marr 17/1/1695 #p _[Saint-Jacques]_-_Reims,51,Marne,Champagne-Ardenne,France
+note une note de mariage
+note * sur plusieurs ligne
+note * avec marqueurs wiki en première colonne
+note * mais pas de commentaire de famille.
 end fevt
 beg
 - h Jacques #occu Marchand 4/2/1705 #bp _[Saint-Symphorien]_-_Reims,51,Marne,Champagne-Ardenne,France 10/3/1774 #dp _[Saint_Pierre]_-_Reims,51,Marne,Champagne-Ardenne,France
@@ -254,7 +301,7 @@ end pevt
 
 pevt Geruzet Marie-Jeanne
 #birt 31/12/1751
-#bapt  #p _[Saint_Pierre]_-_Reims,51,Marne,Champagne-Ardenne,France
+#bapt #p _[Saint_Pierre]_-_Reims,51,Marne,Champagne-Ardenne,France
 #deat 8/1/1830 #p Soissons,02,Aisne,Picardie,France
 end pevt
 
@@ -316,6 +363,34 @@ notes-db
   * test la présence d'une apostrophe dans le texte alternate d'une image,
   (https://github.com/geneweb/geneweb/issues/1558)
   <br>voir les notes du couple [[Jean Pierre/Galichet]] et [[Marie Elisabeth/Loche]]
+
+  * test les différentes combinaisons possibles
+  des notes et commentaires associés à un marriage,
+  pendant la correction du pb #1162
+  (https://github.com/geneweb/geneweb/issues/1162)
+
+  ** les deux champs non présents
+  <br>pour le couple [[Jacques/Geruzet]] et [[Jeanne/Pierquin]]
+  ** que le champ note, avec plusieurs lignes
+  <br>pour le couple [[Anthoine/Geruzet]] et [[Jeanne/Boizot/1]]
+  ** que le champ comm, avec plusieurs lignes (sujet du pb #1162)
+  <br>pour le couple [[Jean/Jayot]] et [[Perrette/Sutaine]]
+  ** que le champ note, avec une seule ligne
+  <br>pour le couple [[Louis/Sutaine]] et [[Claude/Petizon]]
+  ** que le champ comm, avec une seule ligne
+  <br>pour le couple [[Louis/Sutaine/1]] et [[Nicole/Galichet]]
+  ** les deux champs rempli, note une ligne, comm plusieurs lignes
+  <br>pour le couple [[lolo/Galichet]] et [[prenom2/femme2]]
+  ** les deux champs rempli, comm une ligne, note plusieurs lignes
+  <br>pour le couple [[lolo/Galichet]] et [[prenom1/femme1]]
+  ** les deux champs rempli, comm et note une seule ligne
+  <br>pour le couple [[Paul/Galichet]] et [[Florence/Marty]]
+  ** les deux champs rempli, comm et note plusieurs lignes
+  <br>pour le couple [[Jean Pierre/Galichet]] et [[Marie Elisabeth/Loche]]
+
+  * problèmes concernant les notes des évènements par défault:
+  çàd naissance, baptême, décès, inhumation
+  Test fait avec la fiche de [[Paul/Galichet]] avec l'affichage par défaut (p_mod=)
 end notes-db
 
 # extended page "Andre" used by:


### PR DESCRIPTION
Fix #1162  to properly export in gw the multilines family comment (comm flag)

Refer to commits head for details (in reverse order):
* bab1b20d9 test/galichet.gw add combinations of note and comm
* 25bcfc13d remove whitespace on empty event
* be49fe745 fix newline in family comment on gw export
* bd3407255 cherry pick aux_loop_note from gnt branch in gwcomp.ml
* cf1fee761 gwexport_opts: change no_notes
* a21d0c4d7 Add missing  mariage note for default op_m=1 in notes.txt
