### PR TITLE
Always create `notes_d` and `notes` with Gwdb_driver.make

### DIFF
--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -21,7 +21,7 @@ let ( // ) = Filename.concat
 (* Attention: cache files are reorg independant *)
 let set_cache_dir bname =
   let cache_dir = Secure.base_dir () // "etc" // bname // "cache" in
-  File.create_dir ~parent:true cache_dir;
+  Filesystem.create_dir ~parent:true cache_dir;
   cache_dir
 
 let write_cache_file bname fname l =

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1795,8 +1795,8 @@ let geneweb_server () =
   let auto_call =
     try let _ = Sys.getenv "WSERVER" in true with Not_found -> false
   in
-  if not auto_call then
-    begin let hostn =
+  if not auto_call then begin
+    let hostn =
       match !selected_addr with
         Some addr -> addr
       | None -> try Unix.gethostname () with _ -> "computer"
@@ -1835,13 +1835,17 @@ let geneweb_server () =
             null_reopen [Unix.O_WRONLY] Unix.stderr
           end
         else exit 0;
-        try File.create_dir ~parent:true ~required_perm:0o755 !GWPARAM.cnt_dir
+        try
+          Filesystem.create_dir ~parent:true ~required_perm:0o755 !GWPARAM.cnt_dir
         with Sys_error e ->
-          Logs.syslog `LOG_CRIT (Format.sprintf "failure creating %s (%s)\n"
-            !GWPARAM.cnt_dir e);
+          Logs.err (fun k -> k "failure creating %s:@ %s" !GWPARAM.cnt_dir e)
     end;
-  Wserver.start ?addr:!selected_addr ~port:!selected_port ~timeout:!conn_timeout
-    ~max_pending_requests:!max_pending_requests ~n_workers:!n_workers connection
+  Wserver.start
+    ?addr:!selected_addr
+    ~port:!selected_port
+    ~timeout:!conn_timeout
+    ~max_pending_requests:!max_pending_requests
+    ~n_workers:!n_workers connection
 
 let cgi_timeout conf tmout _ =
   Output.header conf "Content-type: text/html; charset=iso-8859-1";
@@ -1925,7 +1929,7 @@ let slashify s =
   String.init (String.length s) conv_char
 
 let make_sock_dir x =
-  File.create_dir ~parent:true x;
+  Filesystem.create_dir ~parent:true x;
   if Sys.unix then ()
   else
     begin

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -1544,7 +1544,7 @@ let rs_printf opts s =
 
 let gwu opts isolated base in_dir out_dir src_oc_ht (per_sel, fam_sel) =
   if out_dir <> "" && not (Sys.file_exists out_dir) then
-    File.create_dir ~parent:true out_dir;
+    Filesystem.create_dir ~parent:true out_dir;
   let to_separate = separate base in
   let out_oc_first = ref true in
   let _ofile, oc, close = opts.oc in

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -1319,6 +1319,7 @@ let make bname particles ((persons, families, strings, bnotes) as _arrays) k =
     if Filename.check_suffix bname ".gwb" then bname else bname ^ ".gwb"
   in
   Filesystem.create_dir ~parent:true (bdir // "notes_d");
+  Filesystem.create_dir (bdir // "wiznotes");
   Filesystem.create_file (bdir // "notes");
   let persons, ascends, unions = persons in
   let families, couples, descends = families in

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -1236,7 +1236,7 @@ let with_database ?(read_only = false) bname k =
         close_out oc)
   in
   let ext_files () =
-    File.walk_folder ~recursive:true
+    Filesystem.walk_folder ~recursive:true
       (fun fl files ->
         match fl with
         | File f when Filename.check_suffix f ".txt" ->
@@ -1318,6 +1318,8 @@ let make bname particles ((persons, families, strings, bnotes) as _arrays) k =
   let bdir =
     if Filename.check_suffix bname ".gwb" then bname else bname ^ ".gwb"
   in
+  Filesystem.create_dir ~parent:true (bdir // "notes_d");
+  Filesystem.create_file (bdir // "notes");
   let persons, ascends, unions = persons in
   let families, couples, descends = families in
   let data : Dbdisk.base_data =

--- a/lib/historyDiff.ml
+++ b/lib/historyDiff.ml
@@ -49,7 +49,7 @@ let create_history_dirs conf fname =
     let dirs =
       [ history_d conf; String.make 1 fname.[0]; String.make 1 fname.[1] ]
     in
-    File.create_dir ~parent:true (List.fold_left Filename.concat "" dirs)
+    Filesystem.create_dir ~parent:true (List.fold_left Filename.concat "" dirs)
 
 (* ************************************************************************ *)
 (*  [Fonc] write_history_file : config -> string -> gen_record -> unit      *)

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -68,7 +68,7 @@ let move_file_to_save file dir =
   (* previous version iterated on file types *)
   try
     let save_dir = Filename.concat dir "saved" in
-    File.create_dir ~parent:true save_dir;
+    Filesystem.create_dir ~parent:true save_dir;
     let fname = Filename.basename file in
     let orig_file = Filename.concat dir fname in
     let saved_file = Filename.concat save_dir fname in
@@ -326,7 +326,7 @@ let effective_send_ok conf base p file =
   in
   let fname = Image.default_portrait_filename base p in
   let dir = !GWPARAM.images_d conf.bname in
-  File.create_dir ~parent:true dir;
+  Filesystem.create_dir ~parent:true dir;
   let fname =
     Filename.concat dir
       (if mode = "portraits" then fname ^ extension_of_type typ else fname)
@@ -412,7 +412,7 @@ let effective_send_c_ok conf base p file file_name =
     if mode = "portraits" then !GWPARAM.portraits_d conf.bname
     else Filename.concat (!GWPARAM.images_d conf.bname) fname
   in
-  File.create_dir ~parent:true dir;
+  Filesystem.create_dir ~parent:true dir;
   let fname =
     Filename.concat dir
       (if mode = "portraits" then fname ^ extension_of_type typ else file_name)
@@ -425,7 +425,7 @@ let effective_send_c_ok conf base p file file_name =
     | Some (`Url url) -> (
         let fname = Image.default_portrait_filename base p in
         let dir = Filename.concat dir "saved" in
-        File.create_dir ~parent:true dir;
+        Filesystem.create_dir ~parent:true dir;
         let fname = Filename.concat dir fname ^ ".url" in
         try write_file fname url
         with _ ->
@@ -571,7 +571,7 @@ let effective_delete_c_ok conf base p =
     if mode = "portraits" then !GWPARAM.portraits_d conf.bname
     else Filename.concat (!GWPARAM.images_d conf.bname) fname
   in
-  File.create_dir ~parent:true dir;
+  Filesystem.create_dir ~parent:true dir;
   (* TODO verify we dont destroy a saved image
       having the same name as portrait! *)
   if delete then

--- a/lib/logs/logs.ml
+++ b/lib/logs/logs.ml
@@ -84,3 +84,4 @@ type 'a msgf = (('a, Format.formatter, unit, unit) format4 -> 'a) -> unit
 let report level fmt = Fmt.kstr (syslog level) ("@[" ^^ fmt ^^ "@]@?")
 let info (msgf : 'a msgf) = msgf @@ report `LOG_INFO
 let debug (msgf : 'a msgf) = msgf @@ report `LOG_DEBUG
+let err (msgf : 'a msgf) = msgf @@ report `LOG_ERR

--- a/lib/logs/logs.mli
+++ b/lib/logs/logs.mli
@@ -57,3 +57,4 @@ type 'a msgf = (('a, Format.formatter, unit, unit) format4 -> 'a) -> unit
 
 val info : 'a msgf -> unit
 val debug : 'a msgf -> unit
+val err : 'a msgf -> unit

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -274,7 +274,7 @@ let commit_notes conf base fnotes s =
     String.concat Filename.dir_sep
       [ Util.bpath conf.bname; base_notes_dir base; fname ]
   in
-  File.create_dir ~parent:true (Filename.dirname fpath);
+  Filesystem.create_dir ~parent:true (Filename.dirname fpath);
   (try Gwdb.commit_notes base fname s
    with Sys_error m ->
      Hutil.incorrect_request conf ~comment:("explication todo: " ^ m));
@@ -289,7 +289,7 @@ let commit_wiznotes conf base fnotes s =
       (Util.bpath (conf.bname ^ ".gwb"))
       [ base_wiznotes_dir base; fname ]
   in
-  File.create_dir ~parent:true (Filename.dirname fpath);
+  Filesystem.create_dir ~parent:true (Filename.dirname fpath);
   Gwdb.commit_wiznotes base fname s;
   History.record conf base (Def.U_Notes (p_getint conf.env "v", fnotes)) "mn";
   update_notes_links_db base pg s

--- a/lib/util/compat.ml
+++ b/lib/util/compat.ml
@@ -27,6 +27,8 @@ module In_channel = struct
 
   let with_open_gen flags perm s f =
     with_open (Stdlib.open_in_gen flags perm) s f
+
+  let input = Stdlib.input
 end
 
 module Out_channel = struct
@@ -41,4 +43,7 @@ module Out_channel = struct
 
   let with_open_gen flags perm s f =
     with_open (Stdlib.open_out_gen flags perm) s f
+
+  let flush = Stdlib.flush
+  let output = Stdlib.output
 end

--- a/lib/util/compat.mli
+++ b/lib/util/compat.mli
@@ -35,6 +35,17 @@ module In_channel : sig
       permission, in case the file must be created (see {!open_gen}).
 
       @since 4.14 *)
+
+  val input : t -> bytes -> int -> int -> int
+  (** [input ic buf pos len] reads up to [len] characters from the given channel
+      [ic], storing them in byte sequence [buf], starting at character number
+      [pos]. It returns the actual number of characters read, between 0 and [len]
+      (inclusive). A return value of 0 means that the end of file was reached.
+
+      Use {!really_input} to read exactly [len] characters.
+
+      @raise Invalid_argument if [pos] and [len] do not designate a valid range of
+      [buf]. *)
 end
 
 module Out_channel : sig
@@ -59,4 +70,16 @@ module Out_channel : sig
       permission, in case the file must be created (see {!open_gen}).
 
       @since 4.14 *)
+
+  val flush : t -> unit
+  (** Flush the buffer associated with the given output channel, performing all
+      pending writes on that channel.  Interactive programs must be careful about
+      flushing standard output and standard error at the right time. *)
+
+  val output : t -> bytes -> int -> int -> unit
+  (** [output oc buf pos len] writes [len] characters from byte sequence [buf],
+      starting at offset [pos], to the given output channel [oc].
+
+      @raise Invalid_argument if [pos] and [len] do not designate a valid range of
+      [buf]. *)
 end

--- a/lib/util/filesystem.ml
+++ b/lib/util/filesystem.ml
@@ -100,3 +100,17 @@ let walk_folder ?(recursive = false) f path acc =
         traverse stack acc
   in
   traverse [ path ] acc
+
+let copy_file src dst =
+  In_channel.with_open_bin src @@ fun ic ->
+  Out_channel.with_open_bin dst @@ fun oc ->
+  let sz = 8192 in
+  let buf = Bytes.create sz in
+  let rec loop () =
+    let r = In_channel.input ic buf 0 sz in
+    if r > 0 then (
+      Out_channel.output oc buf 0 r;
+      loop ())
+    else Out_channel.flush oc
+  in
+  loop ()

--- a/lib/util/filesystem.ml
+++ b/lib/util/filesystem.ml
@@ -102,15 +102,15 @@ let walk_folder ?(recursive = false) f path acc =
   traverse [ path ] acc
 
 let copy_file src dst =
-  In_channel.with_open_bin src @@ fun ic ->
-  Out_channel.with_open_bin dst @@ fun oc ->
+  Compat.In_channel.with_open_bin src @@ fun ic ->
+  Compat.Out_channel.with_open_bin dst @@ fun oc ->
   let sz = 8192 in
   let buf = Bytes.create sz in
   let rec loop () =
-    let r = In_channel.input ic buf 0 sz in
+    let r = Compat.In_channel.input ic buf 0 sz in
     if r > 0 then (
-      Out_channel.output oc buf 0 r;
+      Compat.Out_channel.output oc buf 0 r;
       loop ())
-    else Out_channel.flush oc
+    else Compat.Out_channel.flush oc
   in
   loop ()

--- a/lib/util/filesystem.mli
+++ b/lib/util/filesystem.mli
@@ -52,3 +52,9 @@ val walk_folder : ?recursive:bool -> (entry -> 'a -> 'a) -> string -> 'a -> 'a
 
     If [recursive] is [true], subdirectories are explored recursively.
     The default is [false]. *)
+
+val copy_file : string -> string -> unit
+(** [copy_file src dst] copies the file [src] into the destination [dst].
+    The file [dst] is created, if it does not exist.
+
+    This function can be used to copy binary files. *)

--- a/lib/util/my_gzip.ml
+++ b/lib/util/my_gzip.ml
@@ -41,11 +41,12 @@ let find_nextline b s =
 (* Read from the input channel [ic] until a new line is found in the
    buffer. Return the number of read characters. *)
 let read_until_newline ic =
-  let b = Bytes.create 500 in
+  let sz = 8192 in
+  let buf = Bytes.create sz in
   let rec loop acc =
-    let r = Gzip.input ic.gic b 0 500 in
-    Buffer.add_subbytes ic.tail b 0 r;
-    if contains_newline b r || r = 0 then acc + r else loop (acc + r)
+    let r = Gzip.input ic.gic buf 0 sz in
+    Buffer.add_subbytes ic.tail buf 0 r;
+    if contains_newline buf r || r = 0 then acc + r else loop (acc + r)
   in
   loop 0
 


### PR DESCRIPTION
The script `Gwdb_driver.make`, creating databases, does not creates all the subdirectories. It is simpler to always create `notes_d` and `notes`, even if there is no notes in the database.

The detailed list of the changes:
- Create notes and notes_d in `Gwdb_driver.make`. In particular, `gwc` will always create them. We cannot assume that old databases contain them but we could print a warning message in that case.
- Fix a typo introduced in #2105, the subdirectory is `notes_d`, not `nodes_t`!!
- Add a function `copy_file` into `File` module to copy files. Strangly, this function is not a part of the stdlib of OCaml.
- Use `File.copy_file` function to copy notes and notes_d in `Outbase.output`.
- Change the buffer size in `My_gzip` because it was a bit small for modern computers.
- Rename `File` into `Filesystem` because the module manipulates both files and directories.

This PR should fix #2125.