### PR TITLE
Revert no nnp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
           # v3 builds (newer environments)
           - os: ubuntu-24.04
-            ocaml-compiler: 4.14.2
+            ocaml-compiler: 4.14.2-nnp
             setup-version: v3
 
           - os: ubuntu-24.04
@@ -79,7 +79,7 @@ jobs:
             setup-version: v3
 
           - os: macos-15
-            ocaml-compiler: 4.14.2
+            ocaml-compiler: 4.14.2-nnp
             setup-version: v3
 
           - os: macos-15
@@ -92,6 +92,7 @@ jobs:
 
     env:
       FMT_CI: ${{ matrix.os == 'ubuntu-24.04' && matrix.ocaml-compiler == '4.14.2' && matrix.setup-version == 'v3' }}
+      USE_NNP: ${{ !startsWith(matrix.os, 'windows') && (contains(matrix.ocaml-compiler, 'nnp') || startsWith(matrix.ocaml-compiler, '5')) }}
 
     steps:
       - name: Checkout code
@@ -119,8 +120,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: D:\.opam
-          key: windows-${{ matrix.ocaml-compiler }}-${{ env.FMT_CI == 'true' && 'with-test' || 'no-test' }}-${{ matrix.setup-version }}-${{ hashFiles('*.opam') }}-cache
-          restore-keys: windows-${{ matrix.ocaml-compiler }}-${{ env.FMT_CI == 'true' && 'with-test' || 'no-test' }}-${{ matrix.setup-version }}
+          key: windows-${{ matrix.ocaml-compiler }}-${{ matrix.setup-version }}-${{ hashFiles('*.opam') }}-cache
+          restore-keys: windows-${{ matrix.ocaml-compiler }}-${{ matrix.setup-version }}
 
       - name: Setup Ocaml with v2
         if: matrix.setup-version == 'v2'
@@ -130,25 +131,25 @@ jobs:
 
       - name: Setup Ocaml with v3
         if: matrix.setup-version == 'v3'
-        uses: ocaml/setup-ocaml@v3
+        uses: ocaml/setup-ocaml@master
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler == '4.14.2-nnp' && 'ocaml-variants.4.14.2+options,ocaml-option-nnp' || matrix.ocaml-compiler }}
 
       - name: Install Geneweb dependencies
         run: opam install . --deps-only ${{ env.FMT_CI == 'true' && '--with-test' || '' }}
 
-      - name: Install ancient dependency for Unix
-        if: ${{ runner.os != 'Windows' }}
+      - name: Install ancient dependency
+        if: env.USE_NNP == 'true'
         run: opam pin ancient -y https://github.com/OCamlPro/ocaml-ancient.git
 
       - name: Configure
-        run: opam exec -- ocaml ./configure.ml --sosa-zarith
+        run: opam exec -- ocaml ./configure.ml --sosa-zarith ${{ env.USE_NNP == 'true' && '--gwd-caching' || '' }}
 
       - name: Build Geneweb
         run: opam exec -- make ${{ env.FMT_CI == 'true' && 'fmt ci' || 'build' }} distrib
 
       - name: "Test Geneweb daemon with --cache-in-memory"
-        if: ${{ runner.os != 'Windows' }}
+        if: env.USE_NNP == 'true'
         run: |
           output=$(distribution/gw/gwd -cache-in-memory testing 2>&1)
           if echo "$output" | grep -q "Caching database testing in memory"; then

--- a/configure.ml
+++ b/configure.ml
@@ -8,6 +8,11 @@ let rm = ref ""
 let ext = ref ""
 let os_type = ref ""
 let installed pkg = 0 = Sys.command ("ocamlfind query -qo -qe " ^ pkg)
+
+let nnp_compiler =
+  if not Sys.win32 then 1 = Sys.command "$(ocamlc -config-var naked_pointers)"
+  else false
+
 let errmsg = "usage: " ^ Sys.argv.(0) ^ " [options]"
 let api = ref false
 let sosa = ref `None
@@ -94,13 +99,19 @@ let () =
   in
   let ancient_lib, ancient_file =
     let no_cache = ("", "gw_ancient.dum.ml") in
-    if installed "ancient" then ("ancient", "gw_ancient.wrapped.ml")
+    if nnp_compiler then
+      if installed "ancient" then ("ancient", "gw_ancient.wrapped.ml")
+      else (
+        if !caching then
+          Printf.eprintf
+            "Warning: ocaml-ancient not installed. Cannot enable database \
+             caching.\n";
+        no_cache)
     else (
       if !caching then
         Printf.eprintf
-          "Warning: the ancient package is not installed. Cannot enable \
-           database caching. Install ancient in the current switch with `opam \
-           install ancient`.\n";
+          "Warning: Compiler not set to no-naked-pointers. Cannot enable \
+           database caching.\n";
       no_cache)
   in
   let ch = open_out "Makefile.config" in

--- a/configure.ml
+++ b/configure.ml
@@ -103,15 +103,18 @@ let () =
       if installed "ancient" then ("ancient", "gw_ancient.wrapped.ml")
       else (
         if !caching then
-          Printf.eprintf
+          Format.eprintf
             "Warning: ocaml-ancient not installed. Cannot enable database \
-             caching.\n";
+             caching.@.";
         no_cache)
     else (
       if !caching then
-        Printf.eprintf
-          "Warning: Compiler not set to no-naked-pointers. Cannot enable \
-           database caching.\n";
+        Format.eprintf
+          "Warning: the OCaml compiler was not installed with the \
+          no-naked-pointers@ option. The gwd caching feature requires this \
+          option because GeneWeb@ uses the Marshal module on values from the \
+          database, which is not compatible@ with Ancient when naked pointers \
+          could be present.@.";
       no_cache)
   in
   let ch = open_out "Makefile.config" in

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 #                                                      STAGE 1: Build Geneweb
 ###############################################################################
 
-FROM ocaml/opam:debian-12-ocaml-4.14 AS builder
+FROM ocaml/opam:debian-ocaml-4.14-nnp AS builder
 
 ENV OPAMYES=yes
 ENV OPAMJOBS=2

--- a/dune-project
+++ b/dune-project
@@ -48,5 +48,8 @@
     digestif
     (utop :dev)
   )
-  (depopts ancient)
+  (depopts
+    ocaml-option-nnp
+    ancient
+  )
 )

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -41,7 +41,7 @@ depends: [
   "utop" {dev}
   "odoc" {with-doc}
 ]
-depopts: ["ancient"]
+depopts: ["ocaml-option-nnp" "ancient"]
 dev-repo: "git+https://github.com/geneweb/geneweb.git"
 build: [
   [ "ocaml" "./configure.ml" "--release" ]


### PR DESCRIPTION
This PR reverts #2073. The +nnp option ensures that hashing and marshaling works with Ancient values on OCaml 4. 
Solving #2117 without this constraint may require a lot of work. 

Sorry @a2line for your PR :/

This PR solves #2117.