### PR TITLE
Properly close the database

### DIFF
--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -107,10 +107,9 @@ let bench () =
       let conf = Config.empty in
       let bench_w_base ?t ?(load = []) name fn args =
         Secure.set_base_dir (Filename.dirname bname);
-        let base = Gwdb.open_base bname in
+        Gwdb.with_database bname @@ fun base ->
         List.iter (fun load -> load base) load;
         let r = bench ?t name (fn base) args in
-        Gwdb.close_base base;
         r
       in
       bench_w_base "UpdateData.get_all_data"

--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -167,7 +167,7 @@ let () =
   Arg.parse speclist anonfun usage;
   if not (Array.mem "-bd" Sys.argv) then Secure.set_base_dir ".";
   let bname = Filename.remove_extension (Filename.basename !bname) in
-  let base = Gwdb.open_base (Secure.base_dir () // bname) in
+  Gwdb.with_database (Secure.base_dir () // bname) @@ fun base ->
   cache_dir := set_cache_dir bname;
 
   Printf.printf "Generating cache(s) compressed with gzip\n";

--- a/bin/connex/connex.ml
+++ b/bin/connex/connex.ml
@@ -268,9 +268,8 @@ let speclist =
 let main () =
   Arg.parse speclist (fun s -> bname := s) usage;
   if !ask_for_delete > 0 then
-    Lock.control (Mutil.lock_file !bname) false
-      (fun () -> move (Gwdb.open_base !bname) !bname)
-      ~onerror:Lock.print_try_again
-  else move (Gwdb.open_base !bname) !bname
+    Lock.control (Mutil.lock_file !bname) false ~onerror:Lock.print_try_again
+    @@ fun () -> Gwdb.with_database !bname (fun base -> move base !bname)
+  else Gwdb.with_database !bname (fun base -> move base !bname)
 
 let _ = main ()

--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -115,7 +115,7 @@ let check ~dry_run ~verbosity ~fast ~f_parents ~f_children ~p_parents
   let v2 = !verbosity >= 2 in
   if not v1 then Mutil.verbose := false;
   let fast = !fast in
-  let base = Gwdb.open_base bname in
+  Gwdb.with_database bname @@ fun base ->
   let fix = ref 0 in
   let nb_fam = nb_of_families base in
   let nb_ind = nb_of_persons base in

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3325,7 +3325,7 @@ let main () =
   Gc.compact ();
   let arrays = make_subarrays arrays in
   finish_base arrays ;
-  let base = Gwdb.make !out_file !particles arrays in
+  Gwdb.make !out_file !particles arrays @@ fun base ->
   warning_month_number_dates ();
   if !do_check then begin
     let base_error x =

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -697,30 +697,28 @@ let ged_fam_record opts base (per_sel, _fam_sel) ifam =
   ged_fsource opts base fam;
   ged_comment opts base fam
 
-let gwb2ged with_indexes opts ((per_sel, fam_sel) as sel) =
-  match opts.Gwexport.base with
-  | Some (ifile, base) ->
-      let ofile, oc, close = opts.Gwexport.oc in
-      if not opts.Gwexport.mem then (
-        load_ascends_array base;
-        load_unions_array base;
-        load_couples_array base;
-        load_descends_array base);
-      ged_header opts base ifile ofile;
-      Gwdb.Collection.iter
-        (fun i -> if per_sel i then ged_ind_record with_indexes opts base sel i)
-        (Gwdb.ipers base);
-      Gwdb.Collection.iter
-        (fun i -> if fam_sel i then ged_fam_record opts base sel i)
-        (Gwdb.ifams base);
-      let _ =
-        List.fold_right
-          (fun adop i ->
-            ged_fam_adop opts i adop;
-            i + 1)
-          !adop_fam_list
-          (nb_of_families base + 1)
-      in
-      Printf.ksprintf oc "0 TRLR\n";
-      close ()
-  | None -> assert false
+let gwb2ged base with_indexes opts ((per_sel, fam_sel) as sel) =
+  let bname = Gwdb.bname base in
+  let ofile, oc, close = opts.Gwexport.oc in
+  if not opts.Gwexport.mem then (
+    load_ascends_array base;
+    load_unions_array base;
+    load_couples_array base;
+    load_descends_array base);
+  ged_header opts base bname ofile;
+  Gwdb.Collection.iter
+    (fun i -> if per_sel i then ged_ind_record with_indexes opts base sel i)
+    (Gwdb.ipers base);
+  Gwdb.Collection.iter
+    (fun i -> if fam_sel i then ged_fam_record opts base sel i)
+    (Gwdb.ifams base);
+  let _ =
+    List.fold_right
+      (fun adop i ->
+        ged_fam_adop opts i adop;
+        i + 1)
+      !adop_fam_list
+      (nb_of_families base + 1)
+  in
+  Printf.ksprintf oc "0 TRLR\n";
+  close ()

--- a/bin/gwb2ged/gwb2gedLib.mli
+++ b/bin/gwb2ged/gwb2gedLib.mli
@@ -1,10 +1,11 @@
 val gwb2ged :
+  Gwdb.base ->
   bool ->
   Gwexport.gwexport_opts ->
   (Gwdb.iper -> bool) * (Gwdb.ifam -> bool) ->
   unit
-(** [gwb2ged with_indexes opts sel]
-    Converts a Geneweb database to a GEDCOM file.
+(** [gwb2ged base with_indexes opts sel]
+    Converts a Geneweb database [base] to a GEDCOM file.
     * `with_indexes` specifies if indexes are printed or not;
     * `opts` are the export options
     * `sel` is a pair of selectors returned by the database export

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -1551,7 +1551,7 @@ let empty_base : cbase =
   }
 
 (** Extract information from the [gen.g_base] and create database *)
-let make_base bname gen per_index_ic per_ic =
+let make_base bname gen per_index_ic per_ic k =
   let _ =
     Printf.eprintf "pcnt %d persons %d\n" gen.g_pcnt
       (Array.length gen.g_base.c_persons);
@@ -1609,6 +1609,7 @@ let make_base bname gen per_index_ic per_ic =
       (families, couples, descends),
       strings,
       gen.g_base.c_bnotes )
+    k
 
 (** Write content in the file *)
 let write_file_contents fname text =
@@ -1699,7 +1700,7 @@ let link next_family_fun bdir =
   Hashtbl.clear gen.g_strings;
   Hashtbl.clear gen.g_names;
   Hashtbl.clear fi.f_local_names;
-  let base = make_base bdir gen per_index_ic per_ic in
+  make_base bdir gen per_index_ic per_ic @@ fun base ->
   Hashtbl.clear gen.g_patch_p;
   Gc.full_major ();
   close_in per_index_ic;

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2055,7 +2055,7 @@ let main () =
     (fun dbn ->
        Printf.eprintf "Caching database %s in memory… %!" dbn;
        let dbn = !GWPARAM.bpath dbn in
-       ignore (Gwdb.open_base ~keep_in_memory:true dbn);
+       Gwdb.load_database dbn;
        Printf.eprintf "Done.\n%!"
     )
     !cache_databases;

--- a/bin/gwdiff/gwdiff.ml
+++ b/bin/gwdiff/gwdiff.ml
@@ -617,26 +617,22 @@ let check_args () =
     flush stdout;
     exit 2)
 
+let load_base f k =
+  Gwdb.with_database f (fun base ->
+      load_ascends_array base;
+      load_strings_array base;
+      if not !mem then (
+        load_unions_array base;
+        load_couples_array base;
+        load_descends_array base);
+      k base)
+
 let main () =
   let _ = check_args () in
   let _ = if not !html then cr := "\n" else cr := "<BR>\n" in
-  let load_base file =
-    let base = open_base file in
-    let () = load_ascends_array base in
-    let () = load_strings_array base in
-    let () =
-      if not !mem then
-        let () = load_unions_array base in
-        let () = load_couples_array base in
-        let () = load_descends_array base in
-        ()
-    in
-    base
-  in
-  (* Reference base *)
-  let base1 = load_base !in_file1 in
-  (* Destination base *)
-  let base2 = if !in_file1 != !in_file2 then load_base !in_file2 else base1 in
+  (* [base1] is the reference base and [base2] is the destination base. *)
+  load_base !in_file1 @@ fun base1 ->
+  load_base !in_file2 @@ fun base2 ->
   let iper1 = person_of_key base1 !p1_fn !p1_sn !p1_occ in
   let iper2 = person_of_key base2 !p2_fn !p2_sn !p2_occ in
   if !html then Printf.printf "<BODY>\n";

--- a/bin/gwexport/gwexport.mli
+++ b/bin/gwexport/gwexport.mli
@@ -4,7 +4,6 @@ type gwexport_opts = {
   asc : int option; (* Maximum generation of the root's ascendants *)
   ascdesc : int option;
       (* Maximum generation of the root's ascendants descendants *)
-  base : (string * Gwdb.base) option; (* The base analyzed *)
   censor : int; (* Censors the base for 'n' years *)
   charset : gwexport_charset; (* The charset of the export *)
   desc : int option; (* Maximum generation of the root's descendants *)
@@ -36,20 +35,14 @@ val speclist : gwexport_opts ref -> (Arg.key * Arg.spec * Arg.doc) list
 *)
 (* Used for gwd2ged and gwu. *)
 
-val anonfun : gwexport_opts ref -> Arg.anon_fun
-(** [anonfun opts = fun base_name -> ...]
-    Given a set of options `opts` where `!opts.base` is uninitialized,
-    opens the dir `base_name` and initializes !opts.base with the base name.
-    The output of this function is the second argument of Arg.parse.
-*)
-(* Arg.anon_fun = string -> unit *)
-
 val errmsg : Arg.usage_msg
 (** Default error message.
     This is the third argument of Arg.parse. *)
 
 val select :
-  gwexport_opts -> Gwdb.iper list -> (Gwdb.iper -> bool) * (Gwdb.ifam -> bool)
-(** [select opts ips]
-    Return filters for [iper] and [ifam] to be used when exporting a (portion of a) base.
-*)
+  Gwdb.base ->
+  gwexport_opts ->
+  Gwdb.iper list ->
+  (Gwdb.iper -> bool) * (Gwdb.ifam -> bool)
+(** [select base opts ips] returns filters for [iper] and [ifam] to be used
+    when exporting a portion of the [base]. *)

--- a/bin/gwgc/gwgc.ml
+++ b/bin/gwgc/gwgc.ml
@@ -20,7 +20,7 @@ let () =
   Secure.set_base_dir (Filename.dirname bname);
   Lock.control (Mutil.lock_file bname) true ~onerror:Lock.print_try_again
   @@ fun () ->
-  let base = Database.opendb bname in
+  Database.with_database bname @@ fun base ->
   let p, f, s = Gwdb_gc.gc ~dry_run base in
   Printf.printf
     "%s:\n\tnb of persons: %d\n\tnb of families: %d\n\tnb of strings: %d\n"

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -268,7 +268,7 @@ let main () =
     flush stderr;
     exit 2);
   Secure.set_base_dir (Filename.dirname !fname);
-  let base = Gwdb.open_base !fname in
+  Gwdb.with_database !fname @@ fun base ->
   Sys.catch_break true;
   let () = load_strings_array base in
   let () = load_unions_array base in

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
     camlp-streams
     camlzip
     cppo
-    (fmt :with-test)
+    fmt
     jingoo
     markup
     (ocaml (>= 4.08))

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -19,7 +19,7 @@ depends: [
   "camlp-streams"
   "camlzip"
   "cppo"
-  "fmt" {with-test}
+  "fmt"
   "jingoo"
   "markup"
   "ocaml" {>= "4.08"}

--- a/lib/gwdb-legacy/database.mli
+++ b/lib/gwdb-legacy/database.mli
@@ -1,14 +1,16 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-val opendb : ?read_only:bool -> string -> Dbdisk.dsk_base
-(** Initialise [dsk_base] from the database situated in the specified directory.
-    Initialises both data and functionallity part.
+val with_database : ?read_only:bool -> string -> (Dbdisk.dsk_base -> 'a) -> 'a
+(** [with_database ?read_only dbname k] initializes a [dsk_base] structure
+    from the database located in the specified directory [dbname].
+
+    Both data and functionality part are initialized. The continuation [k]
+    is called with the [dsk_base] structure.
 
     If ~read_only:true, then the database will be loaded in memory,
-    and kept in a cache. All next uses of opendb on the same database
+    and kept in a cache. All next uses of [with_database] on the same database
     will use the memory-loaded database. This constraints operations on the
-    base, and attempt to mutate its values will result in failure.
-*)
+    base, and attempt to mutate its values will result in failure. *)
 
 val make :
   string ->
@@ -21,21 +23,25 @@ val make :
     * int Def.gen_descend array)
   * string array
   * Def.base_notes ->
-  Dbdisk.dsk_base
+  (Dbdisk.dsk_base -> 'a) ->
+  'a
 (** [make bname particles ((persons, ascendants, unions) (families, couples,
-    descendants) strings base_notes)] returns initialised with giving data
-    [dsk_base]. This function is called exclusively for database creating
-    purpose. It means that, it contains only data without functionalities.
-    Either call [opendb] on existing database or call [Gwdb.make], if you
-    want to make requests. *)
+    descendants) strings base_notes) k] initializes a [dsk_base]
+    structure with giving data. The continuation [k] is called with the
+    [dsk_base] structure.
+
+    This function should be called for database creating purpose only.
+    In particular, the functionality part of the [dsk_base] structure is
+    not initalized. *)
 
 (* Ajout pour l'API *)
 
 type synchro_patch = {
   mutable synch_list : (string * int list * int list) list;
 }
-(** List of commited modifications inside the database. First element is a timestamp of a commit,
-    second - changed/added by considered commit person ids, third - changed/added by considered commit families ids. *)
+(** List of commited modifications inside the database. First element is a
+    timestamp of a commit, second - changed/added by considered commit person
+    ids, third - changed/added by considered commit families ids. *)
 
 val input_synchro : string -> synchro_patch
 (** Get [synchro_patch] from the giving database directory. *)

--- a/lib/gwdb-legacy/dbdisk.mli
+++ b/lib/gwdb-legacy/dbdisk.mli
@@ -412,9 +412,6 @@ type base_func = {
   (* Update content (second arg) of the notes' file (first arg) if exists. *)
   commit_wiznotes : string -> string -> unit;
   (* Close every opened channel. *)
-  cleanup : unit -> unit;
-  (* Returns real number of persons inside the base (without empty persons).
-     Pending patches aren't considered. *)
   nb_of_real_persons : unit -> int;
   (* Tells if person with giving id exists in the base.
      Pending patches are also considered. *)

--- a/lib/gwdb-legacy/gwdb_gc.ml
+++ b/lib/gwdb-legacy/gwdb_gc.ml
@@ -162,13 +162,12 @@ let gc ?(dry_run = true) base =
     base.data.couples.clear_array ();
     base.data.descends.clear_array ();
     base.data.strings.clear_array ();
-    let base' =
-      Database.make bname particles
-        ( (persons, ascends, unions),
-          (families, couples, descends),
-          strings,
-          bnotes )
-    in
+    Database.make bname particles
+      ( (persons, ascends, unions),
+        (families, couples, descends),
+        strings,
+        bnotes )
+    @@ fun base' ->
     base'.data.persons.load_array ();
     base'.data.ascends.load_array ();
     base'.data.unions.load_array ();

--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -7,7 +7,6 @@ let load_unions_array base = base.data.unions.load_array ()
 let load_couples_array base = base.data.couples.load_array ()
 let load_descends_array base = base.data.descends.load_array ()
 let load_strings_array base = base.data.strings.load_array ()
-let close_base base = base.func.cleanup ()
 let save_mem = ref false
 let verbose = Mutil.verbose
 
@@ -351,7 +350,6 @@ let output base =
      Mutil.rm tmp_strings_inx;
      Mutil.rm_rf tmp_notes_d;
      raise e);
-  close_base base;
   Mutil.rm (Filename.concat bname "base");
   Sys.rename tmp_base (Filename.concat bname "base");
   Mutil.rm (Filename.concat bname "base.acc");

--- a/lib/gwdb_driver.mli/dune
+++ b/lib/gwdb_driver.mli/dune
@@ -2,5 +2,8 @@
  (name gwdb_driver_mli)
  (public_name geneweb.gwdb_driver)
  (wrapped false)
- (libraries geneweb.def re)
+ (libraries
+   geneweb.def
+   re
+   fmt)
  (virtual_modules gwdb_driver))

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -52,11 +52,25 @@ type string_person_index
 type base
 (** The database representation. *)
 
-val open_base : ?keep_in_memory:bool -> string -> base
-(** Open database associated with (likely situated in) the specified directory. *)
+val load_database : string -> unit
+(** [load_database bname] loads the database [bname] into memory.
+    The database is automatically unloaded upon exit.
 
-val close_base : base -> unit
-(** Close database. May perform some clean up tasks. *)
+    The base is read-only and any attempt to modify its values will
+    result in failure.
+
+    @raise Failwith if the base has already been loaded. *)
+
+val with_database : string -> (base -> 'a) -> 'a
+(** [with_database bname k] loads the database [bname] and invokes the
+    continuation [k] with it.
+
+    If the database [bname] has already been loaded into memory with
+    [load_database], the function uses this in-memory base instead of
+    reloading it.
+
+    If the database [bname] was not loaded in memory, it is unloaded
+    after [k] is executed. *)
 
 val dummy_iper : iper
 (** Dummy person id *)
@@ -662,8 +676,10 @@ val make :
     * int Def.gen_descend array)
   * string array
   * Def.base_notes ->
-  base
-(** [make bname particles arrays] create a base with [bname] name and [arrays] as content. *)
+  (base -> 'a) ->
+  'a
+(** [make bname particles arrays k] create a base with [bname] name and
+    [arrays] as content and invokes the continuation [k] with it. *)
 
 val read_nldb : base -> (iper, ifam) Def.NLDB.t
 (** TODOOCP : doc *)

--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -80,24 +80,43 @@ let check_open fname =
     raise (Sys_error "invalid access"))
 
 (* The following functions perform a [check] before opening the file,
-   preventing potential attacks on the system.
-*)
+   preventing potential attacks on the system. *)
+let with_ic openfun s f =
+  check_open s;
+  let ic = openfun s in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () -> f ic
+
+let with_oc openfun s f =
+  check_open s;
+  let oc = openfun s in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) @@ fun () -> f oc
+
 let open_in fname =
   check_open fname;
   Stdlib.open_in fname
+
+let with_open_in_text s f = with_ic open_in s f
 
 let open_in_bin fname =
   check_open fname;
   Stdlib.open_in_bin fname
 
+let with_open_in_bin s f = with_ic open_in_bin s f
+
 let open_out fname =
   check_open fname;
   Stdlib.open_out fname
+
+let with_open_out_text s f = with_oc open_out s f
 
 let open_out_bin fname =
   check_open fname;
   Stdlib.open_out_bin fname
 
+let with_open_out_bin s f = with_oc open_out_bin s f
+
 let open_out_gen mode perm fname =
   check_open fname;
   Stdlib.open_out_gen mode perm fname
+
+let with_open_out_gen mode perm = with_oc @@ open_out_gen mode perm

--- a/lib/util/secure.mli
+++ b/lib/util/secure.mli
@@ -23,14 +23,30 @@ val check : string -> bool
 val open_in : string -> in_channel
 (** Secured version of [open_in] *)
 
+val with_open_in_text : string -> (in_channel -> 'a) -> 'a
+(** Secured version of [In_channel.with_open_text] *)
+
 val open_in_bin : string -> in_channel
 (** Secured version of [open_in_bin] *)
+
+val with_open_in_bin : string -> (in_channel -> 'a) -> 'a
+(** Secured version of [In_channel.with_open_bin] *)
 
 val open_out : string -> out_channel
 (** Secured version of [open_out] *)
 
+val with_open_out_text : string -> (out_channel -> 'a) -> 'a
+(** Secured version of [Out_channel.open_text] *)
+
 val open_out_bin : string -> out_channel
 (** Secured version of [open_out_bin] *)
 
+val with_open_out_bin : string -> (out_channel -> 'a) -> 'a
+(** Secured version of [Out_channel.with_open_bin] *)
+
 val open_out_gen : open_flag list -> int -> string -> out_channel
 (** Secured version of [open_out_gen] *)
+
+val with_open_out_gen :
+  open_flag list -> int -> string -> (out_channel -> 'a) -> 'a
+(** Secured version of [Out_channel.with_open_gen] *)

--- a/plugins/export/plugin_export.ml
+++ b/plugins/export/plugin_export.ml
@@ -130,7 +130,6 @@ let export conf base =
           no_notes;
           no_picture = getenv_opt "pictures" conf.env = Some "off";
           source;
-          base = Some (Gwdb.bname base, base);
         }
       in
       let select = ((fun i -> IPS.mem i ipers), fun i -> IFS.mem i ifams) in
@@ -139,7 +138,7 @@ let export conf base =
       Wserver.header
         (Printf.sprintf "Content-disposition: attachment; filename=\"%s\"" fname);
       (match output with
-      | `ged -> Gwb2gedLib.gwb2ged false opts select
+      | `ged -> Gwb2gedLib.gwb2ged base false opts select
       | `gw ->
           GwuLib.prepare_free_occ ~select:(fst select) base;
           Output.print_sstring conf "encoding: utf-8\n";

--- a/plugins/fixbase/plugin_fixbase.ml
+++ b/plugins/fixbase/plugin_fixbase.ml
@@ -119,7 +119,7 @@ let fixbase_ok conf base =
   let process () =
     ignore @@ Unix.alarm 0;
     (* cancel timeout *)
-    let base' = Gwdb.open_base @@ !GWPARAM.bpath conf.bname in
+    Gwdb.with_database (!GWPARAM.bpath conf.bname) @@ fun base' ->
     let ipers = ref [] in
     let ifams = ref [] in
     let istrs = ref [] in

--- a/test/merge_test.ml
+++ b/test/merge_test.ml
@@ -35,7 +35,7 @@ let test_is_ancestor () =
       strings,
       base_notes )
   in
-  let base = Gwdb.make "is_ancestor_base" [] data in
+  Gwdb.make "is_ancestor_base" [] data @@ fun base ->
   let child = Gwdb.poi base (iper 0) in
   let father = Gwdb.poi base (iper 1) in
   let mother = Gwdb.poi base (iper 2) in


### PR DESCRIPTION
The current API for opening and closing the database is quite fragile. Developers must manually close it, and it was not done consistently in many places.

In particular, the database was not closed after loading the database with Ancient, leading to a warning message in present of several databases. A one-line PR could fix this issue but I believe we should implement a proper solution rather than applying another hot fix.

This PR replaces the `openbase` by a `with_database` and removes the `close` function. To use a database named `bname`, you now write:
```ocaml
with_database bname (fun base -> ...)
```
The last argument contains your code that uses `base` and `with_database` ensures that all channels are closed and performs some cleanup operations before closing them.

If you want to load the base in memory, you must invoke `load_database bname` before calling `with_database`. In this case, the base is persistant and `with_database` won't unload it after the continuation is executed.

Alas, the old API was used at many places, making this PR is quite long but completely trivial.