### PR TITLE
Do not clean caches of in-memory database in forks

### DIFF
--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -730,9 +730,10 @@ let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
           match !tab with
           | None -> ()
           | Some a ->
-              (match a with
-              | ReadOnly a -> Gw_ancient.delete a
-              | ReadWrite _ -> ());
+              (* We could call [Gw_ancient.delete] here to
+                 free the memory allocated with Ancient. Unfortunately,
+                 [Ancient.delete] is buggy and cannot be used without causing
+                 the process terminate abruptly. *)
               tab := None);
     }
   in

--- a/lib/gwdb-legacy/gwdb_driver.ml
+++ b/lib/gwdb-legacy/gwdb_driver.ml
@@ -88,8 +88,7 @@ let load_database bname =
           load_couples_array base;
           load_descends_array base;
           load_families_array base;
-          load_strings_array base;
-          at_exit @@ fun () -> clear_base base)
+          load_strings_array base)
   | _base -> Fmt.failwith "'%s' is already loaded in memory" bname
 
 let with_database bname k =

--- a/lib/gwdb_driver.mli/gwdb_driver.mli
+++ b/lib/gwdb_driver.mli/gwdb_driver.mli
@@ -54,10 +54,17 @@ type base
 
 val load_database : string -> unit
 (** [load_database bname] loads the database [bname] into memory.
-    The database is automatically unloaded upon exit.
 
     The base is read-only and any attempt to modify its values will
     result in failure.
+
+    A caveat of this function is that the allocated memory cannot be freed
+    before the current process terminates. Under the hood, it uses
+    the Ancient library to map the database into memory, outside the
+    OCaml heap. As a result, the OCaml garbage collector cannot reclaim it and
+    the delete function of Ancient is flawed. For this reason, this function
+    should only be used with databases that are intended to remain in
+    memory during the entire execution of the current process.
 
     @raise Failwith if the base has already been loaded. *)
 


### PR DESCRIPTION
If we register a function with `at_exit` before forking, this function will be called at the termination of any child. In PR #2014, I registered such a function to clean-up databases loaded with Ancient. As a result, the function is called after each worker terminates. Alas, [Ancient.delete] is buggy and cannot be used.

This bug is causing a memory leak in GeneWeb but it is acceptable because the database is intended to stay in memory during the entire execution of the server and the operating system will reclaim resources after the process terminates.

This PR removes the `at_exit` invocation in `load_database` and add documentation to explain the caveat.