### PR TITLE
Fix form's digests for Windows platform

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1059,6 +1059,7 @@ let string_to_char_list s =
   exp (String.length s - 1) []
 
 let make_conf from_addr request script_name env =
+  let secret_salt = Some (Unix.getenv "SECRET_SALT") in
   if !allowed_tags_file <> "" && not (Sys.file_exists !allowed_tags_file) then (
     let str =
      Printf.sprintf
@@ -1319,6 +1320,7 @@ let make_conf from_addr request script_name env =
      output_conf;
      forced_plugins = !forced_plugins;
      plugins = !plugins;
+     secret_salt;
     }
   in
   GWPARAM.cnt_dir := !GWPARAM.cnt_d conf.bname;

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -117,6 +117,7 @@ type config = {
   cgi : bool;
   forced_plugins : string list;
   plugins : string list;
+  secret_salt : string option;
 }
 
 (**/**)
@@ -193,6 +194,7 @@ let empty =
       { status = ignore; header = ignore; body = ignore; flush = ignore };
     forced_plugins = [];
     plugins = [];
+    secret_salt = None;
   }
 
 (**/**)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -122,6 +122,9 @@ type config = {
   cgi : bool;
   forced_plugins : string list;
   plugins : string list;
+  secret_salt : string option;
+      (** Secret salt generated at the server startup. The salt is used in form's
+      digests to enhance security. *)
 }
 (** Geneweb configuration data type *)
 

--- a/lib/hasher.mli
+++ b/lib/hasher.mli
@@ -5,8 +5,9 @@ module type S = sig
   type 'a feeder = 'a -> ctx -> ctx
   (** Type of a feeder function for ['a]. *)
 
-  type 'a hasher = 'a -> string
-  (** Type of a hash function for ['a]. *)
+  type 'a hasher = ?salt:string -> 'a -> string
+  (** Type of a hash function for ['a]. The salt [salt] is added to
+      context before producing the final result. *)
 
   val feeder_to_hasher : 'a feeder -> 'a hasher
   (** [feeder_to_hasher f] converts the feeder [f] into a hash function. *)

--- a/lib/mergeIndOkDisplay.ml
+++ b/lib/mergeIndOkDisplay.ml
@@ -13,7 +13,8 @@ let print_merge conf base =
       let p2 = poi base (iper_of_string i2) in
       let p = reconstitute conf base p1 p2 in
       let sp = UpdateInd.string_person_of base p1 in
-      let digest = Update.digest_person sp in
+      let salt = Option.get conf.secret_salt in
+      let digest = Update.digest_person ~salt sp in
       UpdateInd.print_update_ind conf base p digest;
       MergeIndOk.merge_carrousel conf base p1 p2 p
   | _ -> Hutil.incorrect_request conf

--- a/lib/update.mli
+++ b/lib/update.mli
@@ -95,10 +95,27 @@ val def_error : config -> base -> person Def.error -> unit
 val error : config -> update_error -> 'exn
 val error_locked : config -> 'exn
 val error_digest : config -> 'exn
-val digest_person : (iper, key, string) gen_person -> string
+
+val digest_person : ?salt:string -> (iper, key, string) gen_person -> string
+(** [digest_person ?salt per] generates a digest of the person [pers]. The
+    function is intended for use in form to help prevent:
+      - Concurrent edits of the same person.
+      - Cross-site Request Forgery (CSRF) attacks.
+
+    The optional [salt] parameter should be set to a secret value generated
+    at server startup to strengthen security. *)
 
 val digest_family :
-  (key, ifam, string) gen_family * key gen_couple * key gen_descend -> string
+  ?salt:string ->
+  (key, ifam, string) gen_family * key gen_couple * key gen_descend ->
+  string
+(** [digest_family ?salt fam] generates a digest of the family [fam]. The
+    function is intended for use in form to help prevent:
+      - Concurrent edits of the same family.
+      - Cross-site Request Forgery (CSRF) attacks.
+
+    The optional [salt] parameter should be set to a secret value generated
+    at server startup to strengthen security. *)
 
 val reconstitute_date : config -> string -> date option
 val print_someone : config -> base -> person -> unit

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -692,7 +692,8 @@ let print_mod conf base =
   match p_getenv conf.env "i" with
   | Some i ->
       let sfam = string_family_of conf base (ifam_of_string i) in
-      let digest = Update.digest_family sfam in
+      let salt = Option.get conf.secret_salt in
+      let digest = Update.digest_family ~salt sfam in
       print_update_fam conf base sfam digest
   | _ -> Hutil.incorrect_request conf
 

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -1330,7 +1330,8 @@ let print_mod_aux conf base callback =
   let redisp = Option.is_some (p_getenv conf.env "return") in
   let digest =
     let ini_sfam = UpdateFam.string_family_of conf base sfam.fam_index in
-    Update.digest_family ini_sfam
+    let salt = Option.get conf.secret_salt in
+    Update.digest_family ~salt ini_sfam
   in
   if digest = get conf "digest" then
     if ext || redisp then

--- a/lib/updateInd.ml
+++ b/lib/updateInd.ml
@@ -721,7 +721,8 @@ let print_mod conf base =
   | Some i ->
       let p = poi base (iper_of_string i) in
       let sp = string_person_of base p in
-      let digest = Update.digest_person sp in
+      let salt = Option.get conf.secret_salt in
+      let digest = Update.digest_person ~salt sp in
       print_update_ind conf base sp digest
 
 let print_del conf base =

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -1123,7 +1123,8 @@ let print_mod_aux conf base callback =
   let p, ext = reconstitute_person conf in
   let redisp = Option.is_some (p_getenv conf.env "return") in
   let ini_ps = UpdateInd.string_person_of base (poi base p.key_index) in
-  let digest = Update.digest_person ini_ps in
+  let salt = Option.get conf.secret_salt in
+  let digest = Update.digest_person ~salt ini_ps in
   if digest = get conf "digest" then
     if ext || redisp then UpdateInd.print_update_ind conf base p digest
     else


### PR DESCRIPTION
This PR adds a new environment variable `SECRET_SALT` for the gwd
workers on both Windows and Unix. The master process generates a fresh
secret salt during the startup and sends it to its workers trough this
environment variable.

Fixes issue https://github.com/geneweb/geneweb/issues/2129.