### PR TITLE
Stackoverflow in `first_name_print_list` and `search_first_name_print`

### DIFF
--- a/lib/some.ml
+++ b/lib/some.ml
@@ -250,7 +250,7 @@ let first_name_print_list conf base x1 xl liste =
   (* l'aide sur la sélection d'un individu.          *)
   Util.print_tips_relationship conf;
   let list =
-    List.map
+    List.rev_map
       (fun (sn, ipl) ->
         let txt =
           Util.surname_without_particle base sn ^ Util.surname_particle base sn
@@ -853,14 +853,14 @@ let search_first_name_print conf base x =
   | [] -> first_name_not_found conf x
   | [ (_, (strl, iperl)) ] ->
       let iperl = List.sort_uniq compare iperl in
-      let pl = List.map (pget conf base) iperl in
+      let rev_pl = List.rev_map (pget conf base) iperl in
       let pl =
-        List.fold_right
-          (fun p pl ->
+        List.fold_left
+          (fun pl p ->
             if (not (is_hide_names conf p)) || authorized_age conf base p then
               p :: pl
             else pl)
-          pl []
+          rev_pl []
       in
       first_name_print_list conf base x strl pl
   | _ -> select_first_name conf x list


### PR DESCRIPTION
Searching `Pierre` as a first name in the Roglo database throws a Stack overflow exception.

The `List.map` and `List.fold_right` functions used in `first_name_print_list` and `search_first_name_print` are not tail recursive.

In OCaml 4, the usual workaround is to use a combination of `List.rev_map` and `List.rev`. Both of them are tail recursive, but the code is bit slower (one needs to iterate twice on the list).

In OCaml 5, `List.map` uses a constant stack.

Fortunately, I don't need to use this workaround here.

In `first_name_print_list`, we do not need to preserve the order before the end of the function because the list is sorted before calling `print_alphab_list`.

In `search_first_name_print`, we do not need to preserve the order because we call `first_name_print_list` at the end. To ensure robustness, I use a combination of `List.rev_map` and `List.fold_left`, instead of `List.map` and `List.fold_right`. The produced list is the same, it is tail recursive and we preserve the same performance.