### PR TITLE
3 small fixes in Utf8.skip_html_tags, duplicate close on connection and missing backtrace

### DIFF
--- a/lib/util/utf8.ml
+++ b/lib/util/utf8.ml
@@ -63,14 +63,17 @@ let uppercase s = cmap_utf_8 Uucp.Case.Map.to_upper s
 
 let skip_html_tags s =
   let rec loop i s =
-    if s.[i] = ' ' then loop (i + 1) s
-    else if s.[i] = '<' then
-      let j = try String.index_from s i '>' with Not_found -> -1 in
-      if j = -1 then (
-        Printf.eprintf "WARNING: badly formed string %s\n" s;
-        0)
-      else loop (j + 1) s
-    else i
+    if i = String.length s then i
+    else
+      match s.[i] with
+      | ' ' -> loop (i + 1) s
+      | '<' -> (
+          match String.index_from s i '>' with
+          | exception Not_found ->
+              Printf.eprintf "WARNING: badly formed string %s\n" s;
+              0
+          | j -> loop (j + 1) s)
+      | _ -> i
   in
   loop 0 s
 


### PR DESCRIPTION
This PR contains 3 fixes (2 of them were needed to debug the 3rd one...):
* The initial problem comes from Utf8.skip_html_tags not working when reaching the end of the string
* The second one fixes a duplicate close on a socket, because the `close` always executed in the `finally` was closing an already-closed socket. Checking a ref avoids the problem
* The third one fixes the lack of backtrace on critical errors in connection handling, that was making it hard to locate the cause of the initial problem