### PR TITLE
Refactoring lock system

### DIFF
--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -201,8 +201,12 @@ let main () =
   if !bname = "" then (
     Arg.usage speclist usage;
     exit 2);
-  Lock.control (Mutil.lock_file !bname) false ~onerror:Lock.print_try_again
-  @@ fun () ->
+  let lock_file = Mutil.lock_file !bname in
+  let on_exn exn bt =
+    Format.eprintf "%a@." Lock.pp_exception (exn, bt);
+    exit 2
+  in
+  Lock.control ~on_exn ~wait:false ~lock_file @@ fun () ->
   if
     !f_parents || !f_children || !p_parents || !p_families || !pevents_witnesses
     || !fevents_witnesses || !marriage_divorce || !p_NBDS || !invalid_utf8

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -215,8 +215,12 @@ let main () =
     (* test_base will fail if base exists and force has not been set (-f) *)
     Geneweb.GWPARAM.test_base bname;
     Geneweb.GWPARAM.init_etc bname;
-    Lock.control (Mutil.lock_file bdir) false ~onerror:Lock.print_error_and_exit
-      (fun () ->
+    let lock_file = Mutil.lock_file bdir in
+    let on_exn exn bt =
+      Format.eprintf "%a@." Lock.pp_exception (exn, bt);
+      exit 2
+    in
+    Lock.control ~on_exn ~wait:false ~lock_file (fun () ->
         let next_family_fun = next_family_fun_templ (List.rev !gwo) in
         if Db1link.link next_family_fun bdir then (
           Geneweb.Util.print_default_gwf_file bname;

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -384,10 +384,12 @@ let try_plugin list conf base_name m =
 
 let w_lock ~onerror fn conf (base_name : string option) =
   let bfile = !GWPARAM.bpath conf.bname in
+  (* FIXME: we lost the backtrace because onerror does not handle it. *)
   Lock.control
-    (Mutil.lock_file bfile) true
-    ~onerror:(fun () -> onerror conf base_name)
-    (fun () -> fn conf base_name)
+    ~on_exn:(fun _exn _bt -> onerror conf base_name)
+    ~wait:true
+    ~lock_file:(Mutil.lock_file bfile) @@ fun () ->
+    fn conf base_name
 
 let w_base ~none fn conf (bfile : string option) =
   match bfile with

--- a/bin/gwgc/gwgc.ml
+++ b/bin/gwgc/gwgc.ml
@@ -18,8 +18,12 @@ let () =
   in
   let dry_run = !dry_run in
   Secure.set_base_dir (Filename.dirname bname);
-  Lock.control (Mutil.lock_file bname) true ~onerror:Lock.print_try_again
-  @@ fun () ->
+  let lock_file = Mutil.lock_file bname in
+  let on_exn exn bt =
+    Format.eprintf "%a@." Lock.pp_exception (exn, bt);
+    exit 2
+  in
+  Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
   Database.with_database bname @@ fun base ->
   let p, f, s = Gwdb_gc.gc ~dry_run base in
   Printf.printf

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2157,18 +2157,15 @@ let create_topological_sort conf base =
       in
       Mutil.read_or_create_value ~magic:Mutil.executable_magic tstab_file
         (fun () ->
-          Lock.control (Mutil.lock_file bfile) false
-            ~onerror:(fun () ->
-              let () = load_ascends_array base in
-              let () = load_couples_array base in
-              Consang.topological_sort base (pget conf))
-            (fun () ->
-              let () = load_ascends_array base in
-              let () = load_couples_array base in
-              let tstab = Consang.topological_sort base (pget conf) in
-              if conf.use_restrict && (not conf.wizard) && not conf.friend then
-                base_visible_write base;
-              tstab))
+          load_ascends_array base;
+          load_couples_array base;
+          let tstab = Consang.topological_sort base (pget conf) in
+          (* FIXME: we silently ignores error if we cannot lock the database. *)
+          let on_exn _exn _bt = () in
+          if conf.use_restrict && (not conf.wizard) && not conf.friend then
+            Lock.control ~on_exn ~wait:false ~lock_file:(Mutil.lock_file bfile)
+              (fun () -> base_visible_write base);
+          tstab)
 
 let p_of_sosa conf base sosa p0 =
   let path = Sosa.branches sosa in

--- a/lib/util/lock.mli
+++ b/lib/util/lock.mli
@@ -1,17 +1,18 @@
 val no_lock_flag : bool ref
 (** Flag that indicates if the lock should be used. *)
 
-val print_error_and_exit : unit -> unit
-(** Print lock error message and terminate program. *)
+val pp_exception : Format.formatter -> exn * Printexc.raw_backtrace -> unit
 
-val print_try_again : unit -> unit
-(** Print message about locked database. *)
+val control :
+  on_exn:(exn -> Printexc.raw_backtrace -> 'a) ->
+  wait:bool ->
+  lock_file:string ->
+  (unit -> 'a) ->
+  'a
+(** [control ~on_exn ~wait ~lock_file k] tries to acquire a lock on [lock_file]
+    and invokes [k] on succeed. If [wait] is [true], the function blocks until
+    it acquires the lock. On failure, [on_exn] callback is invoked with the
+    exception and its backtrace.
 
-val control : onerror:(unit -> 'a) -> string -> bool -> (unit -> 'a) -> 'a
-(** [control ~onerror lname wait f] opens file [lname], puts a write lock on it and then calls [f].
-    If [wait] is true then if it tries to access locked file it will be blocked until these lock is removed. Otherwise
-    it will fail, and function [onerror] will be called. If flag [no_lock_flag] is set then returns [f ()] immediatly. *)
-
-val control_retry : onerror:(unit -> 'a) -> string -> (unit -> 'a) -> 'a
-(** Tries to call [control] without blocking. If it fail (lock is put) then call again [control]
-    and waits untill lock is removed. If it fails with another reason calls [onerror]. *)
+    If flag [no_lock_flag] is up, this function invokes immediatly [k] without
+    lock. *)

--- a/plugins/fixbase/plugin_fixbase.ml
+++ b/plugins/fixbase/plugin_fixbase.ml
@@ -417,11 +417,11 @@ let fixbase_ok conf base =
   in
   if dry_run then process ()
   else
+    let lock_file = Mutil.lock_file @@ !GWPARAM.bpath conf.bname in
     Lock.control
-      (Mutil.lock_file @@ !GWPARAM.bpath conf.bname)
-      false
-      ~onerror:(fun () -> GWPARAM.output_error conf Def.Service_Unavailable)
-      process
+      ~on_exn:(fun _exn _bt ->
+        GWPARAM.output_error conf Def.Service_Unavailable)
+      ~wait:false ~lock_file process
 
 let ns = "fixbase"
 


### PR DESCRIPTION
This PR refactors the lock manager located in Lock module. The main motivation is to preserve exception backtraces, which was helpful in debugging issue #2125. Here's a summary of the changes:
- Ensure proper lock release. The file lock is now released after executing the continuation in `Lock.control`. The lock was not being released, meaning that any attempt to re-acquire it in another process would fail. On Windows, it seems that it could fail even if it is the same process which tries to acquire a lock twice.
- Improve the exception handling with a callback `on_exn` provided by the caller of `Lock.control`.
- Remove `Lock.control_try_again`. This function was redundant. Its behavior was trying to acquire the lock, printing a message on failure and trying again with a blocking system call. The motivation of this variant of `Lock.control` might be for debugging but `strace` can easily localize where a software is waiting and, in the future, via Logs, we will emit error messages in the caller of `Lock.control`.
- Previously, no file lock was acquired on Windows. This is unexpected because `Unix.lockf` behaves similarly across platforms. According to the OCaml Unix documentation: 
```quote 
What happens when a process tries to lock a region of a file that is already locked 
by the same process depends on the OS. On POSIX-compliant systems, the 
second lock operation succeeds and may "promote" the older lock from read lock to write lock. 
On Windows, the second lock operation will block or fail.
 ```
 Maybe a process could get stuck on Windows and the feature have been disabled on it. This PR should fix that by ensuring the lock is always released properly. Still, we **MUST** test it on Windows.