### PR TITLE
Do not fail if we cannot open `notes_d` directory

### DIFF
--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -1238,9 +1238,11 @@ let with_database ?(read_only = false) bname k =
     File.walk_folder ~recursive:true
       (fun fl files ->
         match fl with
-        | `File f when Filename.check_suffix f ".txt" ->
+        | File f when Filename.check_suffix f ".txt" ->
             Filename.chop_suffix f ".txt" :: files
-        | `File _ | `Dir _ -> files)
+        | File _ | Dir _ | Exn _ ->
+            (* TODO: we may print a warning for errors. *)
+            files)
       (Filename.concat bname "nodes_d")
       []
   in


### PR DESCRIPTION
PR #2105 changes the behavior of GeneWeb with the directory `notes_d`. The previous iterator silently ignores Unix errors while exploring this directory. In particular, no error was emitted if the directory `notes_d` did not exist.

This PR restores this behavior.