### PR TITLE
Properly clear signal alarm in gwd

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2012,7 +2012,7 @@ let main () =
     ; ("-version", Arg.Unit print_version_commit, " Print the Geneweb version, the source repository and last commit id and message.")
 #ifdef UNIX
     ; ("-max_clients", Arg.Int (fun x -> max_clients := Some x), "<NUM> Max number of clients treated at the same time (default: no limit) (not cgi).")
-    ; ("-conn_tmout", Arg.Int (fun x -> conn_timeout := x), "<SEC> Connection timeout (default " ^ string_of_int !conn_timeout ^ "s; 0 means no limit)." )
+    ; ("-conn_tmout", Arg.Int (fun x -> conn_timeout := x), "<SEC> Connection timeout (only on Unix) (default " ^ string_of_int !conn_timeout ^ "s; 0 means no limit)." )
     ; ("-daemon", Arg.Set daemon, " Unix daemon mode.")
     ; ("-no-fork", Arg.Set Wserver.no_fork, " Prevent forking processes")
     ; ("-cache-in-memory", Arg.String (fun s ->


### PR DESCRIPTION
The gwd webserver uses the Unix signal alarm to set a timelimit per request. This feature does not work properly in no-fork mode because the signal is not reset after treating the request and the signal handler tries to output to a closed socket. This PR refactors the way we manage the signal to ensure that we always unset the signal after treating the request.