### PR TITLE
Replace #ifdef system by (not) Sys.unix

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,7 +1,4 @@
 plugins/forum/plugin_forum.cppo.ml
 bin/ged2gwb/ged2gwb.ml
-bin/gwd/gwd.ml
 lib/logs/logs.ml
-bin/gwd/request.ml
-bin/setup/setup.ml
-lib/util/mutil.ml
+

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2,28 +2,24 @@
 
 module Logs = Geneweb_logs.Logs
 
-let () = 
-  if Sys.getenv_opt "DEBUG" <> None then
-    Sys.enable_runtime_warnings true
+let () = if Sys.getenv_opt "DEBUG" <> None then Sys.enable_runtime_warnings true
 
 open Geneweb
 open Config
 open Def
 open Util
-
 open Gwd_lib
-
 module StrSet = Mutil.StrSet
 
 let output_conf =
-  { status = Wserver.http
-  ; header = Wserver.header
-  ; body = Wserver.print_string
-  ; flush = Wserver.wflush
+  {
+    status = Wserver.http;
+    header = Wserver.header;
+    body = Wserver.print_string;
+    flush = Wserver.wflush;
   }
 
 let printer_conf = { Config.empty with output_conf }
-
 let auth_file = ref ""
 let cache_langs = ref []
 let cache_databases = ref []
@@ -76,68 +72,73 @@ let extract_boundary content_type =
 
 let print_and_cut_if_too_big oc str =
   let rec loop i =
-    if i < String.length str then
-      begin
-        output_char oc str.[i];
-        let i =
-          if i > 700 && String.length str - i > 750 then
-            begin Printf.fprintf oc " ... "; String.length str - 700 end
-          else i + 1
-        in
-        loop i
-      end
+    if i < String.length str then (
+      output_char oc str.[i];
+      let i =
+        if i > 700 && String.length str - i > 750 then (
+          Printf.fprintf oc " ... ";
+          String.length str - 700)
+        else i + 1
+      in
+      loop i)
   in
   loop 0
 
 let deprecated_warning_max_clients () =
-  Format.eprintf "The `-max_clients` option is deprecated and may be removed \
-    in a future release.@ It has no effect.@ Use `-n_workers` and
-    `-max_pending_requests` instead.@."
+  Format.eprintf
+    "The `-max_clients` option is deprecated and may be removed in a future \
+     release.@ It has no effect.@ Use `-n_workers` and\n\
+    \    `-max_pending_requests` instead.@."
 
 let deprecated_warning_no_fork () =
-  Format.eprintf "The `-no-fork` option is deprecated and may be removed \
-    in a future release.@ To achieve the same behavior, use `-n_workers 0` instead.@."
+  Format.eprintf
+    "The `-no-fork` option is deprecated and may be removed in a future \
+     release.@ To achieve the same behavior, use `-n_workers 0` instead.@."
 
-type auth_report =
-  { ar_ok : bool;
-    ar_command : string;
-    ar_passwd : string;
-    ar_scheme : auth_scheme_kind;
-    ar_user : string;
-    ar_name : string;
-    ar_wizard : bool;
-    ar_friend : bool;
-    ar_uauth : string;
-    ar_can_stale : bool }
+type auth_report = {
+  ar_ok : bool;
+  ar_command : string;
+  ar_passwd : string;
+  ar_scheme : auth_scheme_kind;
+  ar_user : string;
+  ar_name : string;
+  ar_wizard : bool;
+  ar_friend : bool;
+  ar_uauth : string;
+  ar_can_stale : bool;
+}
 
 let split_username username =
-    let l1 = String.split_on_char '|' username in
-    match List.length l1 with
-    | 1 -> username, ""
-    | 2 -> (List.nth l1 0), (List.nth l1 1)
-    | _ -> (
-            Logs.syslog `LOG_CRIT "Bad .auth key or sosa encoding";
-            username, "")
+  let l1 = String.split_on_char '|' username in
+  match List.length l1 with
+  | 1 -> (username, "")
+  | 2 -> (List.nth l1 0, List.nth l1 1)
+  | _ ->
+      Logs.syslog `LOG_CRIT "Bad .auth key or sosa encoding";
+      (username, "")
 
 let log_passwd_failed ar tm from request base_file =
   Logs.log @@ fun oc ->
   let referer = Mutil.extract_param "referer: " '\n' request in
   let user_agent = Mutil.extract_param "user-agent: " '\n' request in
   let tm = Unix.localtime tm in
-  Printf.fprintf oc
-    "%s (%d) %s_%s => failed (%s)"
-    (Mutil.sprintf_date tm :> string) (Unix.getpid ()) base_file ar.ar_passwd ar.ar_user;
-  if !trace_failed_passwd then Printf.fprintf oc " (%s)" (String.escaped ar.ar_uauth);
+  Printf.fprintf oc "%s (%d) %s_%s => failed (%s)"
+    (Mutil.sprintf_date tm :> string)
+    (Unix.getpid ()) base_file ar.ar_passwd ar.ar_user;
+  if !trace_failed_passwd then
+    Printf.fprintf oc " (%s)" (String.escaped ar.ar_uauth);
   Printf.fprintf oc "\n  From: %s\n  Agent: %s\n" from user_agent;
   if referer <> "" then Printf.fprintf oc "  Referer: %s\n" referer
 
 let copy_file conf fname =
   match Util.open_etc_file conf fname with
-    Some (ic, _fname) ->
-      begin try
-        while true do let c = input_char ic in Output.printf conf "%c" c done
-      with _ -> ()
-      end;
+  | Some (ic, _fname) ->
+      (try
+         while true do
+           let c = input_char ic in
+           Output.printf conf "%c" c
+         done
+       with _ -> ());
       close_in ic;
       true
   | None -> false
@@ -151,15 +152,18 @@ let robots_txt conf =
   Output.status conf Def.OK;
   Output.header conf "Content-type: text/plain";
   if copy_file conf "robots" then ()
-  else
-    begin Output.print_sstring conf "User-Agent: *\n"; Output.print_sstring conf "Disallow: /\n" end
+  else (
+    Output.print_sstring conf "User-Agent: *\n";
+    Output.print_sstring conf "Disallow: /\n")
 
 let refuse_log conf from =
-  Logs.syslog `LOG_NOTICE @@ "Excluded: " ^ from ;
+  Logs.syslog `LOG_NOTICE @@ "Excluded: " ^ from;
   http conf Def.Forbidden;
   Output.header conf "Content-type: text/html";
-  Output.print_sstring conf "Your access has been disconnected by administrator.\n";
-  let _ = (copy_file conf "refuse" : bool) in ()
+  Output.print_sstring conf
+    "Your access has been disconnected by administrator.\n";
+  let _ = (copy_file conf "refuse" : bool) in
+  ()
 
 let only_log conf from =
   Logs.syslog `LOG_NOTICE @@ "Connection refused from " ^ from;
@@ -169,30 +173,26 @@ let only_log conf from =
   Output.print_sstring conf "<body><h1>Invalid access</h1></body>\n"
 
 let refuse_auth conf from auth auth_type =
-  Logs.syslog `LOG_NOTICE @@
-  Printf.sprintf
-    "Access failed --- From: %s --- Basic realm: %s --- Response: %s"
-    from auth_type auth;
+  Logs.syslog `LOG_NOTICE
+  @@ Printf.sprintf
+       "Access failed --- From: %s --- Basic realm: %s --- Response: %s" from
+       auth_type auth;
   Util.unauthorized conf auth_type
 
 let index_from s o c =
-  match String.index_from_opt s o c with
-  | Some i -> i
-  | None -> String.length s
+  match String.index_from_opt s o c with Some i -> i | None -> String.length s
 
 let index s c = index_from s 0 c
 
 let rec extract_assoc key = function
-  | [] -> "", []
-  | (k, v as kv) :: kvl ->
-    if k = key
-    then Mutil.decode v, kvl
-    else
-      let (v, kvl) = extract_assoc key kvl
-      in v, kv :: kvl
+  | [] -> ("", [])
+  | ((k, v) as kv) :: kvl ->
+      if k = key then (Mutil.decode v, kvl)
+      else
+        let v, kvl = extract_assoc key kvl in
+        (v, kv :: kvl)
 
 let tmp = Filename.get_temp_dir_name ()
-
 let lexicon_fname = ref (Filename.concat tmp "lexicon.bin.")
 
 (* NB: Lexicon will be impacted by plugins even if the base
@@ -204,80 +204,82 @@ let load_lexicon =
     match Hashtbl.find_opt lexicon_cache fname with
     | Some lex -> lex
     | None ->
-       let lex =
-        Mutil.read_or_create_value ~wait:true ~magic:Mutil.random_magic fname
-          begin fun () ->
-            let ht = Hashtbl.create 0 in
-            let rec rev_iter fn = function
-              | [] -> ()
-              | hd :: tl -> rev_iter fn tl ; fn hd
-            in
-            rev_iter begin fun fname ->
-              let fname = Util.search_in_assets fname in
-              if Sys.file_exists fname then
-                Mutil.input_lexicon lang ht begin fun () ->
-                  Secure.open_in fname
-                end
-              else
-                Logs.syslog `LOG_WARNING
-                  (Format.sprintf "File %s unavailable\n" fname)
-            end !lexicon_list ;
-            ht
-          end
-      in
-      Hashtbl.add lexicon_cache fname lex ;
-      lex
+        let lex =
+          Mutil.read_or_create_value ~wait:true ~magic:Mutil.random_magic fname
+            (fun () ->
+              let ht = Hashtbl.create 0 in
+              let rec rev_iter fn = function
+                | [] -> ()
+                | hd :: tl ->
+                    rev_iter fn tl;
+                    fn hd
+              in
+              rev_iter
+                (fun fname ->
+                  let fname = Util.search_in_assets fname in
+                  if Sys.file_exists fname then
+                    Mutil.input_lexicon lang ht (fun () -> Secure.open_in fname)
+                  else
+                    Logs.syslog `LOG_WARNING
+                      (Format.sprintf "File %s unavailable\n" fname))
+                !lexicon_list;
+              ht)
+        in
+        Hashtbl.add lexicon_cache fname lex;
+        lex
 
 let cache_lexicon () =
   List.iter (fun x -> ignore @@ load_lexicon x) !cache_langs
 
-exception Register_plugin_failure of string * [ `dynlink_error of Dynlink.error | `string of string ]
+exception
+  Register_plugin_failure of
+    string * [ `dynlink_error of Dynlink.error | `string of string ]
 
 let register_plugin dir =
-  if !debug then print_endline (__LOC__ ^ ": " ^ dir) ;
-  if not (List.mem dir !unsafe_plugins || GwdPluginMD5.allowed dir) then failwith dir ;
+  if !debug then print_endline (__LOC__ ^ ": " ^ dir);
+  if not (List.mem dir !unsafe_plugins || GwdPluginMD5.allowed dir) then
+    failwith dir;
   let pname = Filename.basename dir in
   let plugin = Filename.concat dir @@ "plugin_" ^ pname ^ ".cmxs" in
-  lexicon_fname := !lexicon_fname ^ pname ^ "." ;
+  lexicon_fname := !lexicon_fname ^ pname ^ ".";
   let lex_dir = Filename.concat (Filename.concat dir "assets") "lex" in
-  if Sys.file_exists lex_dir then begin
+  if Sys.file_exists lex_dir then (
     let lex = Sys.readdir lex_dir in
-    Array.sort compare lex ;
-    Array.iter begin fun f ->
-      let f = Filename.concat lex_dir f in
-      if not (Sys.is_directory f) then lexicon_list := f :: !lexicon_list
-    end lex end ;
+    Array.sort compare lex;
+    Array.iter
+      (fun f ->
+        let f = Filename.concat lex_dir f in
+        if not (Sys.is_directory f) then lexicon_list := f :: !lexicon_list)
+      lex);
   let assets = Filename.concat dir "assets" in
-  GwdPlugin.assets := assets ;
-  begin
-    try Dynlink.loadfile plugin
-    with Dynlink.Error e -> raise (Register_plugin_failure (plugin, `dynlink_error e))
-  end ;
+  GwdPlugin.assets := assets;
+  (try Dynlink.loadfile plugin
+   with Dynlink.Error e ->
+     raise (Register_plugin_failure (plugin, `dynlink_error e)));
   GwdPlugin.assets := ""
 
 let alias_lang lang =
   if String.length lang < 2 then lang
   else
-    let fname =
-      Util.search_in_assets (Filename.concat "lang" "alias_lg.txt")
-    in
+    let fname = Util.search_in_assets (Filename.concat "lang" "alias_lg.txt") in
     try
       let ic = Secure.open_in fname in
       let lang =
         let rec loop () =
           match input_line ic with
-          | line -> begin match String.index_opt line '=' with
+          | line -> (
+              match String.index_opt line '=' with
               | Some i ->
-                if lang = String.sub line 0 i
-                then String.sub line (i + 1) (String.length line - i - 1)
-                else loop ()
-              | None -> loop ()
-            end
+                  if lang = String.sub line 0 i then
+                    String.sub line (i + 1) (String.length line - i - 1)
+                  else loop ()
+              | None -> loop ())
           | exception End_of_file -> lang
         in
         loop ()
       in
-      close_in ic ; lang
+      close_in ic;
+      lang
     with Sys_error _ -> lang
 
 let print_renamed conf new_n =
@@ -288,22 +290,26 @@ let print_renamed conf new_n =
       let rec loop i =
         if i > String.length req then ""
         else if i >= len && String.sub req (i - len) len = conf.bname then
-          String.sub req 0 (i - len) ^ new_n ^
-          String.sub req i (String.length req - i)
+          String.sub req 0 (i - len)
+          ^ new_n
+          ^ String.sub req i (String.length req - i)
         else loop (i + 1)
       in
       loop 0
     in
     "http://" ^ Util.get_server_string conf ^ new_req
   in
-  let env = [ "old", Mutil.encode conf.bname
-            ; "new", Mutil.encode new_n
-            ; "link", Mutil.encode link ] in
-  include_template conf env "renamed"
-    (fun () ->
+  let env =
+    [
+      ("old", Mutil.encode conf.bname);
+      ("new", Mutil.encode new_n);
+      ("link", Mutil.encode link);
+    ]
+  in
+  include_template conf env "renamed" (fun () ->
       let title _ = Output.printf conf "%s -&gt; %s" conf.bname new_n in
       Hutil.header conf title;
-      Output.printf conf "<ul><li><a href=\"%s\">%s</a></li></ul>" link link ;
+      Output.printf conf "<ul><li><a href=\"%s\">%s</a></li></ul>" link link;
       Hutil.trailer conf)
 
 let log_redirect from request req =
@@ -312,66 +318,65 @@ let log_redirect from request req =
     Logs.syslog `LOG_NOTICE @@ Format.asprintf "%a\n" Lock.pp_exception (exn, bt)
   in
   Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
-    let referer = Mutil.extract_param "referer: " '\n' request in
-    Logs.syslog `LOG_NOTICE @@
-    Printf.sprintf "%s --- From: %s --- Referer: %s" req from referer
+  let referer = Mutil.extract_param "referer: " '\n' request in
+  Logs.syslog `LOG_NOTICE
+  @@ Printf.sprintf "%s --- From: %s --- Referer: %s" req from referer
 
 let print_redirected conf from request new_addr =
   let req = Util.get_request_string conf in
   let link = "http://" ^ new_addr ^ req in
-  let env = ["link", Mutil.encode link] in
+  let env = [ ("link", Mutil.encode link) ] in
   log_redirect from request req;
-  include_template conf env "redirect"
-    (fun () ->
+  include_template conf env "redirect" (fun () ->
       let title _ = Output.print_sstring conf "Address changed" in
       Hutil.header conf title;
       Output.print_sstring conf "Use the following address:\n<p>\n";
-      Output.printf conf "<ul><li><a href=\"%s\">%s</a></li></ul>" link link ;
+      Output.printf conf "<ul><li><a href=\"%s\">%s</a></li></ul>" link link;
       Hutil.trailer conf)
 
 let nonce_private_key =
-  Lazy.from_fun
-    (fun () ->
-       let fname = Filename.concat !GWPARAM.cnt_dir "gwd_private.txt" in
-       let k =
-         try
-           let ic = open_in fname in
-           let s =
-             let rec loop () =
-               match input_line ic with
-               | s when s = "" || s.[0] = '#' -> loop ()
-               | s -> s
-               | exception End_of_file -> ""
-             in
-             loop ()
-           in
-           close_in ic;
-           s
-         with Sys_error _ -> ""
-       in
-       if k = "" then
-         begin
-           Random.self_init ();
-           let k = Random.bits () in
-           let oc = open_out fname in
-           Printf.fprintf oc "\
-# Gwd key for better password protection in communication.\n\
-# Changing it makes all users receive their login window again.\n\
-# Generated by program but can be modified by hand to any value.\n";
-           Printf.fprintf oc "\n%d\n" k;
-           close_out oc;
-           string_of_int k
-         end
-       else k)
+  Lazy.from_fun (fun () ->
+      let fname = Filename.concat !GWPARAM.cnt_dir "gwd_private.txt" in
+      let k =
+        try
+          let ic = open_in fname in
+          let s =
+            let rec loop () =
+              match input_line ic with
+              | s when s = "" || s.[0] = '#' -> loop ()
+              | s -> s
+              | exception End_of_file -> ""
+            in
+            loop ()
+          in
+          close_in ic;
+          s
+        with Sys_error _ -> ""
+      in
+      if k = "" then (
+        Random.self_init ();
+        let k = Random.bits () in
+        let oc = open_out fname in
+        Printf.fprintf oc
+          "# Gwd key for better password protection in communication.\n\
+           # Changing it makes all users receive their login window again.\n\
+           # Generated by program but can be modified by hand to any value.\n";
+        Printf.fprintf oc "\n%d\n" k;
+        close_out oc;
+        string_of_int k)
+      else k)
+
 let digest_nonce _ = Lazy.force nonce_private_key
 
 let trace_auth base_env f =
-  if List.mem_assoc "trace_auth" base_env then
+  if List.mem_assoc "trace_auth" base_env then (
     let oc =
-      open_out_gen [Open_wronly; Open_append; Open_creat] 0o777
-        "trace_auth.txt"
+      open_out_gen
+        [ Open_wronly; Open_append; Open_creat ]
+        0o777 "trace_auth.txt"
     in
-    f oc; close_out oc
+    f oc;
+    close_out oc)
 
 let unauth_server conf ar =
   let typ = if ar.ar_passwd = "w" then "Wizard" else "Friend" in
@@ -380,17 +385,22 @@ let unauth_server conf ar =
     let nonce = digest_nonce conf.ctime in
     let _ =
       let tm = Unix.localtime (Unix.time ()) in
-      trace_auth conf.base_env
-        (fun oc ->
-           Printf.fprintf oc
-             "\n401 unauthorized\n- date: %s\n- request:\n%t- passwd: %s\n- nonce: \"%s\"\n- can_stale: %b\n"
-             (Mutil.sprintf_date tm :> string)
-             (fun oc ->
-                List.iter (fun s -> Printf.fprintf oc "  * %s\n" s) conf.request)
-             ar.ar_passwd nonce ar.ar_can_stale)
+      trace_auth conf.base_env (fun oc ->
+          Printf.fprintf oc
+            "\n\
+             401 unauthorized\n\
+             - date: %s\n\
+             - request:\n\
+             %t- passwd: %s\n\
+             - nonce: \"%s\"\n\
+             - can_stale: %b\n"
+            (Mutil.sprintf_date tm :> string)
+            (fun oc ->
+              List.iter (fun s -> Printf.fprintf oc "  * %s\n" s) conf.request)
+            ar.ar_passwd nonce ar.ar_can_stale)
     in
-    Output.header conf "WWW-Authenticate: Digest realm=\"%s %s\"%s%s,qop=\"auth\""
-      typ conf.bname
+    Output.header conf
+      "WWW-Authenticate: Digest realm=\"%s %s\"%s%s,qop=\"auth\"" typ conf.bname
       (if nonce = "" then "" else Printf.sprintf ",nonce=\"%s\"" nonce)
       (if ar.ar_can_stale then ",stale=true" else "")
   else
@@ -398,9 +408,10 @@ let unauth_server conf ar =
   let env =
     List.fold_left
       (fun l (k, v) ->
-        if k = "" || (k = "oc" && (int_of_string (Mutil.decode v)) = 0)
-        then l else (k ^ "=" ^ (Mutil.decode v)) :: l)
-      [] (conf.henv @ conf.senv @ conf.env)
+        if k = "" || (k = "oc" && int_of_string (Mutil.decode v) = 0) then l
+        else (k ^ "=" ^ Mutil.decode v) :: l)
+      []
+      (conf.henv @ conf.senv @ conf.env)
   in
   let env = String.concat "&" env in
   let txt i = transl_nth conf "wizard/wizards/friend/friends/exterior" i in
@@ -415,24 +426,23 @@ let unauth_server conf ar =
   title false;
   Output.print_sstring conf "</h1>\n";
   Output.print_sstring conf "<dl>\n";
-  begin
-    let (alt_bind, alt_access) =
-      if ar.ar_passwd = "w" then "w=f", txt 2 else "w=w", txt 0
-    in
-    Output.print_sstring conf "<dd>\n";
-    Output.print_sstring conf "<ul>\n";
-    Output.print_sstring conf "<li>\n";
-    Output.printf conf {|%s : <a href="%s?%s%s%s">%s</a>|}
-      (transl conf "access") conf.bname env
-      (if env = "" then "" else "&") alt_bind alt_access;
-    Output.print_sstring conf "</li>\n";
-    Output.print_sstring conf "<li>\n";
-    Output.printf conf {|%s : <a href="%s?%s">%s</a>|}
-      (transl conf "access") conf.bname env (txt 4);
-    Output.print_sstring conf "</li>\n";
-    Output.print_sstring conf "</ul>\n";
-    Output.print_sstring conf "</dd>\n"
-  end;
+  (let alt_bind, alt_access =
+     if ar.ar_passwd = "w" then ("w=f", txt 2) else ("w=w", txt 0)
+   in
+   Output.print_sstring conf "<dd>\n";
+   Output.print_sstring conf "<ul>\n";
+   Output.print_sstring conf "<li>\n";
+   Output.printf conf {|%s : <a href="%s?%s%s%s">%s</a>|} (transl conf "access")
+     conf.bname env
+     (if env = "" then "" else "&")
+     alt_bind alt_access;
+   Output.print_sstring conf "</li>\n";
+   Output.print_sstring conf "<li>\n";
+   Output.printf conf {|%s : <a href="%s?%s">%s</a>|} (transl conf "access")
+     conf.bname env (txt 4);
+   Output.print_sstring conf "</li>\n";
+   Output.print_sstring conf "</ul>\n";
+   Output.print_sstring conf "</dd>\n");
   Output.print_sstring conf "</dl>\n";
   Hutil.trailer conf
 
@@ -440,9 +450,8 @@ let gen_match_auth_file test_user_and_password auth_file base_file =
   if auth_file = "" then None
   else
     let aul = read_gen_auth_file auth_file base_file in
-    let rec loop =
-      function
-        au :: aul ->
+    let rec loop = function
+      | au :: aul ->
           if test_user_and_password au then
             let s =
               try
@@ -450,7 +459,8 @@ let gen_match_auth_file test_user_and_password auth_file base_file =
                 String.sub au.au_info 0 i
               with Not_found -> au.au_info
             in
-            let username = (* clean the / needed for sorting *)
+            let username =
+              (* clean the / needed for sorting *)
               try
                 let i = String.index s '/' in
                 let len = String.length s in
@@ -464,88 +474,94 @@ let gen_match_auth_file test_user_and_password auth_file base_file =
     loop aul
 
 let basic_match_auth_file uauth base_file =
-  gen_match_auth_file (fun au -> au.au_user ^ ":" ^ au.au_passwd = uauth) base_file
+  gen_match_auth_file
+    (fun au -> au.au_user ^ ":" ^ au.au_passwd = uauth)
+    base_file
 
 let digest_match_auth_file asch base_file =
   gen_match_auth_file
-    (fun au -> is_that_user_and_password asch au.au_user au.au_passwd) base_file
+    (fun au -> is_that_user_and_password asch au.au_user au.au_passwd)
+    base_file
 
 let match_simple_passwd sauth uauth =
   match String.index_opt sauth ':' with
-    Some _ -> sauth = uauth
-  | None ->
+  | Some _ -> sauth = uauth
+  | None -> (
       match String.index_opt uauth ':' with
-        Some i ->
-          sauth = String.sub uauth (i + 1) (String.length uauth - i - 1)
-      | None -> sauth = uauth
+      | Some i -> sauth = String.sub uauth (i + 1) (String.length uauth - i - 1)
+      | None -> sauth = uauth)
 
 let basic_match_auth passwd auth_file uauth base_file =
   if passwd <> "" && match_simple_passwd passwd uauth then Some ""
   else basic_match_auth_file uauth auth_file base_file
 
 type access_type =
-    ATwizard of string * string
+  | ATwizard of string * string
   | ATfriend of string * string
   | ATnormal
   | ATnone
   | ATset
 
 let compatible_tokens check_from (addr1, base1_pw1) (addr2, base2_pw2) =
-  (not check_from || addr1 = addr2) && base1_pw1 = base2_pw2
+  ((not check_from) || addr1 = addr2) && base1_pw1 = base2_pw2
 
 let get_actlog check_from utm from_addr base_password =
   let fname = !GWPARAM.adm_file "actlog" in
-  if not (Sys.file_exists fname) then (
-    let oc = Secure.open_out fname in
-    close_out oc);
+  (if not (Sys.file_exists fname) then
+   let oc = Secure.open_out fname in
+   close_out oc);
   try
     let ic = Secure.open_in fname in
-      let tmout = float_of_int !login_timeout in
-      let rec loop changed r list =
-        match input_line ic with
-        | line ->
-            let i = index line ' ' in
-            let tm = float_of_string (String.sub line 0 i) in
-            let islash = index_from line (i + 1) '/' in
-            let ispace = index_from line (islash + 1) ' ' in
-            let addr = String.sub line (i + 1) (islash - i - 1) in
-            let db_pwd = String.sub line (islash + 1) (ispace - islash - 1) in
-            let c = line.[ispace+1] in
-            let user =
-              let k = ispace + 3 in
-              if k >= String.length line then ""
-              else String.sub line k (String.length line - k)
-            in
-            let len = String.length user in
-            let user, username =
-              match String.index_opt user ' ' with
-              | Some i ->
-                  String.sub user 0 i, String.sub user (i + 1) (len - i - 1)
-              | None -> user, ""
-            in
-            let (list, r, changed) =
-              if utm -. tm >= tmout then list, r, true
-              else if
-                compatible_tokens check_from (addr, db_pwd)
-                  (from_addr, base_password)
-              then
-                let r = if c = 'w' then ATwizard (user, username) else ATfriend (user, username) in
-                ((from_addr, db_pwd), (utm, c, user, username)) :: list, r, true
-              else ((addr, db_pwd), (tm, c, user, username)) :: list, r, changed
-            in
-            loop changed r list
-        | exception End_of_file ->
-            close_in ic;
-            let list =
-              List.sort (fun (_, (t1, _, _, _)) (_, (t2, _, _, _)) -> compare t2 t1)
-                list
-            in
-            list, r, changed
-      in
-      loop false ATnormal []
-  with Sys_error e -> (
-      Logs.syslog `LOG_WARNING ("Error opening (get) actlog: " ^ e);
-    [], ATnormal, false)
+    let tmout = float_of_int !login_timeout in
+    let rec loop changed r list =
+      match input_line ic with
+      | line ->
+          let i = index line ' ' in
+          let tm = float_of_string (String.sub line 0 i) in
+          let islash = index_from line (i + 1) '/' in
+          let ispace = index_from line (islash + 1) ' ' in
+          let addr = String.sub line (i + 1) (islash - i - 1) in
+          let db_pwd = String.sub line (islash + 1) (ispace - islash - 1) in
+          let c = line.[ispace + 1] in
+          let user =
+            let k = ispace + 3 in
+            if k >= String.length line then ""
+            else String.sub line k (String.length line - k)
+          in
+          let len = String.length user in
+          let user, username =
+            match String.index_opt user ' ' with
+            | Some i ->
+                (String.sub user 0 i, String.sub user (i + 1) (len - i - 1))
+            | None -> (user, "")
+          in
+          let list, r, changed =
+            if utm -. tm >= tmout then (list, r, true)
+            else if
+              compatible_tokens check_from (addr, db_pwd)
+                (from_addr, base_password)
+            then
+              let r =
+                if c = 'w' then ATwizard (user, username)
+                else ATfriend (user, username)
+              in
+              (((from_addr, db_pwd), (utm, c, user, username)) :: list, r, true)
+            else (((addr, db_pwd), (tm, c, user, username)) :: list, r, changed)
+          in
+          loop changed r list
+      | exception End_of_file ->
+          close_in ic;
+          let list =
+            List.sort
+              (fun (_, (t1, _, _, _)) (_, (t2, _, _, _)) -> compare t2 t1)
+              list
+          in
+          (list, r, changed)
+    in
+    loop false ATnormal []
+  with Sys_error e ->
+    Logs.syslog `LOG_WARNING ("Error opening (get) actlog: " ^ e);
+    ([], ATnormal, false)
 
 let set_actlog list =
   let fname = !GWPARAM.adm_file "actlog" in
@@ -553,24 +569,23 @@ let set_actlog list =
     let oc = Secure.open_out fname in
     List.iter
       (fun ((from, base_pw), (a, c, d, e)) ->
-         Printf.fprintf oc "%.0f %s/%s %c%s%s\n" a from base_pw c
-           (if d = "" then "" else " " ^ d)
-           (if e = "" then "" else " " ^ e))
+        Printf.fprintf oc "%.0f %s/%s %c%s%s\n" a from base_pw c
+          (if d = "" then "" else " " ^ d)
+          (if e = "" then "" else " " ^ e))
       list;
     close_out oc
-  with Sys_error e -> (
+  with Sys_error e ->
     Logs.syslog `LOG_WARNING ("Error opening actlog: " ^ e);
-    ())
+    ()
 
 let get_token check_from utm from_addr base_password =
   let lock_file = !GWPARAM.adm_file "gwd.lck" in
   (* FIXME: we silently ignore errors if we cannot lock the database. *)
   let on_exn _exn _bt = ATnormal in
   Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
-       let (list, r, changed) =
-         get_actlog check_from utm from_addr base_password
-       in
-       if changed then set_actlog list; r
+  let list, r, changed = get_actlog check_from utm from_addr base_password in
+  if changed then set_actlog list;
+  r
 
 let mkpasswd () =
   let rec loop len =
@@ -590,34 +605,34 @@ let set_token utm from_addr base_file acc user username =
   (* FIXME: we silently ignore errors if we cannot lock the database. *)
   let on_exn _exn _bt = "" in
   Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
-       random_self_init ();
-       let (list, _, _) = get_actlog false utm "" "" in
-       let (x, xx) =
-         let base = base_file ^ "_" in
-         let rec loop ntimes =
-           if ntimes = 0 then failwith "set_token"
-           else
-             let x = mkpasswd () in
-             let xx = base ^ x in
-             if List.exists
-                 (fun (tok, _) ->
-                    compatible_tokens false tok (from_addr, xx))
-                 list
-             then
-               loop (ntimes - 1)
-             else x, xx
-         in
-         loop 50
-       in
-       let list = ((from_addr, xx), (utm, acc, user, username)) :: list in
-       set_actlog list; x
+  random_self_init ();
+  let list, _, _ = get_actlog false utm "" "" in
+  let x, xx =
+    let base = base_file ^ "_" in
+    let rec loop ntimes =
+      if ntimes = 0 then failwith "set_token"
+      else
+        let x = mkpasswd () in
+        let xx = base ^ x in
+        if
+          List.exists
+            (fun (tok, _) -> compatible_tokens false tok (from_addr, xx))
+            list
+        then loop (ntimes - 1)
+        else (x, xx)
+    in
+    loop 50
+  in
+  let list = ((from_addr, xx), (utm, acc, user, username)) :: list in
+  set_actlog list;
+  x
 
 let index_not_name s =
   let rec loop i =
     if i = String.length s then i
     else
       match s.[i] with
-        'a'..'z' | 'A'..'Z' | '0'..'9' | '-' -> loop (i + 1)
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' -> loop (i + 1)
       | _ -> i
   in
   loop 0
@@ -636,13 +651,14 @@ let refresh_url conf bname =
   in
   http conf Def.OK;
   Output.header conf "Content-type: text/html";
-  Output.printf conf "<head>\n\
-                  <meta http-equiv=\"REFRESH\"\n\
-                  content=\"1;URL=%s\">\n\
-                  </head>\n\
-                  <body>\n\
-                  <a href=\"%s\">%s</a>\n\
-                  </body>"
+  Output.printf conf
+    "<head>\n\
+     <meta http-equiv=\"REFRESH\"\n\
+     content=\"1;URL=%s\">\n\
+     </head>\n\
+     <body>\n\
+     <a href=\"%s\">%s</a>\n\
+     </body>"
     url url url;
   raise Exit
 
@@ -660,9 +676,8 @@ let http_preferred_language request =
       loop [] 0 0
     in
     let list = List.map String.trim list in
-    let rec loop =
-      function
-        lang :: list ->
+    let rec loop = function
+      | lang :: list ->
           if List.mem lang Version.available_languages then lang
           else if String.length lang = 5 then
             let blang = String.sub lang 0 2 in
@@ -680,12 +695,10 @@ let allowed_denied_titles key extra_line env base_env () =
       let fname = List.assoc key base_env in
       if fname = "" then []
       else
-        let ic =
-          Secure.open_in (Filename.concat (Secure.base_dir ()) fname)
-        in
+        let ic = Secure.open_in (Filename.concat (Secure.base_dir ()) fname) in
         let rec loop set =
-          let (line, eof) =
-            try input_line ic, false with End_of_file -> "", true
+          let line, eof =
+            try (input_line ic, false) with End_of_file -> ("", true)
           in
           let set =
             let line = if eof then extra_line |> Mutil.decode else line in
@@ -697,21 +710,24 @@ let allowed_denied_titles key extra_line env base_env () =
                     let len = String.length line in
                     let tit = String.sub line 0 i in
                     let pla = String.sub line (i + 1) (len - i - 1) in
-                    (if tit = "*" then tit else Name.lower tit) ^ "/" ^
-                    (if pla = "*" then pla else Name.lower pla)
+                    (if tit = "*" then tit else Name.lower tit)
+                    ^ "/"
+                    ^ if pla = "*" then pla else Name.lower pla
                 | None -> Name.lower line
               in
               StrSet.add line set
           in
-          if eof then begin close_in ic; StrSet.elements set end else loop set
+          if eof then (
+            close_in ic;
+            StrSet.elements set)
+          else loop set
         in
         loop StrSet.empty
     with Not_found | Sys_error _ -> []
 
 let allowed_titles env =
   let extra_line =
-    try List.assoc "extra_title" env
-    with Not_found -> Adef.encoded ""
+    try List.assoc "extra_title" env with Not_found -> Adef.encoded ""
   in
   allowed_denied_titles "allowed_titles_file" extra_line env
 
@@ -720,49 +736,50 @@ let denied_titles = allowed_denied_titles "denied_titles_file" (Adef.encoded "")
 let parse_digest s =
   let rec parse_main (strm__ : _ Stream.t) =
     match try Some (ident strm__) with Stream.Failure -> None with
-      Some s ->
+    | Some s ->
         let _ =
           try spaces strm__ with Stream.Failure -> raise (Stream.Error "")
         in
         let kvl =
-          try key_eq_val_list strm__ with
-            Stream.Failure -> raise (Stream.Error "")
+          try key_eq_val_list strm__
+          with Stream.Failure -> raise (Stream.Error "")
         in
         if s = "Digest" then kvl else []
     | _ -> []
   and ident (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some ('A'..'Z' | 'a'..'z' as c) ->
+    | Some (('A' .. 'Z' | 'a' .. 'z') as c) ->
         Stream.junk strm__;
         let len =
-          try ident_kont (Buff.store 0 c) strm__ with
-            Stream.Failure -> raise (Stream.Error "")
+          try ident_kont (Buff.store 0 c) strm__
+          with Stream.Failure -> raise (Stream.Error "")
         in
         Buff.get len
     | _ -> raise Stream.Failure
   and ident_kont len (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some ('A'..'Z' | 'a'..'z' as c) ->
-        Stream.junk strm__; ident_kont (Buff.store len c) strm__
+    | Some (('A' .. 'Z' | 'a' .. 'z') as c) ->
+        Stream.junk strm__;
+        ident_kont (Buff.store len c) strm__
     | _ -> len
   and spaces (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some ' ' ->
+    | Some ' ' -> (
         Stream.junk strm__;
-        (try spaces strm__ with Stream.Failure -> raise (Stream.Error ""))
+        try spaces strm__ with Stream.Failure -> raise (Stream.Error ""))
     | _ -> ()
   and key_eq_val_list (strm__ : _ Stream.t) =
     match try Some (key_eq_val strm__) with Stream.Failure -> None with
-      Some kv ->
+    | Some kv ->
         let kvl =
-          try key_eq_val_list_kont strm__ with
-            Stream.Failure -> raise (Stream.Error "")
+          try key_eq_val_list_kont strm__
+          with Stream.Failure -> raise (Stream.Error "")
         in
         kv :: kvl
     | _ -> []
   and key_eq_val_list_kont (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some ',' ->
+    | Some ',' ->
         Stream.junk strm__;
         let _ =
           try spaces strm__ with Stream.Failure -> raise (Stream.Error "")
@@ -771,24 +788,24 @@ let parse_digest s =
           try key_eq_val strm__ with Stream.Failure -> raise (Stream.Error "")
         in
         let kvl =
-          try key_eq_val_list_kont strm__ with
-            Stream.Failure -> raise (Stream.Error "")
+          try key_eq_val_list_kont strm__
+          with Stream.Failure -> raise (Stream.Error "")
         in
         kv :: kvl
     | _ -> []
   and key_eq_val (strm__ : _ Stream.t) =
     let k = ident strm__ in
     match Stream.peek strm__ with
-      Some '=' ->
+    | Some '=' ->
         Stream.junk strm__;
         let v =
           try val_or_str strm__ with Stream.Failure -> raise (Stream.Error "")
         in
-        k, v
+        (k, v)
     | _ -> raise (Stream.Error "")
   and val_or_str (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some '"' ->
+    | Some '"' ->
         Stream.junk strm__;
         let v =
           try string 0 strm__ with Stream.Failure -> raise (Stream.Error "")
@@ -805,13 +822,18 @@ let parse_digest s =
         v
   and string len (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some '"' -> Stream.junk strm__; Buff.get len
-    | Some c -> Stream.junk strm__; string (Buff.store len c) strm__
+    | Some '"' ->
+        Stream.junk strm__;
+        Buff.get len
+    | Some c ->
+        Stream.junk strm__;
+        string (Buff.store len c) strm__
     | _ -> raise Stream.Failure
   and any_val len (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-      Some ('a'..'z' | 'A'..'Z' | '0'..'9' | '-' as c) ->
-        Stream.junk strm__; any_val (Buff.store len c) strm__
+    | Some (('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-') as c) ->
+        Stream.junk strm__;
+        any_val (Buff.store len c) strm__
     | _ -> Buff.get len
   in
   parse_main (Stream.of_string s)
@@ -843,116 +865,165 @@ let basic_authorization from_addr request base_env passwd access_type utm
   let uauth = if passwd = "w" || passwd = "f" then passwd1 else passwd in
   let auto = Mutil.extract_param "gw-connection-type: " '\r' request in
   let uauth = if auto = "auto" then passwd1 else uauth in
-  let (ok, wizard, friend, username) =
-    if not !(Wserver.cgi) && (passwd = "w" || passwd = "f") then
+  let ok, wizard, friend, username =
+    if (not !Wserver.cgi) && (passwd = "w" || passwd = "f") then
       if passwd = "w" then
         if wizard_passwd = "" && wizard_passwd_file = "" then
-          true, true, friend_passwd = "", ""
+          (true, true, friend_passwd = "", "")
         else
-          match basic_match_auth wizard_passwd wizard_passwd_file uauth base_file with
-            Some username -> true, true, false, username
-          | None -> false, false, false, ""
+          match
+            basic_match_auth wizard_passwd wizard_passwd_file uauth base_file
+          with
+          | Some username -> (true, true, false, username)
+          | None -> (false, false, false, "")
       else if passwd = "f" then
         if friend_passwd = "" && friend_passwd_file = "" then
-          true, false, true, ""
+          (true, false, true, "")
         else
-          match basic_match_auth friend_passwd friend_passwd_file uauth base_file with
-            Some username -> true, false, true, username
-          | None -> false, false, false, ""
+          match
+            basic_match_auth friend_passwd friend_passwd_file uauth base_file
+          with
+          | Some username -> (true, false, true, username)
+          | None -> (false, false, false, "")
       else assert false
     else if wizard_passwd = "" && wizard_passwd_file = "" then
-      true, true, friend_passwd = "", ""
+      (true, true, friend_passwd = "", "")
     else
-      match basic_match_auth wizard_passwd wizard_passwd_file uauth base_file with
-        Some username -> true, true, false, username
-      | _ ->
+      match
+        basic_match_auth wizard_passwd wizard_passwd_file uauth base_file
+      with
+      | Some username -> (true, true, false, username)
+      | _ -> (
           if friend_passwd = "" && friend_passwd_file = "" then
-            true, false, true, ""
+            (true, false, true, "")
           else
-            match basic_match_auth friend_passwd friend_passwd_file uauth base_file with
-              Some username -> true, false, true, username
-            | None -> true, false, false, ""
+            match
+              basic_match_auth friend_passwd friend_passwd_file uauth base_file
+            with
+            | Some username -> (true, false, true, username)
+            | None -> (true, false, false, ""))
   in
   let user =
     match String.index_opt uauth ':' with
-      Some i ->
+    | Some i ->
         let s = String.sub uauth 0 i in
         if s = wizard_passwd || s = friend_passwd then "" else s
     | None -> ""
   in
-  let (command, passwd) =
+  let command, passwd =
     if access_type = ATset then
       if wizard then
         let pwd_id = set_token utm from_addr base_file 'w' user username in
-        if !(Wserver.cgi) then command, pwd_id
-        else base_file ^ "_" ^ pwd_id, ""
+        if !Wserver.cgi then (command, pwd_id)
+        else (base_file ^ "_" ^ pwd_id, "")
       else if friend then
         let pwd_id = set_token utm from_addr base_file 'f' user username in
-        if !(Wserver.cgi) then command, pwd_id
-        else base_file ^ "_" ^ pwd_id, ""
-      else if !(Wserver.cgi) then command, ""
-      else base_file, ""
-    else if !(Wserver.cgi) then command, passwd
+        if !Wserver.cgi then (command, pwd_id)
+        else (base_file ^ "_" ^ pwd_id, "")
+      else if !Wserver.cgi then (command, "")
+      else (base_file, "")
+    else if !Wserver.cgi then (command, passwd)
     else if passwd = "" then
       if auto = "auto" then
         let suffix = if wizard then "_w" else if friend then "_f" else "" in
-        base_file ^ suffix, passwd
-      else base_file, ""
-    else base_file ^ "_" ^ passwd, passwd
+        (base_file ^ suffix, passwd)
+      else (base_file, "")
+    else (base_file ^ "_" ^ passwd, passwd)
   in
   let auth_scheme =
-    if not wizard && not friend then NoAuth
+    if (not wizard) && not friend then NoAuth
     else
       let realm =
         if wizard then "Wizard " ^ base_file else "Friend " ^ base_file
       in
-      let (u, p) =
+      let u, p =
         match String.index_opt passwd1 ':' with
-          Some i ->
+        | Some i ->
             let u = String.sub passwd1 0 i in
             let p =
               String.sub passwd1 (i + 1) (String.length passwd1 - i - 1)
             in
-            u, p
-        | None -> "", passwd
+            (u, p)
+        | None -> ("", passwd)
       in
-      HttpAuth (Basic {bs_realm = realm; bs_user = u; bs_pass = p})
+      HttpAuth (Basic { bs_realm = realm; bs_user = u; bs_pass = p })
   in
-  {ar_ok = ok; ar_command = command; ar_passwd = passwd;
-   ar_scheme = auth_scheme; ar_user = user; ar_name = username;
-   ar_wizard = wizard; ar_friend = friend; ar_uauth = uauth;
-   ar_can_stale = false}
+  {
+    ar_ok = ok;
+    ar_command = command;
+    ar_passwd = passwd;
+    ar_scheme = auth_scheme;
+    ar_user = user;
+    ar_name = username;
+    ar_wizard = wizard;
+    ar_friend = friend;
+    ar_uauth = uauth;
+    ar_can_stale = false;
+  }
 
 let bad_nonce_report command passwd_char =
-  {ar_ok = false; ar_command = command; ar_passwd = passwd_char;
-   ar_scheme = NoAuth; ar_user = ""; ar_name = ""; ar_wizard = false;
-   ar_friend = false; ar_uauth = ""; ar_can_stale = true}
+  {
+    ar_ok = false;
+    ar_command = command;
+    ar_passwd = passwd_char;
+    ar_scheme = NoAuth;
+    ar_user = "";
+    ar_name = "";
+    ar_wizard = false;
+    ar_friend = false;
+    ar_uauth = "";
+    ar_can_stale = true;
+  }
 
-let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz base_file =
+let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz
+    base_file =
   let asch = HttpAuth (Digest ds) in
-  if wf_passwd <> "" &&
-     is_that_user_and_password asch ds.ds_username wf_passwd
+  if wf_passwd <> "" && is_that_user_and_password asch ds.ds_username wf_passwd
   then
     if ds.ds_nonce <> nonce then bad_nonce_report command passwd_char
     else
-      {ar_ok = true; ar_command = command ^ "_" ^ passwd_char;
-       ar_passwd = passwd_char; ar_scheme = asch; ar_user = ds.ds_username;
-       ar_name = ""; ar_wizard = wiz; ar_friend = not wiz; ar_uauth = "";
-       ar_can_stale = false}
+      {
+        ar_ok = true;
+        ar_command = command ^ "_" ^ passwd_char;
+        ar_passwd = passwd_char;
+        ar_scheme = asch;
+        ar_user = ds.ds_username;
+        ar_name = "";
+        ar_wizard = wiz;
+        ar_friend = not wiz;
+        ar_uauth = "";
+        ar_can_stale = false;
+      }
   else
     match digest_match_auth_file asch wf_passwd_file base_file with
-      Some username ->
+    | Some username ->
         if ds.ds_nonce <> nonce then bad_nonce_report command passwd_char
         else
-          {ar_ok = true; ar_command = command ^ "_" ^ passwd_char;
-           ar_passwd = passwd_char; ar_scheme = asch;
-           ar_user = ds.ds_username; ar_name = username; ar_wizard = wiz;
-           ar_friend = not wiz; ar_uauth = ""; ar_can_stale = false}
+          {
+            ar_ok = true;
+            ar_command = command ^ "_" ^ passwd_char;
+            ar_passwd = passwd_char;
+            ar_scheme = asch;
+            ar_user = ds.ds_username;
+            ar_name = username;
+            ar_wizard = wiz;
+            ar_friend = not wiz;
+            ar_uauth = "";
+            ar_can_stale = false;
+          }
     | None ->
-        {ar_ok = false; ar_command = command; ar_passwd = passwd_char;
-         ar_scheme = asch; ar_user = ds.ds_username; ar_name = "";
-         ar_wizard = false; ar_friend = false; ar_uauth = "";
-         ar_can_stale = false}
+        {
+          ar_ok = false;
+          ar_command = command;
+          ar_passwd = passwd_char;
+          ar_scheme = asch;
+          ar_user = ds.ds_username;
+          ar_name = "";
+          ar_wizard = false;
+          ar_friend = false;
+          ar_uauth = "";
+          ar_can_stale = false;
+        }
 
 let digest_authorization request base_env passwd utm base_file command =
   let wizard_passwd =
@@ -967,90 +1038,156 @@ let digest_authorization request base_env passwd utm base_file command =
   let friend_passwd_file =
     try List.assoc "friend_passwd_file" base_env with Not_found -> ""
   in
-  let command = if !(Wserver.cgi) then command else base_file in
+  let command = if !Wserver.cgi then command else base_file in
   if wizard_passwd = "" && wizard_passwd_file = "" then
-    {ar_ok = true; ar_command = command; ar_passwd = ""; ar_scheme = NoAuth;
-     ar_user = ""; ar_name = ""; ar_wizard = true;
-     ar_friend = friend_passwd = ""; ar_uauth = ""; ar_can_stale = false}
+    {
+      ar_ok = true;
+      ar_command = command;
+      ar_passwd = "";
+      ar_scheme = NoAuth;
+      ar_user = "";
+      ar_name = "";
+      ar_wizard = true;
+      ar_friend = friend_passwd = "";
+      ar_uauth = "";
+      ar_can_stale = false;
+    }
   else if passwd = "w" || passwd = "f" then
     let auth = Mutil.extract_param "authorization: " '\r' request in
     if Mutil.start_with "Digest " 0 auth then
       let meth =
         match Mutil.extract_param "GET " ' ' request with
-          "" -> "POST"
+        | "" -> "POST"
         | _ -> "GET"
       in
       let _ =
-        trace_auth base_env (fun oc -> Printf.fprintf oc "\nauth = \"%s\"\n" auth)
+        trace_auth base_env (fun oc ->
+            Printf.fprintf oc "\nauth = \"%s\"\n" auth)
       in
       let digenv = parse_digest auth in
       let get_digenv s = try List.assoc s digenv with Not_found -> "" in
       let ds =
-        {ds_username = get_digenv "username"; ds_realm = get_digenv "realm";
-         ds_nonce = get_digenv "nonce"; ds_meth = meth;
-         ds_uri = get_digenv "uri"; ds_qop = get_digenv "qop";
-         ds_nc = get_digenv "nc"; ds_cnonce = get_digenv "cnonce";
-         ds_response = get_digenv "response"}
+        {
+          ds_username = get_digenv "username";
+          ds_realm = get_digenv "realm";
+          ds_nonce = get_digenv "nonce";
+          ds_meth = meth;
+          ds_uri = get_digenv "uri";
+          ds_qop = get_digenv "qop";
+          ds_nc = get_digenv "nc";
+          ds_cnonce = get_digenv "cnonce";
+          ds_response = get_digenv "response";
+        }
       in
       let nonce = digest_nonce utm in
       let _ =
-        trace_auth base_env
-          (fun oc ->
-             Printf.fprintf oc
-               "\nanswer\n- date: %s\n- request:\n%t- passwd: %s\n- nonce: \"%s\"\n- meth: \"%s\"\n- uri: \"%s\"\n"
-               (Mutil.sprintf_date @@ Unix.localtime utm :> string)
-               (fun oc ->
-                  List.iter (fun s -> Printf.fprintf oc "  * %s\n" s) request)
-               passwd nonce ds.ds_meth ds.ds_uri)
+        trace_auth base_env (fun oc ->
+            Printf.fprintf oc
+              "\n\
+               answer\n\
+               - date: %s\n\
+               - request:\n\
+               %t- passwd: %s\n\
+               - nonce: \"%s\"\n\
+               - meth: \"%s\"\n\
+               - uri: \"%s\"\n"
+              (Mutil.sprintf_date @@ Unix.localtime utm :> string)
+              (fun oc ->
+                List.iter (fun s -> Printf.fprintf oc "  * %s\n" s) request)
+              passwd nonce ds.ds_meth ds.ds_uri)
       in
       if passwd = "w" then
-        test_passwd ds nonce command wizard_passwd wizard_passwd_file "w" true base_file
+        test_passwd ds nonce command wizard_passwd wizard_passwd_file "w" true
+          base_file
       else if passwd = "f" then
-        test_passwd ds nonce command friend_passwd friend_passwd_file "f"
-          false base_file
+        test_passwd ds nonce command friend_passwd friend_passwd_file "f" false
+          base_file
       else failwith (Printf.sprintf "not impl (2) %s %s" auth meth)
     else
-      {ar_ok = false; ar_command = command; ar_passwd = passwd;
-       ar_scheme = NoAuth; ar_user = ""; ar_name = ""; ar_wizard = false;
-       ar_friend = false; ar_uauth = ""; ar_can_stale = false}
+      {
+        ar_ok = false;
+        ar_command = command;
+        ar_passwd = passwd;
+        ar_scheme = NoAuth;
+        ar_user = "";
+        ar_name = "";
+        ar_wizard = false;
+        ar_friend = false;
+        ar_uauth = "";
+        ar_can_stale = false;
+      }
   else
     let friend = friend_passwd = "" && friend_passwd_file = "" in
-    {ar_ok = true; ar_command = command; ar_passwd = ""; ar_scheme = NoAuth;
-     ar_user = ""; ar_name = ""; ar_wizard = false; ar_friend = friend;
-     ar_uauth = ""; ar_can_stale = false}
+    {
+      ar_ok = true;
+      ar_command = command;
+      ar_passwd = "";
+      ar_scheme = NoAuth;
+      ar_user = "";
+      ar_name = "";
+      ar_wizard = false;
+      ar_friend = friend;
+      ar_uauth = "";
+      ar_can_stale = false;
+    }
 
 let authorization from_addr request base_env passwd access_type utm base_file
     command =
   match access_type with
-    ATwizard (user, username) ->
-      let (command, passwd) =
-        if !(Wserver.cgi) then command, passwd
-        else if passwd = "" then base_file, ""
-        else base_file ^ "_" ^ passwd, passwd
+  | ATwizard (user, username) ->
+      let command, passwd =
+        if !Wserver.cgi then (command, passwd)
+        else if passwd = "" then (base_file, "")
+        else (base_file ^ "_" ^ passwd, passwd)
       in
-      let auth_scheme = TokenAuth {ts_user = user; ts_pass = passwd} in
-      {ar_ok = true; ar_command = command; ar_passwd = passwd;
-       ar_scheme = auth_scheme; ar_user = user; ar_name = username;
-       ar_wizard = true; ar_friend = false; ar_uauth = "";
-       ar_can_stale = false}
+      let auth_scheme = TokenAuth { ts_user = user; ts_pass = passwd } in
+      {
+        ar_ok = true;
+        ar_command = command;
+        ar_passwd = passwd;
+        ar_scheme = auth_scheme;
+        ar_user = user;
+        ar_name = username;
+        ar_wizard = true;
+        ar_friend = false;
+        ar_uauth = "";
+        ar_can_stale = false;
+      }
   | ATfriend (user, username) ->
-      let (command, passwd) =
-        if !(Wserver.cgi) then command, passwd
-        else if passwd = "" then base_file, ""
-        else base_file ^ "_" ^ passwd, passwd
+      let command, passwd =
+        if !Wserver.cgi then (command, passwd)
+        else if passwd = "" then (base_file, "")
+        else (base_file ^ "_" ^ passwd, passwd)
       in
-      let auth_scheme = TokenAuth {ts_user = user; ts_pass = passwd} in
-      {ar_ok = true; ar_command = command; ar_passwd = passwd;
-       ar_scheme = auth_scheme; ar_user = user; ar_name = username;
-       ar_wizard = false; ar_friend = true; ar_uauth = "";
-       ar_can_stale = false}
+      let auth_scheme = TokenAuth { ts_user = user; ts_pass = passwd } in
+      {
+        ar_ok = true;
+        ar_command = command;
+        ar_passwd = passwd;
+        ar_scheme = auth_scheme;
+        ar_user = user;
+        ar_name = username;
+        ar_wizard = false;
+        ar_friend = true;
+        ar_uauth = "";
+        ar_can_stale = false;
+      }
   | ATnormal ->
-      let (command, passwd) =
-        if !(Wserver.cgi) then command, "" else base_file, ""
+      let command, passwd =
+        if !Wserver.cgi then (command, "") else (base_file, "")
       in
-      {ar_ok = true; ar_command = command; ar_passwd = passwd;
-       ar_scheme = NoAuth; ar_user = ""; ar_name = ""; ar_wizard = false;
-       ar_friend = false; ar_uauth = ""; ar_can_stale = false}
+      {
+        ar_ok = true;
+        ar_command = command;
+        ar_passwd = passwd;
+        ar_scheme = NoAuth;
+        ar_user = "";
+        ar_name = "";
+        ar_wizard = false;
+        ar_friend = false;
+        ar_uauth = "";
+        ar_can_stale = false;
+      }
   | ATnone | ATset ->
       if !use_auth_digest_scheme then
         digest_authorization request base_env passwd utm base_file command
@@ -1059,15 +1196,15 @@ let authorization from_addr request base_env passwd access_type utm base_file
           base_file command
 
 let string_to_char_list s =
-  let rec exp i l =
-    if i < 0 then l else exp (i - 1) (s.[i] :: l) in
+  let rec exp i l = if i < 0 then l else exp (i - 1) (s.[i] :: l) in
   exp (String.length s - 1) []
 
 let retrieve_secret_salt () =
   match Unix.getenv "SECRET_SALT" with
   | exception Not_found ->
-      Logs.err (fun k -> k "Secret salt missing, the worker %d cannot \
-        continue its job." (Unix.getpid ()));
+      Logs.err (fun k ->
+          k "Secret salt missing, the worker %d cannot continue its job."
+            (Unix.getpid ()));
       exit 1
   | s -> Some s
 
@@ -1075,63 +1212,61 @@ let make_conf from_addr request script_name env =
   let secret_salt = retrieve_secret_salt () in
   if !allowed_tags_file <> "" && not (Sys.file_exists !allowed_tags_file) then (
     let str =
-     Printf.sprintf
-       "Requested allowed_tags file (%s) absent" !allowed_tags_file
+      Printf.sprintf "Requested allowed_tags file (%s) absent"
+        !allowed_tags_file
     in
     GWPARAM.errors_other := str :: !GWPARAM.errors_other;
     Logs.syslog `LOG_WARNING str);
   let utm = Unix.time () in
   let tm = Unix.localtime utm in
   let cgi = !Wserver.cgi in
-  let (command, base_file, passwd, env, access_type) =
-    let (base_access, env) =
-      let (x, env) = extract_assoc "b" env in
-      if x <> "" || cgi then x, env else script_name, env
+  let command, base_file, passwd, env, access_type =
+    let base_access, env =
+      let x, env = extract_assoc "b" env in
+      if x <> "" || cgi then (x, env) else (script_name, env)
     in
     let bname, access =
       match String.split_on_char '_' base_access with
-      | [ bname ] -> bname, ""
-      | [ bname ; access ] -> bname, access
-      | _ -> (
-        Logs.syslog
-          `LOG_CRIT (Format.sprintf "bad bname: (%s)\n" base_access);
-        assert false)
+      | [ bname ] -> (bname, "")
+      | [ bname; access ] -> (bname, access)
+      | _ ->
+          Logs.syslog `LOG_CRIT (Format.sprintf "bad bname: (%s)\n" base_access);
+          assert false
     in
     let bases = Util.get_bases_list () in
-    let bname = match  bases with [x] -> x | _ -> bname in
-    let (passwd, env, access_type) =
+    let bname = match bases with [ x ] -> x | _ -> bname in
+    let passwd, env, access_type =
       let has_passwd = List.mem_assoc "w" env in
-      let (x, env) = extract_assoc "w" env in
-      if has_passwd
-      then x, env, (match x with "w" | "f" | "" -> ATnone | _ -> ATset)
+      let x, env = extract_assoc "w" env in
+      if has_passwd then
+        (x, env, match x with "w" | "f" | "" -> ATnone | _ -> ATset)
       else
         let access_type =
           match access with
           | "" | "w" | "f" -> ATnone
           | _ -> get_token true utm from_addr base_access
         in
-        access, env, access_type
+        (access, env, access_type)
     in
     let command = script_name in
-    command, bname, passwd, env, access_type
+    (command, bname, passwd, env, access_type)
   in
-  let (lang, env) = extract_assoc "lang" env in
+  let lang, env = extract_assoc "lang" env in
   let lang =
-    if lang = "" && !choose_browser_lang
-    then http_preferred_language request
+    if lang = "" && !choose_browser_lang then http_preferred_language request
     else lang
   in
   let lang = alias_lang lang in
-  let (from, env) =
-    let (x, env) = extract_assoc "opt" env in
+  let from, env =
+    let x, env = extract_assoc "opt" env in
     match x with
-    | "from" -> "from", env
-    | "" -> "", env
-    | _ -> "", ("opt", Mutil.encode x) :: env
+    | "from" -> ("from", env)
+    | "" -> ("", env)
+    | _ -> ("", ("opt", Mutil.encode x) :: env)
   in
-  let (threshold_test, env) = extract_assoc "threshold" env in
-  if threshold_test <> ""
-  then RelationLink.threshold := int_of_string threshold_test;
+  let threshold_test, env = extract_assoc "threshold" env in
+  if threshold_test <> "" then
+    RelationLink.threshold := int_of_string threshold_test;
   GWPARAM.test_reorg base_file;
   let base_env = Util.read_base_env base_file !gw_prefix !debug in
   let default_lang =
@@ -1141,26 +1276,26 @@ let make_conf from_addr request script_name env =
     with Not_found -> !default_lang
   in
   let browser_lang =
-    if !choose_browser_lang then http_preferred_language request
-    else ""
+    if !choose_browser_lang then http_preferred_language request else ""
   in
   let default_lang = if browser_lang = "" then default_lang else browser_lang in
   let vowels =
     match List.assoc_opt "vowels" base_env with
     | Some l ->
         let rec loop acc i =
-          if i < String.length l then (
+          if i < String.length l then
             let s, j = Name.unaccent_utf_8 true l i in
-            loop (s :: acc) j)
+            loop (s :: acc) j
           else acc
-        in loop [] 0
-    | _ -> ["a"; "e"; "i"; "o"; "u"; "y"]
+        in
+        loop [] 0
+    | _ -> [ "a"; "e"; "i"; "o"; "u"; "y" ]
   in
   let lexicon_lang = if lang = "" then default_lang else lang in
   let lexicon = load_lexicon lexicon_lang in
   (* A l'initialisation de la config, il n'y a pas de sosa_ref. *)
   (* Il sera mis à jour par effet de bord dans request.ml       *)
-  let default_sosa_ref = Gwdb.dummy_iper, None in
+  let default_sosa_ref = (Gwdb.dummy_iper, None) in
   let ar =
     authorization from_addr request base_env passwd access_type utm base_file
       command
@@ -1168,185 +1303,177 @@ let make_conf from_addr request script_name env =
   let wizard_just_friend =
     if !wizard_just_friend then true
     else
-      try List.assoc "wizard_just_friend" base_env = "yes" with
-        Not_found -> false
+      try List.assoc "wizard_just_friend" base_env = "yes"
+      with Not_found -> false
   in
   let is_rtl =
     try Hashtbl.find lexicon " !dir" = "rtl" with Not_found -> false
   in
   let manitou =
     try
-      ar.ar_wizard && ar.ar_user <> "" &&
-      p_getenv env "manitou" <> Some "off" &&
-      List.assoc "manitou" base_env = ar.ar_user
+      ar.ar_wizard && ar.ar_user <> ""
+      && p_getenv env "manitou" <> Some "off"
+      && List.assoc "manitou" base_env = ar.ar_user
     with Not_found -> false
   in
   let supervisor =
     try
-      ar.ar_wizard && ar.ar_user <> "" &&
-      List.assoc "supervisor" base_env = ar.ar_user
+      ar.ar_wizard && ar.ar_user <> ""
+      && List.assoc "supervisor" base_env = ar.ar_user
     with Not_found -> false
   in
   let wizard_just_friend = if manitou then false else wizard_just_friend in
   let private_years =
-    try int_of_string (List.assoc "private_years" base_env) with
-    Not_found | Failure _ -> 150
+    try int_of_string (List.assoc "private_years" base_env)
+    with Not_found | Failure _ -> 150
   in
   let username, userkey = split_username ar.ar_name in
   let conf =
-    {from = from_addr;
-     api_mode = false;
-     manitou;
-     supervisor;
-     wizard = ar.ar_wizard && not wizard_just_friend;
-     is_printed_by_template = true;
-     debug = !debug;
-     query_start = Unix.gettimeofday ();
-     friend = ar.ar_friend || wizard_just_friend && ar.ar_wizard;
-     semi_public =
-       begin try List.assoc "semi_public" base_env = "yes" with
-         Not_found -> false
-       end;
-     just_friend_wizard = ar.ar_wizard && wizard_just_friend;
-     user = ar.ar_user;
-     username;
-     userkey = (Name.lower userkey);
-     user_iper = None;
-     auth_scheme = ar.ar_scheme;
-     command = ar.ar_command;
-     indep_command =
-       (if !(Wserver.cgi) then ar.ar_command else "geneweb") ^ "?";
-     highlight =
-       begin try List.assoc "highlight_color" base_env with
-         Not_found -> green_color
-       end;
-     lang = if lang = "" then default_lang else lang;
-     vowels=vowels;
-     default_lang;
-     browser_lang;
-     default_sosa_ref;
-     multi_parents =
-       begin try List.assoc "multi_parents" base_env = "yes" with
-         Not_found -> false
-       end;
-     authorized_wizards_notes =
-       begin try List.assoc "authorized_wizards_notes" base_env = "yes" with
-         Not_found -> false
-       end;
-     public_if_titles =
-       begin try List.assoc "public_if_titles" base_env = "yes" with
-         Not_found -> false
-       end;
-     public_if_no_date =
-       begin try List.assoc "public_if_no_date" base_env = "yes" with
-         Not_found -> false
-       end;
-     setup_link = !setup_link;
-     access_by_key =
-       begin try List.assoc "access_by_key" base_env = "yes" with
-         Not_found -> ar.ar_wizard && ar.ar_friend
-       end;
-     private_years = private_years;
-     private_years_death =
-       begin try int_of_string (List.assoc "private_years_death" base_env) with
-         Not_found | Failure _ -> private_years
-       end;
-     private_years_marriage =
-       begin try int_of_string (List.assoc "private_years_marriage" base_env) with
-         Not_found | Failure _ -> private_years
-       end;
-     hide_names =
-       if ar.ar_wizard || ar.ar_friend then false
-       else
-         begin try List.assoc "hide_private_names" base_env = "yes" with
-           Not_found -> false
-         end;
-     use_restrict =
-       if ar.ar_wizard || ar.ar_friend then false
-       else
-         begin try List.assoc "use_restrict" base_env = "yes" with
-           Not_found -> false
-         end;
-     no_image =
-       if ar.ar_wizard || ar.ar_friend then false
-       else
-         begin try List.assoc "no_image_for_visitor" base_env = "yes" with
-           Not_found -> false
-         end;
-     no_note =
-       if ar.ar_wizard || ar.ar_friend then false
-       else
-         begin try List.assoc "no_note_for_visitor" base_env = "yes" with
-           Not_found -> false
-         end;
-     bname = Filename.remove_extension base_file;
-     nb_of_persons = -1;
-     nb_of_families = -1;
-     env = env; senv = [];
-     cgi_passwd = ar.ar_passwd;
-     henv =
-       (if not !(Wserver.cgi) then []
-        else if ar.ar_passwd = "" then ["b", Mutil.encode base_file]
-        else ["b", Mutil.encode @@ base_file ^ "_" ^ ar.ar_passwd]) @
-       (if lang = "" then [] else ["lang", Mutil.encode lang]) @
-       (if from = "" then [] else ["opt", Mutil.encode from]);
-     base_env;
-     allowed_titles = Lazy.from_fun (allowed_titles env base_env);
-     denied_titles = Lazy.from_fun (denied_titles env base_env);
-     request; lexicon;
-     charset = "UTF-8"; is_rtl;
-     left = if is_rtl then "right" else "left";
-     right = if is_rtl then "left" else "right";
-     auth_file =
-       begin try
-         let x = List.assoc "auth_file" base_env in
-         if x = "" then !auth_file else Filename.concat (!GWPARAM.bpath base_file) x
-       with Not_found -> !auth_file
-       end;
-     border =
-       begin match Util.p_getint env "border" with
-         Some i -> i
-       | None -> 0
-       end;
-     n_connect = None;
-     today =
-       {day = tm.Unix.tm_mday; month = succ tm.Unix.tm_mon;
-        year = tm.Unix.tm_year + 1900; prec = Sure; delta = 0};
-     today_wd = tm.Unix.tm_wday;
-     time = tm.Unix.tm_hour, tm.Unix.tm_min, tm.Unix.tm_sec; ctime = utm;
-     gw_prefix =
-       if !gw_prefix <> "" then !gw_prefix
-       else String.concat Filename.dir_sep [ "gw" ];
-     images_prefix = (
-       match !gw_prefix, !images_prefix with
-       | gw_p, im_p when gw_p <> "" && im_p = "" ->
-           String.concat Filename.dir_sep [ gw_p; "images" ]
-       | _, im_p when im_p <> "" ->  im_p
-       | _, _ -> (Filename.concat "gw" "images"));
-     etc_prefix = (
-       match !gw_prefix, !etc_prefix with
-       | gw_p, etc_p when gw_p <> "" && etc_p = "" ->
-           String.concat Filename.dir_sep [ gw_p; "etc" ]
-       | _, etc_p when etc_p <> "" ->  etc_p
-       | _, _ -> (Filename.concat "gw" "etc"));
-     cgi;
-     output_conf;
-     forced_plugins = !forced_plugins;
-     plugins = !plugins;
-     secret_salt;
-     predictable_mode = !predictable_mode;
+    {
+      from = from_addr;
+      api_mode = false;
+      manitou;
+      supervisor;
+      wizard = ar.ar_wizard && not wizard_just_friend;
+      is_printed_by_template = true;
+      debug = !debug;
+      query_start = Unix.gettimeofday ();
+      friend = ar.ar_friend || (wizard_just_friend && ar.ar_wizard);
+      semi_public =
+        (try List.assoc "semi_public" base_env = "yes" with Not_found -> false);
+      just_friend_wizard = ar.ar_wizard && wizard_just_friend;
+      user = ar.ar_user;
+      username;
+      userkey = Name.lower userkey;
+      user_iper = None;
+      auth_scheme = ar.ar_scheme;
+      command = ar.ar_command;
+      indep_command = (if !Wserver.cgi then ar.ar_command else "geneweb") ^ "?";
+      highlight =
+        (try List.assoc "highlight_color" base_env
+         with Not_found -> green_color);
+      lang = (if lang = "" then default_lang else lang);
+      vowels;
+      default_lang;
+      browser_lang;
+      default_sosa_ref;
+      multi_parents =
+        (try List.assoc "multi_parents" base_env = "yes"
+         with Not_found -> false);
+      authorized_wizards_notes =
+        (try List.assoc "authorized_wizards_notes" base_env = "yes"
+         with Not_found -> false);
+      public_if_titles =
+        (try List.assoc "public_if_titles" base_env = "yes"
+         with Not_found -> false);
+      public_if_no_date =
+        (try List.assoc "public_if_no_date" base_env = "yes"
+         with Not_found -> false);
+      setup_link = !setup_link;
+      access_by_key =
+        (try List.assoc "access_by_key" base_env = "yes"
+         with Not_found -> ar.ar_wizard && ar.ar_friend);
+      private_years;
+      private_years_death =
+        (try int_of_string (List.assoc "private_years_death" base_env)
+         with Not_found | Failure _ -> private_years);
+      private_years_marriage =
+        (try int_of_string (List.assoc "private_years_marriage" base_env)
+         with Not_found | Failure _ -> private_years);
+      hide_names =
+        (if ar.ar_wizard || ar.ar_friend then false
+        else
+          try List.assoc "hide_private_names" base_env = "yes"
+          with Not_found -> false);
+      use_restrict =
+        (if ar.ar_wizard || ar.ar_friend then false
+        else
+          try List.assoc "use_restrict" base_env = "yes"
+          with Not_found -> false);
+      no_image =
+        (if ar.ar_wizard || ar.ar_friend then false
+        else
+          try List.assoc "no_image_for_visitor" base_env = "yes"
+          with Not_found -> false);
+      no_note =
+        (if ar.ar_wizard || ar.ar_friend then false
+        else
+          try List.assoc "no_note_for_visitor" base_env = "yes"
+          with Not_found -> false);
+      bname = Filename.remove_extension base_file;
+      nb_of_persons = -1;
+      nb_of_families = -1;
+      env;
+      senv = [];
+      cgi_passwd = ar.ar_passwd;
+      henv =
+        ((if not !Wserver.cgi then []
+         else if ar.ar_passwd = "" then [ ("b", Mutil.encode base_file) ]
+         else [ ("b", Mutil.encode @@ base_file ^ "_" ^ ar.ar_passwd) ])
+        @ (if lang = "" then [] else [ ("lang", Mutil.encode lang) ])
+        @ if from = "" then [] else [ ("opt", Mutil.encode from) ]);
+      base_env;
+      allowed_titles = Lazy.from_fun (allowed_titles env base_env);
+      denied_titles = Lazy.from_fun (denied_titles env base_env);
+      request;
+      lexicon;
+      charset = "UTF-8";
+      is_rtl;
+      left = (if is_rtl then "right" else "left");
+      right = (if is_rtl then "left" else "right");
+      auth_file =
+        (try
+           let x = List.assoc "auth_file" base_env in
+           if x = "" then !auth_file
+           else Filename.concat (!GWPARAM.bpath base_file) x
+         with Not_found -> !auth_file);
+      border = (match Util.p_getint env "border" with Some i -> i | None -> 0);
+      n_connect = None;
+      today =
+        {
+          day = tm.Unix.tm_mday;
+          month = succ tm.Unix.tm_mon;
+          year = tm.Unix.tm_year + 1900;
+          prec = Sure;
+          delta = 0;
+        };
+      today_wd = tm.Unix.tm_wday;
+      time = (tm.Unix.tm_hour, tm.Unix.tm_min, tm.Unix.tm_sec);
+      ctime = utm;
+      gw_prefix =
+        (if !gw_prefix <> "" then !gw_prefix
+        else String.concat Filename.dir_sep [ "gw" ]);
+      images_prefix =
+        (match (!gw_prefix, !images_prefix) with
+        | gw_p, im_p when gw_p <> "" && im_p = "" ->
+            String.concat Filename.dir_sep [ gw_p; "images" ]
+        | _, im_p when im_p <> "" -> im_p
+        | _, _ -> Filename.concat "gw" "images");
+      etc_prefix =
+        (match (!gw_prefix, !etc_prefix) with
+        | gw_p, etc_p when gw_p <> "" && etc_p = "" ->
+            String.concat Filename.dir_sep [ gw_p; "etc" ]
+        | _, etc_p when etc_p <> "" -> etc_p
+        | _, _ -> Filename.concat "gw" "etc");
+      cgi;
+      output_conf;
+      forced_plugins = !forced_plugins;
+      plugins = !plugins;
+      secret_salt;
+      predictable_mode = !predictable_mode;
     }
   in
   GWPARAM.cnt_dir := !GWPARAM.cnt_d conf.bname;
-  conf, ar
+  (conf, ar)
 
 let log tm conf from gauth request script_name contents =
   Logs.log @@ fun oc ->
   let referer = Mutil.extract_param "referer: " '\n' request in
   let user_agent = Mutil.extract_param "user-agent: " '\n' request in
   let tm = Unix.localtime tm in
-  Printf.fprintf oc
-    "%s (%d) %s?" (Mutil.sprintf_date tm :> string) (Unix.getpid ()) script_name ;
+  Printf.fprintf oc "%s (%d) %s?"
+    (Mutil.sprintf_date tm :> string)
+    (Unix.getpid ()) script_name;
   print_and_cut_if_too_big oc contents;
   output_char oc '\n';
   Printf.fprintf oc "  From: %s\n" from;
@@ -1358,51 +1485,49 @@ let log tm conf from gauth request script_name contents =
     Printf.fprintf oc "  User: %s%s(friend)\n" conf.user
       (if conf.user = "" then "" else " ");
   if user_agent <> "" then Printf.fprintf oc "  Agent: %s\n" user_agent;
-  if referer <> "" then
-    begin
-      Printf.fprintf oc "  Referer: ";
-      print_and_cut_if_too_big oc referer;
-      Printf.fprintf oc "\n"
-    end
+  if referer <> "" then (
+    Printf.fprintf oc "  Referer: ";
+    print_and_cut_if_too_big oc referer;
+    Printf.fprintf oc "\n")
 
 let is_robot from =
   let lock_file = !GWPARAM.adm_file "gwd.lck" in
   (* FIXME: we silently ignore errors if we cannot lock the database. *)
   let on_exn _exn _bt = false in
   Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
-       let (robxcl, _) = Robot.robot_excl () in
-       List.mem_assoc from robxcl.Robot.excl
+  let robxcl, _ = Robot.robot_excl () in
+  List.mem_assoc from robxcl.Robot.excl
 
 let auth_err request auth_file =
-  if auth_file = "" then false, ""
+  if auth_file = "" then (false, "")
   else
     let auth = Mutil.extract_param "authorization: " '\r' request in
     if auth <> "" then
       match try Some (Secure.open_in auth_file) with Sys_error _ -> None with
-        Some ic ->
+      | Some ic -> (
           let auth =
             let i = String.length "Basic " in
             Base64.decode (String.sub auth i (String.length auth - i))
           in
-          begin try
+          try
             let rec loop () =
-              if auth = input_line ic then
-                begin
-                  close_in ic;
-                  let s =
-                    try
-                      let i = String.rindex auth ':' in String.sub auth 0 i
-                    with Not_found -> "..."
-                  in
-                  false, s
-                end
+              if auth = input_line ic then (
+                close_in ic;
+                let s =
+                  try
+                    let i = String.rindex auth ':' in
+                    String.sub auth 0 i
+                  with Not_found -> "..."
+                in
+                (false, s))
               else loop ()
             in
             loop ()
-          with End_of_file -> close_in ic; true, auth
-          end
-      | _ -> true, "(auth file '" ^ auth_file ^ "' not found)"
-    else true, "(authorization not provided)"
+          with End_of_file ->
+            close_in ic;
+            (true, auth))
+      | _ -> (true, "(auth file '" ^ auth_file ^ "' not found)")
+    else (true, "(authorization not provided)")
 
 let no_access conf =
   let title _ = Output.print_sstring conf "Error" in
@@ -1411,22 +1536,21 @@ let no_access conf =
   Hutil.trailer conf
 
 let log_and_robot_check conf auth from request script_name contents =
-  if !robot_xcl = None
-  then log (Unix.time ()) conf from auth request script_name contents
+  if !robot_xcl = None then
+    log (Unix.time ()) conf from auth request script_name contents
   else
     let lock_file = !GWPARAM.adm_file "gwd.lck" in
     (* FIXME: we silently ignore errors if we cannot lock the database. *)
     let on_exn _exn _bt = () in
     Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
-        let tm = Unix.time () in
-        begin match !robot_xcl with
-          | Some (cnt, sec) ->
-            let s = "suicide" in
-            let suicide = Util.p_getenv conf.env s <> None in
-            conf.n_connect <- Some (Robot.check tm from cnt sec conf suicide)
-          | _ -> ()
-        end;
-        log tm conf from auth request script_name contents
+    let tm = Unix.time () in
+    (match !robot_xcl with
+    | Some (cnt, sec) ->
+        let s = "suicide" in
+        let suicide = Util.p_getenv conf.env s <> None in
+        conf.n_connect <- Some (Robot.check tm from cnt sec conf suicide)
+    | _ -> ());
+    log tm conf from auth request script_name contents
 
 let conf_and_connection =
   let slow_query_threshold =
@@ -1439,74 +1563,74 @@ let conf_and_connection =
     ^<^ (if conf.wizard then "_w?" else if conf.friend then "_f?" else "?")
     ^<^ contents
   in
-  fun from request script_name (contents: Adef.encoded_string) env ->
-  let (conf, passwd_err) = make_conf from request script_name env in
-  match !redirected_addr with
-    Some addr -> print_redirected conf from request addr
-  | None ->
-      let (auth_err, auth) =
-        if conf.auth_file = "" then false, ""
-        else if !(Wserver.cgi) then true, ""
-        else auth_err request conf.auth_file
-      in
-      let mode = Util.p_getenv conf.env "m" in
-      if mode <> Some "IM" then begin
-          let contents =
-            if List.mem_assoc "log_pwd" env then Adef.encoded "..." else contents
-          in
-          log_and_robot_check conf auth from request script_name (contents :> string)
-        end;
-      match !(Wserver.cgi), auth_err, passwd_err with
-        true, true, _ ->
-          if is_robot from then Robot.robot_error conf 0 0
-          else no_access conf
-      | _, true, _ ->
-          if is_robot from then Robot.robot_error conf 0 0
-          else
-            let auth_type =
-              let x =
-                try List.assoc "auth_file" conf.base_env with Not_found -> ""
-              in
-              if x = "" then "GeneWeb service" else "database " ^ conf.bname
-            in
-            refuse_auth conf from auth auth_type
-      | _, _, ({ar_ok = false} as ar) ->
-          if is_robot from then Robot.robot_error conf 0 0
-          else
-            let tm = Unix.time () in
-            let lock_file = !GWPARAM.adm_file "gwd.lck" in
-            (* FIXME: we silently ignore errors if we cannot lock the database. *)
-            let on_exn _exn _bt = () in
-            Lock.control ~on_exn ~wait:true ~lock_file
-              (fun () -> log_passwd_failed ar tm from request conf.bname);
-            unauth_server conf ar
-      | _ ->
-        let printexc bt exn =
-          Logs.syslog `LOG_CRIT
-            ((context conf contents :> string) ^ " " ^ Printexc.to_string exn);
-          if Printexc.backtrace_status () then
-            let s = Format.sprintf "Backtrace:@ %s" bt in
-            Logs.syslog `LOG_CRIT s
+  fun from request script_name (contents : Adef.encoded_string) env ->
+    let conf, passwd_err = make_conf from request script_name env in
+    match !redirected_addr with
+    | Some addr -> print_redirected conf from request addr
+    | None -> (
+        let auth_err, auth =
+          if conf.auth_file = "" then (false, "")
+          else if !Wserver.cgi then (true, "")
+          else auth_err request conf.auth_file
         in
-        try
-          let t1 = Unix.gettimeofday () in
-          Request.treat_request conf ;
-          let t2 = Unix.gettimeofday () in
-          if t2 -. t1 > slow_query_threshold
-          then
-            Logs.syslog
-              `LOG_WARNING
-              (Printf.sprintf "%s slow query (%.3f)"
-                 (context conf contents : Adef.encoded_string :> string) (t2 -. t1))
-        with
-        | Exit -> ()
-        | (Def.HttpExn (code, _)) as exn ->
-          let bt = Printexc.get_backtrace () in
-          GWPARAM.output_error conf code ;
-          printexc bt exn
-        | exn ->
-          let bt = Printexc.get_backtrace () in
-          printexc bt exn
+        let mode = Util.p_getenv conf.env "m" in
+        (if mode <> Some "IM" then
+         let contents =
+           if List.mem_assoc "log_pwd" env then Adef.encoded "..." else contents
+         in
+         log_and_robot_check conf auth from request script_name
+           (contents :> string));
+        match (!Wserver.cgi, auth_err, passwd_err) with
+        | true, true, _ ->
+            if is_robot from then Robot.robot_error conf 0 0 else no_access conf
+        | _, true, _ ->
+            if is_robot from then Robot.robot_error conf 0 0
+            else
+              let auth_type =
+                let x =
+                  try List.assoc "auth_file" conf.base_env
+                  with Not_found -> ""
+                in
+                if x = "" then "GeneWeb service" else "database " ^ conf.bname
+              in
+              refuse_auth conf from auth auth_type
+        | _, _, ({ ar_ok = false } as ar) ->
+            if is_robot from then Robot.robot_error conf 0 0
+            else
+              let tm = Unix.time () in
+              let lock_file = !GWPARAM.adm_file "gwd.lck" in
+              (* FIXME: we silently ignore errors if we cannot lock the database. *)
+              let on_exn _exn _bt = () in
+              Lock.control ~on_exn ~wait:true ~lock_file (fun () ->
+                  log_passwd_failed ar tm from request conf.bname);
+              unauth_server conf ar
+        | _ -> (
+            let printexc bt exn =
+              Logs.syslog `LOG_CRIT
+                ((context conf contents :> string)
+                ^ " " ^ Printexc.to_string exn);
+              if Printexc.backtrace_status () then
+                let s = Format.sprintf "Backtrace:@ %s" bt in
+                Logs.syslog `LOG_CRIT s
+            in
+            try
+              let t1 = Unix.gettimeofday () in
+              Request.treat_request conf;
+              let t2 = Unix.gettimeofday () in
+              if t2 -. t1 > slow_query_threshold then
+                Logs.syslog `LOG_WARNING
+                  (Printf.sprintf "%s slow query (%.3f)"
+                     (context conf contents : Adef.encoded_string :> string)
+                     (t2 -. t1))
+            with
+            | Exit -> ()
+            | Def.HttpExn (code, _) as exn ->
+                let bt = Printexc.get_backtrace () in
+                GWPARAM.output_error conf code;
+                printexc bt exn
+            | exn ->
+                let bt = Printexc.get_backtrace () in
+                printexc bt exn))
 
 let chop_extension name =
   let rec loop i =
@@ -1526,7 +1650,7 @@ let match_strings regexp s =
     else if regexp.[i] = s.[j] then loop (i + 1) (j + 1)
     else if regexp.[i] = '*' then
       if i + 1 = String.length regexp then true
-      else if regexp.[i+1] = s.[j] then loop (i + 2) (j + 1)
+      else if regexp.[i + 1] = s.[j] then loop (i + 2) (j + 1)
       else loop i (j + 1)
     else false
   in
@@ -1538,22 +1662,27 @@ let excluded from =
     let ic = open_in efname in
     let rec loop () =
       match input_line ic with
-      | line when match_strings line from -> close_in ic ; true
+      | line when match_strings line from ->
+          close_in ic;
+          true
       | _ -> loop ()
-      | exception End_of_file -> close_in ic ; false
+      | exception End_of_file ->
+          close_in ic;
+          false
     in
     loop ()
   with Sys_error _ -> false
 
 let image_request conf script_name env =
-  match Util.p_getenv env "m", Util.p_getenv env "v" with
-    Some "IM", Some fname ->
+  match (Util.p_getenv env "m", Util.p_getenv env "v") with
+  | Some "IM", Some fname ->
       let fname =
         if fname.[0] = '/' then String.sub fname 1 (String.length fname - 1)
         else fname
       in
-      let `Path fname = Image.path_of_filename conf fname in
-      let _ = ImageDisplay.print_image_file conf fname in true
+      let (`Path fname) = Image.path_of_filename conf fname in
+      let _ = ImageDisplay.print_image_file conf fname in
+      true
   | _ ->
       let s = script_name in
       if Mutil.start_with "images/" 0 s then
@@ -1563,8 +1692,9 @@ let image_request conf script_name env =
         (* empeche d'avoir des images qui se trouvent dans le dossier   *)
         (* image. Si on ne fait pas de basename, alors ça marche.       *)
         (* let fname = Filename.basename fname in *)
-        let `Path fname = Image.path_of_filename conf fname in
-        let _ = ImageDisplay.print_image_file conf fname in true
+        let (`Path fname) = Image.path_of_filename conf fname in
+        let _ = ImageDisplay.print_image_file conf fname in
+        true
       else false
 
 (* Une version un peu à cheval entre avant et maintenant afin de   *)
@@ -1586,20 +1716,20 @@ type misc_fname =
 
 let content_misc conf len misc_fname =
   Output.status conf Def.OK;
-  let (fname, t) =
+  let fname, t =
     match misc_fname with
-    | Css fname -> fname, "text/css; charset=UTF-8"
-    | Eot fname -> fname, "application/font-eot"
-    | Js fname -> fname, "text/javascript; charset=UTF-8"
-    | Map fname -> fname, "application/json"
-    | Otf fname -> fname, "application/font-otf"
-    | Other fname -> fname, "text/plain"
-    | Png fname -> fname, "image/png"
-    | Svg fname -> fname, "application/font-svg"
-    | Ttf fname -> fname, "application/font-ttf"
-    | Woff fname -> fname, "application/font-woff"
-    | Woff2 fname -> fname, "application/font-woff2"
-    | CacheGz fname -> fname, "application/gzip"
+    | Css fname -> (fname, "text/css; charset=UTF-8")
+    | Eot fname -> (fname, "application/font-eot")
+    | Js fname -> (fname, "text/javascript; charset=UTF-8")
+    | Map fname -> (fname, "application/json")
+    | Otf fname -> (fname, "application/font-otf")
+    | Other fname -> (fname, "text/plain")
+    | Png fname -> (fname, "image/png")
+    | Svg fname -> (fname, "application/font-svg")
+    | Ttf fname -> (fname, "application/font-ttf")
+    | Woff fname -> (fname, "application/font-woff")
+    | Woff2 fname -> (fname, "application/font-woff2")
+    | CacheGz fname -> (fname, "application/gzip")
   in
   Output.header conf "Content-type: %s" t;
   Output.header conf "Content-length: %d" len;
@@ -1609,57 +1739,64 @@ let content_misc conf len misc_fname =
   Output.flush conf
 
 let find_misc_file conf name =
-  if Sys.file_exists name
-  && List.exists (fun p -> Mutil.start_with (Filename.concat p "assets") 0 name) !plugins
+  if
+    Sys.file_exists name
+    && List.exists
+         (fun p -> Mutil.start_with (Filename.concat p "assets") 0 name)
+         !plugins
   then name
   else
     let name' = Filename.concat (!GWPARAM.etc_d conf.bname) name in
     if Sys.file_exists name' then name'
     else
       let name' = Util.search_in_assets @@ Filename.concat "etc" name in
-      if Sys.file_exists name' then name'
-      else ""
+      if Sys.file_exists name' then name' else ""
 
 let print_misc_file conf misc_fname =
   match misc_fname with
-    Css fname | Js fname | Otf fname | Svg fname | Woff fname | Eot fname |
-    Ttf fname | Woff2 fname | CacheGz fname ->
-      begin
-        try
-          let ic = Secure.open_in_bin fname in
-          let buf = Bytes.create 1024 in
-          let len = in_channel_length ic in
-          content_misc conf len misc_fname;
-          let rec loop len =
-            if len = 0 then ()
-            else
-              let olen = min (Bytes.length buf) len in
-              really_input ic buf 0 olen;
-              Wserver.printf "%s" (Bytes.sub_string buf 0 olen);
-              loop (len - olen)
-          in
-          loop len; close_in ic; true
-        with Sys_error _ -> false
-      end
+  | Css fname
+  | Js fname
+  | Otf fname
+  | Svg fname
+  | Woff fname
+  | Eot fname
+  | Ttf fname
+  | Woff2 fname
+  | CacheGz fname -> (
+      try
+        let ic = Secure.open_in_bin fname in
+        let buf = Bytes.create 1024 in
+        let len = in_channel_length ic in
+        content_misc conf len misc_fname;
+        let rec loop len =
+          if len = 0 then ()
+          else
+            let olen = min (Bytes.length buf) len in
+            really_input ic buf 0 olen;
+            Wserver.printf "%s" (Bytes.sub_string buf 0 olen);
+            loop (len - olen)
+        in
+        loop len;
+        close_in ic;
+        true
+      with Sys_error _ -> false)
   | Other _ -> false
-  | Map fname
-  | Png fname
-    ->
-    let ic = Secure.open_in_bin fname in
-    let buf = Bytes.create 1024 in
-    let len = in_channel_length ic in
-    content_misc conf len misc_fname;
-    let rec loop len =
-      if len = 0 then ()
-      else
-        let olen = min (Bytes.length buf) len in
-        really_input ic buf 0 olen;
-        Output.print_sstring conf (Bytes.sub_string buf 0 olen);
-        loop (len - olen)
-    in
-    loop len;
-    close_in ic;
-    true
+  | Map fname | Png fname ->
+      let ic = Secure.open_in_bin fname in
+      let buf = Bytes.create 1024 in
+      let len = in_channel_length ic in
+      content_misc conf len misc_fname;
+      let rec loop len =
+        if len = 0 then ()
+        else
+          let olen = min (Bytes.length buf) len in
+          really_input ic buf 0 olen;
+          Output.print_sstring conf (Bytes.sub_string buf 0 olen);
+          loop (len - olen)
+      in
+      loop len;
+      close_in ic;
+      true
 
 let misc_request conf fname =
   let fname = find_misc_file conf fname in
@@ -1700,7 +1837,7 @@ let extract_multipart boundary str =
   let next_line i =
     let i = skip_nl i in
     let rec loop s i =
-      if i = String.length str || str.[i] = '\n' || str.[i] = '\r' then s, i
+      if i = String.length str || str.[i] = '\n' || str.[i] = '\r' then (s, i)
       else loop (s ^ String.make 1 str.[i]) (i + 1)
     in
     loop "" i
@@ -1709,25 +1846,26 @@ let extract_multipart boundary str =
   let rec loop i =
     if i = String.length str then []
     else
-      let (s, i) = next_line i in
+      let s, i = next_line i in
       if s = boundary then
-        let (s, i) = next_line i in
+        let s, i = next_line i in
         let s = String.lowercase_ascii s |> Adef.encoded in
         let env = Util.create_env s in
-        match Util.p_getenv env "name", Util.p_getenv env "filename" with
-          Some var, Some filename ->
+        match (Util.p_getenv env "name", Util.p_getenv env "filename") with
+        | Some var, Some filename ->
             let var = strip_quotes var in
             let filename = strip_quotes filename in
             let i = skip_nl i in
             let i1 =
               let rec loop i =
                 if i < String.length str then
-                  if i > String.length boundary &&
-                     String.sub str (i - String.length boundary)
-                       (String.length boundary) =
-                       boundary
-                  then
-                    i - String.length boundary
+                  if
+                    i > String.length boundary
+                    && String.sub str
+                         (i - String.length boundary)
+                         (String.length boundary)
+                       = boundary
+                  then i - String.length boundary
                   else loop (i + 1)
                 else i
               in
@@ -1739,9 +1877,9 @@ let extract_multipart boundary str =
             :: loop i1
         | Some var, None ->
             let var = strip_quotes var in
-            let (s, i) = next_line i in
+            let s, i = next_line i in
             if s = "" then
-              let (s, i) = next_line i in
+              let s, i = next_line i in
               (var, Adef.encoded s) :: loop i
             else loop i
         | _ -> loop i
@@ -1749,111 +1887,112 @@ let extract_multipart boundary str =
       else loop i
   in
   let env = loop 0 in
-  let (str, _) =
+  let str, _ =
     List.fold_left
       (fun (str, sep) (v, x) ->
-         if v = "file" then str, sep else str ^^^ sep ^<^ v ^<^ "=" ^<^ x, "&")
-      (Adef.encoded "", "") env
+        if v = "file" then (str, sep) else (str ^^^ sep ^<^ v ^<^ "=" ^<^ x, "&"))
+      (Adef.encoded "", "")
+      env
   in
-  str, env
+  (str, env)
 
-let build_env request (contents : Adef.encoded_string)
-  : Adef.encoded_string * (string * Adef.encoded_string) list =
+let build_env request (contents : Adef.encoded_string) :
+    Adef.encoded_string * (string * Adef.encoded_string) list =
   let content_type = Mutil.extract_param "content-type: " '\n' request in
   if is_multipart_form content_type then
-    let boundary = (extract_boundary (Adef.encoded content_type) : Adef.encoded_string :> string) in
+    let boundary =
+      (extract_boundary (Adef.encoded content_type)
+        : Adef.encoded_string
+        :> string)
+    in
     extract_multipart boundary contents
-  else contents, Util.create_env contents
+  else (contents, Util.create_env contents)
 
 let connection (addr, request) script_name contents0 =
   let from =
     match addr with
-      Unix.ADDR_UNIX x -> x
-    | Unix.ADDR_INET (iaddr, _) ->
+    | Unix.ADDR_UNIX x -> x
+    | Unix.ADDR_INET (iaddr, _) -> (
         if !no_host_address then Unix.string_of_inet_addr iaddr
         else
-          try (Unix.gethostbyaddr iaddr).Unix.h_name with
-            _ -> Unix.string_of_inet_addr iaddr
+          try (Unix.gethostbyaddr iaddr).Unix.h_name
+          with _ -> Unix.string_of_inet_addr iaddr)
   in
   if script_name = "robots.txt" then robots_txt printer_conf
   else if excluded from then refuse_log printer_conf from
   else
-    begin
-      let accept =
-        if !only_addresses = [] then true else List.mem from !only_addresses
+    let accept =
+      if !only_addresses = [] then true else List.mem from !only_addresses
     in
-      if not accept then only_log printer_conf from
-      else
-        try
-          let (contents, env) = build_env request contents0 in
-          if not (image_request printer_conf script_name env)
+    if not accept then only_log printer_conf from
+    else
+      try
+        let contents, env = build_env request contents0 in
+        if
+          (not (image_request printer_conf script_name env))
           && not (misc_request printer_conf script_name)
-          then
-            conf_and_connection from request script_name contents env
-        with Exit -> ()
-    end
+        then conf_and_connection from request script_name contents env
+      with Exit -> ()
 
 let null_reopen flags fd =
-  if Sys.unix then
+  if Sys.unix then (
     let fd2 = Unix.openfile "/dev/null" flags 0 in
-    Unix.dup2 fd2 fd; Unix.close fd2
+    Unix.dup2 fd2 fd;
+    Unix.close fd2)
 
 let geneweb_server () =
   let auto_call =
-    try let _ = Sys.getenv "WSERVER" in true with Not_found -> false
+    try
+      let _ = Sys.getenv "WSERVER" in
+      true
+    with Not_found -> false
   in
-  if not auto_call then begin
+  if not auto_call then (
     let hostn =
       match !selected_addr with
-        Some addr -> addr
-      | None -> try Unix.gethostname () with _ -> "computer"
+      | Some addr -> addr
+      | None -> ( try Unix.gethostname () with _ -> "computer")
     in
-      Printf.eprintf "GeneWeb %s - " Version.ver;
-      if not !daemon then
-        begin
-          Printf.eprintf "Possible addresses:\n\
-                  http://localhost:%d/base\n\
-                  http://127.0.0.1:%d/base\n\
-                  http://%s:%d/base\n"
-            !selected_port !selected_port hostn !selected_port;
-          Printf.eprintf "where \"base\" is the name of the database\n\
-                   Type “Ctrl+C” to stop the service\n";
-          if !debug then ( (* taken from Michel Normand commit 1874dcbf7 *)
-          Printf.eprintf "gwd parameters (after GWPARAM.init & cache_lexicon):\n";
-          Printf.eprintf "  source: %s\n" Version.src;
-          Printf.eprintf "  branch: %s\n" Version.branch;
-          Printf.eprintf "  commit: %s\n" Version.commit_id;
-          Printf.eprintf "  gwd: %s\n" Sys.argv.(0);
-          Printf.eprintf "  current_dir_name: %s\n" (Sys.getcwd ());
-          Printf.eprintf "  gw_prefix: %s\n" !gw_prefix;
-          Printf.eprintf "  etc_prefix: %s\n" !etc_prefix;
-          Printf.eprintf "  images_prefix: %s\n" !images_prefix;
-          Printf.eprintf "  images_dir: %s\n" !images_dir;
-          List.iter
-            (fun a -> Printf.eprintf "  secure asset: %s\n" a) (Secure.assets ());
-          Printf.eprintf "TODO: how to print content of conf ?\n";)
-        end;
-      flush stderr;
-      if !daemon then
-        if Unix.fork () = 0 then
-          begin
-            Unix.close Unix.stdin;
-            null_reopen [Unix.O_WRONLY] Unix.stdout;
-            null_reopen [Unix.O_WRONLY] Unix.stderr
-          end
-        else exit 0;
-        try
-          Filesystem.create_dir ~parent:true ~required_perm:0o755 !GWPARAM.cnt_dir
-        with Sys_error e ->
-          Logs.err (fun k -> k "failure creating %s:@ %s" !GWPARAM.cnt_dir e)
-    end;
+    Printf.eprintf "GeneWeb %s - " Version.ver;
+    if not !daemon then (
+      Printf.eprintf
+        "Possible addresses:\n\
+         http://localhost:%d/base\n\
+         http://127.0.0.1:%d/base\n\
+         http://%s:%d/base\n"
+        !selected_port !selected_port hostn !selected_port;
+      Printf.eprintf
+        "where \"base\" is the name of the database\n\
+         Type “Ctrl+C” to stop the service\n";
+      if !debug then (
+        (* taken from Michel Normand commit 1874dcbf7 *)
+        Printf.eprintf "gwd parameters (after GWPARAM.init & cache_lexicon):\n";
+        Printf.eprintf "  source: %s\n" Version.src;
+        Printf.eprintf "  branch: %s\n" Version.branch;
+        Printf.eprintf "  commit: %s\n" Version.commit_id;
+        Printf.eprintf "  gwd: %s\n" Sys.argv.(0);
+        Printf.eprintf "  current_dir_name: %s\n" (Sys.getcwd ());
+        Printf.eprintf "  gw_prefix: %s\n" !gw_prefix;
+        Printf.eprintf "  etc_prefix: %s\n" !etc_prefix;
+        Printf.eprintf "  images_prefix: %s\n" !images_prefix;
+        Printf.eprintf "  images_dir: %s\n" !images_dir;
+        List.iter
+          (fun a -> Printf.eprintf "  secure asset: %s\n" a)
+          (Secure.assets ());
+        Printf.eprintf "TODO: how to print content of conf ?\n"));
+    flush stderr;
+    if !daemon then
+      if Unix.fork () = 0 then (
+        Unix.close Unix.stdin;
+        null_reopen [ Unix.O_WRONLY ] Unix.stdout;
+        null_reopen [ Unix.O_WRONLY ] Unix.stderr)
+      else exit 0;
+    try Filesystem.create_dir ~parent:true ~required_perm:0o755 !GWPARAM.cnt_dir
+    with Sys_error e ->
+      Logs.err (fun k -> k "failure creating %s:@ %s" !GWPARAM.cnt_dir e));
   let with_salt = not !predictable_mode in
-  Wserver.start
-    ~with_salt
-    ?addr:!selected_addr
-    ~port:!selected_port
-    ~timeout:!conn_timeout
-    ~max_pending_requests:!max_pending_requests
+  Wserver.start ~with_salt ?addr:!selected_addr ~port:!selected_port
+    ~timeout:!conn_timeout ~max_pending_requests:!max_pending_requests
     ~n_workers:!n_workers connection
 
 let cgi_timeout conf tmout _ =
@@ -1867,14 +2006,16 @@ let cgi_timeout conf tmout _ =
 
 let manage_cgi_timeout tmout =
   if tmout > 0 then
-    let _ = Sys.signal Sys.sigalrm (Sys.Signal_handle (cgi_timeout printer_conf tmout)) in
-    let _ = Unix.alarm tmout in ()
+    let _ =
+      Sys.signal Sys.sigalrm
+        (Sys.Signal_handle (cgi_timeout printer_conf tmout))
+    in
+    let _ = Unix.alarm tmout in
+    ()
 
 let geneweb_cgi addr script_name contents =
   if Sys.unix then manage_cgi_timeout !conn_timeout;
-  begin try Unix.mkdir !GWPARAM.cnt_dir 0o755 with
-    Unix.Unix_error (_, _, _) -> ()
-  end;
+  (try Unix.mkdir !GWPARAM.cnt_dir 0o755 with Unix.Unix_error (_, _, _) -> ());
   let add k x request =
     try
       let v = Sys.getenv x in
@@ -1893,36 +2034,37 @@ let read_input len =
   if len >= 0 then really_input_string stdin len
   else
     let buff = Buffer.create 0 in
-    begin try
-      while true do let l = input_line stdin in Buffer.add_string buff l done
-    with End_of_file -> ()
-    end;
+    (try
+       while true do
+         let l = input_line stdin in
+         Buffer.add_string buff l
+       done
+     with End_of_file -> ());
     Buffer.contents buff
 
 let arg_parse_in_file fname speclist anonfun errmsg =
   try
     let ic = open_in fname in
     let list =
-      let rec loop acc = match input_line ic with
+      let rec loop acc =
+        match input_line ic with
         | line -> loop (if line <> "" then line :: acc else acc)
         | exception End_of_file ->
-          close_in ic ;
-          List.rev acc
-      in loop []
+            close_in ic;
+            List.rev acc
+      in
+      loop []
     in
     let list =
-      match list with
-        [x] -> Gutil.arg_list_of_string x
-      | _ -> list
+      match list with [ x ] -> Gutil.arg_list_of_string x | _ -> list
     in
-    Arg.parse_argv
-      ~current:(ref 0) (Array.of_list @@ Sys.argv.(0) :: list)
+    Arg.parse_argv ~current:(ref 0)
+      (Array.of_list @@ (Sys.argv.(0) :: list))
       speclist anonfun errmsg
   with Sys_error _ -> ()
 
 let robot_exclude_arg s =
-  try
-    robot_xcl := Scanf.sscanf s "%d,%d" (fun cnt sec -> Some (cnt, sec))
+  try robot_xcl := Scanf.sscanf s "%d,%d" (fun cnt sec -> Some (cnt, sec))
   with _ ->
     Printf.eprintf "Bad use of option -robot_xcl\n";
     Printf.eprintf "Use option -help for usage.\n";
@@ -1930,83 +2072,81 @@ let robot_exclude_arg s =
     exit 2
 
 let slashify s =
-  let conv_char i =
-    match s.[i] with
-      '\\' -> '/'
-    | x -> x
-  in
+  let conv_char i = match s.[i] with '\\' -> '/' | x -> x in
   String.init (String.length s) conv_char
 
 let make_sock_dir x =
   Filesystem.create_dir ~parent:true x;
   if Sys.unix then ()
-  else
-    begin
-      Wserver.sock_in := Filename.concat x "gwd.sin";
-      Wserver.sock_out := Filename.concat x "gwd.sou"
-    end;
+  else (
+    Wserver.sock_in := Filename.concat x "gwd.sin";
+    Wserver.sock_out := Filename.concat x "gwd.sou");
   GWPARAM.sock_dir := x
 
 let arg_plugin_doc opt doc =
-  doc ^ " Combine with -force to enable for every base. \
-         Combine with -unsafe to allow unverified plugins. \
-         e.g. \"" ^ opt ^ " -unsafe -force\"."
+  doc
+  ^ " Combine with -force to enable for every base. Combine with -unsafe to \
+     allow unverified plugins. e.g. \"" ^ opt ^ " -unsafe -force\"."
 
 let arg_plugin_aux () =
   let aux (unsafe, force, p) =
-    incr Arg.current ;
-    assert (!Arg.current < Array.length Sys.argv) ;
+    incr Arg.current;
+    assert (!Arg.current < Array.length Sys.argv);
     match Sys.argv.(!Arg.current) with
-    | "-unsafe" -> (true ,force, p)
-    |  "-force" -> (unsafe, true, p)
-    |        p' -> assert (p = "") ; (unsafe, force, p')
+    | "-unsafe" -> (true, force, p)
+    | "-force" -> (unsafe, true, p)
+    | p' ->
+        assert (p = "");
+        (unsafe, force, p')
   in
-  let rec loop ( (_, _, p) as acc ) = if p = "" then loop (aux acc) else acc in
+  let rec loop ((_, _, p) as acc) = if p = "" then loop (aux acc) else acc in
   loop (false, false, "")
 
 let arg_plugin opt doc =
-  ( opt
-  , Arg.Unit begin fun () ->
-      let (unsafe, force, s) = arg_plugin_aux () in
-      if unsafe then unsafe_plugins := !unsafe_plugins @ [s] ;
-      if force then forced_plugins := !forced_plugins @ [ Filename.basename s ] ;
-      plugins := !plugins @ [s]
-    end
-  , arg_plugin_doc opt doc
-  )
+  ( opt,
+    Arg.Unit
+      (fun () ->
+        let unsafe, force, s = arg_plugin_aux () in
+        if unsafe then unsafe_plugins := !unsafe_plugins @ [ s ];
+        if force then
+          forced_plugins := !forced_plugins @ [ Filename.basename s ];
+        plugins := !plugins @ [ s ]),
+    arg_plugin_doc opt doc )
 
 let arg_plugins opt doc =
-  ( opt
-  , Arg.Unit begin fun () ->
-      let (unsafe, force, s) = arg_plugin_aux () in
-      let ps = Array.to_list (Sys.readdir s) in
-      let deps_ht = Hashtbl.create 0 in
-      let deps =
-        List.map begin fun pname ->
-          let dir = Filename.concat s pname in
-          if not unsafe && not (GwdPluginMD5.allowed dir) then failwith s ;
-          Hashtbl.add deps_ht pname dir ;
-          let f = Filename.concat dir "META" in
-          if Sys.file_exists f
-          then (pname, GwdPluginMETA.((parse f).depends))
-          else (pname, [])
-        end ps
-      in
-      begin match GwdPluginDep.sort deps with
+  ( opt,
+    Arg.Unit
+      (fun () ->
+        let unsafe, force, s = arg_plugin_aux () in
+        let ps = Array.to_list (Sys.readdir s) in
+        let deps_ht = Hashtbl.create 0 in
+        let deps =
+          List.map
+            (fun pname ->
+              let dir = Filename.concat s pname in
+              if (not unsafe) && not (GwdPluginMD5.allowed dir) then failwith s;
+              Hashtbl.add deps_ht pname dir;
+              let f = Filename.concat dir "META" in
+              if Sys.file_exists f then
+                (pname, GwdPluginMETA.((parse f).depends))
+              else (pname, []))
+            ps
+        in
+        match GwdPluginDep.sort deps with
         | GwdPluginDep.ErrorCycle _ -> assert false
         | GwdPluginDep.Sorted deps ->
-          List.iter begin fun pname ->
-            try
-              let s = Hashtbl.find deps_ht pname in
-              if unsafe then unsafe_plugins := !unsafe_plugins @ [s] ;
-              if force then forced_plugins := !forced_plugins @ [pname] ;
-              plugins := !plugins @ [s]
-            with Not_found -> raise (Register_plugin_failure (pname, `string ("Missing plugin")))
-          end deps
-      end
-    end
-  , arg_plugin_doc opt doc
-  )
+            List.iter
+              (fun pname ->
+                try
+                  let s = Hashtbl.find deps_ht pname in
+                  if unsafe then unsafe_plugins := !unsafe_plugins @ [ s ];
+                  if force then forced_plugins := !forced_plugins @ [ pname ];
+                  plugins := !plugins @ [ s ]
+                with Not_found ->
+                  raise
+                    (Register_plugin_failure (pname, `string "Missing plugin")))
+              deps),
+    arg_plugin_doc opt doc )
 
 let print_version_commit () =
   Printf.printf "Geneweb version %s\nRepository %s\n" Version.ver Version.src;
@@ -2018,192 +2158,306 @@ let set_debug_flag () =
   Logs.debug_flag := true;
   Printexc.record_backtrace true
 
-let set_verbosity_level lvl =
-  Logs.verbosity_level := lvl
+let set_verbosity_level lvl = Logs.verbosity_level := lvl
 
 let set_predictable_mode () =
-  Logs.warn (fun k -> k "Predictable mode must not be enabled in production. \
-    It disables security enhancements.");
+  Logs.warn (fun k ->
+      k
+        "Predictable mode must not be enabled in production. It disables \
+         security enhancements.");
   predictable_mode := true
 
 let main () =
-  if not Sys.unix then begin
+  if not Sys.unix then (
     Wserver.sock_in := "gwd.sin";
-    Wserver.sock_out := "gwd.sou";
-  end;
+    Wserver.sock_out := "gwd.sou");
   let usage =
-    "Usage: " ^ Filename.basename Sys.argv.(0) ^
-    " [options] where options are:"
+    "Usage: " ^ Filename.basename Sys.argv.(0) ^ " [options] where options are:"
   in
   let force_cgi = ref false in
   let speclist =
     [
-      ("-hd", Arg.String (fun x -> gw_prefix := x; Secure.add_assets x), "<DIR> Specify where the “etc”, “images” and “lang” directories are installed (default if empty is “gw”).")
-    ; ("-bd", Arg.String Secure.set_base_dir, "<DIR> Specify where the “bases” directory with databases is installed (default if empty is “bases”).")
-    ; ("-wd", Arg.String make_sock_dir, "<DIR> Directory for socket communication (Windows) and access count.")
-    ; ("-cache_langs", Arg.String (fun s -> List.iter (Mutil.list_ref_append cache_langs) @@ String.split_on_char ',' s), " Lexicon languages to be cached.")
-    ; ("-cgi", Arg.Set force_cgi, " Force CGI mode.")
-    ; ("-etc_prefix", Arg.String (fun x -> etc_prefix := x; Secure.add_assets x), "<DIR> Specify where the “etc” directory is installed (default if empty is [-hd value]/etc).")
-    ; ("-images_prefix", Arg.String (fun x -> images_prefix := x), "<DIR> Specify where the “images” directory is installed (default if empty is [-hd value]/images).")
-    ; ("-images_dir", Arg.String (fun x -> images_dir := x), "<DIR> Same than previous but directory name relative to current.")
-    ; ("-a", Arg.String (fun x -> selected_addr := Some x), "<ADDRESS> Select a specific address (default = any address of this computer).")
-    ; ("-p", Arg.Int (fun x -> selected_port := x), "<NUMBER> Select a port number (default = " ^ string_of_int !selected_port ^ ").")
-    ; ("-setup_link", Arg.Set setup_link, " Display a link to local gwsetup in bottom of pages.")
-    ; ("-allowed_tags", Arg.String (fun x -> Util.allowed_tags_file := x), "<FILE> HTML tags which are allowed to be displayed. One tag per line in file.")
-    ; ("-wizard", Arg.String (fun x -> wizard_passwd := x), "<PASSWD> Set a wizard password.")
-    ; ("-friend", Arg.String (fun x -> friend_passwd := x), "<PASSWD> Set a friend password.")
-    ; ("-wjf", Arg.Set wizard_just_friend, " Wizard just friend (permanently).")
-    ; ("-lang", Arg.String (fun x -> default_lang := x), "<LANG> Set a default language (default: " ^ !default_lang ^ ").")
-    ; ("-blang", Arg.Set choose_browser_lang, " Select the user browser language if any.")
-    ; ("-only", Arg.String (fun x -> only_addresses := x :: !only_addresses), "<ADDRESS> Only inet address accepted.")
-    ; ("-auth", Arg.String (fun x -> auth_file := x), "<FILE> Authorization file to restrict access. The file must hold lines of the form \"user:password\".")
-    ; ("-no_host_address", Arg.Set no_host_address, " Force no reverse host by address.")
-    ; ("-digest", Arg.Set use_auth_digest_scheme, " Use Digest authorization scheme (more secure on passwords)")
-    ; ("-add_lexicon", Arg.String (Mutil.list_ref_append lexicon_list), "<FILE> Add file as lexicon.")
-    ; ("-log", Arg.String (fun x -> Logs.oc := Some (match x with "-" | "<stdout>" -> stdout | "2" | "<stderr>" -> stderr | _ -> open_out x)), {|<FILE> Log trace to this file. Use "-" or "<stdout>" to redirect output to stdout or "<stderr>" to output log to stderr.|})
-    ; ("-log_level", Arg.Int set_verbosity_level, {|<N> Send messages with severity <= <N> to syslog (default: |} ^ string_of_int !Logs.verbosity_level ^ {|).|})
-    ; ("-robot_xcl", Arg.String robot_exclude_arg, "<CNT>,<SEC> Exclude connections when more than <CNT> requests in <SEC> seconds.")
-    ; ("-min_disp_req", Arg.Int (fun x -> Robot.min_disp_req := x), " Minimum number of requests in robot trace (default: " ^ string_of_int !(Robot.min_disp_req) ^ ").")
-    ; ("-login_tmout", Arg.Int (fun x -> login_timeout := x), "<SEC> Login timeout for entries with passwords in CGI mode (default " ^ string_of_int !login_timeout ^ "s).")
-    ; ("-redirect", Arg.String (fun x -> redirected_addr := Some x), "<ADDR> Send a message to say that this service has been redirected to <ADDR>.")
-    ; ("-trace_failed_passwd", Arg.Set trace_failed_passwd, " Print the failed passwords in log (except if option -digest is set). ")
-    ; ("-debug", Arg.Unit set_debug_flag, " Enable debug mode")
-    ; ("-nolock", Arg.Set Lock.no_lock_flag, " Do not lock files before writing.")
-    ; (arg_plugin "-plugin" "<PLUGIN>.cmxs load a safe plugin." )
-    ; (arg_plugins "-plugins" "<DIR> load all plugins in <DIR>.")
-    ; ("-version", Arg.Unit print_version_commit, " Print the Geneweb version, the source repository and last commit id and message.")
+      ( "-hd",
+        Arg.String
+          (fun x ->
+            gw_prefix := x;
+            Secure.add_assets x),
+        "<DIR> Specify where the “etc”, “images” and “lang” directories are \
+         installed (default if empty is “gw”)." );
+      ( "-bd",
+        Arg.String Secure.set_base_dir,
+        "<DIR> Specify where the “bases” directory with databases is installed \
+         (default if empty is “bases”)." );
+      ( "-wd",
+        Arg.String make_sock_dir,
+        "<DIR> Directory for socket communication (Windows) and access count."
+      );
+      ( "-cache_langs",
+        Arg.String
+          (fun s ->
+            List.iter (Mutil.list_ref_append cache_langs)
+            @@ String.split_on_char ',' s),
+        " Lexicon languages to be cached." );
+      ("-cgi", Arg.Set force_cgi, " Force CGI mode.");
+      ( "-etc_prefix",
+        Arg.String
+          (fun x ->
+            etc_prefix := x;
+            Secure.add_assets x),
+        "<DIR> Specify where the “etc” directory is installed (default if \
+         empty is [-hd value]/etc)." );
+      ( "-images_prefix",
+        Arg.String (fun x -> images_prefix := x),
+        "<DIR> Specify where the “images” directory is installed (default if \
+         empty is [-hd value]/images)." );
+      ( "-images_dir",
+        Arg.String (fun x -> images_dir := x),
+        "<DIR> Same than previous but directory name relative to current." );
+      ( "-a",
+        Arg.String (fun x -> selected_addr := Some x),
+        "<ADDRESS> Select a specific address (default = any address of this \
+         computer)." );
+      ( "-p",
+        Arg.Int (fun x -> selected_port := x),
+        "<NUMBER> Select a port number (default = "
+        ^ string_of_int !selected_port
+        ^ ")." );
+      ( "-setup_link",
+        Arg.Set setup_link,
+        " Display a link to local gwsetup in bottom of pages." );
+      ( "-allowed_tags",
+        Arg.String (fun x -> Util.allowed_tags_file := x),
+        "<FILE> HTML tags which are allowed to be displayed. One tag per line \
+         in file." );
+      ( "-wizard",
+        Arg.String (fun x -> wizard_passwd := x),
+        "<PASSWD> Set a wizard password." );
+      ( "-friend",
+        Arg.String (fun x -> friend_passwd := x),
+        "<PASSWD> Set a friend password." );
+      ("-wjf", Arg.Set wizard_just_friend, " Wizard just friend (permanently).");
+      ( "-lang",
+        Arg.String (fun x -> default_lang := x),
+        "<LANG> Set a default language (default: " ^ !default_lang ^ ")." );
+      ( "-blang",
+        Arg.Set choose_browser_lang,
+        " Select the user browser language if any." );
+      ( "-only",
+        Arg.String (fun x -> only_addresses := x :: !only_addresses),
+        "<ADDRESS> Only inet address accepted." );
+      ( "-auth",
+        Arg.String (fun x -> auth_file := x),
+        "<FILE> Authorization file to restrict access. The file must hold \
+         lines of the form \"user:password\"." );
+      ( "-no_host_address",
+        Arg.Set no_host_address,
+        " Force no reverse host by address." );
+      ( "-digest",
+        Arg.Set use_auth_digest_scheme,
+        " Use Digest authorization scheme (more secure on passwords)" );
+      ( "-add_lexicon",
+        Arg.String (Mutil.list_ref_append lexicon_list),
+        "<FILE> Add file as lexicon." );
+      ( "-log",
+        Arg.String
+          (fun x ->
+            Logs.oc :=
+              Some
+                (match x with
+                | "-" | "<stdout>" -> stdout
+                | "2" | "<stderr>" -> stderr
+                | _ -> open_out x)),
+        {|<FILE> Log trace to this file. Use "-" or "<stdout>" to redirect output to stdout or "<stderr>" to output log to stderr.|}
+      );
+      ( "-log_level",
+        Arg.Int set_verbosity_level,
+        {|<N> Send messages with severity <= <N> to syslog (default: |}
+        ^ string_of_int !Logs.verbosity_level
+        ^ {|).|} );
+      ( "-robot_xcl",
+        Arg.String robot_exclude_arg,
+        "<CNT>,<SEC> Exclude connections when more than <CNT> requests in \
+         <SEC> seconds." );
+      ( "-min_disp_req",
+        Arg.Int (fun x -> Robot.min_disp_req := x),
+        " Minimum number of requests in robot trace (default: "
+        ^ string_of_int !Robot.min_disp_req
+        ^ ")." );
+      ( "-login_tmout",
+        Arg.Int (fun x -> login_timeout := x),
+        "<SEC> Login timeout for entries with passwords in CGI mode (default "
+        ^ string_of_int !login_timeout
+        ^ "s)." );
+      ( "-redirect",
+        Arg.String (fun x -> redirected_addr := Some x),
+        "<ADDR> Send a message to say that this service has been redirected to \
+         <ADDR>." );
+      ( "-trace_failed_passwd",
+        Arg.Set trace_failed_passwd,
+        " Print the failed passwords in log (except if option -digest is set). "
+      );
+      ("-debug", Arg.Unit set_debug_flag, " Enable debug mode");
+      ( "-nolock",
+        Arg.Set Lock.no_lock_flag,
+        " Do not lock files before writing." );
+      arg_plugin "-plugin" "<PLUGIN>.cmxs load a safe plugin.";
+      arg_plugins "-plugins" "<DIR> load all plugins in <DIR>.";
+      ( "-version",
+        Arg.Unit print_version_commit,
+        " Print the Geneweb version, the source repository and last commit id \
+         and message." );
     ]
   in
   let speclist =
     if Sys.unix then
-      speclist @ [
-        ("-max_clients", Arg.Unit deprecated_warning_max_clients, "<NUM> Max number of clients treated at the same time (default: no limit) (not cgi) (DEPRECATED).");
-        ("-n_workers", Arg.Int (fun x -> n_workers := x), "<NUM> Number of workers used by the server (default: " ^ string_of_int default_n_workers ^ ")");
-        ("-max_pending_requests", Arg.Int (fun x -> max_pending_requests := x), "<NUM> Maximum number of pending requests (default: " ^ string_of_int default_max_pending_requests ^ ")");
-        ("-conn_tmout", Arg.Int (fun x -> conn_timeout := x), "<SEC> Connection timeout (only on Unix) (default " ^ string_of_int !conn_timeout ^ "s; 0 means no limit).");
-        ("-daemon", Arg.Set daemon, " Unix daemon mode.");
-        ("-no-fork", Arg.Unit (fun () -> deprecated_warning_no_fork (); n_workers := 0), " Prevent forking processes (DEPRECATED)");
-        ("-cache-in-memory", Arg.String (fun s ->
-            if Gw_ancient.is_available then
-              cache_databases := s::!cache_databases
-            else
-              failwith "-cache-in-memory option unavailable for this build."
-          ), "<DATABASE> Preload this database in memory");
-        ("-predictable_mode", Arg.Unit set_predictable_mode, " Turn on the predictable mode. In this mode, the behavior of the server is predictable, which is helpful for debugging or testing. (default: false)")
-      ]
-    else
       speclist
+      @ [
+          ( "-max_clients",
+            Arg.Unit deprecated_warning_max_clients,
+            "<NUM> Max number of clients treated at the same time (default: no \
+             limit) (not cgi) (DEPRECATED)." );
+          ( "-n_workers",
+            Arg.Int (fun x -> n_workers := x),
+            "<NUM> Number of workers used by the server (default: "
+            ^ string_of_int default_n_workers
+            ^ ")" );
+          ( "-max_pending_requests",
+            Arg.Int (fun x -> max_pending_requests := x),
+            "<NUM> Maximum number of pending requests (default: "
+            ^ string_of_int default_max_pending_requests
+            ^ ")" );
+          ( "-conn_tmout",
+            Arg.Int (fun x -> conn_timeout := x),
+            "<SEC> Connection timeout (only on Unix) (default "
+            ^ string_of_int !conn_timeout
+            ^ "s; 0 means no limit)." );
+          ("-daemon", Arg.Set daemon, " Unix daemon mode.");
+          ( "-no-fork",
+            Arg.Unit
+              (fun () ->
+                deprecated_warning_no_fork ();
+                n_workers := 0),
+            " Prevent forking processes (DEPRECATED)" );
+          ( "-cache-in-memory",
+            Arg.String
+              (fun s ->
+                if Gw_ancient.is_available then
+                  cache_databases := s :: !cache_databases
+                else
+                  failwith "-cache-in-memory option unavailable for this build."),
+            "<DATABASE> Preload this database in memory" );
+          ( "-predictable_mode",
+            Arg.Unit set_predictable_mode,
+            " Turn on the predictable mode. In this mode, the behavior of the \
+             server is predictable, which is helpful for debugging or testing. \
+             (default: false)" );
+        ]
+    else speclist
   in
   let speclist = List.sort compare speclist in
   let speclist = Arg.align speclist in
   let anonfun s = raise (Arg.Bad ("don't know what to do with " ^ s)) in
-  if Sys.unix then begin
-    default_lang := begin
-      let s = try Sys.getenv "LANG" with Not_found -> "" in
-      if List.mem s Version.available_languages then s
-      else
-        let s = try Sys.getenv "LC_CTYPE" with Not_found -> "" in
-        if String.length s >= 2 then
-          let s = String.sub s 0 2 in
-          if List.mem s Version.available_languages then s else "en"
-        else "en"
-    end
-  end;
-  arg_parse_in_file (chop_extension Sys.argv.(0) ^ ".arg") speclist anonfun usage;
+  (if Sys.unix then
+   default_lang :=
+     let s = try Sys.getenv "LANG" with Not_found -> "" in
+     if List.mem s Version.available_languages then s
+     else
+       let s = try Sys.getenv "LC_CTYPE" with Not_found -> "" in
+       if String.length s >= 2 then
+         let s = String.sub s 0 2 in
+         if List.mem s Version.available_languages then s else "en"
+       else "en");
+  arg_parse_in_file
+    (chop_extension Sys.argv.(0) ^ ".arg")
+    speclist anonfun usage;
   Arg.parse speclist anonfun usage;
   let gwd_cmd =
-    Array.fold_left (fun acc arg ->
-      if arg.[0] = '-' then acc ^ "<br><b>" ^ arg ^ "</b> "
-      else acc ^ arg) "" Sys.argv
+    Array.fold_left
+      (fun acc arg ->
+        if arg.[0] = '-' then acc ^ "<br><b>" ^ arg ^ "</b> " else acc ^ arg)
+      "" Sys.argv
   in
   Geneweb.GWPARAM.gwd_cmd := gwd_cmd;
-  List.iter register_plugin !plugins ;
-  GWPARAM.init "" ;
-  cache_lexicon () ;
+  List.iter register_plugin !plugins;
+  GWPARAM.init "";
+  cache_lexicon ();
   List.iter
     (fun dbn ->
-       Printf.eprintf "Caching database %s in memory… %!" dbn;
-       let dbn = !GWPARAM.bpath dbn in
-       Gwdb.load_database dbn;
-       Printf.eprintf "Done.\n%!"
-    )
+      Printf.eprintf "Caching database %s in memory… %!" dbn;
+      let dbn = !GWPARAM.bpath dbn in
+      Gwdb.load_database dbn;
+      Printf.eprintf "Done.\n%!")
     !cache_databases;
   if !auth_file <> "" && !force_cgi then
-    Logs.syslog `LOG_WARNING "-auth option is not compatible with CGI mode.\n \
-      Use instead friend_passwd_file= and wizard_passwd_file= in .cgf file\n";
+    Logs.syslog `LOG_WARNING
+      "-auth option is not compatible with CGI mode.\n\
+      \ Use instead friend_passwd_file= and wizard_passwd_file= in .cgf file\n";
   if !use_auth_digest_scheme && !force_cgi then
     Logs.syslog `LOG_WARNING "-digest option is not compatible with CGI mode.\n";
-  if !images_dir <> "" then
-    begin let abs_dir =
-      let f =
-        Util.search_in_assets (Filename.concat !images_dir "gwback.jpg")
-      in
-      let d = Filename.dirname f in
-      if Filename.is_relative d then Filename.concat (Sys.getcwd ()) d else d
-    in
-      images_prefix := "file://" ^ slashify abs_dir
-    end;
+  (if !images_dir <> "" then
+   let abs_dir =
+     let f = Util.search_in_assets (Filename.concat !images_dir "gwback.jpg") in
+     let d = Filename.dirname f in
+     if Filename.is_relative d then Filename.concat (Sys.getcwd ()) d else d
+   in
+   images_prefix := "file://" ^ slashify abs_dir);
   GWPARAM.cnt_dir := !GWPARAM.cnt_d "";
   Wserver.stop_server :=
-    List.fold_left Filename.concat !GWPARAM.cnt_dir ["STOP_SERVER"];
-  let (query, cgi) =
-    try Sys.getenv "QUERY_STRING" |> Adef.encoded, true
-    with Not_found -> "" |> Adef.encoded, !force_cgi
+    List.fold_left Filename.concat !GWPARAM.cnt_dir [ "STOP_SERVER" ];
+  let query, cgi =
+    try (Sys.getenv "QUERY_STRING" |> Adef.encoded, true)
+    with Not_found -> ("" |> Adef.encoded, !force_cgi)
   in
   if not !debug then Sys.enable_runtime_warnings false;
   Util.is_welcome := false;
-  if cgi then
-    begin
-      Wserver.cgi := true;
-      let query =
-        if Sys.getenv_opt "REQUEST_METHOD" = Some "POST" then
-          let len =
-            try int_of_string (Sys.getenv "CONTENT_LENGTH")
-            with Not_found -> -1
-          in
-          set_binary_mode_in stdin true;
-          read_input len |> Adef.encoded
-        else query
-      in
-      let addr =
-        try Sys.getenv "REMOTE_HOST"
-        with Not_found ->
-        try Sys.getenv "REMOTE_ADDR"
-        with Not_found -> ""
-      in
-      let script =
-        try Sys.getenv "SCRIPT_NAME" with Not_found -> Sys.argv.(0)
-      in
-      geneweb_cgi addr (Filename.basename script) query
-    end
+  if cgi then (
+    Wserver.cgi := true;
+    let query =
+      if Sys.getenv_opt "REQUEST_METHOD" = Some "POST" then (
+        let len =
+          try int_of_string (Sys.getenv "CONTENT_LENGTH") with Not_found -> -1
+        in
+        set_binary_mode_in stdin true;
+        read_input len |> Adef.encoded)
+      else query
+    in
+    let addr =
+      try Sys.getenv "REMOTE_HOST"
+      with Not_found -> ( try Sys.getenv "REMOTE_ADDR" with Not_found -> "")
+    in
+    let script =
+      try Sys.getenv "SCRIPT_NAME" with Not_found -> Sys.argv.(0)
+    in
+    geneweb_cgi addr (Filename.basename script) query)
   else geneweb_server ()
 
 let () =
-  try main ()
-  with
+  try main () with
   | Unix.Unix_error (Unix.EADDRINUSE, "bind", _) ->
-    Printf.eprintf "\nError: ";
-    Printf.eprintf "the port %d" !selected_port;
-    Printf.eprintf " is already used by another GeneWeb daemon \
-                    or by another program. Solution: kill the other program \
-                    or launch GeneWeb with another port number (option -p)";
-    flush stderr
+      Printf.eprintf "\nError: ";
+      Printf.eprintf "the port %d" !selected_port;
+      Printf.eprintf
+        " is already used by another GeneWeb daemon or by another program. \
+         Solution: kill the other program or launch GeneWeb with another port \
+         number (option -p)";
+      flush stderr
   | Unix.Unix_error (Unix.ENOTCONN, _, _) when Sys.unix ->
-    Logs.syslog `LOG_WARNING ({|Unix.Unix_error(Unix.ENOTCONN, "shutdown", "")|})
+      Logs.syslog `LOG_WARNING
+        {|Unix.Unix_error(Unix.ENOTCONN, "shutdown", "")|}
   | Unix.Unix_error (Unix.EACCES, "bind", _) when Sys.unix ->
-    Printf.eprintf
-      "Error: invalid access to the port %d: users port number less \
-       than 1024 are reserved to the system. Solution: do it as root \
-       or choose another port number greater than 1024."
-      !selected_port;
-    flush stderr
+      Printf.eprintf
+        "Error: invalid access to the port %d: users port number less than \
+         1024 are reserved to the system. Solution: do it as root or choose \
+         another port number greater than 1024."
+        !selected_port;
+      flush stderr
   | Register_plugin_failure (p, `dynlink_error e) ->
-    Logs.syslog `LOG_CRIT (p ^ ": " ^ Dynlink.error_message e)
+      Logs.syslog `LOG_CRIT (p ^ ": " ^ Dynlink.error_message e)
   | Register_plugin_failure (p, `string s) ->
-    Logs.syslog `LOG_CRIT (p ^ ": " ^ s)
+      Logs.syslog `LOG_CRIT (p ^ ": " ^ s)
   | exn ->
-    let bt = Printexc.get_backtrace () in
-    Logs.syslog `LOG_CRIT (Printexc.to_string exn);
-    if Printexc.backtrace_status () then
-      let s = Format.sprintf "Backtrace:@ %s" bt in
-      Logs.syslog `LOG_CRIT s
+      let bt = Printexc.get_backtrace () in
+      Logs.syslog `LOG_CRIT (Printexc.to_string exn);
+      if Printexc.backtrace_status () then
+        let s = Format.sprintf "Backtrace:@ %s" bt in
+        Logs.syslog `LOG_CRIT s

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -476,8 +476,8 @@ let treat_request =
           ~comment:"Wizard actions not allowed on this base"
   else
   begin
-#ifdef UNIX
-    begin match bfile with
+    if Sys.unix then begin
+      match bfile with
       | None -> ()
       | Some bfile ->
         let stat = Unix.stat bfile in
@@ -490,7 +490,7 @@ let treat_request =
         if puid <> fuid then Unix.setuid fuid ;
         if pgid <> fgid then Unix.setgid fgid ;
     end ;
-#endif
+    
     let plugins =
       match List.assoc_opt "plugins" conf.Config.base_env with
       | None -> []

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -5,7 +5,6 @@ open Config
 open Def
 open Gwdb
 open Util
-
 module Logs = Geneweb_logs.Logs
 module Sosa = Geneweb_sosa
 
@@ -14,55 +13,53 @@ let person_is_std_key conf base p k =
   if k = Name.strip_lower (p_first_name base p ^ " " ^ p_surname base p) then
     true
   else if
-    List.exists (fun n -> Name.strip n = k)
+    List.exists
+      (fun n -> Name.strip n = k)
       (person_misc_names base p (nobtit conf base))
-  then
-    true
+  then true
   else false
 
 let select_std_eq conf base pl k =
   List.fold_right
-    (fun p pl -> if person_is_std_key conf base p k then p :: pl else pl) pl
-    []
+    (fun p pl -> if person_is_std_key conf base p k then p :: pl else pl)
+    pl []
 
 let find_all conf base an =
   let sosa_ref = Util.find_sosa_ref conf base in
   let sosa_nb = try Some (Sosa.of_string an) with _ -> None in
-  match sosa_ref, sosa_nb with
+  match (sosa_ref, sosa_nb) with
   | Some p, Some n ->
-    if n <> Sosa.zero then
-      match Util.branch_of_sosa conf base n p with
-        Some (p :: _) -> [p], true
-      | _ -> [], false
-    else [], false
+      if n <> Sosa.zero then
+        match Util.branch_of_sosa conf base n p with
+        | Some (p :: _) -> ([ p ], true)
+        | _ -> ([], false)
+      else ([], false)
   | _ ->
-    let acc = Option.to_list @@ SearchName.search_by_key conf base an in
-    if acc <> [] then acc, false
-    else
-      ( SearchName.search_key_aux begin fun conf base acc an ->
-            let spl = select_std_eq conf base acc an in
-            if spl = [] then
-              if acc = [] then SearchName.search_by_name conf base an
-              else acc
-            else spl
-          end conf base an
-      , false )
+      let acc = Option.to_list @@ SearchName.search_by_key conf base an in
+      if acc <> [] then (acc, false)
+      else
+        ( SearchName.search_key_aux
+            (fun conf base acc an ->
+              let spl = select_std_eq conf base acc an in
+              if spl = [] then
+                if acc = [] then SearchName.search_by_name conf base an else acc
+              else spl)
+            conf base an,
+          false )
 
 let relation_print conf base p =
   let p1 =
     match p_getenv conf.senv "ei" with
     | Some i ->
-      conf.senv <- [] ;
-      let i = iper_of_string i in
-      if Gwdb.iper_exists base i
-      then Some (pget conf base i)
-      else None
-    | None ->
-      match find_person_in_env conf base "1" with
-      | Some p1 ->
         conf.senv <- [];
-        Some p1
-      | None -> None
+        let i = iper_of_string i in
+        if Gwdb.iper_exists base i then Some (pget conf base i) else None
+    | None -> (
+        match find_person_in_env conf base "1" with
+        | Some p1 ->
+            conf.senv <- [];
+            Some p1
+        | None -> None)
   in
   RelationDisplay.print conf base p p1
 
@@ -73,52 +70,53 @@ let specify conf base n pl1 pl2 pl3 =
   let ptll pl =
     List.map
       (fun p ->
-         let tl = ref [] in
-         let add_tl t =
-           tl :=
-             let rec add_rec =
-               function
-                 t1 :: tl1 ->
-                 if eq_istr t1.t_ident t.t_ident &&
-                    eq_istr t1.t_place t.t_place
-                 then
-                   t1 :: tl1
-                 else t1 :: add_rec tl1
-               | [] -> [t]
-             in
-             add_rec !tl
-         in
-         let compare_and_add t pn =
-           let pn = sou base pn in
-           if Name.crush_lower pn = n then add_tl t
-           else
-             match get_qualifiers p with
-               nn :: _ ->
-               let nn = sou base nn in
-               if Name.crush_lower (pn ^ " " ^ nn) = n then add_tl t
-             | _ -> ()
-         in
-         List.iter
-           (fun t ->
-              match t.t_name, get_public_name p with
-                Tname s, _ -> compare_and_add t s
-              | _, pn when sou base pn <> "" -> compare_and_add t pn
-              | _ -> ())
-           (nobtit conf base p);
-         p, !tl)
+        let tl = ref [] in
+        let add_tl t =
+          tl :=
+            let rec add_rec = function
+              | t1 :: tl1 ->
+                  if
+                    eq_istr t1.t_ident t.t_ident && eq_istr t1.t_place t.t_place
+                  then t1 :: tl1
+                  else t1 :: add_rec tl1
+              | [] -> [ t ]
+            in
+            add_rec !tl
+        in
+        let compare_and_add t pn =
+          let pn = sou base pn in
+          if Name.crush_lower pn = n then add_tl t
+          else
+            match get_qualifiers p with
+            | nn :: _ ->
+                let nn = sou base nn in
+                if Name.crush_lower (pn ^ " " ^ nn) = n then add_tl t
+            | _ -> ()
+        in
+        List.iter
+          (fun t ->
+            match (t.t_name, get_public_name p) with
+            | Tname s, _ -> compare_and_add t s
+            | _, pn when sou base pn <> "" -> compare_and_add t pn
+            | _ -> ())
+          (nobtit conf base p);
+        (p, !tl))
       pl
   in
 
   let sort_ptll ptll =
-    let l = List.rev_map (fun (p, v) ->
-      let bi = get_birth p in
-      let bi =
-         if bi = Date.cdate_None then get_baptism p
-         else bi
-      in
-      (p, v, Date.cdate_to_dmy_opt bi)) ptll
+    let l =
+      List.rev_map
+        (fun (p, v) ->
+          let bi = get_birth p in
+          let bi = if bi = Date.cdate_None then get_baptism p else bi in
+          (p, v, Date.cdate_to_dmy_opt bi))
+        ptll
     in
-    List.sort (fun (_, _, dmy1) (_, _, dmy2) -> Option.compare Date.compare_dmy dmy2 dmy1) l
+    List.sort
+      (fun (_, _, dmy1) (_, _, dmy2) ->
+        Option.compare Date.compare_dmy dmy2 dmy1)
+      l
     |> List.rev_map (fun (p, v, _) -> (p, v))
   in
   Printf.eprintf "sort ptll\n";
@@ -135,111 +133,112 @@ let specify conf base n pl1 pl2 pl3 =
   Output.print_sstring conf "<ul>\n";
   List.iter
     (fun (p, _tl) ->
-       Output.print_sstring conf "<li>\n";
-       SosaCache.print_sosa conf base p true;
-       Update.print_person_parents_and_spouses conf base p;
-       Output.print_sstring conf "</li>\n"
-    ) ptll1;
+      Output.print_sstring conf "<li>\n";
+      SosaCache.print_sosa conf base p true;
+      Update.print_person_parents_and_spouses conf base p;
+      Output.print_sstring conf "</li>\n")
+    ptll1;
   Output.print_sstring conf "</ul>\n";
   if ptll2 <> [] then (
-    Output.print_sstring conf (transl conf "other possibilities" |> Utf8.capitalize_fst);
+    Output.print_sstring conf
+      (transl conf "other possibilities" |> Utf8.capitalize_fst);
     Output.print_sstring conf "<ul>\n";
     List.iter
       (fun (p, _tl) ->
-         Output.print_sstring conf "<li>\n";
-         SosaCache.print_sosa conf base p true;
-         Update.print_person_parents_and_spouses conf base p;
-         Output.print_sstring conf "</li>\n"
-      ) ptll2;
+        Output.print_sstring conf "<li>\n";
+        SosaCache.print_sosa conf base p true;
+        Update.print_person_parents_and_spouses conf base p;
+        Output.print_sstring conf "</li>\n")
+      ptll2;
     Output.print_sstring conf "</ul>\n");
   if ptll3 <> [] then (
-    Output.print_sstring conf (transl conf "with spouse name" |> Utf8.capitalize_fst);
+    Output.print_sstring conf
+      (transl conf "with spouse name" |> Utf8.capitalize_fst);
     Output.print_sstring conf "<ul>\n";
     List.iter
       (fun (p, _tl) ->
-         Output.print_sstring conf "<li>\n";
-         SosaCache.print_sosa conf base p true;
-         Update.print_person_parents_and_spouses conf base p;
-         Output.print_sstring conf "</li>\n"
-      ) ptll3;
+        Output.print_sstring conf "<li>\n";
+        SosaCache.print_sosa conf base p true;
+        Update.print_person_parents_and_spouses conf base p;
+        Output.print_sstring conf "</li>\n")
+      ptll3;
     Output.print_sstring conf "</ul>\n");
 
   Hutil.trailer conf
 
 let this_request_updates_database conf =
   match p_getenv conf.env "m" with
-  | Some ("ADD_FAM" | "ADD_IND" | "CHANGE_WIZ_VIS" | "CHG_CHN" |
-        "CHG_FAM_ORD" | "DEL_FAM" | "DEL_IMAGE" | "DEL_IND" |
-        "INV_FAM" | "KILL_ANC" | "MOD_FAM" | "MOD_IND" |
-        "MOD_NOTES" | "MOD_WIZNOTES" | "MRG_DUP_IND_Y_N" |
-        "MRG_DUP_FAM_Y_N" | "MRG_IND" | "MRG_MOD_FAM" | "MRG_MOD_IND" |
-        "MOD_DATA" | "SND_IMAGE") -> true
+  | Some
+      ( "ADD_FAM" | "ADD_IND" | "CHANGE_WIZ_VIS" | "CHG_CHN" | "CHG_FAM_ORD"
+      | "DEL_FAM" | "DEL_IMAGE" | "DEL_IND" | "INV_FAM" | "KILL_ANC" | "MOD_FAM"
+      | "MOD_IND" | "MOD_NOTES" | "MOD_WIZNOTES" | "MRG_DUP_IND_Y_N"
+      | "MRG_DUP_FAM_Y_N" | "MRG_IND" | "MRG_MOD_FAM" | "MRG_MOD_IND"
+      | "MOD_DATA" | "SND_IMAGE" ) ->
+      true
   | _ -> false
 
 let incorrect_request ?(comment = "") conf =
-  Hutil.incorrect_request ~comment:comment conf
+  Hutil.incorrect_request ~comment conf
 
 let person_selected conf base p =
   match p_getenv conf.senv "em" with
-    Some "R" -> relation_print conf base p
+  | Some "R" -> relation_print conf base p
   | Some _ -> incorrect_request conf ~comment:"incorrect em= value"
-  | None -> record_visited conf (get_iper p); Perso.print conf base p
+  | None ->
+      record_visited conf (get_iper p);
+      Perso.print conf base p
 
 let person_selected_with_redirect conf base p =
   match p_getenv conf.senv "em" with
   | Some "R" -> relation_print conf base p
   | Some _ -> incorrect_request conf ~comment:"Incorrect em= value"
   | None ->
-    Wserver.http_redirect_temporarily
-      (commd conf ^^^ Util.acces conf base p :> string)
+      Wserver.http_redirect_temporarily
+        (commd conf ^^^ Util.acces conf base p :> string)
 
 let updmenu_print = Perso.interp_templ "updmenu"
 
 let very_unknown conf _ =
-  match p_getenv conf.env "n", p_getenv conf.env "p" with
+  match (p_getenv conf.env "n", p_getenv conf.env "p") with
   | Some sname, Some fname ->
-    let title _ =
-      transl conf "not found"
-      |> Utf8.capitalize_fst
-      |> Output.print_sstring conf ;
-      Output.print_sstring conf (transl conf ":") ;
-      Output.print_sstring conf {| "|} ;
-      Output.print_string conf (Util.escape_html fname) ;
-      Output.print_sstring conf {| |} ;
-      Output.print_string conf (Util.escape_html sname) ;
-      Output.print_sstring conf {|"|} ;
-    in
-    Output.status conf Def.Not_Found;
-    Hutil.header ~error:true conf title;
-    Hutil.trailer conf
-  | _ ->
-    match p_getenv conf.env "i" with
-    | Some i ->
       let title _ =
-        Output.print_sstring conf "<kbd>" ;
-        Output.print_string conf (Util.escape_html i) ;
-        Output.print_sstring conf "</kbd>" ;
-        Output.print_sstring conf (transl conf ":") ;
-        Output.print_sstring conf " " ;
-        transl conf "not found"
-        |> Utf8.capitalize_fst
-        |> Output.print_sstring conf ;
+        transl conf "not found" |> Utf8.capitalize_fst
+        |> Output.print_sstring conf;
+        Output.print_sstring conf (transl conf ":");
+        Output.print_sstring conf {| "|};
+        Output.print_string conf (Util.escape_html fname);
+        Output.print_sstring conf {| |};
+        Output.print_string conf (Util.escape_html sname);
+        Output.print_sstring conf {|"|}
       in
       Output.status conf Def.Not_Found;
       Hutil.header ~error:true conf title;
       Hutil.trailer conf
-    | None -> Hutil.incorrect_request conf ~comment:"Missing p=, n= and i="
+  | _ -> (
+      match p_getenv conf.env "i" with
+      | Some i ->
+          let title _ =
+            Output.print_sstring conf "<kbd>";
+            Output.print_string conf (Util.escape_html i);
+            Output.print_sstring conf "</kbd>";
+            Output.print_sstring conf (transl conf ":");
+            Output.print_sstring conf " ";
+            transl conf "not found" |> Utf8.capitalize_fst
+            |> Output.print_sstring conf
+          in
+          Output.status conf Def.Not_Found;
+          Hutil.header ~error:true conf title;
+          Hutil.trailer conf
+      | None -> Hutil.incorrect_request conf ~comment:"Missing p=, n= and i=")
 
 (* Print Not found page *)
 let unknown conf n =
   let title _ =
-    transl conf "not found"
-    |> Utf8.capitalize_fst
-    |> Output.print_sstring conf ;
-    Output.print_sstring conf (transl conf ":") ;
-    Output.print_sstring conf {| "|} ;
-    Output.print_string conf (Util.escape_html n) ;
-    Output.print_sstring conf {|"|} ;
+    transl conf "not found" |> Utf8.capitalize_fst |> Output.print_sstring conf;
+    Output.print_sstring conf (transl conf ":");
+    Output.print_sstring conf {| "|};
+    Output.print_string conf (Util.escape_html n);
+    Output.print_sstring conf {|"|}
   in
   Output.status conf Def.Not_Found;
   Hutil.header ~error:true conf title;
@@ -249,42 +248,44 @@ let make_henv conf base =
   let conf =
     match Util.find_sosa_ref conf base with
     | Some p ->
-      let x =
-        let first_name = p_first_name base p in
-        let surname = p_surname base p in
-        if Util.accessible_by_key conf base p first_name surname then
-          [ "pz", Name.lower first_name |> Mutil.encode
-          ; "nz", Name.lower surname |> Mutil.encode
-          ; "ocz", get_occ p |> string_of_int |> Mutil.encode
-          ]
-        else [ "iz", get_iper p |> string_of_iper |> Mutil.encode ]
-      in
-      { conf with henv = conf.henv @ x }
+        let x =
+          let first_name = p_first_name base p in
+          let surname = p_surname base p in
+          if Util.accessible_by_key conf base p first_name surname then
+            [
+              ("pz", Name.lower first_name |> Mutil.encode);
+              ("nz", Name.lower surname |> Mutil.encode);
+              ("ocz", get_occ p |> string_of_int |> Mutil.encode);
+            ]
+          else [ ("iz", get_iper p |> string_of_iper |> Mutil.encode) ]
+        in
+        { conf with henv = conf.henv @ x }
     | None -> conf
   in
   let conf =
     match p_getenv conf.env "dsrc" with
     | Some "" | None -> conf
-    | Some s -> { conf with henv = conf.henv @ ["dsrc", Mutil.encode s] }
+    | Some s -> { conf with henv = conf.henv @ [ ("dsrc", Mutil.encode s) ] }
   in
   let conf =
     match p_getenv conf.env "templ" with
     | None -> conf
-    | Some s -> { conf with henv = conf.henv @ ["templ", Mutil.encode s] }
+    | Some s -> { conf with henv = conf.henv @ [ ("templ", Mutil.encode s) ] }
   in
   let conf =
     match Util.p_getenv conf.env "escache" with
-    | Some _ -> { conf with henv = conf.henv @ ["escache", escache_value base] }
+    | Some _ ->
+        { conf with henv = conf.henv @ [ ("escache", escache_value base) ] }
     | None -> conf
   in
   let conf =
-    if Util.p_getenv conf.env "manitou" = Some "off"
-    then { conf with henv = conf.henv @ ["manitou", Adef.encoded "off"] }
+    if Util.p_getenv conf.env "manitou" = Some "off" then
+      { conf with henv = conf.henv @ [ ("manitou", Adef.encoded "off") ] }
     else conf
   in
   let conf =
-    if Util.p_getenv conf.env "fmode" = Some "on"
-    then { conf with henv = conf.henv @ ["fmode", Adef.encoded "on"] }
+    if Util.p_getenv conf.env "fmode" = Some "on" then
+      { conf with henv = conf.henv @ [ ("fmode", Adef.encoded "on") ] }
     else conf
   in
   let conf =
@@ -293,95 +294,118 @@ let make_henv conf base =
       Gwdb.person_of_key base fn sn (if oc = "" then 0 else int_of_string oc)
     with
     | Some ip ->
-      { conf with
+        {
+          conf with
           semi_public =
-            if conf.semi_public then get_access (poi base ip) = SemiPublic
-            else true;
-          user_iper = Some ip }
+            (if conf.semi_public then get_access (poi base ip) = SemiPublic
+            else true);
+          user_iper = Some ip;
+        }
     | None -> conf
   in
   let aux param conf =
     match Util.p_getenv conf.env param with
-    | Some s -> { conf with henv = conf.henv @ [param, Mutil.encode s] }
+    | Some s -> { conf with henv = conf.henv @ [ (param, Mutil.encode s) ] }
     | None -> conf
   in
-  aux "alwsurn" conf
-  |> aux "pure_xhtml"
-  |> aux "size"
-  |> aux "p_mod"
+  aux "alwsurn" conf |> aux "pure_xhtml" |> aux "size" |> aux "p_mod"
   |> aux "wide"
 
 let special_vars =
-  [ "alwsurn"; "cgl"; "dsrc"; "em"; "ei"; "ep"; "en"; "eoc"; "escache"; "et";
-    "iz"; "long"; "manitou"; "nz"; "ocz"; "fmode";
-    "p_mod"; "pure_xhtml"; "pz"; "size"; "templ"; "wide" ]
+  [
+    "alwsurn";
+    "cgl";
+    "dsrc";
+    "em";
+    "ei";
+    "ep";
+    "en";
+    "eoc";
+    "escache";
+    "et";
+    "iz";
+    "long";
+    "manitou";
+    "nz";
+    "ocz";
+    "fmode";
+    "p_mod";
+    "pure_xhtml";
+    "pz";
+    "size";
+    "templ";
+    "wide";
+  ]
 
-let only_special_env env = List.for_all (fun (x, _) -> List.mem x special_vars) env
+let only_special_env env =
+  List.for_all (fun (x, _) -> List.mem x special_vars) env
 
 let make_senv conf base =
   let set_senv conf vm vi =
     let aux k v conf =
-      if p_getenv conf.env k = Some v
-      then { conf with senv = conf.senv @ [ k, Mutil.encode v ] }
+      if p_getenv conf.env k = Some v then
+        { conf with senv = conf.senv @ [ (k, Mutil.encode v) ] }
       else conf
     in
     let conf =
-      { conf with senv = ["em", vm; "ei", vi] }
-      |> aux "long" "on"
+      { conf with senv = [ ("em", vm); ("ei", vi) ] } |> aux "long" "on"
     in
     let conf =
       match p_getenv conf.env "et" with
-      | Some x -> { conf with senv = conf.senv @ ["et", Mutil.encode x] }
+      | Some x -> { conf with senv = conf.senv @ [ ("et", Mutil.encode x) ] }
       | _ -> conf
     in
     let conf = aux "cgl" "on" conf in
     let conf =
       match p_getenv conf.env "bd" with
       | None | Some ("0" | "") -> conf
-      | Some x -> { conf with senv = conf.senv @ ["bd", Mutil.encode x] }
+      | Some x -> { conf with senv = conf.senv @ [ ("bd", Mutil.encode x) ] }
     in
     match p_getenv conf.env "color" with
-    | Some x -> { conf with senv = conf.senv @ ["color", Mutil.encode x] }
+    | Some x -> { conf with senv = conf.senv @ [ ("color", Mutil.encode x) ] }
     | _ -> conf
   in
   let get x = Util.p_getenv conf.env x in
-  match get "em", get "ei", get "ep", get "en", get "eoc" with
-  | Some vm, Some vi, _, _, _ -> set_senv conf (Mutil.encode vm) (Mutil.encode vi)
+  match (get "em", get "ei", get "ep", get "en", get "eoc") with
+  | Some vm, Some vi, _, _, _ ->
+      set_senv conf (Mutil.encode vm) (Mutil.encode vi)
   | Some vm, None, Some vp, Some vn, voco ->
-    let voc =
-      match voco with
-      | Some voc -> (try int_of_string voc with Failure _ -> 0)
-      | None -> 0
-    in
-    let ip =
-      match person_of_key base vp vn voc with
-      | Some ip -> ip
-      | None -> Hutil.incorrect_request conf
-          ~comment:"Incorrect em=, ei=, ep=, en=, eoc= configuration"; raise Exit
-    in
-    let vi = string_of_iper ip in
-    set_senv conf (Mutil.encode vm) (Mutil.encode vi)
+      let voc =
+        match voco with
+        | Some voc -> ( try int_of_string voc with Failure _ -> 0)
+        | None -> 0
+      in
+      let ip =
+        match person_of_key base vp vn voc with
+        | Some ip -> ip
+        | None ->
+            Hutil.incorrect_request conf
+              ~comment:"Incorrect em=, ei=, ep=, en=, eoc= configuration";
+            raise Exit
+      in
+      let vi = string_of_iper ip in
+      set_senv conf (Mutil.encode vm) (Mutil.encode vi)
   | _ -> conf
 
 let propose_base conf =
   let title _ = Output.print_sstring conf "Base" in
   Hutil.header conf title;
-  Output.print_sstring conf {|<ul><li><form method="GET" action="|} ;
-  Output.print_sstring conf conf.indep_command ;
-  Output.print_sstring conf {|">|} ;
-  Output.print_sstring conf {|<input name="b" size="40"> =&gt; |} ;
-  Output.print_sstring conf {|<button type="submit" class="btn btn-secondary btn-lg">|} ;
+  Output.print_sstring conf {|<ul><li><form method="GET" action="|};
+  Output.print_sstring conf conf.indep_command;
+  Output.print_sstring conf {|">|};
+  Output.print_sstring conf {|<input name="b" size="40"> =&gt; |};
+  Output.print_sstring conf
+    {|<button type="submit" class="btn btn-secondary btn-lg">|};
   transl_nth conf "validate/delete" 0
-  |> Utf8.capitalize_fst
-  |> Output.print_sstring conf ;
+  |> Utf8.capitalize_fst |> Output.print_sstring conf;
   Output.print_sstring conf "</button></li></ul>";
   Hutil.trailer conf
 
 let try_plugin list conf base_name m =
   let fn =
-    if List.mem "*" list
-    then (fun ( _, fn) -> fn conf base_name)
-    else (fun (ns, fn) -> (List.mem ns conf.forced_plugins || List.mem ns list) && fn conf base_name)
+    if List.mem "*" list then fun (_, fn) -> fn conf base_name
+    else fun (ns, fn) ->
+      (List.mem ns conf.forced_plugins || List.mem ns list) && fn conf base_name
   in
   List.exists fn (Hashtbl.find_all GwdPlugin.ht m)
 
@@ -390,32 +414,39 @@ let w_lock ~onerror fn conf (base_name : string option) =
   (* FIXME: we lost the backtrace because onerror does not handle it. *)
   Lock.control
     ~on_exn:(fun _exn _bt -> onerror conf base_name)
-    ~wait:true
-    ~lock_file:(Mutil.lock_file bfile) @@ fun () ->
-    fn conf base_name
+    ~wait:true ~lock_file:(Mutil.lock_file bfile)
+  @@ fun () -> fn conf base_name
 
 let w_base ~none fn conf (bfile : string option) =
   match bfile with
   | None -> none conf
-  | Some bfile ->
-     try
-       Gwdb.with_database bfile (fun base ->
-        let conf = make_henv conf base in
-        let conf = make_senv conf base in
-        let conf = match Util.default_sosa_ref conf base with
-          | Some p -> { conf with default_sosa_ref = get_iper p, Some p;
-              nb_of_persons = Gwdb.nb_of_persons base;
-              nb_of_families = Gwdb.nb_of_families base}
-          | None -> { conf with
-              nb_of_persons = Gwdb.nb_of_persons base;
-              nb_of_families = Gwdb.nb_of_families base}
-        in
-        fn conf base)
-     with _ ->
-       (* FIXME: If the exception is raised after printing the HTTP header,
-          the function [none] fails and raises an exception with a cryptic
-          backtrace. *)
-       none conf
+  | Some bfile -> (
+      try
+        Gwdb.with_database bfile (fun base ->
+            let conf = make_henv conf base in
+            let conf = make_senv conf base in
+            let conf =
+              match Util.default_sosa_ref conf base with
+              | Some p ->
+                  {
+                    conf with
+                    default_sosa_ref = (get_iper p, Some p);
+                    nb_of_persons = Gwdb.nb_of_persons base;
+                    nb_of_families = Gwdb.nb_of_families base;
+                  }
+              | None ->
+                  {
+                    conf with
+                    nb_of_persons = Gwdb.nb_of_persons base;
+                    nb_of_families = Gwdb.nb_of_families base;
+                  }
+            in
+            fn conf base)
+      with _ ->
+        (* FIXME: If the exception is raised after printing the HTTP header,
+           the function [none] fails and raises an exception with a cryptic
+           backtrace. *)
+        none conf)
 
 let w_person ~none fn conf base =
   match find_person_in_env conf base "" with
@@ -423,10 +454,8 @@ let w_person ~none fn conf base =
   | _ -> none conf base
 
 let w_wizard fn conf base =
-  if conf.wizard then
-    fn conf base
-  else if conf.just_friend_wizard then
-    GWPARAM.output_error conf Def.Forbidden
+  if conf.wizard then fn conf base
+  else if conf.just_friend_wizard then GWPARAM.output_error conf Def.Forbidden
   else
     (* FIXME: send authentification headers *)
     GWPARAM.output_error conf Def.Unauthorized
@@ -442,443 +471,426 @@ let treat_request =
   in
   let w_person = w_person ~none:SrcfileDisplay.print_welcome in
   let print_page conf l =
-      w_base (
-        if only_special_env conf.env then SrcfileDisplay.print_welcome
-        else w_person @@ fun conf base p ->
-          match p_getenv conf.env "ptempl" with
-          | Some t when List.assoc_opt "ptempl" conf.base_env = Some "yes" ->
+    w_base
+      (if only_special_env conf.env then SrcfileDisplay.print_welcome
+      else
+        w_person @@ fun conf base p ->
+        match p_getenv conf.env "ptempl" with
+        | Some t when List.assoc_opt "ptempl" conf.base_env = Some "yes" ->
             Perso.interp_templ t conf base p
-          | _ -> person_selected conf base p) conf l
+        | _ -> person_selected conf base p)
+      conf l
   in
   let handle_no_bfile conf l =
     if conf.bname = "" then
       include_template conf [] "index" (fun () -> propose_base conf)
-    else
-      print_page conf l
+    else print_page conf l
   in
   fun conf ->
-  let bfile =
-    if conf.bname = "" then None
-    else (
-      let bfile = Filename.concat (Secure.base_dir ()) (conf.bname ^ ".gwb") in
-      if Sys.file_exists bfile
-      then Some bfile
-      else None)
-  in
-  let process () =
-  if conf.wizard
-  || conf.friend
-  || List.assoc_opt "visitor_access" conf.base_env <> Some "no"
-  then
-  if List.assoc_opt "wizards_cant_write" conf.base_env = Some "yes"
-    && this_request_updates_database conf then
-      Hutil.incorrect_request conf
-          ~comment:"Wizard actions not allowed on this base"
-  else
-  begin
-    if Sys.unix then begin
-      match bfile with
-      | None -> ()
-      | Some bfile ->
-        let stat = Unix.stat bfile in
-        let fuid = stat.Unix.st_uid in
-        let fgid = stat.Unix.st_gid in
-        let pgid = Unix.getgid () in
-        let puid = Unix.getuid () in
-        (* FIXME possible issue with effective uid/gid! *)
-        (* see setuid, setgid man pages *)
-        if puid <> fuid then Unix.setuid fuid ;
-        if pgid <> fgid then Unix.setgid fgid ;
-    end ;
-    
-    let plugins =
-      match List.assoc_opt "plugins" conf.Config.base_env with
-      | None -> []
-      | Some list -> String.split_on_char ',' list |> List.map String.trim
-    in
-    if List.mem "*" plugins then
-      List.iter (fun (_ , fn) -> fn conf bfile) !GwdPlugin.se
-    else
-      List.iter (fun (ns, fn) -> if List.mem ns plugins then fn conf bfile) !GwdPlugin.se ;
-    let m = Option.value ~default:"" (p_getenv conf.env "m") in
-    if not @@ try_plugin plugins conf bfile m
-    then begin
-        if List.assoc_opt "counter" conf.base_env <> Some "no" &&
-          m <> "IM" && m <> "IM_C" && m <> "SRC" && m <> "DOC"
-        then begin
-          match
-            if only_special_env conf.env
-            then SrcfileDisplay.incr_welcome_counter conf
-            else SrcfileDisplay.incr_request_counter conf
-          with
-          | Some (welcome_cnt, request_cnt, start_date) ->
-            Logs.log begin fun oc ->
-              let thousand oc x = output_string oc @@ Mutil.string_of_int_sep ","  x in
-              Printf.fprintf oc "  #accesses %a (#welcome %a) since %s\n"
-                thousand (welcome_cnt + request_cnt) thousand welcome_cnt
-                start_date
-            end ;
-          | None -> ()
-        end ;
-        let incorrect_request ?(comment = "") conf _ =
-          incorrect_request ~comment:comment conf
+    let bfile =
+      if conf.bname = "" then None
+      else
+        let bfile =
+          Filename.concat (Secure.base_dir ()) (conf.bname ^ ".gwb")
         in
-        let doc_aux conf base print =
-          match Util.p_getenv conf.env "s" with
-          | Some f ->
-                if Filename.check_suffix f ".txt" then
-                  let f = Filename.chop_suffix f ".txt" in
-                  SrcfileDisplay.print_source conf base f
-                else print conf f
-          | _ -> incorrect_request conf ~comment:"Missing s= for m=DOC" base
+        if Sys.file_exists bfile then Some bfile else None
+    in
+    let process () =
+      if
+        conf.wizard || conf.friend
+        || List.assoc_opt "visitor_access" conf.base_env <> Some "no"
+      then
+        if
+          List.assoc_opt "wizards_cant_write" conf.base_env = Some "yes"
+          && this_request_updates_database conf
+        then
+          Hutil.incorrect_request conf
+            ~comment:"Wizard actions not allowed on this base"
+        else (
+          (if Sys.unix then
+           match bfile with
+           | None -> ()
+           | Some bfile ->
+               let stat = Unix.stat bfile in
+               let fuid = stat.Unix.st_uid in
+               let fgid = stat.Unix.st_gid in
+               let pgid = Unix.getgid () in
+               let puid = Unix.getuid () in
+               (* FIXME possible issue with effective uid/gid! *)
+               (* see setuid, setgid man pages *)
+               if puid <> fuid then Unix.setuid fuid;
+               if pgid <> fgid then Unix.setgid fgid);
+
+          let plugins =
+            match List.assoc_opt "plugins" conf.Config.base_env with
+            | None -> []
+            | Some list -> String.split_on_char ',' list |> List.map String.trim
+          in
+          if List.mem "*" plugins then
+            List.iter (fun (_, fn) -> fn conf bfile) !GwdPlugin.se
+          else
+            List.iter
+              (fun (ns, fn) -> if List.mem ns plugins then fn conf bfile)
+              !GwdPlugin.se;
+          let m = Option.value ~default:"" (p_getenv conf.env "m") in
+          if not @@ try_plugin plugins conf bfile m then
+            ((if
+              List.assoc_opt "counter" conf.base_env <> Some "no"
+              && m <> "IM" && m <> "IM_C" && m <> "SRC" && m <> "DOC"
+             then
+              match
+                if only_special_env conf.env then
+                  SrcfileDisplay.incr_welcome_counter conf
+                else SrcfileDisplay.incr_request_counter conf
+              with
+              | Some (welcome_cnt, request_cnt, start_date) ->
+                  Logs.log (fun oc ->
+                      let thousand oc x =
+                        output_string oc @@ Mutil.string_of_int_sep "," x
+                      in
+                      Printf.fprintf oc
+                        "  #accesses %a (#welcome %a) since %s\n" thousand
+                        (welcome_cnt + request_cnt)
+                        thousand welcome_cnt start_date)
+              | None -> ());
+             let incorrect_request ?(comment = "") conf _ =
+               incorrect_request ~comment conf
+             in
+             let doc_aux conf base print =
+               match Util.p_getenv conf.env "s" with
+               | Some f ->
+                   if Filename.check_suffix f ".txt" then
+                     let f = Filename.chop_suffix f ".txt" in
+                     SrcfileDisplay.print_source conf base f
+                   else print conf f
+               | _ ->
+                   incorrect_request conf ~comment:"Missing s= for m=DOC" base
+             in
+             match m with
+             | "" -> (
+                 match bfile with
+                 | Some bfile -> (
+                     (* We attempt to load the database in order to detect issues. *)
+                     try
+                       Gwdb.with_database bfile ignore;
+                       print_page
+                     with _ -> handle_no_bfile)
+                 | None -> handle_no_bfile)
+             | "A" -> AscendDisplay.print |> w_person |> w_base
+             | "ADD_FAM" -> w_wizard @@ w_base @@ UpdateFam.print_add
+             | "ADD_FAM_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_add
+             | "ADD_IND" -> w_wizard @@ w_base @@ UpdateInd.print_add
+             | "ADD_IND_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_add
+             | "ADD_PAR" -> w_wizard @@ w_base @@ UpdateFam.print_add_parents
+             | "ADD_PAR_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_add_parents
+             | "ANM" ->
+                 w_base @@ fun conf _ ->
+                 BirthdayDisplay.print_anniversaries conf
+             | "AN" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some x ->
+                     BirthdayDisplay.print_birth conf base (int_of_string x)
+                 | _ -> BirthdayDisplay.print_menu_birth conf base)
+             | "AD" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some x ->
+                     BirthdayDisplay.print_dead conf base (int_of_string x)
+                 | _ -> BirthdayDisplay.print_menu_dead conf base)
+             | "AM" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some x ->
+                     BirthdayDisplay.print_marriage conf base (int_of_string x)
+                 | _ -> BirthdayDisplay.print_menu_marriage conf base)
+             | "AS" ->
+                 w_base @@ fun conf base ->
+                 SrcfileDisplay.print conf base "advanced"
+             | "AS_OK" -> w_base @@ AdvSearchOkDisplay.print
+             | "C" -> w_base @@ w_person @@ CousinsDisplay.print
+             | "CHK_DATA" -> w_base @@ CheckDataDisplay.print
+             | "CAL" -> w_base @@ Hutil.print_calendar
+             | "CHG_CHN" when conf.wizard ->
+                 w_wizard @@ w_base @@ ChangeChildrenDisplay.print
+             | "CHG_CHN_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ ChangeChildrenDisplay.print_ok
+             | "CHG_EVT_IND_ORD" ->
+                 w_wizard @@ w_base @@ UpdateInd.print_change_event_order
+             | "CHG_EVT_IND_ORD_OK" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ UpdateIndOk.print_change_event_order
+             | "CHG_EVT_FAM_ORD" ->
+                 w_wizard @@ w_base @@ UpdateFam.print_change_event_order
+             | "CHG_EVT_FAM_ORD_OK" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ UpdateFamOk.print_change_event_order
+             | "CHG_FAM_ORD" ->
+                 w_wizard @@ w_base @@ UpdateFam.print_change_order
+             | "CHG_FAM_ORD_OK" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ UpdateFamOk.print_change_order_ok
+             | "CONN_WIZ" ->
+                 w_wizard @@ w_base @@ WiznotesDisplay.connected_wizards
+             | "D" -> w_base @@ w_person @@ DescendDisplay.print
+             | "DAG" -> w_base @@ DagDisplay.print
+             | "DEL_FAM" -> w_wizard @@ w_base @@ UpdateFam.print_del
+             | "DEL_FAM_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_del
+             | "DEL_IMAGE" ->
+                 w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_del
+             | "DEL_IMAGE_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_del_ok
+             | "DEL_IMAGE_C_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_main_c
+             | "DEL_IND" -> w_wizard @@ w_base @@ UpdateInd.print_del
+             | "DEL_IND_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_del
+             | "DOC" ->
+                 w_base @@ fun conf base ->
+                 doc_aux conf base ImageDisplay.print_source
+             | "DOCH" ->
+                 w_base @@ fun conf base ->
+                 doc_aux conf base (fun conf _base ->
+                     ImageDisplay.print_html conf)
+             | "F" -> w_base @@ w_person @@ Perso.interp_templ "family"
+             | "H" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some f -> SrcfileDisplay.print conf base f
+                 | None ->
+                     incorrect_request conf base ~comment:"Missing v= for m=H")
+             | "HIST" -> w_base @@ History.print
+             | "HIST_CLEAN" ->
+                 w_wizard @@ w_base
+                 @@ fun conf _ -> HistoryDiffDisplay.print_clean conf
+             | "HIST_CLEAN_OK" ->
+                 w_wizard @@ w_base
+                 @@ fun conf _ -> HistoryDiffDisplay.print_clean_ok conf
+             | "HIST_DIFF" -> w_base @@ HistoryDiffDisplay.print
+             | "HIST_SEARCH" -> w_base @@ History.print_search
+             | "IM_C" -> w_base @@ ImageCarrousel.print_c ~saved:false
+             | "IM_C_S" -> w_base @@ ImageCarrousel.print_c ~saved:true
+             | "IM" -> w_base @@ ImageDisplay.print
+             | "IMH" -> w_base @@ fun conf _ -> ImageDisplay.print_html conf
+             | "INV_FAM" -> w_wizard @@ w_base @@ UpdateFam.print_inv
+             | "INV_FAM_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_inv
+             | "KILL_ANC" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ MergeIndDisplay.print_kill_ancestors
+             | "L" ->
+                 w_base @@ fun conf base ->
+                 Perso.interp_templ "list" conf base
+                   (Gwdb.empty_person base Gwdb.dummy_iper)
+             | "LB" when conf.wizard || conf.friend ->
+                 w_base @@ BirthDeathDisplay.print_birth
+             | "LD" when conf.wizard || conf.friend ->
+                 w_base @@ BirthDeathDisplay.print_death
+             | "LINKED" -> w_base @@ w_person @@ Perso.print_what_links
+             | "LL" -> w_base @@ BirthDeathDisplay.print_longest_lived
+             | "LM" when conf.wizard || conf.friend ->
+                 w_base @@ BirthDeathDisplay.print_marriage
+             | "MISC_NOTES" -> w_base @@ NotesDisplay.print_misc_notes
+             | "MISC_NOTES_SEARCH" ->
+                 w_base @@ NotesDisplay.print_misc_notes_search
+             | "MOD_DATA" -> w_wizard @@ w_base @@ UpdateDataDisplay.print_mod
+             | "MOD_DATA_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateDataDisplay.print_mod_ok
+             | "MOD_FAM" -> w_wizard @@ w_base @@ UpdateFam.print_mod
+             | "MOD_FAM_OK" when conf.wizard ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_mod
+             | "MOD_IND" -> w_wizard @@ w_base @@ UpdateInd.print_mod
+             | "MOD_IND_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_mod
+             | "MOD_NOTES" -> w_wizard @@ w_base @@ NotesDisplay.print_mod
+             | "MOD_NOTES_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ NotesDisplay.print_mod_ok
+             | "MOD_WIZNOTES" when conf.authorized_wizards_notes ->
+                 w_base @@ WiznotesDisplay.print_mod
+             | "MOD_WIZNOTES_OK" when conf.authorized_wizards_notes ->
+                 w_lock @@ w_base @@ WiznotesDisplay.print_mod_ok
+             | "MRG" -> w_wizard @@ w_base @@ w_person @@ MergeDisplay.print
+             | "MRG_DUP" -> w_wizard @@ w_base @@ MergeDupDisplay.main_page
+             | "MRG_DUP_IND_Y_N" ->
+                 w_wizard @@ w_lock @@ w_base @@ MergeDupDisplay.answ_ind_y_n
+             | "MRG_DUP_FAM_Y_N" ->
+                 w_wizard @@ w_lock @@ w_base @@ MergeDupDisplay.answ_fam_y_n
+             | "MRG_FAM" -> w_wizard @@ w_base @@ MergeFamDisplay.print
+             | "MRG_FAM_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ MergeFamOk.print_merge
+             | "MRG_MOD_FAM_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ MergeFamOk.print_mod_merge
+             | "MRG_IND" ->
+                 w_wizard @@ w_lock @@ w_base @@ MergeIndDisplay.print
+             | "MRG_IND_OK" ->
+                 (* despite the _OK suffix, this one does not actually update databse *)
+                 w_wizard @@ w_base @@ MergeIndOkDisplay.print_merge
+             | "MRG_MOD_IND_OK" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ MergeIndOkDisplay.print_mod_merge
+             | "N" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some v ->
+                     Some.search_surname_print conf base Some.surname_not_found
+                       v
+                 | _ -> AllnDisplay.print_surnames conf base)
+             | "NG" -> (
+                 w_base @@ fun conf base ->
+                 (* Rétro-compatibilité <= 6.06 *)
+                 let env =
+                   match p_getenv conf.env "n" with
+                   | Some n -> (
+                       match p_getenv conf.env "t" with
+                       | Some "P" -> ("fn", Mutil.encode n) :: conf.env
+                       | Some "N" -> ("sn", Mutil.encode n) :: conf.env
+                       | _ -> ("v", Mutil.encode n) :: conf.env)
+                   | None -> conf.env
+                 in
+                 let conf = { conf with env } in
+                 (* Nouveau mode de recherche. *)
+                 match p_getenv conf.env "select" with
+                 | Some "input" | None -> (
+                     (* Récupère le contenu non vide de la recherche. *)
+                     let real_input label =
+                       match p_getenv conf.env label with
+                       | Some s -> if s = "" then None else Some s
+                       | None -> None
+                     in
+                     (* Recherche par clé, sosa, alias ... *)
+                     let search n =
+                       let pl, sosa_acc = find_all conf base n in
+                       match pl with
+                       | [] -> Some.search_surname_print conf base unknown n
+                       | [ p ] ->
+                           if
+                             sosa_acc
+                             || Gutil.person_of_string_key base n <> None
+                             || person_is_std_key conf base p n
+                           then person_selected_with_redirect conf base p
+                           else specify conf base n pl [] []
+                       | pl -> specify conf base n pl [] []
+                     in
+                     match real_input "v" with
+                     | Some n -> search n
+                     | None -> (
+                         match (real_input "fn", real_input "sn") with
+                         | Some fn, Some sn -> search (fn ^ " " ^ sn)
+                         | Some fn, None ->
+                             Some.search_first_name_print conf base fn
+                         | None, Some sn ->
+                             Some.search_surname_print conf base unknown sn
+                         | None, None ->
+                             incorrect_request conf base
+                               ~comment:"Missing fn= and sn= for m=NG"))
+                 | Some i ->
+                     relation_print conf base
+                       (pget conf base (iper_of_string i)))
+             | "NOTES" -> w_base @@ NotesDisplay.print
+             | "OA" when conf.wizard || conf.friend ->
+                 w_base @@ BirthDeathDisplay.print_oldest_alive
+             | "OE" when conf.wizard || conf.friend ->
+                 w_base @@ BirthDeathDisplay.print_oldest_engagements
+             | "P" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some v -> Some.search_first_name_print conf base v
+                 | None -> AllnDisplay.print_first_names conf base)
+             | "PERSO" ->
+                 w_base @@ w_person @@ Geneweb.Perso.interp_templ "perso"
+             | "POP_PYR" when conf.wizard || conf.friend ->
+                 w_base @@ BirthDeathDisplay.print_population_pyramid
+             | "PS" -> w_base @@ PlaceDisplay.print_all_places_surnames
+             | "PPS" -> w_base @@ Place.print_all_places_surnames
+             | "R" -> w_base @@ w_person @@ relation_print
+             | "REFRESH" -> w_base @@ w_person @@ Perso.interp_templ "carrousel"
+             | "REQUEST" ->
+                 w_wizard @@ fun _ _ ->
+                 Output.status conf Def.OK;
+                 Output.header conf "Content-type: text";
+                 List.iter
+                   (fun s ->
+                     Output.print_sstring conf s;
+                     Output.print_sstring conf "\n")
+                   conf.Config.request
+             | "RESET_IMAGE_C_OK" -> w_base @@ ImageCarrousel.print_main_c
+             | "RL" -> w_base @@ RelationLink.print
+             | "RLM" -> w_base @@ RelationDisplay.print_multi
+             | "S" ->
+                 w_base @@ fun conf base ->
+                 SearchName.print conf base specify unknown
+             | "SND_IMAGE" ->
+                 w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print
+             | "SND_IMAGE_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_send_ok
+             | "SND_IMAGE_C" ->
+                 w_base @@ w_person @@ Perso.interp_templ "carrousel"
+             | "SND_IMAGE_C_OK" ->
+                 w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_main_c
+             | "SRC" -> (
+                 w_base @@ fun conf base ->
+                 match p_getenv conf.env "v" with
+                 | Some f -> SrcfileDisplay.print_source conf base f
+                 | _ ->
+                     incorrect_request conf base ~comment:"Missing v= for m=SRC"
+                 )
+             | "STAT" ->
+                 w_base @@ fun conf _ -> BirthDeathDisplay.print_statistics conf
+             | "CHANGE_WIZ_VIS" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ WiznotesDisplay.change_wizard_visibility
+             | "TP" -> (
+                 w_base @@ fun conf base ->
+                 match Util.p_getenv conf.env "v" with
+                 | Some f -> (
+                     match Util.find_person_in_env conf base "" with
+                     | Some p -> Perso.interp_templ ("tp_" ^ f) conf base p
+                     | _ ->
+                         Perso.interp_templ ("tp0_" ^ f) conf base
+                           (Gwdb.empty_person base Gwdb.dummy_iper))
+                 | None ->
+                     incorrect_request conf base ~comment:"Missing v= for m=TP")
+             | "TT" -> w_base @@ TitleDisplay.print
+             | "U" -> w_wizard @@ w_base @@ w_person @@ updmenu_print
+             | "VIEW_WIZNOTES" when conf.authorized_wizards_notes ->
+                 w_wizard @@ w_base @@ WiznotesDisplay.print_view
+             | "WIZNOTES" when conf.authorized_wizards_notes ->
+                 w_base @@ WiznotesDisplay.print
+             | "WIZNOTES_SEARCH" when conf.authorized_wizards_notes ->
+                 w_base @@ WiznotesDisplay.print_search
+             | _ ->
+                 w_base @@ fun conf base ->
+                 let str = Format.sprintf "m=%s is not available here" m in
+                 incorrect_request conf base ~comment:str)
+              conf bfile)
+      else
+        let title _ =
+          Printf.sprintf "%s %s %s"
+            (transl conf "base" |> Utf8.capitalize_fst)
+            conf.bname
+            (transl conf "reserved to friends or wizards")
+          |> Output.print_sstring conf
         in
-        match m with
-        | "" -> (
-          match bfile with
-          | Some bfile -> (
-            (* We attempt to load the database in order to detect issues. *)
-            try
-              Gwdb.with_database bfile ignore;
-              print_page
-            with _ -> handle_no_bfile)
-          | None -> handle_no_bfile)
-
-        | "A" ->
-          AscendDisplay.print |> w_person |> w_base
-        | "ADD_FAM" ->
-          w_wizard @@ w_base @@ UpdateFam.print_add
-        | "ADD_FAM_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_add
-        | "ADD_IND" ->
-          w_wizard @@ w_base @@ UpdateInd.print_add
-        | "ADD_IND_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_add
-        | "ADD_PAR" ->
-          w_wizard @@ w_base @@ UpdateFam.print_add_parents
-        | "ADD_PAR_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_add_parents
-        | "ANM" ->
-          w_base @@ fun conf _ -> BirthdayDisplay.print_anniversaries conf
-        | "AN" ->
-          w_base @@ fun conf base -> begin match p_getenv conf.env "v" with
-            | Some x -> BirthdayDisplay.print_birth conf base (int_of_string x)
-            | _ -> BirthdayDisplay.print_menu_birth conf base
-          end
-        | "AD" ->
-          w_base @@ fun conf base -> begin match p_getenv conf.env "v" with
-            | Some x -> BirthdayDisplay.print_dead conf base (int_of_string x)
-            | _ -> BirthdayDisplay.print_menu_dead conf base
-          end
-        | "AM" ->
-          w_base @@ fun conf base -> begin match p_getenv conf.env "v" with
-            | Some x -> BirthdayDisplay.print_marriage conf base (int_of_string x)
-            | _ -> BirthdayDisplay.print_menu_marriage conf base
-          end
-        | "AS" ->
-          w_base @@ fun conf base ->
-            SrcfileDisplay.print conf base "advanced"
-        | "AS_OK" ->
-          w_base @@ AdvSearchOkDisplay.print
-        | "C" ->
-          w_base @@ w_person @@ CousinsDisplay.print
-        | "CHK_DATA" ->
-          w_base @@ CheckDataDisplay.print
-        | "CAL" -> w_base @@ Hutil.print_calendar
-        | "CHG_CHN" when conf.wizard ->
-          w_wizard @@ w_base @@ ChangeChildrenDisplay.print
-        | "CHG_CHN_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ ChangeChildrenDisplay.print_ok
-        | "CHG_EVT_IND_ORD" ->
-          w_wizard @@ w_base @@ UpdateInd.print_change_event_order
-        | "CHG_EVT_IND_ORD_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_change_event_order
-        | "CHG_EVT_FAM_ORD" ->
-          w_wizard @@ w_base @@ UpdateFam.print_change_event_order
-        | "CHG_EVT_FAM_ORD_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_change_event_order
-        | "CHG_FAM_ORD" ->
-          w_wizard @@ w_base @@ UpdateFam.print_change_order
-        | "CHG_FAM_ORD_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_change_order_ok
-        | "CONN_WIZ" ->
-          w_wizard @@ w_base @@ WiznotesDisplay.connected_wizards
-        | "D" ->
-          w_base @@ w_person @@ DescendDisplay.print
-        | "DAG" ->
-          w_base @@ DagDisplay.print
-        | "DEL_FAM" ->
-          w_wizard @@ w_base @@ UpdateFam.print_del
-        | "DEL_FAM_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_del
-        | "DEL_IMAGE" ->
-          w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_del
-        | "DEL_IMAGE_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_del_ok
-        | "DEL_IMAGE_C_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_main_c
-        | "DEL_IND" ->
-          w_wizard @@ w_base @@ UpdateInd.print_del
-        | "DEL_IND_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_del
-        | "DOC" ->
-          w_base @@ fun conf base -> doc_aux conf base
-            ImageDisplay.print_source
-        | "DOCH" ->
-          w_base @@ fun conf base -> doc_aux conf base
-            (fun conf _base -> ImageDisplay.print_html conf)
-        | "F" ->
-          w_base @@ w_person @@ Perso.interp_templ "family"
-        | "H" ->
-          w_base @@ fun conf base ->
-            ( match p_getenv conf.env "v" with
-            | Some f -> SrcfileDisplay.print conf base f
-            | None -> incorrect_request conf base ~comment:"Missing v= for m=H")
-        | "HIST" ->
-          w_base @@ History.print
-        | "HIST_CLEAN" ->
-          w_wizard @@ w_base @@ fun conf _ -> HistoryDiffDisplay.print_clean conf
-        | "HIST_CLEAN_OK" ->
-          w_wizard @@ w_base @@ fun conf _ -> HistoryDiffDisplay.print_clean_ok conf
-        | "HIST_DIFF" ->
-          w_base @@ HistoryDiffDisplay.print
-        | "HIST_SEARCH" ->
-          w_base @@ History.print_search
-        | "IM_C" ->
-          w_base @@ ImageCarrousel.print_c ~saved:false
-        | "IM_C_S" ->
-          w_base @@ ImageCarrousel.print_c ~saved:true
-        | "IM" ->
-          w_base @@ ImageDisplay.print
-        | "IMH" ->
-          w_base @@ fun conf _ -> ImageDisplay.print_html conf
-        | "INV_FAM" ->
-          w_wizard @@ w_base @@ UpdateFam.print_inv
-        | "INV_FAM_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_inv
-        | "KILL_ANC" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeIndDisplay.print_kill_ancestors
-        | "L" -> w_base @@ fun conf base -> Perso.interp_templ "list" conf base
-              (Gwdb.empty_person base Gwdb.dummy_iper)
-        | "LB" when conf.wizard || conf.friend ->
-          w_base @@ BirthDeathDisplay.print_birth
-        | "LD" when conf.wizard || conf.friend ->
-          w_base @@ BirthDeathDisplay.print_death
-        | "LINKED" ->
-          w_base @@ w_person @@ Perso.print_what_links
-        | "LL" ->
-          w_base @@ BirthDeathDisplay.print_longest_lived
-        | "LM" when conf.wizard || conf.friend ->
-          w_base @@ BirthDeathDisplay.print_marriage
-        | "MISC_NOTES" ->
-          w_base @@ NotesDisplay.print_misc_notes
-        | "MISC_NOTES_SEARCH" ->
-          w_base @@ NotesDisplay.print_misc_notes_search
-        | "MOD_DATA" ->
-          w_wizard @@ w_base @@ UpdateDataDisplay.print_mod
-        | "MOD_DATA_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateDataDisplay.print_mod_ok
-        | "MOD_FAM" ->
-          w_wizard @@ w_base @@ UpdateFam.print_mod
-        | "MOD_FAM_OK" when conf.wizard ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateFamOk.print_mod
-        | "MOD_IND" ->
-          w_wizard @@ w_base @@ UpdateInd.print_mod
-        | "MOD_IND_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ UpdateIndOk.print_mod
-        | "MOD_NOTES" ->
-          w_wizard @@ w_base @@ NotesDisplay.print_mod
-        | "MOD_NOTES_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ NotesDisplay.print_mod_ok
-        | "MOD_WIZNOTES" when conf.authorized_wizards_notes ->
-          w_base @@ WiznotesDisplay.print_mod
-        | "MOD_WIZNOTES_OK" when conf.authorized_wizards_notes ->
-          w_lock @@ w_base @@ WiznotesDisplay.print_mod_ok
-        | "MRG" ->
-          w_wizard @@ w_base @@ w_person @@ MergeDisplay.print
-        | "MRG_DUP" ->
-          w_wizard @@ w_base @@ MergeDupDisplay.main_page
-        | "MRG_DUP_IND_Y_N" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeDupDisplay.answ_ind_y_n
-        | "MRG_DUP_FAM_Y_N" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeDupDisplay.answ_fam_y_n
-        | "MRG_FAM" ->
-          w_wizard @@ w_base @@ MergeFamDisplay.print
-        | "MRG_FAM_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeFamOk.print_merge
-        | "MRG_MOD_FAM_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeFamOk.print_mod_merge
-        | "MRG_IND" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeIndDisplay.print
-        | "MRG_IND_OK" -> (* despite the _OK suffix, this one does not actually update databse *)
-          w_wizard @@ w_base @@ MergeIndOkDisplay.print_merge
-        | "MRG_MOD_IND_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ MergeIndOkDisplay.print_mod_merge
-        | "N" ->
-          w_base @@ fun conf base -> begin match p_getenv conf.env "v" with
-            | Some v -> Some.search_surname_print conf base Some.surname_not_found v
-            | _ -> AllnDisplay.print_surnames conf base
-          end
-        | "NG" -> w_base @@ begin fun conf base ->
-            (* Rétro-compatibilité <= 6.06 *)
-            let env =
-              match p_getenv conf.env "n" with
-                Some n ->
-                begin match p_getenv conf.env "t" with
-                    Some "P" -> ("fn", Mutil.encode n) :: conf.env
-                  | Some "N" -> ("sn", Mutil.encode n) :: conf.env
-                  | _ -> ("v", Mutil.encode n) :: conf.env
-                end
-              | None -> conf.env
-            in
-            let conf = {conf with env = env} in
-            (* Nouveau mode de recherche. *)
-            match p_getenv conf.env "select" with
-            | Some "input" | None ->
-              (* Récupère le contenu non vide de la recherche. *)
-              let real_input label =
-                match p_getenv conf.env label with
-                | Some s -> if s = "" then None else Some s
-                | None -> None
-              in
-              (* Recherche par clé, sosa, alias ... *)
-              let search n =
-                let (pl, sosa_acc) = find_all conf base n in
-                match pl with
-                | [] ->
-                  Some.search_surname_print conf base unknown n
-                | [p] ->
-                  if sosa_acc
-                  || Gutil.person_of_string_key base n <> None
-                  || person_is_std_key conf base p n
-                  then person_selected_with_redirect conf base p
-                  else specify conf base n pl [] []
-                | pl -> specify conf base n pl [] []
-              in
-              begin match real_input "v" with
-                | Some n -> search n
-                | None ->
-                  match real_input "fn", real_input "sn" with
-                    Some fn, Some sn -> search (fn ^ " " ^ sn)
-                  | Some fn, None ->
-                    Some.search_first_name_print conf base fn
-                  | None, Some sn ->
-                    Some.search_surname_print conf base unknown sn
-                  | None, None -> incorrect_request conf base
-                    ~comment:"Missing fn= and sn= for m=NG"
-              end
-            | Some i ->
-              relation_print conf base
-                (pget conf base (iper_of_string i))
-          end
-        | "NOTES" ->
-          w_base @@ NotesDisplay.print
-        | "OA" when conf.wizard || conf.friend ->
-          w_base @@ BirthDeathDisplay.print_oldest_alive
-        | "OE" when conf.wizard || conf.friend ->
-          w_base @@ BirthDeathDisplay.print_oldest_engagements
-        | "P" ->
-          w_base @@ fun conf base -> begin match p_getenv conf.env "v" with
-            | Some v -> Some.search_first_name_print conf base v
-            | None -> AllnDisplay.print_first_names conf base
-          end
-        | "PERSO" ->
-          w_base @@ w_person @@ Geneweb.Perso.interp_templ "perso"
-
-        | "POP_PYR" when conf.wizard || conf.friend ->
-          w_base @@ BirthDeathDisplay.print_population_pyramid
-        | "PS" ->
-          w_base @@ PlaceDisplay.print_all_places_surnames
-        | "PPS" ->
-          w_base @@ Place.print_all_places_surnames
-        | "R" ->
-          w_base @@ w_person @@ relation_print
-        | "REFRESH" ->
-          w_base @@ w_person @@ Perso.interp_templ "carrousel"
-        | "REQUEST" ->
-          w_wizard @@ fun _ _ ->
-            Output.status conf Def.OK;
-            Output.header conf "Content-type: text";
-            List.iter begin fun s ->
-              Output.print_sstring conf s ;
-              Output.print_sstring conf "\n"
-            end conf.Config.request ;
-
-        | "RESET_IMAGE_C_OK" ->
-          w_base @@ ImageCarrousel.print_main_c
-
-        | "RL" ->
-          w_base @@ RelationLink.print
-        | "RLM" ->
-          w_base @@ RelationDisplay.print_multi
-        | "S" ->
-          w_base @@ fun conf base -> SearchName.print conf base specify unknown
-
-        | "SND_IMAGE" -> w_wizard @@w_lock @@ w_base @@ ImageCarrousel.print
-        | "SND_IMAGE_OK" ->
-           w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_send_ok
-        | "SND_IMAGE_C" ->
-          w_base @@ w_person @@ Perso.interp_templ "carrousel"
-        | "SND_IMAGE_C_OK" ->
-          w_wizard @@ w_lock @@ w_base @@ ImageCarrousel.print_main_c
-
-        | "SRC" ->
-          w_base @@ fun conf base -> begin match p_getenv conf.env "v" with
-            | Some f -> SrcfileDisplay.print_source conf base f
-            | _ -> incorrect_request conf base ~comment:"Missing v= for m=SRC"
-          end
-        | "STAT" ->
-          w_base @@ fun conf _ -> BirthDeathDisplay.print_statistics conf
-        | "CHANGE_WIZ_VIS" ->
-          w_wizard @@ w_lock @@ w_base @@ WiznotesDisplay.change_wizard_visibility
-        | "TP" ->
-          w_base @@ fun conf base ->
-            begin match Util.p_getenv conf.env "v" with
-            | Some f ->
-              begin match Util.find_person_in_env conf base "" with
-              | Some p -> Perso.interp_templ ("tp_" ^ f) conf base p
-              | _ -> Perso.interp_templ ("tp0_" ^ f) conf base
-                       (Gwdb.empty_person base Gwdb.dummy_iper)
-              end
-            | None -> incorrect_request conf base ~comment:"Missing v= for m=TP"
-            end
-        | "TT" ->
-          w_base @@ TitleDisplay.print
-        | "U" ->
-          w_wizard @@ w_base @@ w_person @@ updmenu_print
-        | "VIEW_WIZNOTES" when conf.authorized_wizards_notes ->
-          w_wizard @@ w_base @@ WiznotesDisplay.print_view
-        | "WIZNOTES" when conf.authorized_wizards_notes ->
-          w_base @@ WiznotesDisplay.print
-        | "WIZNOTES_SEARCH" when conf.authorized_wizards_notes ->
-          w_base @@ WiznotesDisplay.print_search
-        | _ ->
-            w_base @@ fun conf base ->
-            let str = Format.sprintf "m=%s is not available here" m in
-            incorrect_request conf base ~comment:str
-      end conf bfile ;
-  end else begin
-    let title _ =
-      Printf.sprintf "%s %s %s"
-      (transl conf "base" |> Utf8.capitalize_fst)
-      conf.bname
-      (transl conf "reserved to friends or wizards")
-      |> Output.print_sstring conf
-    in
-    Hutil.rheader conf title ;
-    let base_name =
-      if conf.cgi then (Printf.sprintf "b=%s&" conf.bname) else ""
-    in
-    let user = transl_nth conf "user/password/cancel" 0 in
-    let passwd = transl_nth conf "user/password/cancel" 1 in
-    let referer =
-      match Util.extract_value '?' (get_referer conf :> string) with
-      | exception Not_found -> ""
-      | referer when referer <> "" -> "&" ^ referer
-      | _ -> ""
-    in
-    let body =
-      if conf.cgi then
-        Printf.sprintf {|
+        Hutil.rheader conf title;
+        let base_name =
+          if conf.cgi then Printf.sprintf "b=%s&" conf.bname else ""
+        in
+        let user = transl_nth conf "user/password/cancel" 0 in
+        let passwd = transl_nth conf "user/password/cancel" 1 in
+        let referer =
+          match Util.extract_value '?' (get_referer conf :> string) with
+          | exception Not_found -> ""
+          | referer when referer <> "" -> "&" ^ referer
+          | _ -> ""
+        in
+        let body =
+          if conf.cgi then
+            Printf.sprintf
+              {|
             <input type="text" class="form-control" name="w"
               title="%s/%s %s" placeholder="%s:%s"
               aria-label="password input"
@@ -887,44 +899,54 @@ let treat_request =
             <div class="input-group-append">
               <button type="submit" class="btn btn-primary">OK</button>
             </div>|}
-            (transl_nth conf "wizard/wizards/friend/friends/exterior" 2)
-            (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
-            passwd user passwd user passwd
-      else
-        Printf.sprintf {|
+              (transl_nth conf "wizard/wizards/friend/friends/exterior" 2)
+              (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
+              passwd user passwd user passwd
+          else
+            Printf.sprintf
+              {|
             <div>
               <ul>
               <li>%s%s <a href="%s?%sw=f%s"> %s</a></li>
               <li>%s%s <a href="%s?%sw=w%s"> %s</a></li>
               </ul>
             </div> |}
-            (transl conf "access" |> Utf8.capitalize_fst) (transl conf ":")
-            (conf.command :> string) base_name referer
-            (transl_nth conf "wizard/wizards/friend/friends/exterior" 2)
-            (transl conf "access" |> Utf8.capitalize_fst) (transl conf ":")
-            (conf.command :> string) base_name referer
-            (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
-    in
-    Output.print_sstring conf
-      (Printf.sprintf {|
+              (transl conf "access" |> Utf8.capitalize_fst)
+              (transl conf ":")
+              (conf.command :> string)
+              base_name referer
+              (transl_nth conf "wizard/wizards/friend/friends/exterior" 2)
+              (transl conf "access" |> Utf8.capitalize_fst)
+              (transl conf ":")
+              (conf.command :> string)
+              base_name referer
+              (transl_nth conf "wizard/wizards/friend/friends/exterior" 0)
+        in
+        Output.print_sstring conf
+          (Printf.sprintf
+             {|
         <form class="form-inline" method="post" action="%s">
           <div class="input-group mt-1">
             <input type="hidden" name="b" value="%s">
             %s
           </div>
         </form>
-      |} (conf.command :> string) (conf.bname) body
-      );
-    Hutil.trailer conf
-  end
-  in
-  if conf.debug then Mutil.bench (__FILE__ ^ " " ^ string_of_int __LINE__) process
-  else process ()
+      |}
+             (conf.command :> string)
+             conf.bname body);
+        Hutil.trailer conf
+    in
+    if conf.debug then
+      Mutil.bench (__FILE__ ^ " " ^ string_of_int __LINE__) process
+    else process ()
 
 let treat_request conf =
-  GWPARAM.init_etc conf.bname ;
+  GWPARAM.init_etc conf.bname;
   (* TODO verify if we need init_etc here *)
-  let conf = { conf with
-    base_env = Util.read_base_env conf.bname conf.gw_prefix conf.debug }
+  let conf =
+    {
+      conf with
+      base_env = Util.read_base_env conf.bname conf.gw_prefix conf.debug;
+    }
   in
   try treat_request conf with Update.ModErr _ -> Output.flush conf

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -23,12 +23,11 @@ let printer_conf =
 let slashify s =
   String.map (function '\\' -> '/' | c -> c) s
 
-#ifdef UNIX
-let slashify_linux_dos s = s
-#else
 let slashify_linux_dos s =
-  String.map (function '/' -> '\\' | c -> c) s
-#endif
+  if Sys.unix then
+    s
+  else
+    String.map (function '/' -> '\\' | c -> c) s
 
 let decode s = Mutil.decode (Adef.encoded s)
 let encode s = (Mutil.encode s :> string)
@@ -355,11 +354,7 @@ let only_file_name =
 (* like %l, %L, %P, ... and they may be different! %G  *)
 let macro conf =
   function
-#ifdef UNIX
-  | '/' -> "/"
-#else
-  | '/' -> "\\"
-#endif
+  | '/' -> if Sys.unix then "/" else "\\"
   | 'a' -> strip_spaces (s_getenv conf.env "anon")
   | 'c' -> stringify !setup_dir
   | 'd' -> conf.comm
@@ -729,14 +724,11 @@ and print_selector conf print =
       Not_found -> try Sys.getenv "HOME" with Not_found -> Sys.getcwd ()
   in
   let list =
-#ifdef UNIX
-#else
     let sel =
-      if String.length sel = 3 && sel.[1] = ':' && sel.[2] = '\\'
+      if not Sys.unix && String.length sel = 3 && sel.[1] = ':' && sel.[2] = '\\'
       then sel ^ "."
       else sel
     in
-#endif
     try
       let dh = Unix.opendir sel in
       let rec loop list =
@@ -764,13 +756,12 @@ and print_selector conf print =
       (fun x ->
          let d =
            if x = ".." then
-#ifdef UNIX
-             Filename.dirname sel
-#else
-             if sel.[String.length sel - 1] <> '\\'
-             then Filename.dirname sel ^ "\\"
-             else Filename.dirname sel
-#endif
+             if Sys.unix then
+               Filename.dirname sel
+             else
+               if sel.[String.length sel - 1] <> '\\'
+               then Filename.dirname sel ^ "\\"
+               else Filename.dirname sel
            else Filename.concat sel x
          in
          let x = if is_directory d then Filename.concat x "" else x in d, x)
@@ -988,23 +979,21 @@ let ged2gwb_check conf =
   let conf = {conf with env = ("f", "on") :: conf.env} in
   gwc_or_ged2gwb out_name_of_ged conf
 
-#ifdef WINDOWS
 let infer_rc conf rc =
-  if rc > 0 then rc
-  else
-    match p_getenv conf.env "o" with
-      Some out_file -> if Sys.file_exists (out_file ^ ".gwb") then 0 else 2
-    | _ -> 0
-#endif
+  if not Sys.unix then
+    if rc > 0 then rc
+    else
+      match p_getenv conf.env "o" with
+        Some out_file -> if Sys.file_exists (out_file ^ ".gwb") then 0 else 2
+      | _ -> 0
+  else rc
 
 let gwc conf =
   let rc =
     let comm = stringify (Filename.concat !bin_dir "gwc") in
     exec_f (comm ^ parameters conf.env)
   in
-#ifdef WINDOWS
-  let rc = infer_rc conf rc in
-#endif
+  let rc = if not Sys.unix then infer_rc conf rc else rc in
   let gwo = strip_spaces (s_getenv conf.env "anon") ^ "o" in
   (try Sys.remove gwo with Sys_error _ -> ());
   Printf.eprintf "\n";
@@ -1173,11 +1162,10 @@ let update_nldb_check conf =
 
 let has_gwu dir =
   try
-#ifdef UNIX
-    Array.mem "gwu" (Sys.readdir dir)
-#else
-    Array.exists (fun s -> String.lowercase_ascii s = "gwu.exe") (Sys.readdir dir)
-#endif
+    if Sys.unix then
+      Array.mem "gwu" (Sys.readdir dir)
+    else
+      Array.exists (fun s -> String.lowercase_ascii s = "gwu.exe") (Sys.readdir dir)
   with _ -> false
 
 let recover conf =
@@ -1203,16 +1191,13 @@ let recover conf =
   if init_dir = "" then print_file conf "err_miss.htm"
   else if init_dir = dest_dir then print_file conf "err_smdr.htm"
   else if not (Sys.file_exists init_dir) then print_file conf "err_ndir.htm"
-#ifdef UNIX
-  else if
-      try
-        (Unix.stat (Filename.concat init_dir ".")).Unix.st_ino
-        =
-        (Unix.stat (Filename.concat dest_dir ".")).Unix.st_ino
-      with Unix.Unix_error (_, _, _) -> false
-  then
-    print_file conf "err_smdr.htm"
-#endif
+  else if Sys.unix &&
+          (try
+             (Unix.stat (Filename.concat init_dir ".")).Unix.st_ino
+             =
+             (Unix.stat (Filename.concat dest_dir ".")).Unix.st_ino
+           with Unix.Unix_error (_, _, _) -> false)
+       then print_file conf "err_smdr.htm"
   else if not dir_has_gwu then print_file conf "err_ngw.htm"
   else print_file conf "recover1.htm"
 
@@ -1301,9 +1286,7 @@ let recover_2 conf =
         Printf.eprintf "$ %s\n" c;
         flush stderr;
         let rc = Sys.command c in
-#ifdef WINDOWS
-        let rc = infer_rc conf rc in
-#endif
+        let rc = if not Sys.unix then infer_rc conf rc else rc in
         Printf.eprintf "\n"; flush stderr; rc
       end
     else rc
@@ -1336,19 +1319,22 @@ let cleanup_1 conf =
   let _ = Sys.command c in
   Printf.eprintf "$ mkdir old\n";
   (try Unix.mkdir "old" 0o755 with Unix.Unix_error (_, _, _) -> ());
-#ifdef UNIX
-  Printf.eprintf "$ rm -rf old/%s\n" in_base_dir ;
-#else
-  Printf.eprintf "$ del old\\%s\\*.*\n" in_base_dir;
-  Printf.eprintf "$ rmdir old\\%s\n" in_base_dir;
-#endif
+  
+  if Sys.unix then
+    Printf.eprintf "$ rm -rf old/%s\n" in_base_dir
+  else begin
+    Printf.eprintf "$ del old\\%s\\*.*\n" in_base_dir;
+    Printf.eprintf "$ rmdir old\\%s\n" in_base_dir;
+  end;
+  
   flush stderr;
   Mutil.rm_rf (Filename.concat "old" in_base_dir);
-#ifdef UNIX
-  Printf.eprintf "$ mv %s old/.\n" in_base_dir ;
-#else
-  Printf.eprintf "$ move %s old\\.\n" in_base_dir;
-#endif
+  
+  if Sys.unix then
+    Printf.eprintf "$ mv %s old/.\n" in_base_dir
+  else
+    Printf.eprintf "$ move %s old\\.\n" in_base_dir;
+    
   flush stderr;
   Sys.rename in_base_dir (Filename.concat "old" in_base_dir);
   let c =
@@ -1358,9 +1344,9 @@ let cleanup_1 conf =
   Printf.eprintf "$ %s\n" c;
   flush stderr;
   let rc = Sys.command c in
-#ifdef WINDOWS
-  let rc = infer_rc conf rc in
-#endif
+  
+  let rc = if not Sys.unix then infer_rc conf rc else rc in
+  
   Printf.eprintf "\n";
   flush stderr;
   if rc > 1 then
@@ -1599,9 +1585,7 @@ let ged2gwb conf =
     let comm = stringify (Filename.concat !bin_dir conf.comm) in
     exec_f (comm ^ " -fne '\"\"'" ^ parameters conf.env)
   in
-#ifdef WINDOWS
-  let rc = infer_rc conf rc in
-#endif
+  let rc = if not Sys.unix then infer_rc conf rc else rc in
   Printf.eprintf "\n";
   flush stderr;
   if rc > 1 then print_file conf "bso_err.htm"
@@ -1880,14 +1864,14 @@ let setup (addr, req) comm (env_str : Adef.encoded_string) =
   else setup_comm conf comm
 
 let wrap_setup a b (c : Adef.encoded_string) =
-#ifdef WINDOWS
-  (* another process have been launched, therefore we lost variables;
-     and we cannot parse the arg list again, because of possible spaces
-     in arguments which may appear as separators *)
-  (try default_lang := Sys.getenv "GWLANG" with Not_found -> ());
-  (try setup_dir := Sys.getenv "GWGD" with Not_found -> ());
-  (try bin_dir := Sys.getenv "GWGD" with Not_found -> ());
-#endif
+  if not Sys.unix then begin
+    (* another process have been launched, therefore we lost variables;
+       and we cannot parse the arg list again, because of possible spaces
+       in arguments which may appear as separators *)
+    (try default_lang := Sys.getenv "GWLANG" with Not_found -> ());
+    (try setup_dir := Sys.getenv "GWGD" with Not_found -> ());
+    (try bin_dir := Sys.getenv "GWGD" with Not_found -> ());
+  end;
   try setup a b c with Exit -> ()
 
 let copy_text lang fname =
@@ -1950,32 +1934,31 @@ let speclist =
 
 let anonfun s = raise (Arg.Bad ("don't know what to do with " ^ s))
 
-#ifdef UNIX
 let null_reopen flags fd =
-  let fd2 = Unix.openfile "/dev/null" flags 0 in
-  Unix.dup2 fd2 fd;
-  Unix.close fd2
-#endif
+  if Sys.unix then begin
+    let fd2 = Unix.openfile "/dev/null" flags 0 in
+    Unix.dup2 fd2 fd;
+    Unix.close fd2
+  end
 
 let setup_available_languages = ["de"; "en"; "es"; "fr"; "it"; "lv"; "sv"]
 
 let intro () =
   let (default_gwd_lang, default_setup_lang) =
-#ifdef UNIX
-    let s = try Sys.getenv "LANG" with Not_found -> "" in
-    if List.mem s Version.available_languages
-    then s, (if List.mem s setup_available_languages then s else "en")
-    else
-      let s = try Sys.getenv "LC_CTYPE" with Not_found -> "" in
-      if String.length s >= 2 then
-        let s = String.sub s 0 2 in
-        if List.mem s Version.available_languages
-        then s, (if List.mem s setup_available_languages then s else "en")
+    if Sys.unix then
+      let s = try Sys.getenv "LANG" with Not_found -> "" in
+      if List.mem s Version.available_languages
+      then s, (if List.mem s setup_available_languages then s else "en")
+      else
+        let s = try Sys.getenv "LC_CTYPE" with Not_found -> "" in
+        if String.length s >= 2 then
+          let s = String.sub s 0 2 in
+          if List.mem s Version.available_languages
+          then s, (if List.mem s setup_available_languages then s else "en")
+          else !default_lang, !default_lang
         else !default_lang, !default_lang
-      else !default_lang, !default_lang
-#else
-    !default_lang, !default_lang
-#endif
+    else
+      !default_lang, !default_lang
   in
   Secure.set_base_dir ".";
   Arg.parse speclist anonfun usage;
@@ -1983,7 +1966,7 @@ let intro () =
   default_lang := default_setup_lang;
   let (gwd_lang, setup_lang) =
     if !daemon then
-#ifdef UNIX
+      if Sys.unix then
         let setup_lang =
           if String.length !lang_param < 2 then default_setup_lang
           else !lang_param
@@ -1997,9 +1980,8 @@ let intro () =
           end
         else exit 0;
         default_gwd_lang, setup_lang
-#else
-      default_gwd_lang, default_setup_lang
-#endif
+      else
+        default_gwd_lang, default_setup_lang
     else
       let (gwd_lang, setup_lang) =
         if String.length !lang_param < 2 then
@@ -2016,17 +1998,16 @@ let intro () =
   in
   set_gwd_default_language_if_absent gwd_lang;
   default_lang := setup_lang;
-#ifdef WINDOWS
-  Unix.putenv "GWLANG" setup_lang;
-  Unix.putenv "GWGD" !setup_dir;
-#endif
+  if not Sys.unix then begin
+    Unix.putenv "GWLANG" setup_lang;
+    Unix.putenv "GWGD" !setup_dir;
+  end;
   Printf.printf "\n";
   flush stdout
 
 let () =
-#ifdef UNIX
-  intro () ;
-#else
-  if Sys.getenv_opt "WSERVER" = None then intro () ;
-#endif
+  if Sys.unix then
+    intro ()
+  else
+    if Sys.getenv_opt "WSERVER" = None then intro ();
   Wserver.start ~port:!port ~max_pending_requests:150 ~n_workers:1 wrap_setup

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -12,43 +12,40 @@ let bname = ref ""
 let commnd = ref ""
 
 let printer_conf =
-  { Config.empty with output_conf =
-                        { status = Wserver.http
-                        ; header = Wserver.header
-                        ; body = Wserver.print_string
-                        ; flush = Wserver.wflush
-                        }
+  {
+    Config.empty with
+    output_conf =
+      {
+        status = Wserver.http;
+        header = Wserver.header;
+        body = Wserver.print_string;
+        flush = Wserver.wflush;
+      };
   }
 
-let slashify s =
-  String.map (function '\\' -> '/' | c -> c) s
+let slashify s = String.map (function '\\' -> '/' | c -> c) s
 
 let slashify_linux_dos s =
-  if Sys.unix then
-    s
-  else
-    String.map (function '/' -> '\\' | c -> c) s
+  if Sys.unix then s else String.map (function '/' -> '\\' | c -> c) s
 
 let decode s = Mutil.decode (Adef.encoded s)
 let encode s = (Mutil.encode s :> string)
 
-let rec list_remove_assoc x =
-  function
-    (x1, y1) :: l -> if x = x1 then l else (x1, y1) :: list_remove_assoc x l
+let rec list_remove_assoc x = function
+  | (x1, y1) :: l -> if x = x1 then l else (x1, y1) :: list_remove_assoc x l
   | [] -> []
 
-let rec list_assoc_all x =
-  function
-    [] -> []
-  | (a, b) :: l ->
-      if a = x then b :: list_assoc_all x l else list_assoc_all x l
+let rec list_assoc_all x = function
+  | [] -> []
+  | (a, b) :: l -> if a = x then b :: list_assoc_all x l else list_assoc_all x l
 
-type config =
-  { lang : string;
-    comm : string;
-    env : (string * string) list;
-    request : string list;
-    lexicon : (string, string) Hashtbl.t }
+type config = {
+  lang : string;
+  comm : string;
+  env : (string * string) list;
+  request : string list;
+  lexicon : (string, string) Hashtbl.t;
+}
 
 let transl conf w =
   try Hashtbl.find conf.lexicon w with Not_found -> "[" ^ w ^ "]"
@@ -58,13 +55,12 @@ let charset conf =
 
 let header_no_page_title conf title =
   Output.status printer_conf Def.OK;
-  Output.header printer_conf "Content-type: text/html; charset=%s" (charset conf);
+  Output.header printer_conf "Content-type: text/html; charset=%s"
+    (charset conf);
   Output.print_sstring printer_conf
     "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\" \
-     \"http://www.w3.org/TR/REC-html40/loose.dtd\">\
-     <head>\
-     <meta name=\"robots\" content=\"none\">\
-     <title>";
+     \"http://www.w3.org/TR/REC-html40/loose.dtd\"><head><meta name=\"robots\" \
+     content=\"none\"><title>";
   title true;
   Output.print_sstring printer_conf "</title></head><body>"
 
@@ -74,12 +70,15 @@ let abs_setup_dir () =
   else !setup_dir
 
 let trailer _conf =
-  Output.print_sstring printer_conf {|<br><div id="footer"><hr><div><em>|} ;
-  Output.print_sstring printer_conf {|<a href="https://github.com/geneweb/geneweb/">|} ;
-  Output.print_sstring printer_conf {|<img src="images/logo_bas.png" style="border:0"></a>|} ;
-  Output.print_sstring printer_conf {| Version |} ;
-  Output.print_sstring printer_conf Version.ver ;
-  Output.print_sstring printer_conf " Copyright &copy; 1998-2021</em></div></div></body></html>"
+  Output.print_sstring printer_conf {|<br><div id="footer"><hr><div><em>|};
+  Output.print_sstring printer_conf
+    {|<a href="https://github.com/geneweb/geneweb/">|};
+  Output.print_sstring printer_conf
+    {|<img src="images/logo_bas.png" style="border:0"></a>|};
+  Output.print_sstring printer_conf {| Version |};
+  Output.print_sstring printer_conf Version.ver;
+  Output.print_sstring printer_conf
+    " Copyright &copy; 1998-2021</em></div></div></body></html>"
 
 let header conf title =
   header_no_page_title conf title;
@@ -100,9 +99,7 @@ let strip_spaces str =
     let rec loop i =
       if i = String.length str then i
       else
-        match str.[i] with
-          ' ' | '\r' | '\n' | '\t' -> loop (i + 1)
-        | _ -> i
+        match str.[i] with ' ' | '\r' | '\n' | '\t' -> loop (i + 1) | _ -> i
     in
     loop 0
   in
@@ -111,7 +108,7 @@ let strip_spaces str =
       if i = -1 then i + 1
       else
         match str.[i] with
-          ' ' | '\r' | '\n' | '\t' -> loop (i - 1)
+        | ' ' | '\r' | '\n' | '\t' -> loop (i - 1)
         | _ -> i + 1
     in
     loop (String.length str - 1)
@@ -121,9 +118,7 @@ let strip_spaces str =
   else String.sub str start (stop - start)
 
 let getenv env label = decode (List.assoc (decode label) env)
-
 let p_getenv env label = try Some (getenv env label) with Not_found -> None
-
 let s_getenv env label = try getenv env label with Not_found -> ""
 
 let rec skip_spaces s i =
@@ -133,18 +128,16 @@ let create_env s =
   let s = (s : Adef.encoded_string :> string) in
   let rec get_assoc beg i =
     if i = String.length s then
-      if i = beg then [] else [String.sub s beg (i - beg)]
+      if i = beg then [] else [ String.sub s beg (i - beg) ]
     else if s.[i] = ';' || s.[i] = '&' then
       let next_i = skip_spaces s (succ i) in
       String.sub s beg (i - beg) :: get_assoc next_i next_i
     else get_assoc beg (succ i)
   in
   let rec separate i s =
-    if i = String.length s then s, ""
+    if i = String.length s then (s, "")
     else if s.[i] = '=' then
-      ( String.sub s 0 i
-      , String.sub s (succ i) (String.length s - succ i)
-      )
+      (String.sub s 0 i, String.sub s (succ i) (String.length s - succ i))
     else separate (succ i) s
   in
   List.map (separate 0) (get_assoc 0 0)
@@ -153,38 +146,38 @@ let numbered_key k =
   if k = "" then None
   else
     match k.[String.length k - 1] with
-      '1'..'9' as c -> Some (String.sub k 0 (String.length k - 1), c)
+    | '1' .. '9' as c -> Some (String.sub k 0 (String.length k - 1), c)
     | _ -> None
 
 let stringify s =
-  try let _ = String.index s ' ' in "\"" ^ s ^ "\"" with Not_found -> s
+  try
+    let _ = String.index s ' ' in
+    "\"" ^ s ^ "\""
+  with Not_found -> s
 
 let parameters =
-  let rec loop comm =
-    function
-      (k, s) :: env ->
+  let rec loop comm = function
+    | (k, s) :: env -> (
         let k = strip_spaces (decode k) in
         let s = strip_spaces (decode s) in
         if k = "" || s = "" then loop comm env
         else if k = "opt" then loop comm env
         else if k = "anon" then loop (comm ^ " " ^ stringify s) env
         else
-          begin match numbered_key k with
-            Some (k, '1') ->
-              let (s, env) =
-                let rec loop s =
-                  function
-                    (k1, s1) :: env as genv ->
-                      begin match numbered_key k1 with
-                        Some (k1, _) when k1 = k ->
+          match numbered_key k with
+          | Some (k, '1') ->
+              let s, env =
+                let rec loop s = function
+                  | (k1, s1) :: env as genv -> (
+                      match numbered_key k1 with
+                      | Some (k1, _) when k1 = k ->
                           let s1 = strip_spaces (decode s1) in
                           let s =
                             if s1 = "" then s else s ^ " \"" ^ s1 ^ "\""
                           in
                           loop s env
-                      | _ -> s, genv
-                      end
-                  | [] -> s, []
+                      | _ -> (s, genv))
+                  | [] -> (s, [])
                 in
                 loop ("\"" ^ s ^ "\"") env
               in
@@ -193,33 +186,36 @@ let parameters =
           | None ->
               if s = "none" then loop comm env
               else if s = "on" then loop (comm ^ " -" ^ k) env
-              else if s.[0] = '_' then
-                loop (comm ^ " -" ^ k ^ stringify s) env
+              else if s.[0] = '_' then loop (comm ^ " -" ^ k ^ stringify s) env
               else if s.[String.length s - 1] = '_' then
                 loop (comm ^ " -" ^ s ^ k) env
-              else loop (comm ^ " -" ^ k ^ " " ^ stringify s) env
-          end
+              else loop (comm ^ " -" ^ k ^ " " ^ stringify s) env)
     | [] -> comm
   in
   loop ""
 
 let parameters_1 =
-  let rec loop comm bname =
-    function
+  let rec loop comm bname = function
     | (k, s) :: env ->
         let k = strip_spaces (decode k) in
         let s = strip_spaces (decode s) in
         if k = "" || s = "" then loop comm bname env
         else if k = "opt" then loop comm bname env
-        else if k = "gwd_p" && s <> "" then loop (comm ^ " -gwd_p " ^ stringify s ) bname env
-        else if k = "anon" && s <> "" then loop (comm ^ " " ^ stringify s) (stringify s) env
+        else if k = "gwd_p" && s <> "" then
+          loop (comm ^ " -gwd_p " ^ stringify s) bname env
+        else if k = "anon" && s <> "" then
+          loop (comm ^ " " ^ stringify s) (stringify s) env
         else if k = "a" then loop (comm ^ " -a") bname env
         else if k = "s" then loop (comm ^ " -s") bname env
-        else if k = "d" && s <> "" then loop (comm ^ " -d " ^ stringify s ) bname env
-        else if k = "i" && s <> "" then loop (comm ^ " -i " ^ stringify s) bname env
+        else if k = "d" && s <> "" then
+          loop (comm ^ " -d " ^ stringify s) bname env
+        else if k = "i" && s <> "" then
+          loop (comm ^ " -i " ^ stringify s) bname env
         else if k = "bf" then loop (comm ^ " -bf") bname env
-        else if k = "del" && s <> "" then loop (comm ^ " -del " ^ stringify s) bname env
-        else if k = "cnt" && s <> "" then loop (comm ^ " -cnt " ^ stringify s) bname env
+        else if k = "del" && s <> "" then
+          loop (comm ^ " -del " ^ stringify s) bname env
+        else if k = "cnt" && s <> "" then
+          loop (comm ^ " -cnt " ^ stringify s) bname env
         else if k = "exact" then loop (comm ^ " -exact") bname env
         else if k = "o1" && s <> "" then
           let out = stringify s in
@@ -228,7 +224,9 @@ let parameters_1 =
           if s = "choice" then loop comm bname env
           else
             let out = stringify s in
-            let out = if out = "/notes_d/connex.txt" then bname  ^ ".gwb" ^ out else out in
+            let out =
+              if out = "/notes_d/connex.txt" then bname ^ ".gwb" ^ out else out
+            in
             let out = slashify_linux_dos out in
             comm ^ " -o " ^ out ^ " > " ^ out
         else loop comm bname env
@@ -237,8 +235,7 @@ let parameters_1 =
   loop "" ""
 
 let parameters_2 =
-  let rec loop comm =
-    function
+  let rec loop comm = function
     | (k, s) :: env ->
         let k = strip_spaces (decode k) in
         let s = strip_spaces (decode s) in
@@ -249,72 +246,66 @@ let parameters_2 =
         else if k = "a1" then loop (comm ^ " -1 " ^ stringify s) env
         else if k = "a2" then loop (comm ^ " " ^ stringify s) env
         else if k = "a3" then loop (comm ^ " " ^ stringify s) env
-        else if k = "b1" then loop (comm ^ " -2 "  ^ stringify s) env
+        else if k = "b1" then loop (comm ^ " -2 " ^ stringify s) env
         else if k = "b2" then loop (comm ^ " " ^ stringify s) env
         else if k = "b3" then loop (comm ^ " " ^ stringify s) env
         else if k = "ad" then loop (comm ^ " -ad ") env
         else if k = "d" then loop (comm ^ " -d ") env
         else if k = "mem" then loop (comm ^ " -mem") env
-        else if k = "o" then loop (comm ^ " -o " ^ stringify s ^ " > " ^ stringify s) env
+        else if k = "o" then
+          loop (comm ^ " -o " ^ stringify s ^ " > " ^ stringify s) env
         else loop comm env
     | [] -> comm
   in
   loop ""
 
-
 let parameters_3 =
-  let rec loop comm =
-    function
-      (k, s) :: env ->
+  let rec loop comm = function
+    | (k, s) :: env ->
         let k = strip_spaces (decode k) in
         if k = "" || k = "opt" then loop comm env
-        else if k = "anon" && s <> "" then
-          loop (comm ^ " " ^ stringify s) env
+        else if k = "anon" && s <> "" then loop (comm ^ " " ^ stringify s) env
         else if k = "bd" && s <> "" then
           loop (comm ^ " -" ^ stringify k ^ " " ^ stringify s) env
-        else (
-          loop (comm ^ " -" ^ stringify k) env)
+        else loop (comm ^ " -" ^ stringify k) env
     | [] -> comm
   in
   loop ""
 
-let rec list_replace k v =
-  function
-    [] -> [k, v]
+let rec list_replace k v = function
+  | [] -> [ (k, v) ]
   | (k1, _) :: env when k1 = k -> (k1, v) :: env
   | kv :: env -> kv :: list_replace k v env
 
-let conf_with_env conf k v = {conf with env = list_replace k v conf.env}
+let conf_with_env conf k v = { conf with env = list_replace k v conf.env }
 
 let all_db dir =
   let list = ref [] in
   let dh = Unix.opendir dir in
-  begin try
-    while true do
-      let e = Unix.readdir dh in
-      if Filename.check_suffix e ".gwb" then
-        list := Filename.chop_suffix e ".gwb" :: !list
-    done
-  with End_of_file -> ()
-  end;
+  (try
+     while true do
+       let e = Unix.readdir dh in
+       if Filename.check_suffix e ".gwb" then
+         list := Filename.chop_suffix e ".gwb" :: !list
+     done
+   with End_of_file -> ());
   Unix.closedir dh;
   list := List.sort compare !list;
   !list
 
 let selected env =
-  List.fold_right (fun (k, v) env -> if v = "on_" then k :: env else env) env
-    []
+  List.fold_right (fun (k, v) env -> if v = "on_" then k :: env else env) env []
 
 let parse_upto lim =
   let rec loop len (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-    | Some c when c = lim -> Stream.junk strm__; Buff.get len
-    | Some c ->
-      Stream.junk strm__;
-      begin
+    | Some c when c = lim ->
+        Stream.junk strm__;
+        Buff.get len
+    | Some c -> (
+        Stream.junk strm__;
         try loop (Buff.store len c) strm__
-        with Stream.Failure -> raise (Stream.Error "")
-      end
+        with Stream.Failure -> raise (Stream.Error ""))
     | _ -> raise Stream.Failure
   in
   loop 0
@@ -322,38 +313,38 @@ let parse_upto lim =
 let parse_upto_void lim =
   let rec loop len (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
-    | Some c when c = lim -> Stream.junk strm__; ()
-    | Some c ->
-      Stream.junk strm__;
-      begin
+    | Some c when c = lim ->
+        Stream.junk strm__;
+        ()
+    | Some c -> (
+        Stream.junk strm__;
         try loop (Buff.store len c) strm__
-        with Stream.Failure -> raise (Stream.Error "")
-      end
+        with Stream.Failure -> raise (Stream.Error ""))
     | _ -> raise Stream.Failure
   in
   loop 0
 
 let is_directory x =
-  try (Unix.lstat x).Unix.st_kind = Unix.S_DIR with
-    Unix.Unix_error (_, _, _) -> false
+  try (Unix.lstat x).Unix.st_kind = Unix.S_DIR
+  with Unix.Unix_error (_, _, _) -> false
 
 let server_string conf =
   let s = Mutil.extract_param "host: " '\r' conf.request in
-  try let i = String.rindex s ':' in String.sub s 0 i with
-    Not_found -> "127.0.0.1"
+  try
+    let i = String.rindex s ':' in
+    String.sub s 0 i
+  with Not_found -> "127.0.0.1"
 
 let referer conf = Mutil.extract_param "referer: " '\r' conf.request
 
 let only_file_name =
-  lazy begin
-    if !only_file = "" then Filename.concat !setup_dir "only.txt"
-    else Filename.concat !setup_dir !only_file
-  end
+  lazy
+    (if !only_file = "" then Filename.concat !setup_dir "only.txt"
+    else Filename.concat !setup_dir !only_file)
 
 (* this set of macros are used within translations, hence the repeat of some *)
 (* like %l, %L, %P, ... and they may be different! %G  *)
-let macro conf =
-  function
+let macro conf = function
   | '/' -> if Sys.unix then "/" else "\\"
   | 'a' -> strip_spaces (s_getenv conf.env "anon")
   | 'c' -> stringify !setup_dir
@@ -363,7 +354,9 @@ let macro conf =
   | 'm' -> server_string conf
   | 'n' -> referer conf
   | 'o' -> strip_spaces (s_getenv conf.env "o")
-  | 'O' -> Filename.remove_extension (Filename.basename (strip_spaces (s_getenv conf.env "o")))
+  | 'O' ->
+      Filename.remove_extension
+        (Filename.basename (strip_spaces (s_getenv conf.env "o")))
   | 'p' -> parameters conf.env
   | 'q' -> Version.ver
   | 'u' -> Filename.dirname (abs_setup_dir ())
@@ -377,7 +370,7 @@ let macro conf =
   | 'L' ->
       let lang = conf.lang in
       let lang_def = transl conf "!languages" in
-      (Translate.language_name ~sep:'|' lang lang_def)
+      Translate.language_name ~sep:'|' lang lang_def
   | 'P' -> string_of_int !gwd_port
   | 'Q' -> parameters_1 conf.env
   | 'R' -> parameters_2 conf.env
@@ -386,10 +379,14 @@ let macro conf =
 
 let get_variable (strm : _ Stream.t) =
   let rec loop len =
-     match Stream.peek strm with
-     | Some ';' -> Stream.junk strm; Buff.get len
-     | Some c -> Stream.junk strm; loop (Buff.store len c)
-     | _ -> raise Stream.Failure
+    match Stream.peek strm with
+    | Some ';' ->
+        Stream.junk strm;
+        Buff.get len
+    | Some c ->
+        Stream.junk strm;
+        loop (Buff.store len c)
+    | _ -> raise Stream.Failure
   in
   loop 0
 
@@ -397,8 +394,12 @@ let get_binding strm =
   let rec loop len =
     match Stream.peek strm with
     | Some '=' ->
-      Stream.junk strm; let k = Buff.get len in k, get_variable strm
-    | Some c -> Stream.junk strm; loop (Buff.store len c)
+        Stream.junk strm;
+        let k = Buff.get len in
+        (k, get_variable strm)
+    | Some c ->
+        Stream.junk strm;
+        loop (Buff.store len c)
     | _ -> raise Stream.Failure
   in
   loop 0
@@ -408,38 +409,41 @@ let variables bname =
   let fname = Filename.concat (Filename.concat dir "lang") bname in
   let ic = open_in fname in
   let strm = Stream.of_channel ic in
-  let (vlist, flist) =
+  let vlist, flist =
     let rec loop (vlist, flist) =
       match Stream.peek strm with
       | Some '%' ->
-        Stream.junk strm;
-        let (vlist, flist) =
-          let (strm : _ Stream.t) = strm in
-          match Stream.peek strm with
-            Some ('E' | 'C') ->
-            Stream.junk strm;
-            let (v, _) = get_binding strm in
-            if not (List.mem v vlist) then v :: vlist, flist
-            else vlist, flist
-          | Some 'V' ->
-            Stream.junk strm;
-            let v = get_variable strm in
-            if not (List.mem v vlist) then v :: vlist, flist
-            else vlist, flist
-          | Some 'F' ->
-            Stream.junk strm;
-            let v = get_variable strm in
-            if not (List.mem v flist) then vlist, v :: flist
-            else vlist, flist
-          | _ -> vlist, flist
-        in
-        loop (vlist, flist)
-      | Some _ -> Stream.junk strm; loop (vlist, flist)
-      | _ -> vlist, flist
+          Stream.junk strm;
+          let vlist, flist =
+            let (strm : _ Stream.t) = strm in
+            match Stream.peek strm with
+            | Some ('E' | 'C') ->
+                Stream.junk strm;
+                let v, _ = get_binding strm in
+                if not (List.mem v vlist) then (v :: vlist, flist)
+                else (vlist, flist)
+            | Some 'V' ->
+                Stream.junk strm;
+                let v = get_variable strm in
+                if not (List.mem v vlist) then (v :: vlist, flist)
+                else (vlist, flist)
+            | Some 'F' ->
+                Stream.junk strm;
+                let v = get_variable strm in
+                if not (List.mem v flist) then (vlist, v :: flist)
+                else (vlist, flist)
+            | _ -> (vlist, flist)
+          in
+          loop (vlist, flist)
+      | Some _ ->
+          Stream.junk strm;
+          loop (vlist, flist)
+      | _ -> (vlist, flist)
     in
     loop ([], [])
   in
-  close_in ic; List.rev vlist, flist
+  close_in ic;
+  (List.rev vlist, flist)
 
 let nth_field s n =
   let rec loop nth i =
@@ -451,13 +455,11 @@ let nth_field s n =
   loop 0 0
 
 let translate_phrase lexicon s n =
-  let n =
-    match n with
-      Some n -> n
-    | None -> 0
-  in
-  try let s = Hashtbl.find lexicon s in nth_field s n with
-    Not_found -> "[" ^ nth_field s n ^ "]"
+  let n = match n with Some n -> n | None -> 0 in
+  try
+    let s = Hashtbl.find lexicon s in
+    nth_field s n
+  with Not_found -> "[" ^ nth_field s n ^ "]"
 
 let file_contents fname =
   try
@@ -466,35 +468,38 @@ let file_contents fname =
       match try Some (input_char ic) with End_of_file -> None with
       | Some '\r' -> loop len
       | Some c -> loop (Buff.store len c)
-      | None -> close_in ic ; Buff.get len
-    in loop 0
+      | None ->
+          close_in ic;
+          Buff.get len
+    in
+    loop 0
   with Sys_error _ -> ""
 
 let cut_at_equal s =
   match String.index_opt s '=' with
   | Some i ->
-    (String.sub s 0 i, String.sub s (succ i) (String.length s - succ i))
+      (String.sub s 0 i, String.sub s (succ i) (String.length s - succ i))
   | None -> (s, "")
 
 let loc_read_base_env bname =
   let fname = !GWPARAM.config bname in
   match try Some (open_in fname) with Sys_error _ -> None with
   | Some ic ->
-    let rec loop env =
-      match try Some (input_line ic) with End_of_file -> None with
-      | None -> close_in ic ; env
-      | Some s ->
-          let s =
-            if String.length s >= 1 &&
-            (Char.code s.[String.length s - 1] = 13)
-            then String.sub s 0 (String.length s - 1)
-            else s
-          in
-          if s = "" || s.[0] = '#'
-          then loop env
-          else loop (cut_at_equal s :: env)
-    in
-    loop []
+      let rec loop env =
+        match try Some (input_line ic) with End_of_file -> None with
+        | None ->
+            close_in ic;
+            env
+        | Some s ->
+            let s =
+              if String.length s >= 1 && Char.code s.[String.length s - 1] = 13
+              then String.sub s 0 (String.length s - 1)
+              else s
+            in
+            if s = "" || s.[0] = '#' then loop env
+            else loop (cut_at_equal s :: env)
+      in
+      loop []
   | None -> []
 
 let rec split_string acc s =
@@ -502,80 +507,99 @@ let rec split_string acc s =
   else
     match String.index_from_opt s 70 ' ' with
     | Some i when String.length s > i + 3 ->
-        split_string (acc ^ (String.sub s 0 i) ^ "\n") (String.sub s (i + 1) (String.length s - i - 1))
+        split_string
+          (acc ^ String.sub s 0 i ^ "\n")
+          (String.sub s (i + 1) (String.length s - i - 1))
     | _ -> acc ^ s
 
 let rec copy_from_stream conf print strm =
   try
     while true do
       match Stream.next strm with
-        '[' ->
-          begin match Stream.peek strm with
+      | '[' -> (
+          match Stream.peek strm with
           | Some '\n' ->
               let s = parse_upto ']' strm in
-              print "Translations must be on a single line: [string to translate]";
+              print
+                "Translations must be on a single line: [string to translate]";
               print s
           | _ ->
               let s =
                 let rec loop len =
                   match Stream.peek strm with
-                  | Some ']' -> Stream.junk strm; Buff.get len
-                  | Some c -> Stream.junk strm; loop (Buff.store len c)
+                  | Some ']' ->
+                      Stream.junk strm;
+                      Buff.get len
+                  | Some c ->
+                      Stream.junk strm;
+                      loop (Buff.store len c)
                   | _ -> Buff.get len
                 in
                 loop 0
               in
               let n =
                 match Stream.peek strm with
-                | Some ('0'..'9' as c) ->
-                  Stream.junk strm; (Char.code c - Char.code '0')
+                | Some ('0' .. '9' as c) ->
+                    Stream.junk strm;
+                    Char.code c - Char.code '0'
                 | _ -> 0
               in
               (* translate before macro processing *)
-              let s = (nth_field (transl conf s) n) in
+              let s = nth_field (transl conf s) n in
               (* FIXME must be more efficient way of doing this (with buffers?) *)
               let s =
                 let rec loop acc s =
                   if String.length s = 0 then acc
+                  else if s.[0] = '%' then
+                    loop
+                      (acc ^ macro conf s.[1])
+                      (String.sub s 2 (String.length s - 2))
                   else
-                    if s.[0] = '%' then loop (acc ^ (macro conf s.[1])) (String.sub s 2 (String.length s - 2))
-                    else loop (acc ^ (String.sub s 0 1)) (String.sub s 1 (String.length s - 1))
-                in loop "" s
+                    loop
+                      (acc ^ String.sub s 0 1)
+                      (String.sub s 1 (String.length s - 1))
+                in
+                loop "" s
               in
-              print (split_string "" s)
-          end
-      | '%' ->
+              print (split_string "" s))
+      | '%' -> (
           let c = Stream.next strm in
-          begin match c with
+          match c with
           | '(' ->
-                let rec loop () =
-                  let _s = parse_upto '%' strm in
-                  let c = Stream.next strm in
-                  if c = ')' then () else loop ()
-                in loop ()
+              let rec loop () =
+                let _s = parse_upto '%' strm in
+                let c = Stream.next strm in
+                if c = ')' then () else loop ()
+              in
+              loop ()
           | 'b' -> for_all conf print (all_db ".") strm
           | 'e' ->
               print "lang=";
               print conf.lang;
               List.iter
                 (fun (k, s) ->
-                   if k = "opt" then ()
-                   else begin print ";"; print k; print "="; print s; () end)
+                  if k = "opt" then ()
+                  else (
+                    print ";";
+                    print k;
+                    print "=";
+                    print s;
+                    ()))
                 conf.env
           | 'f' ->
               (* see r *)
-                let in_file = get_variable strm in
-                let s =
-                  file_contents
-                    (slashify_linux_dos (!bin_dir ^ "/setup/" ^ in_file))
-                in
-                let in_base = strip_spaces (s_getenv conf.env "anon") in
-                GWPARAM.test_reorg in_base;
-                let benv = loc_read_base_env in_base in
-                let conf = { conf with env = benv @ conf.env} in
-                (* depending on when %f is called, conf may be sketchy *)
-                (* conf will know bvars from basename.gwf and evars from url *)
-                copy_from_stream conf print (Stream.of_string s)
+              let in_file = get_variable strm in
+              let s =
+                file_contents
+                  (slashify_linux_dos (!bin_dir ^ "/setup/" ^ in_file))
+              in
+              let in_base = strip_spaces (s_getenv conf.env "anon") in
+              GWPARAM.test_reorg in_base;
+              let benv = loc_read_base_env in_base in
+              let conf = { conf with env = benv @ conf.env } in
+              (* depending on when %f is called, conf may be sketchy *)
+              (* conf will know bvars from basename.gwf and evars from url *)
+              copy_from_stream conf print (Stream.of_string s)
           | 'g' -> print_specific_file conf print "comm.log" strm
           | 'h' ->
               print "<input type=hidden name=lang value=";
@@ -583,21 +607,20 @@ let rec copy_from_stream conf print strm =
               print ">\n";
               List.iter
                 (fun (k, s) ->
-                   if k <> "opt" then
-                     begin
-                       print "<input type=hidden name=";
-                       print k;
-                       print " value=\"";
-                       print (decode s);
-                       print "\">\n"
-                     end)
+                  if k <> "opt" then (
+                    print "<input type=hidden name=";
+                    print k;
+                    print " value=\"";
+                    print (decode s);
+                    print "\">\n"))
                 conf.env
           | 'j' -> print_selector conf print
           | 'k' -> for_all conf print (fst (List.split conf.env)) strm
           | 'l' -> print conf.lang
           | 'r' ->
               print_specific_file conf print
-                (Filename.concat !setup_dir "gwd.arg") strm
+                (Filename.concat !setup_dir "gwd.arg")
+                strm
           | 's' -> for_all conf print (selected conf.env) strm
           | 't' -> print_if conf print (not Sys.unix) strm
           | 'v' ->
@@ -607,41 +630,43 @@ let rec copy_from_stream conf print strm =
               print_if conf print (Sys.file_exists (base ^ ".gwb")) strm
           | 'y' -> for_all conf print (all_db (s_getenv conf.env "anon")) strm
           | 'z' -> print (string_of_int !port)
-          | 'A'..'Z' | '0'..'9' as c ->
-              begin match c with
-              | 'C' | 'E' ->
-                  let (k, v) = get_binding strm in
-                  begin match p_getenv conf.env k with
-                    Some x ->
+          | ('A' .. 'Z' | '0' .. '9') as c -> (
+              match c with
+              | 'C' | 'E' -> (
+                  let k, v = get_binding strm in
+                  match p_getenv conf.env k with
+                  | Some x ->
                       if x = v then
                         print (if c = 'C' then " checked" else " selected")
-                  | None -> ()
-                  end
+                  | None -> ())
               | 'D' -> print (transl conf "!doc")
-           (* | 'F' see 'V' *)
+              (* | 'F' see 'V' *)
               | 'G' -> print_specific_file_tail conf print "gwsetup.log" strm
               | 'H' ->
                   (* print the content of -o filename, prepend bname *)
                   let outfile = strip_spaces (s_getenv conf.env "o") in
                   let bname = strip_spaces (s_getenv conf.env "anon") in
-                  let outfile = if bname <> ""
-                    then slashify_linux_dos bname ^ ".gwb" ^ outfile
+                  let outfile =
+                    if bname <> "" then
+                      slashify_linux_dos bname ^ ".gwb" ^ outfile
                     else outfile
                   in
-                  print_specific_file conf print outfile strm;
+                  print_specific_file conf print outfile strm
               | 'I' ->
                   (* %Ivar;value;{var = value part|false part} *)
                   (* var is a evar from url or a bvar from basename.gwf or setup.gwf *)
                   let k1 = get_variable strm in
                   let k2 = get_variable strm in
                   print_if_else conf print (p_getenv conf.env k1 = Some k2) strm
-              | 'K' -> (* print the name of -o filename, prepend bname or -o1 filename *)
+              | 'K' ->
+                  (* print the name of -o filename, prepend bname or -o1 filename *)
                   let outfile1 = strip_spaces (s_getenv conf.env "o") in
                   let bname = strip_spaces (s_getenv conf.env "anon") in
                   let outfile2 = strip_spaces (s_getenv conf.env "o1") in
                   let outfile =
                     if outfile2 <> "" then outfile2
-                    else if bname <> "" then slashify_linux_dos bname ^ ".gwb" ^ outfile1
+                    else if bname <> "" then
+                      slashify_linux_dos bname ^ ".gwb" ^ outfile1
                     else outfile1
                   in
                   print outfile
@@ -650,82 +675,86 @@ let rec copy_from_stream conf print strm =
                   let lang_def = transl conf "!languages" in
                   print (Translate.language_name ~sep:'|' lang lang_def)
               | 'O' ->
-                  let fname = Filename.remove_extension
-                    (Filename.basename (strip_spaces (s_getenv conf.env "o")))
+                  let fname =
+                    Filename.remove_extension
+                      (Filename.basename (strip_spaces (s_getenv conf.env "o")))
                   in
                   let fname = slashify_linux_dos fname in
                   print fname
               | 'P' -> print (string_of_int !gwd_port)
               | 'Q' -> print (parameters_1 conf.env) (* same as p *)
               | 'R' -> print (parameters_2 conf.env) (* same as p *)
-              | 'V' | 'F' ->
+              | 'V' | 'F' -> (
                   let k = get_variable strm in
-                  begin match p_getenv conf.env k with
-                    Some v -> print v
-                  | None -> ()
-                  end
+                  match p_getenv conf.env k with
+                  | Some v -> print v
+                  | None -> ())
               | 'S' -> print (parameters_3 conf.env)
-              | _ ->
-                match p_getenv conf.env (String.make 1 c) with
-                | Some v ->
-                  begin match Stream.peek strm with
-                    | Some '{' ->
-                      Stream.junk strm;
-                      let s = parse_upto '}' strm in
-                      print "\"";
-                      print s;
-                      print "\"";
-                      if v = s then print " selected"
-                    | Some '[' ->
-                      Stream.junk strm;
-                      let s = parse_upto ']' strm in
-                      print "\"";
-                      print s;
-                      print "\"";
-                      if v = s then print " checked"
-                    | _ -> print (strip_spaces v)
-                  end
-                | None -> print ("BAD MACRO 2" ^ String.make 1 c)
-              end
-          | c -> print (macro conf c)
-          end
+              | _ -> (
+                  match p_getenv conf.env (String.make 1 c) with
+                  | Some v -> (
+                      match Stream.peek strm with
+                      | Some '{' ->
+                          Stream.junk strm;
+                          let s = parse_upto '}' strm in
+                          print "\"";
+                          print s;
+                          print "\"";
+                          if v = s then print " selected"
+                      | Some '[' ->
+                          Stream.junk strm;
+                          let s = parse_upto ']' strm in
+                          print "\"";
+                          print s;
+                          print "\"";
+                          if v = s then print " checked"
+                      | _ -> print (strip_spaces v))
+                  | None -> print ("BAD MACRO 2" ^ String.make 1 c)))
+          | c -> print (macro conf c))
       | c -> print (String.make 1 c)
     done
   with Stream.Failure -> ()
+
 and print_specific_file conf print fname strm =
   match Stream.next strm with
-    '{' ->
+  | '{' ->
       let s = parse_upto '}' strm in
-      if Sys.file_exists fname then
+      if Sys.file_exists fname then (
         let ic = open_in fname in
         if in_channel_length ic = 0 then
           copy_from_stream conf print (Stream.of_string s)
         else copy_from_stream conf print (Stream.of_channel ic);
-        close_in ic
+        close_in ic)
       else copy_from_stream conf print (Stream.of_string s)
   | _ -> ()
+
 and print_specific_file_tail conf print fname strm =
   match Stream.next strm with
-    '{' ->
-    (* TODO implement the "tail" part *)
+  | '{' ->
+      (* TODO implement the "tail" part *)
       let s = parse_upto '}' strm in
-      if Sys.file_exists fname then begin
+      if Sys.file_exists fname then (
         let ic = open_in fname in
         if in_channel_length ic = 0 then
           copy_from_stream conf print (Stream.of_string s)
         else copy_from_stream conf print (Stream.of_channel ic);
-        close_in ic
-      end
+        close_in ic)
       else copy_from_stream conf print (Stream.of_string s)
   | _ -> ()
+
 and print_selector conf print =
   let sel =
-    try getenv conf.env "sel" with
-      Not_found -> try Sys.getenv "HOME" with Not_found -> Sys.getcwd ()
+    try getenv conf.env "sel"
+    with Not_found -> (
+      try Sys.getenv "HOME" with Not_found -> Sys.getcwd ())
   in
   let list =
     let sel =
-      if not Sys.unix && String.length sel = 3 && sel.[1] = ':' && sel.[2] = '\\'
+      if
+        (not Sys.unix)
+        && String.length sel = 3
+        && sel.[1] = ':'
+        && sel.[2] = '\\'
       then sel ^ "."
       else sel
     in
@@ -733,7 +762,7 @@ and print_selector conf print =
       let dh = Unix.opendir sel in
       let rec loop list =
         match try Some (Unix.readdir dh) with End_of_file -> None with
-          Some x ->
+        | Some x ->
             let list =
               if x = ".." then x :: list
               else if String.length x > 0 && x.[0] = '.' then list
@@ -743,7 +772,7 @@ and print_selector conf print =
         | None -> List.sort compare list
       in
       loop []
-    with Unix.Unix_error (_, _, _) -> [".."]
+    with Unix.Unix_error (_, _, _) -> [ ".." ]
   in
   print "<pre>\n";
   print "     ";
@@ -754,94 +783,96 @@ and print_selector conf print =
   let list =
     List.map
       (fun x ->
-         let d =
-           if x = ".." then
-             if Sys.unix then
-               Filename.dirname sel
-             else
-               if sel.[String.length sel - 1] <> '\\'
-               then Filename.dirname sel ^ "\\"
-               else Filename.dirname sel
-           else Filename.concat sel x
-         in
-         let x = if is_directory d then Filename.concat x "" else x in d, x)
+        let d =
+          if x = ".." then
+            if Sys.unix then Filename.dirname sel
+            else if sel.[String.length sel - 1] <> '\\' then
+              Filename.dirname sel ^ "\\"
+            else Filename.dirname sel
+          else Filename.concat sel x
+        in
+        let x = if is_directory d then Filename.concat x "" else x in
+        (d, x))
       list
   in
   let max_len =
-    List.fold_left (fun max_len (_, x) -> max max_len (String.length x)) 0
-      list
+    List.fold_left (fun max_len (_, x) -> max max_len (String.length x)) 0 list
   in
   let min_interv = 2 in
   let line_len = 72 in
   let n_by_line = max 1 ((line_len + min_interv) / (max_len + min_interv)) in
   let newline () = print "\n" in
   newline ();
-  begin let rec loop i =
-    function
-      (d, x) :: list ->
-        print "<a class=\"j\" href=\"";
-        print conf.comm;
-        print "?lang=";
-        print conf.lang;
-        print ";";
-        List.iter
-          (fun (k, v) ->
-             if k <> "sel" && k <> "body_prop"
-             then begin print k; print "="; print v; print ";" end)
-          conf.env;
-        print "sel=";
-        print (encode d);
-        print "\">";
-        print x;
-        print "</a>";
-        if i = n_by_line then begin newline (); loop 1 list end
-        else if list = [] then newline ()
-        else
-          begin
-            print (String.make (max_len + 2 - String.length x) ' ');
-            loop (i + 1) list
-          end
-    | [] -> print "\n"
-  in
-    loop 1 list
-  end;
+  (let rec loop i = function
+     | (d, x) :: list ->
+         print "<a class=\"j\" href=\"";
+         print conf.comm;
+         print "?lang=";
+         print conf.lang;
+         print ";";
+         List.iter
+           (fun (k, v) ->
+             if k <> "sel" && k <> "body_prop" then (
+               print k;
+               print "=";
+               print v;
+               print ";"))
+           conf.env;
+         print "sel=";
+         print (encode d);
+         print "\">";
+         print x;
+         print "</a>";
+         if i = n_by_line then (
+           newline ();
+           loop 1 list)
+         else if list = [] then newline ()
+         else (
+           print (String.make (max_len + 2 - String.length x) ' ');
+           loop (i + 1) list)
+     | [] -> print "\n"
+   in
+   loop 1 list);
   print "</pre>\n"
+
 and print_if conf print cond strm =
   match Stream.next strm with
-    '{' ->
+  | '{' ->
       let s = parse_upto '}' strm in
       if cond then copy_from_stream conf print (Stream.of_string s)
   | _ -> ()
+
 and print_if_else conf print cond strm =
   match Stream.next strm with
-    '{' ->
+  | '{' ->
       let s1 = parse_upto '|' strm in
       let s2 = parse_upto '}' strm in
       if cond then copy_from_stream conf print (Stream.of_string s1)
       else copy_from_stream conf print (Stream.of_string s2)
   | _ -> ()
+
 and for_all conf print list strm =
   match Stream.next strm with
-    '{' ->
+  | '{' ->
       let s_exist = parse_upto '|' strm in
       let s_empty = parse_upto '}' strm in
       let eol =
         match Stream.peek strm with
-        | Some '\\' -> Stream.junk strm ; false
+        | Some '\\' ->
+            Stream.junk strm;
+            false
         | _ -> true
       in
       if list <> [] then
         List.iter
           (fun db ->
-             let conf = conf_with_env conf "anon" db in
-             copy_from_stream conf print (Stream.of_string s_exist);
-             if eol then print "\n")
+            let conf = conf_with_env conf "anon" db in
+            copy_from_stream conf print (Stream.of_string s_exist);
+            if eol then print "\n")
           list
-      else
-        begin
-          copy_from_stream conf print (Stream.of_string s_empty);
-          if eol then print "\n"
-        end
+      else (
+        copy_from_stream conf print (Stream.of_string s_empty);
+        if eol then print "\n")
   | _ -> ()
 
 let print_file conf bname =
@@ -850,19 +881,22 @@ let print_file conf bname =
   let ic_opt = try Some (open_in fname) with Sys_error _ -> None in
   match ic_opt with
   | Some ic ->
-    Output.status printer_conf Def.OK;
-    Output.header printer_conf "Content-type: text/html; charset=%s" (charset conf);
-    copy_from_stream conf (Output.print_sstring printer_conf) (Stream.of_channel ic);
-    close_in ic;
-    trailer conf
+      Output.status printer_conf Def.OK;
+      Output.header printer_conf "Content-type: text/html; charset=%s"
+        (charset conf);
+      copy_from_stream conf
+        (Output.print_sstring printer_conf)
+        (Stream.of_channel ic);
+      close_in ic;
+      trailer conf
   | None ->
-    let title _ = Output.print_sstring printer_conf "Error" in
-    header conf title;
-    Output.print_sstring printer_conf "<ul><li>\n";
-    Output.printf printer_conf "Cannot access file \"%s\".\n" fname;
-    Output.print_sstring printer_conf "</ul>\n";
-    trailer conf;
-    raise Exit
+      let title _ = Output.print_sstring printer_conf "Error" in
+      header conf title;
+      Output.print_sstring printer_conf "<ul><li>\n";
+      Output.printf printer_conf "Cannot access file \"%s\".\n" fname;
+      Output.print_sstring printer_conf "</ul>\n";
+      trailer conf;
+      raise Exit
 
 let error conf str =
   header conf (fun _ -> Output.print_sstring printer_conf "Incorrect request");
@@ -894,30 +928,26 @@ let basename s =
     if i < 0 then s
     else
       match s.[i] with
-        'a'..'z' | 'A'..'Z' | '0'..'9' | '_' | '.' -> loop (i - 1)
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' -> loop (i - 1)
       | _ -> String.sub s (i + 1) (String.length s - i - 1)
   in
   loop (String.length s - 1)
 
 let setup_gen conf =
   match p_getenv conf.env "v" with
-    Some fname -> print_file conf (basename fname)
+  | Some fname -> print_file conf (basename fname)
   | _ -> error conf "request needs \"v\" parameter"
 
 let simple conf =
   let ged =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   let ged =
     if Filename.check_suffix (String.lowercase_ascii ged) ".ged" then ged
     else ""
   in
   let out_file =
-    match p_getenv conf.env "o" with
-      Some f -> strip_spaces f
-    | _ -> ""
+    match p_getenv conf.env "o" with Some f -> strip_spaces f | _ -> ""
   in
   let out_file =
     if ged = "" then out_file
@@ -927,36 +957,33 @@ let simple conf =
   let env = ("f", "on") :: conf.env in
   let env = list_replace "anon" ged env in
   let conf =
-    {comm = if ged = "" then "gwc" else "ged2gwb";
-     env = list_replace "o" out_file env; lang = conf.lang;
-     request = conf.request; lexicon = conf.lexicon}
+    {
+      comm = (if ged = "" then "gwc" else "ged2gwb");
+      env = list_replace "o" out_file env;
+      lang = conf.lang;
+      request = conf.request;
+      lexicon = conf.lexicon;
+    }
   in
-  if ged <> "" && not (Sys.file_exists ged) then
-    print_file conf "err_unkn.htm"
+  if ged <> "" && not (Sys.file_exists ged) then print_file conf "err_unkn.htm"
   else if out_file = "" then print_file conf "err_miss.htm"
   else if not (Mutil.good_name out_file) then print_file conf "err_name.htm"
   else print_file conf "bso.htm"
 
 let gwc_or_ged2gwb out_name_of_in_name conf =
   let fname =
-    match p_getenv conf.env "fname" with
-    | Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "fname" with Some f -> strip_spaces f | None -> ""
   in
   let in_file =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   let in_file =
     if fname = "" then in_file
-    else in_file ^ (if Sys.unix then "/" else "\\" ) ^ fname
+    else in_file ^ (if Sys.unix then "/" else "\\") ^ fname
   in
   let conf = conf_with_env conf "anon" in_file in
   let out_file =
-    match p_getenv conf.env "o" with
-      Some f -> strip_spaces f
-    | _ -> ""
+    match p_getenv conf.env "o" with Some f -> strip_spaces f | _ -> ""
   in
   let out_file =
     if out_file = "" then out_name_of_in_name in_file else out_file
@@ -966,17 +993,17 @@ let gwc_or_ged2gwb out_name_of_in_name conf =
   let conf = conf_with_env conf "fname" "" in
   let conf = conf_with_env conf "o" out_file in
   if in_file = "" || out_file = "" then print_file conf "err_miss.htm"
-  else if not (Sys.file_exists in_file) && not (String.contains fname '*')
+  else if (not (Sys.file_exists in_file)) && not (String.contains fname '*')
   then print_file conf "err_unkn.htm"
   else if not (Mutil.good_name out_file) then print_file conf "err_name.htm"
   else print_file conf "bso.htm"
 
 let gwc_check conf =
-  let conf = {conf with env = ("nofail", "on") :: ("f", "on") :: conf.env} in
+  let conf = { conf with env = ("nofail", "on") :: ("f", "on") :: conf.env } in
   gwc_or_ged2gwb out_name_of_gw conf
 
 let ged2gwb_check conf =
-  let conf = {conf with env = ("f", "on") :: conf.env} in
+  let conf = { conf with env = ("f", "on") :: conf.env } in
   gwc_or_ged2gwb out_name_of_ged conf
 
 let infer_rc conf rc =
@@ -984,7 +1011,7 @@ let infer_rc conf rc =
     if rc > 0 then rc
     else
       match p_getenv conf.env "o" with
-        Some out_file -> if Sys.file_exists (out_file ^ ".gwb") then 0 else 2
+      | Some out_file -> if Sys.file_exists (out_file ^ ".gwb") then 0 else 2
       | _ -> 0
   else rc
 
@@ -998,11 +1025,9 @@ let gwc conf =
   (try Sys.remove gwo with Sys_error _ -> ());
   Printf.eprintf "\n";
   flush stderr;
-  if rc > 1 then print_file conf "bso_err.htm"
-  else print_file conf "bso_ok.htm"
+  if rc > 1 then print_file conf "bso_err.htm" else print_file conf "bso_ok.htm"
 
-let gwdiff_check conf =
-  print_file conf "bsi_diff.htm"
+let gwdiff_check conf = print_file conf "bsi_diff.htm"
 
 let gwdiff ok_file conf =
   let rc =
@@ -1018,8 +1043,7 @@ let gwdiff ok_file conf =
     in
     print_file conf ok_file
 
-let gwfixbase_check conf =
-  print_file conf "bsi_fix.htm"
+let gwfixbase_check conf = print_file conf "bsi_fix.htm"
 
 let gwfixbase ok_file conf =
   let rc =
@@ -1028,30 +1052,24 @@ let gwfixbase ok_file conf =
   in
   Printf.eprintf "\n";
   flush stderr;
-  if rc > 1 then print_file conf "bsi_err.htm"
-  else
-    print_file conf ok_file
+  if rc > 1 then print_file conf "bsi_err.htm" else print_file conf ok_file
 
 let cache_files_check conf =
   let in_base =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   if in_base = "" then print_file conf "err_miss.htm";
   print_file conf "bsi_cache_files.htm"
 
 let cache_files ok_file conf =
   let rc =
-    let comm =
-      stringify (Filename.concat !bin_dir "cache_files") ^ " " in
-      exec_f (comm ^ (parameters_3 conf.env) ^ " > comm.log")
-    in
+    let comm = stringify (Filename.concat !bin_dir "cache_files") ^ " " in
+    exec_f (comm ^ parameters_3 conf.env ^ " > comm.log")
+  in
   flush stderr;
   if rc > 1 then print_file conf "bsi_err.htm" else print_file conf ok_file
 
-let connex_check conf =
-  print_file conf "bsi_connex.htm"
+let connex_check conf = print_file conf "bsi_connex.htm"
 
 let connex ok_file conf =
   let ic = Unix.open_process_in "uname" in
@@ -1059,35 +1077,34 @@ let connex ok_file conf =
   let () = close_in ic in
   let rc =
     let commnd =
-      "cd " ^ (Sys.getcwd ()) ^ "; tput bel;" ^
-      (stringify (Filename.concat !bin_dir "connex")) ^ " " ^
-      parameters_1 conf.env
+      "cd " ^ Sys.getcwd () ^ "; tput bel;"
+      ^ stringify (Filename.concat !bin_dir "connex")
+      ^ " " ^ parameters_1 conf.env
     in
     if uname = "Darwin" then
       let launch = "tell application \"Terminal\" to do script " in
-      Sys.command ("osascript -e '" ^ launch ^ " \" " ^ commnd ^ " \"' " )
+      Sys.command ("osascript -e '" ^ launch ^ " \" " ^ commnd ^ " \"' ")
     else if uname = "Linux" then
       (* non testé ! *)
       Sys.command ("xterm -e \" " ^ commnd ^ " \" ")
     else if Sys.win32 then
       (* à compléter et tester ! *)
-      let commnd = (stringify (Filename.concat !bin_dir "connex")) ^ " " ^
-                   parameters_1 conf.env in
-      Sys.command (commnd)
-    else begin
-      Printf.eprintf "%s (%s) %s (%s)\n"
-        "Unknown Os_type" Sys.os_type "or wrong uname response" uname;
-      2
-    end
+      let commnd =
+        stringify (Filename.concat !bin_dir "connex")
+        ^ " " ^ parameters_1 conf.env
+      in
+      Sys.command commnd
+    else (
+      Printf.eprintf "%s (%s) %s (%s)\n" "Unknown Os_type" Sys.os_type
+        "or wrong uname response" uname;
+      2)
   in
   flush stderr;
   if rc > 1 then print_file conf "bsi_err.htm" else print_file conf ok_file
 
 let gwu_or_gwb2ged_check suffix conf =
   let in_file =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   let od =
     match p_getenv conf.env "od" with
@@ -1096,7 +1113,7 @@ let gwu_or_gwb2ged_check suffix conf =
   in
   let out_file =
     match p_getenv conf.env "o" with
-      Some f -> Filename.basename (strip_spaces f)
+    | Some f -> Filename.basename (strip_spaces f)
     | None -> ""
   in
   let odir =
@@ -1110,9 +1127,7 @@ let gwu_or_gwb2ged_check suffix conf =
     if out_file = "" || out_file = Filename.current_dir_name then
       in_file ^ suffix
     else if Filename.check_suffix out_file suffix then out_file
-    else if
-      Filename.check_suffix out_file (String.uppercase_ascii suffix)
-    then
+    else if Filename.check_suffix out_file (String.uppercase_ascii suffix) then
       out_file
     else out_file ^ suffix
   in
@@ -1144,119 +1159,104 @@ let gwu_1 = gwb2ged_or_gwu_1 "gwu_ok.htm"
 
 let consang_check conf =
   let in_f =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   if in_f = "" then print_file conf "err_miss.htm"
   else print_file conf "bsi.htm"
 
 let update_nldb_check conf =
   let in_f =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   if in_f = "" then print_file conf "err_miss.htm"
   else print_file conf "bsi.htm"
 
 let has_gwu dir =
   try
-    if Sys.unix then
-      Array.mem "gwu" (Sys.readdir dir)
+    if Sys.unix then Array.mem "gwu" (Sys.readdir dir)
     else
-      Array.exists (fun s -> String.lowercase_ascii s = "gwu.exe") (Sys.readdir dir)
+      Array.exists
+        (fun s -> String.lowercase_ascii s = "gwu.exe")
+        (Sys.readdir dir)
   with _ -> false
 
 let recover conf =
   let init_dir =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
-  let (init_dir, dir_has_gwu) =
-    if has_gwu init_dir then init_dir, true
+  let init_dir, dir_has_gwu =
+    if has_gwu init_dir then (init_dir, true)
     else
       let dir = init_dir in
-      if has_gwu dir then dir, true
+      if has_gwu dir then (dir, true)
       else
         let dir = Filename.dirname init_dir in
-        if has_gwu dir then dir, true
+        if has_gwu dir then (dir, true)
         else
           let dir = Filename.concat dir "gw" in
-          if has_gwu dir then dir, true else init_dir, false
+          if has_gwu dir then (dir, true) else (init_dir, false)
   in
   let conf = conf_with_env conf "anon" init_dir in
   let dest_dir = Sys.getcwd () in
   if init_dir = "" then print_file conf "err_miss.htm"
   else if init_dir = dest_dir then print_file conf "err_smdr.htm"
   else if not (Sys.file_exists init_dir) then print_file conf "err_ndir.htm"
-  else if Sys.unix &&
-          (try
-             (Unix.stat (Filename.concat init_dir ".")).Unix.st_ino
-             =
-             (Unix.stat (Filename.concat dest_dir ".")).Unix.st_ino
-           with Unix.Unix_error (_, _, _) -> false)
-       then print_file conf "err_smdr.htm"
+  else if
+    Sys.unix
+    &&
+    try
+      (Unix.stat (Filename.concat init_dir ".")).Unix.st_ino
+      = (Unix.stat (Filename.concat dest_dir ".")).Unix.st_ino
+    with Unix.Unix_error (_, _, _) -> false
+  then print_file conf "err_smdr.htm"
   else if not dir_has_gwu then print_file conf "err_ngw.htm"
   else print_file conf "recover1.htm"
 
 let recover_1 conf =
   let in_file =
-    match p_getenv conf.env "i" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "i" with Some f -> strip_spaces f | None -> ""
   in
   let out_file =
-    match p_getenv conf.env "o" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "o" with Some f -> strip_spaces f | None -> ""
   in
   let by_gedcom =
-    match p_getenv conf.env "ged" with
-      Some "on" -> true
-    | _ -> false
+    match p_getenv conf.env "ged" with Some "on" -> true | _ -> false
   in
   let out_file = if out_file = "" then in_file else out_file in
   let conf = conf_with_env conf "o" out_file in
   if in_file = "" then print_file conf "err_miss.htm"
   else if not (Mutil.good_name out_file) then print_file conf "err_name.htm"
   else
-    let (old_to_src, o_opt, tmp, src_to_new) =
-      if not by_gedcom then "gwu", " > ", "tmp.gw", "gwc"
-      else "gwb2ged", " -o ", "tmp.ged", "ged2gwb"
+    let old_to_src, o_opt, tmp, src_to_new =
+      if not by_gedcom then ("gwu", " > ", "tmp.gw", "gwc")
+      else ("gwb2ged", " -o ", "tmp.ged", "ged2gwb")
     in
     let conf =
-      {conf with env =
-        ("U", old_to_src) :: ("O", o_opt) :: ("T", tmp) ::
-        ("src2new", src_to_new) :: conf.env}
+      {
+        conf with
+        env =
+          ("U", old_to_src) :: ("O", o_opt) :: ("T", tmp)
+          :: ("src2new", src_to_new) :: conf.env;
+      }
     in
     print_file conf "recover2.htm"
 
 let recover_2 conf =
   let init_dir =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   let in_file =
-    match p_getenv conf.env "i" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "i" with Some f -> strip_spaces f | None -> ""
   in
   let out_file =
-    match p_getenv conf.env "o" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "o" with Some f -> strip_spaces f | None -> ""
   in
   let by_gedcom =
-    match p_getenv conf.env "ged" with
-      Some "on" -> true
-    | _ -> false
+    match p_getenv conf.env "ged" with Some "on" -> true | _ -> false
   in
-  let (old_to_src, o_opt, tmp, src_to_new) =
-    if not by_gedcom then "gwu", " > ", "tmp.gw", "gwc"
-    else "gwb2ged", " -o ", "tmp.ged", "ged2gwb"
+  let old_to_src, o_opt, tmp, src_to_new =
+    if not by_gedcom then ("gwu", " > ", "tmp.gw", "gwc")
+    else ("gwb2ged", " -o ", "tmp.ged", "ged2gwb")
   in
   let out_file = if out_file = "" then in_file else out_file in
   let conf = conf_with_env conf "o" out_file in
@@ -1267,48 +1267,51 @@ let recover_2 conf =
       flush stderr;
       Sys.chdir init_dir;
       let c =
-        Filename.concat "." old_to_src ^ " " ^ in_file ^ o_opt ^
-        stringify (Filename.concat dir tmp)
+        Filename.concat "." old_to_src
+        ^ " " ^ in_file ^ o_opt
+        ^ stringify (Filename.concat dir tmp)
       in
-      Printf.eprintf "$ %s\n" c; flush stderr; Sys.command c
-    with e -> Sys.chdir dir; raise e
+      Printf.eprintf "$ %s\n" c;
+      flush stderr;
+      Sys.command c
+    with e ->
+      Sys.chdir dir;
+      raise e
   in
   let rc =
-    if rc = 0 then
-      begin
-        Printf.eprintf "$ cd \"%s\"\n" dir;
-        flush stderr;
-        Sys.chdir dir;
-        let c =
-          Filename.concat !bin_dir src_to_new ^ " " ^ tmp ^ " -f -o " ^
-          out_file ^ " > " ^ "comm.log"
-        in
-        Printf.eprintf "$ %s\n" c;
-        flush stderr;
-        let rc = Sys.command c in
-        let rc = if not Sys.unix then infer_rc conf rc else rc in
-        Printf.eprintf "\n"; flush stderr; rc
-      end
+    if rc = 0 then (
+      Printf.eprintf "$ cd \"%s\"\n" dir;
+      flush stderr;
+      Sys.chdir dir;
+      let c =
+        Filename.concat !bin_dir src_to_new
+        ^ " " ^ tmp ^ " -f -o " ^ out_file ^ " > " ^ "comm.log"
+      in
+      Printf.eprintf "$ %s\n" c;
+      flush stderr;
+      let rc = Sys.command c in
+      let rc = if not Sys.unix then infer_rc conf rc else rc in
+      Printf.eprintf "\n";
+      flush stderr;
+      rc)
     else rc
   in
-  if rc > 1 then begin Sys.chdir dir; print_file conf "err_reco.htm" end
+  if rc > 1 then (
+    Sys.chdir dir;
+    print_file conf "err_reco.htm")
   else print_file conf "bso_ok.htm"
 
 let cleanup conf =
   let in_base =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
-  let conf = {conf with comm = "."} in
+  let conf = { conf with comm = "." } in
   if in_base = "" then print_file conf "err_miss.htm"
   else print_file conf "cleanup1.htm"
 
 let cleanup_1 conf =
   let in_base =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   let in_base_dir = in_base ^ ".gwb" in
   Printf.eprintf "$ cd \"%s\"\n" (Sys.getcwd ());
@@ -1319,74 +1322,74 @@ let cleanup_1 conf =
   let _ = Sys.command c in
   Printf.eprintf "$ mkdir old\n";
   (try Unix.mkdir "old" 0o755 with Unix.Unix_error (_, _, _) -> ());
-  
-  if Sys.unix then
-    Printf.eprintf "$ rm -rf old/%s\n" in_base_dir
-  else begin
+
+  if Sys.unix then Printf.eprintf "$ rm -rf old/%s\n" in_base_dir
+  else (
     Printf.eprintf "$ del old\\%s\\*.*\n" in_base_dir;
-    Printf.eprintf "$ rmdir old\\%s\n" in_base_dir;
-  end;
-  
+    Printf.eprintf "$ rmdir old\\%s\n" in_base_dir);
+
   flush stderr;
   Mutil.rm_rf (Filename.concat "old" in_base_dir);
-  
-  if Sys.unix then
-    Printf.eprintf "$ mv %s old/.\n" in_base_dir
-  else
-    Printf.eprintf "$ move %s old\\.\n" in_base_dir;
-    
+
+  if Sys.unix then Printf.eprintf "$ mv %s old/.\n" in_base_dir
+  else Printf.eprintf "$ move %s old\\.\n" in_base_dir;
+
   flush stderr;
   Sys.rename in_base_dir (Filename.concat "old" in_base_dir);
   let c =
-    Filename.concat !bin_dir "gwc" ^ " tmp.gw -nofail -o " ^ in_base ^
-    " > comm.log 2>&1"
+    Filename.concat !bin_dir "gwc"
+    ^ " tmp.gw -nofail -o " ^ in_base ^ " > comm.log 2>&1"
   in
   Printf.eprintf "$ %s\n" c;
   flush stderr;
   let rc = Sys.command c in
-  
+
   let rc = if not Sys.unix then infer_rc conf rc else rc in
-  
+
   Printf.eprintf "\n";
   flush stderr;
   if rc > 1 then
-    let conf = {conf with comm = "gwc"} in print_file conf "bsi_err.htm"
+    let conf = { conf with comm = "gwc" } in
+    print_file conf "bsi_err.htm"
   else print_file conf "clean_ok.htm"
 
 let rec check_new_names conf l1 l2 =
-  match l1, l2 with
-    (k, v) :: l, x :: m ->
-      if k <> x then begin print_file conf "err_outd.htm"; raise Exit end
-      else if not (Mutil.good_name v) then
-        let conf = {conf with env = ("o", v) :: conf.env} in
-        print_file conf "err_name.htm"; raise Exit
+  match (l1, l2) with
+  | (k, v) :: l, x :: m ->
+      if k <> x then (
+        print_file conf "err_outd.htm";
+        raise Exit)
+      else if not (Mutil.good_name v) then (
+        let conf = { conf with env = ("o", v) :: conf.env } in
+        print_file conf "err_name.htm";
+        raise Exit)
       else check_new_names conf l m
   | [], [] -> ()
-  | _ -> print_file conf "err_outd.htm"; raise Exit
+  | _ ->
+      print_file conf "err_outd.htm";
+      raise Exit
 
-let rec check_rename_conflict conf =
-  function
-    x :: l ->
-      if List.mem x l then
-        let conf = {conf with env = ("o", x) :: conf.env} in
-        print_file conf "err_cnfl.htm"; raise Exit
+let rec check_rename_conflict conf = function
+  | x :: l ->
+      if List.mem x l then (
+        let conf = { conf with env = ("o", x) :: conf.env } in
+        print_file conf "err_cnfl.htm";
+        raise Exit)
       else check_rename_conflict conf l
   | [] -> ()
 
 let rename conf =
   let rename_list =
-    List.map (fun (k, v) -> k, strip_spaces (decode v)) conf.env
+    List.map (fun (k, v) -> (k, strip_spaces (decode v))) conf.env
   in
   try
     check_new_names conf rename_list (all_db ".");
     check_rename_conflict conf (snd (List.split rename_list));
     List.iter
-      (fun (k, v) ->
-         if k <> v then Sys.rename (k ^ ".gwb") ("_" ^ k ^ ".gwb"))
+      (fun (k, v) -> if k <> v then Sys.rename (k ^ ".gwb") ("_" ^ k ^ ".gwb"))
       rename_list;
     List.iter
-      (fun (k, v) ->
-         if k <> v then Sys.rename ("_" ^ k ^ ".gwb") (v ^ ".gwb"))
+      (fun (k, v) -> if k <> v then Sys.rename ("_" ^ k ^ ".gwb") (v ^ ".gwb"))
       rename_list;
     print_file conf "ren_ok.htm"
   with Exit -> ()
@@ -1399,22 +1402,17 @@ let delete_1 conf =
 
 let merge conf =
   let out_file =
-    match p_getenv conf.env "o" with
-      Some f -> strip_spaces f
-    | _ -> ""
+    match p_getenv conf.env "o" with Some f -> strip_spaces f | _ -> ""
   in
-  let conf = {conf with comm = "."} in
+  let conf = { conf with comm = "." } in
   let bases = selected conf.env in
-  if out_file = "" || List.length bases < 2 then
-    print_file conf "err_miss.htm"
+  if out_file = "" || List.length bases < 2 then print_file conf "err_miss.htm"
   else if not (Mutil.good_name out_file) then print_file conf "err_name.htm"
   else print_file conf "merge_1.htm"
 
 let merge_1 conf =
   let out_file =
-    match p_getenv conf.env "o" with
-      Some f -> strip_spaces f
-    | _ -> ""
+    match p_getenv conf.env "o" with Some f -> strip_spaces f | _ -> ""
   in
   let bases = selected conf.env in
   let dir = Sys.getcwd () in
@@ -1422,16 +1420,16 @@ let merge_1 conf =
   flush stderr;
   Sys.chdir dir;
   let rc =
-    let rec loop =
-      function
-        [] -> 0
+    let rec loop = function
+      | [] -> 0
       | b :: bases ->
           let c =
             Filename.concat !bin_dir "gwu" ^ " " ^ b ^ " -o " ^ b ^ ".gw"
           in
           Printf.eprintf "$ %s\n" c;
           flush stderr;
-          let r = Sys.command c in if r = 0 then loop bases else r
+          let r = Sys.command c in
+          if r = 0 then loop bases else r
     in
     loop bases
   in
@@ -1439,39 +1437,39 @@ let merge_1 conf =
     if rc <> 0 then rc
     else
       let c =
-        Filename.concat !bin_dir "gwc" ^
-        List.fold_left
-          (fun s b ->
-             if s = "" then " " ^ b ^ ".gw" else s ^ " -sep " ^ b ^ ".gw")
-          "" bases ^
-        " -f -o " ^ out_file ^ " > comm.log 2>&1"
+        Filename.concat !bin_dir "gwc"
+        ^ List.fold_left
+            (fun s b ->
+              if s = "" then " " ^ b ^ ".gw" else s ^ " -sep " ^ b ^ ".gw")
+            "" bases
+        ^ " -f -o " ^ out_file ^ " > comm.log 2>&1"
       in
-      Printf.eprintf "$ %s\n" c; flush stderr; Sys.command c
+      Printf.eprintf "$ %s\n" c;
+      flush stderr;
+      Sys.command c
   in
-  if rc > 1 then print_file conf "bso_err.htm"
-  else print_file conf "bso_ok.htm"
+  if rc > 1 then print_file conf "bso_err.htm" else print_file conf "bso_ok.htm"
 
 let read_gwd_arg () =
   let fname = Filename.concat !setup_dir "gwd.arg" in
   match try Some (open_in fname) with Sys_error _ -> None with
-    Some ic ->
+  | Some ic ->
       let list =
         let rec loop list =
           match try Some (input_line ic) with End_of_file -> None with
-            Some "" -> loop list
+          | Some "" -> loop list
           | Some s -> loop (s :: list)
           | None -> list
         in
         loop []
       in
       close_in ic;
-      let rec loop env =
-        function
-          x :: l ->
+      let rec loop env = function
+        | x :: l ->
             if x.[0] = '-' then
               let x = String.sub x 1 (String.length x - 1) in
               match l with
-                y :: l when y.[0] <> '-' -> loop ((x, y) :: env) l
+              | y :: l when y.[0] <> '-' -> loop ((x, y) :: env) l
               | _ -> loop ((x, "") :: env) l
             else loop env l
         | [] -> List.rev env
@@ -1481,84 +1479,85 @@ let read_gwd_arg () =
 
 let gwf conf =
   let in_base =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
   if in_base = "" then print_file conf "err_miss.htm"
   else
     let benv = loc_read_base_env in_base in
     let trailer =
-      if !GWPARAM.reorg
-        then (Filename.concat (!GWPARAM.lang_d in_base "") (in_base ^ ".trl"))
-        else (Filename.concat "lang" (in_base ^ ".trl"))
-      |> file_contents
-      |> Util.escape_html
-      |> fun s -> (s :> string)
+      if !GWPARAM.reorg then
+        Filename.concat (!GWPARAM.lang_d in_base "") (in_base ^ ".trl")
+      else
+        Filename.concat "lang" (in_base ^ ".trl")
+        |> file_contents |> Util.escape_html
+        |> fun s -> (s :> string)
     in
-    let conf = { conf with env = benv @ ("trailer", trailer) :: conf.env } in
+    let conf = { conf with env = benv @ (("trailer", trailer) :: conf.env) } in
     print_file conf "gwf_1.htm"
 
 let gwf_1 conf =
   let in_base =
-    match p_getenv conf.env "anon" with
-      Some f -> strip_spaces f
-    | None -> ""
+    match p_getenv conf.env "anon" with Some f -> strip_spaces f | None -> ""
   in
-  let reorg =
-    match p_getenv conf.env "reorg" with
-    | Some s ->  s
-    | _ -> ""
-  in
+  let reorg = match p_getenv conf.env "reorg" with Some s -> s | _ -> "" in
   if reorg = "on" then GWPARAM.reorg := true;
   GWPARAM.test_reorg in_base;
   let benv = loc_read_base_env in_base in
-  let (vars, _) = variables "gwf_1.htm" in
-  let oc = open_out
-    ( if !GWPARAM.reorg then
-        (Filename.concat (!GWPARAM.bpath in_base) in_base ^ ".gwf")
-      else (in_base ^ ".gwf"))
+  let vars, _ = variables "gwf_1.htm" in
+  let oc =
+    open_out
+      (if !GWPARAM.reorg then
+       Filename.concat (!GWPARAM.bpath in_base) in_base ^ ".gwf"
+      else in_base ^ ".gwf")
   in
   let body_prop =
     match p_getenv conf.env "proposed_body_prop" with
-      Some "" | None -> s_getenv conf.env "body_prop"
+    | Some "" | None -> s_getenv conf.env "body_prop"
     | Some x -> x
   in
   Printf.fprintf oc "# File generated by \"setup\"\n\n";
   List.iter
     (fun k ->
-       match k with
-         "body_prop" ->
-           if body_prop = "" then ()
-           else Printf.fprintf oc "body_prop=%s\n" body_prop
-       | _ -> Printf.fprintf oc "%s=%s\n" k (s_getenv conf.env k))
+      match k with
+      | "body_prop" ->
+          if body_prop = "" then ()
+          else Printf.fprintf oc "body_prop=%s\n" body_prop
+      | _ -> Printf.fprintf oc "%s=%s\n" k (s_getenv conf.env k))
     vars;
   List.iter
-    (fun (k, v) -> if List.mem k vars then () else Printf.fprintf oc "%s=%s\n" k v)
+    (fun (k, v) ->
+      if List.mem k vars then () else Printf.fprintf oc "%s=%s\n" k v)
     benv;
   close_out oc;
   let trl = strip_spaces (strip_control_m (s_getenv conf.env "trailer")) in
 
-
   let trl_dir = !GWPARAM.etc_d in_base in
-  let trl_file = Filename.concat trl_dir ("trl.txt") in
-  try Unix.mkdir trl_dir  0o755 with Unix.Unix_error (_, _, _) -> ();
-  begin try
-    if trl = "" then Sys.remove trl_file
-    else
-      let oc = open_out trl_file in
-      output_string oc trl; output_string oc "\n"; close_out oc
-  with Sys_error _ -> ()
-  end;
-  print_file conf "gwf_ok.htm"
+  let trl_file = Filename.concat trl_dir "trl.txt" in
+  try Unix.mkdir trl_dir 0o755
+  with Unix.Unix_error (_, _, _) ->
+    ();
+    (try
+       if trl = "" then Sys.remove trl_file
+       else
+         let oc = open_out trl_file in
+         output_string oc trl;
+         output_string oc "\n";
+         close_out oc
+     with Sys_error _ -> ());
+    print_file conf "gwf_ok.htm"
 
 let gwd conf =
   let aenv = read_gwd_arg () in
   let get v = try List.assoc v aenv with Not_found -> "" in
   let conf =
-    {conf with env =
-      ("default_lang", get "lang") :: ("only", get "only") ::
-      ("log", Filename.basename (get "log")) :: conf.env}
+    {
+      conf with
+      env =
+        ("default_lang", get "lang")
+        :: ("only", get "only")
+        :: ("log", Filename.basename (get "log"))
+        :: conf.env;
+    }
   in
   print_file conf "gwd.htm"
 
@@ -1566,16 +1565,15 @@ let gwd_1 conf =
   let oc = open_out (Filename.concat !setup_dir "gwd.arg") in
   let print_param k =
     match p_getenv conf.env k with
-      Some v when v <> "" -> Printf.fprintf oc "-%s\n%s\n" k v
+    | Some v when v <> "" -> Printf.fprintf oc "-%s\n%s\n" k v
     | _ -> ()
   in
-  if  p_getenv conf.env "setup_link" <> None
-  then Printf.fprintf oc "-setup_link\n" ;
+  if p_getenv conf.env "setup_link" <> None then
+    Printf.fprintf oc "-setup_link\n";
   print_param "only";
-  begin match p_getenv conf.env "default_lang" with
-    Some v when v <> "" -> Printf.fprintf oc "-lang\n%s\n" v
-  | _ -> ()
-  end;
+  (match p_getenv conf.env "default_lang" with
+  | Some v when v <> "" -> Printf.fprintf oc "-lang\n%s\n" v
+  | _ -> ());
   print_param "log";
   close_out oc;
   print_file conf "gwd_ok.htm"
@@ -1589,10 +1587,10 @@ let ged2gwb conf =
   Printf.eprintf "\n";
   flush stderr;
   if rc > 1 then print_file conf "bso_err.htm"
-  else (
+  else
     let bname = try List.assoc "o" conf.env with Not_found -> "" in
     Util.print_default_gwf_file bname;
-    print_file conf "bso_ok.htm")
+    print_file conf "bso_ok.htm"
 
 let consang conf ok_file =
   let rc =
@@ -1615,11 +1613,11 @@ let update_nldb conf ok_file =
 let separate_slashed_filename s =
   let rec loop i =
     match try Some (String.index_from s i '/') with Not_found -> None with
-      Some j ->
+    | Some j ->
         if j > i then String.sub s i (j - i) :: loop (j + 1) else loop (j + 1)
     | None ->
         if i >= String.length s then []
-        else [String.sub s i (String.length s - i)]
+        else [ String.sub s i (String.length s - i) ]
   in
   loop 0
 
@@ -1631,14 +1629,16 @@ let end_with s x =
 let print_typed_file conf typ fname =
   let ic_opt = try Some (open_in_bin fname) with Sys_error _ -> None in
   match ic_opt with
-    Some ic ->
+  | Some ic ->
       Output.status printer_conf Def.OK;
       Output.header printer_conf "Content-type: %s" typ;
       Output.header printer_conf "Content-length: %d" (in_channel_length ic);
-      begin try
-        while true do let c = input_char ic in Output.printf printer_conf "%c" c done
-      with End_of_file -> ()
-      end;
+      (try
+         while true do
+           let c = input_char ic in
+           Output.printf printer_conf "%c" c
+         done
+       with End_of_file -> ());
       close_in ic
   | None ->
       let title _ = Output.print_sstring printer_conf "Error" in
@@ -1670,11 +1670,12 @@ let has_gwb_directories dh =
       if Filename.check_suffix e ".gwb" then true else loop ()
     in
     loop ()
-  with End_of_file -> Unix.closedir dh; false
+  with End_of_file ->
+    Unix.closedir dh;
+    false
 
-let setup_comm_ok conf =
-  function
-    "gwsetup" -> setup_gen conf
+let setup_comm_ok conf = function
+  | "gwsetup" -> setup_gen conf
   | "simple" -> simple conf
   | "recover" -> recover conf
   | "recover_1" -> recover_1 conf
@@ -1686,83 +1687,72 @@ let setup_comm_ok conf =
   | "delete_1" -> delete_1 conf
   | "merge" -> merge conf
   | "merge_1" -> merge_1 conf
-  | "gwc" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> gwc_check conf
-      | _ -> gwc conf
-      end
-  | "gwu" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> gwu conf
-      | _ -> gwu_1 conf
-      end
-  | "ged2gwb" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> ged2gwb_check conf
-      | _ -> ged2gwb conf
-      end
-  | "gwb2ged" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> gwb2ged conf
-      | _ -> gwb2ged_1 conf
-      end
-  | "consang" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> consang_check conf
-      | _ -> consang conf "consg_ok.htm"
-      end
-  | "update_nldb" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> update_nldb_check conf
-      | _ -> update_nldb conf "update_nldb_ok.htm"
-      end
+  | "gwc" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> gwc_check conf
+      | _ -> gwc conf)
+  | "gwu" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> gwu conf
+      | _ -> gwu_1 conf)
+  | "ged2gwb" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> ged2gwb_check conf
+      | _ -> ged2gwb conf)
+  | "gwb2ged" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> gwb2ged conf
+      | _ -> gwb2ged_1 conf)
+  | "consang" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> consang_check conf
+      | _ -> consang conf "consg_ok.htm")
+  | "update_nldb" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> update_nldb_check conf
+      | _ -> update_nldb conf "update_nldb_ok.htm")
   | "gwf" -> gwf conf
   | "gwf_1" -> gwf_1 conf
   | "gwd" -> gwd conf
   | "gwd_1" -> gwd_1 conf
-  | "cache_files" ->
-      begin match p_getenv conf.env "opt" with
-        Some "check" -> cache_files_check conf
-      | _ -> cache_files "cache_files_ok.htm" conf
-      end
-  | "connex" ->
-       begin match p_getenv conf.env "opt" with
+  | "cache_files" -> (
+      match p_getenv conf.env "opt" with
+      | Some "check" -> cache_files_check conf
+      | _ -> cache_files "cache_files_ok.htm" conf)
+  | "connex" -> (
+      match p_getenv conf.env "opt" with
       | Some "check" -> connex_check conf
-      | _ -> connex "connex_ok.htm" conf
-      end
-  | "gwdiff" ->
-       begin match p_getenv conf.env "opt" with
+      | _ -> connex "connex_ok.htm" conf)
+  | "gwdiff" -> (
+      match p_getenv conf.env "opt" with
       | Some "check" -> gwdiff_check conf
-      | _ -> gwdiff "gwdiff_ok.htm" conf
-      end
-  | "gwfixbase" ->
-       begin match p_getenv conf.env "opt" with
+      | _ -> gwdiff "gwdiff_ok.htm" conf)
+  | "gwfixbase" -> (
+      match p_getenv conf.env "opt" with
       | Some "check" -> gwfixbase_check conf
-      | _ -> gwfixbase "gwfix_ok.htm" conf
-      end
-
+      | _ -> gwfixbase "gwfix_ok.htm" conf)
   | x ->
-      if Mutil.start_with "doc/" 0 x
-      || Mutil.start_with "images/" 0 x
-      || Mutil.start_with "css/" 0 x
-      then
-        raw_file conf x
+      if
+        Mutil.start_with "doc/" 0 x
+        || Mutil.start_with "images/" 0 x
+        || Mutil.start_with "css/" 0 x
+      then raw_file conf x
       else error conf ("bad command: \"" ^ x ^ "\"")
 
 let setup_comm conf comm =
   match p_getenv conf.env "cancel" with
-    Some _ -> setup_gen {conf with env = ["lang", conf.lang; "v", "main.htm"]}
+  | Some _ ->
+      setup_gen { conf with env = [ ("lang", conf.lang); ("v", "main.htm") ] }
   | None -> setup_comm_ok conf comm
 
 let string_of_sockaddr = function
   | Unix.ADDR_UNIX s -> s
   | Unix.ADDR_INET (a, _) ->
-    let str = Unix.string_of_inet_addr a in
-    if str = "::ffff:127.0.0.1"
-    then "::1"
-    else if String.length str > 7 && String.sub str 0 7 = "::ffff:"
-    then String.sub str 7 (String.length str - 7)
-    else str
+      let str = Unix.string_of_inet_addr a in
+      if str = "::ffff:127.0.0.1" then "::1"
+      else if String.length str > 7 && String.sub str 0 7 = "::ffff:" then
+        String.sub str 7 (String.length str - 7)
+      else str
 
 let only_addr () =
   let local_addr =
@@ -1772,9 +1762,10 @@ let only_addr () =
   in
   let fname = Lazy.force only_file_name in
   match try Some (open_in fname) with Sys_error _ -> None with
-    Some ic ->
+  | Some ic ->
       let v = try input_line ic with End_of_file -> local_addr in
-      close_in ic; v
+      close_in ic;
+      v
   | None -> local_addr
 
 let lindex s c =
@@ -1789,50 +1780,51 @@ let input_lexicon lang =
   let t = Hashtbl.create 501 in
   try
     let ic =
-      List.fold_right Filename.concat [!setup_dir; "setup"; "lang"] "lexicon.txt"
+      List.fold_right Filename.concat
+        [ !setup_dir; "setup"; "lang" ]
+        "lexicon.txt"
       |> open_in
     in
     let derived_lang =
-      match lindex lang '-' with
-        Some i -> String.sub lang 0 i
-      | _ -> ""
+      match lindex lang '-' with Some i -> String.sub lang 0 i | _ -> ""
     in
     try
-      begin try
-        while true do
-          let k =
-            let rec find_key line =
-              if String.length line < 4 then find_key (input_line ic)
-              else if String.sub line 0 4 <> "    " then
-                find_key (input_line ic)
-              else line
-            in
-            find_key (input_line ic)
-          in
-          let k = String.sub k 4 (String.length k - 4) in
-          let rec loop line =
-            match lindex line ':' with
-              Some i ->
-                let line_lang = String.sub line 0 i in
-                if line_lang = lang ||
-                   line_lang = derived_lang && not (Hashtbl.mem t k)
-                then
-                  begin let v =
+      (try
+         while true do
+           let k =
+             let rec find_key line =
+               if String.length line < 4 then find_key (input_line ic)
+               else if String.sub line 0 4 <> "    " then
+                 find_key (input_line ic)
+               else line
+             in
+             find_key (input_line ic)
+           in
+           let k = String.sub k 4 (String.length k - 4) in
+           let rec loop line =
+             match lindex line ':' with
+             | Some i ->
+                 let line_lang = String.sub line 0 i in
+                 (if
+                  line_lang = lang
+                  || (line_lang = derived_lang && not (Hashtbl.mem t k))
+                 then
+                  let v =
                     if i + 1 = String.length line then ""
                     else String.sub line (i + 2) (String.length line - i - 2)
                   in
-                    Hashtbl.add t k v
-                  end;
-                loop (input_line ic)
-            | None -> ()
-          in
-          loop (input_line ic)
-        done
-      with End_of_file -> ()
-      end;
+                  Hashtbl.add t k v);
+                 loop (input_line ic)
+             | None -> ()
+           in
+           loop (input_line ic)
+         done
+       with End_of_file -> ());
       close_in ic;
       t
-    with e -> close_in ic; raise e
+    with e ->
+      close_in ic;
+      raise e
   with Sys_error _ -> t
 
 let setup (addr, req) comm (env_str : Adef.encoded_string) =
@@ -1843,47 +1835,44 @@ let setup (addr, req) comm (env_str : Adef.encoded_string) =
         if comm = "" then !default_lang else String.lowercase_ascii comm
       in
       let lexicon = input_lexicon lang in
-      {lang = lang; comm = ""; env = env; request = req; lexicon = lexicon}
+      { lang; comm = ""; env; request = req; lexicon }
     else
-      let (lang, env) =
+      let lang, env =
         match p_getenv env "lang" with
-          Some x -> x, list_remove_assoc "lang" env
-        | _ -> !default_lang, env
+        | Some x -> (x, list_remove_assoc "lang" env)
+        | _ -> (!default_lang, env)
       in
       let lexicon = input_lexicon lang in
-      {lang = lang; comm = comm; env = env; request = req; lexicon = lexicon}
+      { lang; comm; env; request = req; lexicon }
   in
   let saddr = string_of_sockaddr addr in
   let s = only_addr () in
-  if s <> saddr then
-    let conf = {conf with env = ["anon", saddr; "o", s]} in
-    Printf.eprintf "Invalid request from \"%s\"; only \"%s\" accepted.\n" saddr s;
+  if s <> saddr then (
+    let conf = { conf with env = [ ("anon", saddr); ("o", s) ] } in
+    Printf.eprintf "Invalid request from \"%s\"; only \"%s\" accepted.\n" saddr
+      s;
     flush stderr;
-    print_file conf "err_acc.htm"
+    print_file conf "err_acc.htm")
   else if conf.comm = "" then print_file conf "welcome.htm"
   else setup_comm conf comm
 
 let wrap_setup a b (c : Adef.encoded_string) =
-  if not Sys.unix then begin
+  if not Sys.unix then (
     (* another process have been launched, therefore we lost variables;
        and we cannot parse the arg list again, because of possible spaces
        in arguments which may appear as separators *)
     (try default_lang := Sys.getenv "GWLANG" with Not_found -> ());
     (try setup_dir := Sys.getenv "GWGD" with Not_found -> ());
-    (try bin_dir := Sys.getenv "GWGD" with Not_found -> ());
-  end;
+    try bin_dir := Sys.getenv "GWGD" with Not_found -> ());
   try setup a b c with Exit -> ()
 
 let copy_text lang fname =
   let dir = Filename.concat !setup_dir "setup" in
   let fname = Filename.concat dir fname in
   match try Some (open_in fname) with Sys_error _ -> None with
-    Some ic ->
+  | Some ic ->
       let lexicon = input_lexicon lang in
-      let conf =
-        {lang = lang; comm = ""; env = []; request = [];
-         lexicon = lexicon}
-      in
+      let conf = { lang; comm = ""; env = []; request = []; lexicon } in
       copy_from_stream conf print_string (Stream.of_channel ic);
       flush stdout;
       close_in ic
@@ -1891,19 +1880,21 @@ let copy_text lang fname =
       Printf.printf "\nCannot access file \"%s\".\n" fname;
       Printf.printf "Type \"Enter\" to exit\n? ";
       flush stdout;
-      let _ = input_line stdin in (); exit 2
+      let _ = input_line stdin in
+      ();
+      exit 2
 
 let set_gwd_default_language_if_absent lang =
   let env = read_gwd_arg () in
   let fname = Filename.concat !setup_dir "gwd.arg" in
   match try Some (open_out fname) with Sys_error _ -> None with
-    Some oc ->
+  | Some oc ->
       let lang_found = ref false in
       List.iter
         (fun (k, v) ->
-           Printf.fprintf oc "-%s\n" k;
-           if k = "lang" then lang_found := true;
-           if v <> "" then Printf.fprintf oc "%s\n" v)
+          Printf.fprintf oc "-%s\n" k;
+          if k = "lang" then lang_found := true;
+          if v <> "" then Printf.fprintf oc "%s\n" v)
         env;
       if not !lang_found then Printf.fprintf oc "-lang\n%s\n" lang;
       close_out oc
@@ -1913,101 +1904,100 @@ let daemon = ref false
 
 let usage =
   "Usage: " ^ Filename.basename Sys.argv.(0) ^ " [options] where options are:"
+
 let speclist =
-  [("-bd", Arg.String (fun x -> base_dir := x),
-    "<dir> Directory where the databases are installed.");
-   ("-gwd_p", Arg.Int (fun x -> gwd_port := x),
-    "<number> Specify the port number of gwd (default = " ^
-      string_of_int !gwd_port ^ "); > 1024 for normal users.");
-   ("-lang", Arg.String (fun x -> lang_param := x), "<string> default lang");
-   ("-daemon", Arg.Set daemon, " Unix daemon mode.");
-   ("-p", Arg.Int (fun x -> port := x),
-    "<number> Select a port number (default = " ^ string_of_int !port ^
-    "); > 1024 for normal users.");
-   ("-only", Arg.String (fun s -> only_file := s),
-    "<file> File containing the only authorized address");
-   ("-gd", Arg.String (fun x -> setup_dir := x), "<string> gwsetup directory");
-   ("-bindir", Arg.String (fun x -> bin_dir := x),
-    "<string> binary directory (default = value of option -gd)")
+  [
+    ( "-bd",
+      Arg.String (fun x -> base_dir := x),
+      "<dir> Directory where the databases are installed." );
+    ( "-gwd_p",
+      Arg.Int (fun x -> gwd_port := x),
+      "<number> Specify the port number of gwd (default = "
+      ^ string_of_int !gwd_port ^ "); > 1024 for normal users." );
+    ("-lang", Arg.String (fun x -> lang_param := x), "<string> default lang");
+    ("-daemon", Arg.Set daemon, " Unix daemon mode.");
+    ( "-p",
+      Arg.Int (fun x -> port := x),
+      "<number> Select a port number (default = " ^ string_of_int !port
+      ^ "); > 1024 for normal users." );
+    ( "-only",
+      Arg.String (fun s -> only_file := s),
+      "<file> File containing the only authorized address" );
+    ("-gd", Arg.String (fun x -> setup_dir := x), "<string> gwsetup directory");
+    ( "-bindir",
+      Arg.String (fun x -> bin_dir := x),
+      "<string> binary directory (default = value of option -gd)" );
   ]
   |> List.sort compare |> Arg.align
 
 let anonfun s = raise (Arg.Bad ("don't know what to do with " ^ s))
 
 let null_reopen flags fd =
-  if Sys.unix then begin
+  if Sys.unix then (
     let fd2 = Unix.openfile "/dev/null" flags 0 in
     Unix.dup2 fd2 fd;
-    Unix.close fd2
-  end
+    Unix.close fd2)
 
-let setup_available_languages = ["de"; "en"; "es"; "fr"; "it"; "lv"; "sv"]
+let setup_available_languages = [ "de"; "en"; "es"; "fr"; "it"; "lv"; "sv" ]
 
 let intro () =
-  let (default_gwd_lang, default_setup_lang) =
+  let default_gwd_lang, default_setup_lang =
     if Sys.unix then
       let s = try Sys.getenv "LANG" with Not_found -> "" in
-      if List.mem s Version.available_languages
-      then s, (if List.mem s setup_available_languages then s else "en")
+      if List.mem s Version.available_languages then
+        (s, if List.mem s setup_available_languages then s else "en")
       else
         let s = try Sys.getenv "LC_CTYPE" with Not_found -> "" in
         if String.length s >= 2 then
           let s = String.sub s 0 2 in
-          if List.mem s Version.available_languages
-          then s, (if List.mem s setup_available_languages then s else "en")
-          else !default_lang, !default_lang
-        else !default_lang, !default_lang
-    else
-      !default_lang, !default_lang
+          if List.mem s Version.available_languages then
+            (s, if List.mem s setup_available_languages then s else "en")
+          else (!default_lang, !default_lang)
+        else (!default_lang, !default_lang)
+    else (!default_lang, !default_lang)
   in
   Secure.set_base_dir ".";
   Arg.parse speclist anonfun usage;
   if !bin_dir = "" then bin_dir := !setup_dir;
   default_lang := default_setup_lang;
-  let (gwd_lang, setup_lang) =
+  let gwd_lang, setup_lang =
     if !daemon then
-      if Sys.unix then
+      if Sys.unix then (
         let setup_lang =
           if String.length !lang_param < 2 then default_setup_lang
           else !lang_param
         in
         Printf.printf "To start, open location http://localhost:%d/\n" !port;
         flush stdout;
-        if Unix.fork () = 0 then
-          begin
-            Unix.close Unix.stdin;
-            null_reopen [Unix.O_WRONLY] Unix.stdout
-          end
+        if Unix.fork () = 0 then (
+          Unix.close Unix.stdin;
+          null_reopen [ Unix.O_WRONLY ] Unix.stdout)
         else exit 0;
-        default_gwd_lang, setup_lang
-      else
-        default_gwd_lang, default_setup_lang
+        (default_gwd_lang, setup_lang))
+      else (default_gwd_lang, default_setup_lang)
     else
-      let (gwd_lang, setup_lang) =
-        if String.length !lang_param < 2 then
-          begin
-            copy_text "" "intro.txt";
-            let x = String.lowercase_ascii (input_line stdin) in
-            if String.length x < 2 then default_gwd_lang, default_setup_lang
-            else let x = String.sub x 0 2 in x, x
-          end
-        else !lang_param, !lang_param
+      let gwd_lang, setup_lang =
+        if String.length !lang_param < 2 then (
+          copy_text "" "intro.txt";
+          let x = String.lowercase_ascii (input_line stdin) in
+          if String.length x < 2 then (default_gwd_lang, default_setup_lang)
+          else
+            let x = String.sub x 0 2 in
+            (x, x))
+        else (!lang_param, !lang_param)
       in
       copy_text setup_lang (Filename.concat "lang" "intro.txt");
-      gwd_lang, setup_lang
+      (gwd_lang, setup_lang)
   in
   set_gwd_default_language_if_absent gwd_lang;
   default_lang := setup_lang;
-  if not Sys.unix then begin
+  if not Sys.unix then (
     Unix.putenv "GWLANG" setup_lang;
-    Unix.putenv "GWGD" !setup_dir;
-  end;
+    Unix.putenv "GWGD" !setup_dir);
   Printf.printf "\n";
   flush stdout
 
 let () =
-  if Sys.unix then
-    intro ()
-  else
-    if Sys.getenv_opt "WSERVER" = None then intro ();
+  if Sys.unix then intro ()
+  else if Sys.getenv_opt "WSERVER" = None then intro ();
   Wserver.start ~port:!port ~max_pending_requests:150 ~n_workers:1 wrap_setup

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -10,9 +10,7 @@ let bench name fn =
         if i < 0 then String.concat "" (if x > 0 then "+" :: acc else acc)
         else
           let acc =
-            if n > 0
-            && n mod 3 = 0
-            && (n <> 1 && String.unsafe_get s 0 <> '-')
+            if n > 0 && n mod 3 = 0 && n <> 1 && String.unsafe_get s 0 <> '-'
             then aux i :: "," :: acc
             else aux i :: acc
           in
@@ -21,62 +19,56 @@ let bench name fn =
       loop (String.length s - 1) 0 []
     in
     Printf.printf
-      "\
-      \tminor_words : %s\n\
-      \tpromoted_words : %s\n\
-      \tmajor_words : %s\n\
-      \tminor_collections : %s\n\
-      \tmajor_collections : %s\n\
-      \theap_words : %s\n\
-      \theap_chunks : %s\n\
-      \tlive_words : %s\n\
-      \tlive_blocks : %s\n\
-      \tfree_words : %s\n\
-      \tfree_blocks : %s\n\
-      \tlargest_free : %s\n\
-      \tfragments : %s\n\
-      \tcompactions : %s\n\
-      \ttop_heap_words : %s\n\
-      \tstack_size : %s\n\
-      "
+      "\tminor_words : %s\n\
+       \tpromoted_words : %s\n\
+       \tmajor_words : %s\n\
+       \tminor_collections : %s\n\
+       \tmajor_collections : %s\n\
+       \theap_words : %s\n\
+       \theap_chunks : %s\n\
+       \tlive_words : %s\n\
+       \tlive_blocks : %s\n\
+       \tfree_words : %s\n\
+       \tfree_blocks : %s\n\
+       \tlargest_free : %s\n\
+       \tfragments : %s\n\
+       \tcompactions : %s\n\
+       \ttop_heap_words : %s\n\
+       \tstack_size : %s\n"
       (gc.minor_words |> truncate |> pint)
       (gc.promoted_words |> truncate |> pint)
       (gc.major_words |> truncate |> pint)
       (gc.minor_collections |> pint)
       (gc.major_collections |> pint)
-      (gc.heap_words |> pint)
-      (gc.heap_chunks |> pint)
-      (gc.live_words |> pint)
-      (gc.live_blocks |> pint)
-      (gc.free_words |> pint)
-      (gc.free_blocks |> pint)
-      (gc.largest_free |> pint)
-      (gc.fragments |> pint)
-      (gc.compactions |> pint)
+      (gc.heap_words |> pint) (gc.heap_chunks |> pint) (gc.live_words |> pint)
+      (gc.live_blocks |> pint) (gc.free_words |> pint) (gc.free_blocks |> pint)
+      (gc.largest_free |> pint) (gc.fragments |> pint) (gc.compactions |> pint)
       (gc.top_heap_words |> pint)
       (gc.stack_size |> pint)
   in
- (* OCaml 4.12 added [forced_major_collections] field. *)
- (* Using [@warning "-23"] and "gc1 with" as a workaround. *)
-  let [@warning "-23"] diff gc1 gc2 =
-    Gc.{ gc1 with
-         minor_words = gc2.minor_words -. gc1.minor_words
-       ; promoted_words = gc2.promoted_words -. gc1.promoted_words
-       ; major_words = gc2.major_words -. gc1.major_words
-       ; minor_collections = gc2.minor_collections - gc1.minor_collections
-       ; major_collections = gc2.major_collections - gc1.major_collections
-       ; heap_words = gc2.heap_words - gc1.heap_words
-       ; heap_chunks = gc2.heap_chunks - gc1.heap_chunks
-       ; live_words = gc2.live_words - gc1.live_words
-       ; live_blocks = gc2.live_blocks - gc1.live_blocks
-       ; free_words = gc2.free_words - gc1.free_words
-       ; free_blocks = gc2.free_blocks - gc1.free_blocks
-       ; largest_free = gc2.largest_free - gc1.largest_free
-       ; fragments = gc2.fragments - gc1.fragments
-       ; compactions = gc2.compactions - gc1.compactions
-       ; top_heap_words = gc2.top_heap_words - gc1.top_heap_words
-       ; stack_size = gc2.stack_size - gc1.stack_size
-       }
+  (* OCaml 4.12 added [forced_major_collections] field. *)
+  (* Using [@warning "-23"] and "gc1 with" as a workaround. *)
+  let[@warning "-23"] diff gc1 gc2 =
+    Gc.
+      {
+        gc1 with
+        minor_words = gc2.minor_words -. gc1.minor_words;
+        promoted_words = gc2.promoted_words -. gc1.promoted_words;
+        major_words = gc2.major_words -. gc1.major_words;
+        minor_collections = gc2.minor_collections - gc1.minor_collections;
+        major_collections = gc2.major_collections - gc1.major_collections;
+        heap_words = gc2.heap_words - gc1.heap_words;
+        heap_chunks = gc2.heap_chunks - gc1.heap_chunks;
+        live_words = gc2.live_words - gc1.live_words;
+        live_blocks = gc2.live_blocks - gc1.live_blocks;
+        free_words = gc2.free_words - gc1.free_words;
+        free_blocks = gc2.free_blocks - gc1.free_blocks;
+        largest_free = gc2.largest_free - gc1.largest_free;
+        fragments = gc2.fragments - gc1.fragments;
+        compactions = gc2.compactions - gc1.compactions;
+        top_heap_words = gc2.top_heap_words - gc1.top_heap_words;
+        stack_size = gc2.stack_size - gc1.stack_size;
+      }
   in
   let gc1 = Gc.stat () in
   let p1 = Sys.time () in
@@ -85,24 +77,22 @@ let bench name fn =
   let t2 = Unix.gettimeofday () in
   let p2 = Sys.time () in
   let gc2 = Gc.stat () in
-  Printf.printf "[%s]: %fs (~%fs CPU)\n" name (t2 -. t1) (p2 -. p1) ;
-  pprint_gc (diff gc1 gc2) ;
+  Printf.printf "[%s]: %fs (~%fs CPU)\n" name (t2 -. t1) (p2 -. p1);
+  pprint_gc (diff gc1 gc2);
   res
 
 let print_callstack ?(max = 5) () =
   Printexc.(print_raw_backtrace stderr @@ get_callstack max)
 
 let verbose = ref true
-
-let rm fname =
-  if Sys.file_exists fname then Sys.remove fname
-
-let mv src dst =
-  if Sys.file_exists src then Sys.rename src dst
+let rm fname = if Sys.file_exists fname then Sys.remove fname
+let mv src dst = if Sys.file_exists src then Sys.rename src dst
 
 let list_iter_first f = function
   | [] -> ()
-  | hd :: tl -> f true hd ; List.iter (f false) tl
+  | hd :: tl ->
+      f true hd;
+      List.iter (f false) tl
 
 (* [decline] has been deprecated since version 5.00
    compatibility code: *)
@@ -110,38 +100,38 @@ let colon_to_at_word s ibeg iend =
   let iendroot =
     let rec loop i =
       if i + 3 >= iend then iend
-      else if s.[i] = ':' && s.[i+2] = ':' then i
+      else if s.[i] = ':' && s.[i + 2] = ':' then i
       else loop (i + 1)
     in
     loop ibeg
   in
   if iendroot = iend then String.sub s ibeg (iend - ibeg)
   else
-    let (listdecl, maxd) =
+    let listdecl, maxd =
       let rec loop list maxd i =
-        if i >= iend then list, maxd
+        if i >= iend then (list, maxd)
         else
           let inext =
             let rec loop i =
               if i + 3 >= iend then iend
-              else if s.[i] = ':' && s.[i+2] = ':' then i
+              else if s.[i] = ':' && s.[i + 2] = ':' then i
               else loop (i + 1)
             in
             loop (i + 3)
           in
-          let (e, d) =
+          let e, d =
             let i = i + 3 in
             let j = inext in
-            if i < j && s.[i] = '+' then String.sub s (i + 1) (j - i - 1), 0
+            if i < j && s.[i] = '+' then (String.sub s (i + 1) (j - i - 1), 0)
             else if i < j && s.[i] = '-' then
               let rec loop n i =
                 if i < j && s.[i] = '-' then loop (n + 1) (i + 1)
-                else String.sub s i (j - i), n
+                else (String.sub s i (j - i), n)
               in
               loop 1 (i + 1)
-            else String.sub s i (j - i), iendroot - ibeg
+            else (String.sub s i (j - i), iendroot - ibeg)
           in
-          loop ((s.[i+1], e) :: list) (max d maxd) inext
+          loop ((s.[i + 1], e) :: list) (max d maxd) inext
       in
       loop [] 0 iendroot
     in
@@ -150,8 +140,9 @@ let colon_to_at_word s ibeg iend =
     let s =
       List.fold_left
         (fun t (c, e) ->
-           Printf.sprintf "%c?%s%s" c e (if t = "" then "" else ":" ^ t))
-        (String.sub s (ibeg + len) (iendroot - ibeg - len)) listdecl
+          Printf.sprintf "%c?%s%s" c e (if t = "" then "" else ":" ^ t))
+        (String.sub s (ibeg + len) (iendroot - ibeg - len))
+        listdecl
     in
     root ^ "@(" ^ s ^ ")"
 
@@ -161,7 +152,7 @@ let colon_to_at s =
       if i = ibeg then "" else colon_to_at_word s ibeg i
     else
       match s.[i] with
-        ' ' | '<' | '/' as sep ->
+      | (' ' | '<' | '/') as sep ->
           colon_to_at_word s ibeg i ^ String.make 1 sep ^ loop (i + 1) (i + 1)
       | '>' -> String.sub s ibeg (i + 1 - ibeg) ^ loop (i + 1) (i + 1)
       | _ -> loop ibeg (i + 1)
@@ -174,9 +165,7 @@ let decline case s =
 (* end compatibility code *)
 
 let nominative s =
-  match String.rindex_opt s ':' with
-    Some _ -> decline 'n' s
-  | _ -> s
+  match String.rindex_opt s ':' with Some _ -> decline 'n' s | _ -> s
 
 let mkdir_p ?(perm = 0o755) d =
   let rec loop d =
@@ -184,27 +173,39 @@ let mkdir_p ?(perm = 0o755) d =
     if d1 <> d && String.length d1 < String.length d then loop d1;
     if not (Sys.file_exists d) then
       try Unix.mkdir d perm
-      with Unix.Unix_error (_, _, _) ->
-        Printf.eprintf "Failed mkdir: %s\n" d
+      with Unix.Unix_error (_, _, _) -> Printf.eprintf "Failed mkdir: %s\n" d
   in
   loop d
 
-let lock_file bname = (Filename.remove_extension bname) ^ ".lck"
+let lock_file bname = Filename.remove_extension bname ^ ".lck"
 
 let initial n =
   let rec loop i =
     if i = String.length n then 0
     else
-      match n.[i] with
-        'A'..'Z' | '\192'..'\221' -> i
-      | _ -> loop (succ i)
+      match n.[i] with 'A' .. 'Z' | '\192' .. '\221' -> i | _ -> loop (succ i)
   in
   loop 0
 
 let default_particles =
   let upper =
-    [ "AF " ; "D'" ; "D’" ; "DAL " ; "DE " ; "DES " ; "DI " ; "DU " ; "OF "
-    ; "VAN " ; "VON UND ZU " ; "VON " ; "Y " ; "ZU " ; "ZUR " ]
+    [
+      "AF ";
+      "D'";
+      "D’";
+      "DAL ";
+      "DE ";
+      "DES ";
+      "DI ";
+      "DU ";
+      "OF ";
+      "VAN ";
+      "VON UND ZU ";
+      "VON ";
+      "Y ";
+      "ZU ";
+      "ZUR ";
+    ]
   in
   List.rev_append (List.rev_map String.lowercase_ascii upper) upper
 
@@ -218,18 +219,18 @@ let input_particles fname =
       | '\r' -> loop list len
       | c -> loop list (Buff.store len c)
       | exception End_of_file ->
-        close_in ic;
-        List.rev (if len = 0 then list else Buff.get len :: list)
+          close_in ic;
+          List.rev (if len = 0 then list else Buff.get len :: list)
     in
     loop [] 0
   with Sys_error _ -> default_particles
 
-let saints = ["saint"; "sainte"]
+let saints = [ "saint"; "sainte" ]
 
 let surnames_pieces surname =
   let surname = Name.lower surname in
   let flush i0 i1 =
-    if i1 > i0 then [String.sub surname i0 (i1 - i0)] else []
+    if i1 > i0 then [ String.sub surname i0 (i1 - i0) ] else []
   in
   let rec loop i0 iw i =
     if i = String.length surname then
@@ -247,19 +248,19 @@ let surnames_pieces surname =
 let tr c1 c2 s =
   match String.rindex_opt s c1 with
   | Some _ ->
-    String.init
-      (String.length s)
-      (fun i -> let c = String.unsafe_get s i in if c = c1 then c2 else c)
+      String.init (String.length s) (fun i ->
+          let c = String.unsafe_get s i in
+          if c = c1 then c2 else c)
   | None -> s
 
 let unsafe_tr c1 c2 s =
   match String.rindex_opt s c1 with
   | Some _ ->
-    let bytes = Bytes.unsafe_of_string s in
-    for i = 0 to Bytes.length bytes - 1 do
-      if Bytes.unsafe_get bytes i = c1 then Bytes.unsafe_set bytes i c2
-    done ;
-    Bytes.unsafe_to_string bytes
+      let bytes = Bytes.unsafe_of_string s in
+      for i = 0 to Bytes.length bytes - 1 do
+        if Bytes.unsafe_get bytes i = c1 then Bytes.unsafe_set bytes i c2
+      done;
+      Bytes.unsafe_to_string bytes
   | None -> s
 
 let utf_8_of_iso_8859_1 str =
@@ -283,10 +284,10 @@ let iso_8859_1_of_utf_8 s =
     else
       let c = s.[i] in
       match Char.code c with
-        0xC2 when i + 1 < String.length s ->
-          loop (i + 2) (Buff.store len s.[i+1])
+      | 0xC2 when i + 1 < String.length s ->
+          loop (i + 2) (Buff.store len s.[i + 1])
       | 0xC3 when i + 1 < String.length s ->
-          loop (i + 2) (Buff.store len (Char.chr (Char.code s.[i+1] + 0x40)))
+          loop (i + 2) (Buff.store len (Char.chr (Char.code s.[i + 1] + 0x40)))
       | _ -> loop (i + 1) (Buff.store len c)
   in
   loop 0 0
@@ -297,9 +298,7 @@ let strip_all_trailing_spaces s =
     let rec loop i =
       if i < 0 then 0
       else
-        match s.[i] with
-          ' ' | '\t' | '\r' | '\n' -> loop (i - 1)
-        | _ -> i + 1
+        match s.[i] with ' ' | '\t' | '\r' | '\n' -> loop (i - 1) | _ -> i + 1
     in
     loop (String.length s - 1)
   in
@@ -307,25 +306,28 @@ let strip_all_trailing_spaces s =
     if i = len then Buffer.contents b
     else
       match s.[i] with
-        '\r' -> loop (i + 1)
+      | '\r' -> loop (i + 1)
       | ' ' | '\t' ->
           let rec loop0 j =
             if j = len then Buffer.contents b
             else
               match s.[j] with
-                ' ' | '\t' | '\r' -> loop0 (j + 1)
+              | ' ' | '\t' | '\r' -> loop0 (j + 1)
               | '\n' -> loop j
-              | _ -> Buffer.add_char b s.[i]; loop (i + 1)
+              | _ ->
+                  Buffer.add_char b s.[i];
+                  loop (i + 1)
           in
           loop0 (i + 1)
-      | c -> Buffer.add_char b c; loop (i + 1)
+      | c ->
+          Buffer.add_char b c;
+          loop (i + 1)
   in
   loop 0
 
 let roman_of_arabian n =
-  let build one five ten =
-    function
-      0 -> ""
+  let build one five ten = function
+    | 0 -> ""
     | 1 -> one
     | 2 -> one ^ one
     | 3 -> one ^ one ^ one
@@ -336,39 +338,44 @@ let roman_of_arabian n =
     | 8 -> five ^ one ^ one ^ one
     | _ -> one ^ ten
   in
-  build "M" "M" "M" (n / 1000 mod 10) ^ build "C" "D" "M" (n / 100 mod 10) ^
-  build "X" "L" "C" (n / 10 mod 10) ^ build "I" "V" "X" (n mod 10)
+  build "M" "M" "M" (n / 1000 mod 10)
+  ^ build "C" "D" "M" (n / 100 mod 10)
+  ^ build "X" "L" "C" (n / 10 mod 10)
+  ^ build "I" "V" "X" (n mod 10)
 
 let arabian_of_roman s =
   let decode_digit one five ten r =
     let rec loop cnt i =
-      if i >= String.length s then 10 * r + cnt, i
+      if i >= String.length s then ((10 * r) + cnt, i)
       else if s.[i] = one then loop (cnt + 1) (i + 1)
       else if s.[i] = five then
-        if cnt = 0 then loop 5 (i + 1) else 10 * r + 5 - cnt, i + 1
-      else if s.[i] = ten then 10 * r + 10 - cnt, i + 1
-      else 10 * r + cnt, i
+        if cnt = 0 then loop 5 (i + 1) else ((10 * r) + 5 - cnt, i + 1)
+      else if s.[i] = ten then ((10 * r) + 10 - cnt, i + 1)
+      else ((10 * r) + cnt, i)
     in
     loop 0
   in
-  let (r, i) = decode_digit 'M' 'M' 'M' 0 0 in
-  let (r, i) = decode_digit 'C' 'D' 'M' r i in
-  let (r, i) = decode_digit 'X' 'L' 'C' r i in
-  let (r, i) = decode_digit 'I' 'V' 'X' r i in
+  let r, i = decode_digit 'M' 'M' 'M' 0 0 in
+  let r, i = decode_digit 'C' 'D' 'M' r i in
+  let r, i = decode_digit 'X' 'L' 'C' r i in
+  let r, i = decode_digit 'I' 'V' 'X' r i in
   if i = String.length s then r else raise Not_found
 
-module StrSet = Set.Make (struct type t = string let compare = compare end)
+module StrSet = Set.Make (struct
+  type t = string
+
+  let compare = compare
+end)
 
 let start_with ini i s =
   let inilen = String.length ini in
   let strlen = String.length s in
-  if i < 0 || i > strlen then raise (Invalid_argument "start_with") ;
+  if i < 0 || i > strlen then raise (Invalid_argument "start_with");
   let rec loop i1 i2 =
     if i1 = inilen then true
-    else if i2 = strlen
-    then false
-    else if String.unsafe_get s i2 = String.unsafe_get ini i1
-    then loop (i1 + 1) (i2 + 1)
+    else if i2 = strlen then false
+    else if String.unsafe_get s i2 = String.unsafe_get ini i1 then
+      loop (i1 + 1) (i2 + 1)
     else false
   in
   loop 0 i
@@ -376,15 +383,14 @@ let start_with ini i s =
 let start_with_wildcard ini i s =
   let inilen = String.length ini in
   let strlen = String.length s in
-  if i < 0 || i > strlen then raise (Invalid_argument "start_with_wildcard") ;
+  if i < 0 || i > strlen then raise (Invalid_argument "start_with_wildcard");
   let rec loop i1 i2 =
     if i1 = inilen then true
-    else if i2 = strlen
-    then
-      if String.unsafe_get ini i1 = '_'
-      then loop (i1 + 1) i2 else false
-    else if String.unsafe_get s i2 = String.unsafe_get ini i1
-         || (String.unsafe_get s i2 = ' ' && String.unsafe_get ini i1 = '_')
+    else if i2 = strlen then
+      if String.unsafe_get ini i1 = '_' then loop (i1 + 1) i2 else false
+    else if
+      String.unsafe_get s i2 = String.unsafe_get ini i1
+      || (String.unsafe_get s i2 = ' ' && String.unsafe_get ini i1 = '_')
     then loop (i1 + 1) (i2 + 1)
     else false
   in
@@ -396,30 +402,25 @@ let contains str sub =
   let rec aux i1 i2 =
     if i1 = sublen then true
     else if i2 = strlen then false
-    else if String.unsafe_get str i2 = String.unsafe_get sub i1
-    then aux (i1 + 1) (i2 + 1)
+    else if String.unsafe_get str i2 = String.unsafe_get sub i1 then
+      aux (i1 + 1) (i2 + 1)
     else false
   in
   let rec loop i =
-    if i + sublen <= strlen then aux 0 i || loop (i + 1)
-    else false
-  in loop 0
+    if i + sublen <= strlen then aux 0 i || loop (i + 1) else false
+  in
+  loop 0
 
 let compile_particles list =
   let parts =
     list
     |> List.map (fun s -> Re.str (tr '_' ' ' s))
-    |> Re.alt
-    |> Re.longest
-    |> Re.group
+    |> Re.alt |> Re.longest |> Re.group
   in
-  Re.(seq [ bos ; parts ; greedy (rep notnl) ])
-  |> Re.compile
+  Re.(seq [ bos; parts; greedy (rep notnl) ]) |> Re.compile
 
 let get_particle re s =
-  match Re.exec_opt re s with
-  | Some g -> Re.Group.get g 1
-  | None -> ""
+  match Re.exec_opt re s with Some g -> Re.Group.get g 1 | None -> ""
 
 let compare_after_particle particles s1 s2 =
   let p1 = get_particle particles s1 in
@@ -441,29 +442,31 @@ let fallback = ref []
 let read_fallback lang fname =
   fallback := [];
   let rec aux a b i =
-    i = -1
-    || (String.unsafe_get a i = String.unsafe_get b i
-        && aux a b (i - 1) )
+    i = -1 || (String.unsafe_get a i = String.unsafe_get b i && aux a b (i - 1))
   in
-  let ic = try Some (Secure.open_in fname)
-    with Sys_error _ -> None
-  in
+  let ic = try Some (Secure.open_in fname) with Sys_error _ -> None in
   match ic with
   | Some ic ->
-    let rec one_line () =
-      match input_line ic with
-      | exception End_of_file -> close_in ic
-      | line -> (
-          let lang_len = String.length lang in
-          match String.index_opt line ':' with
-          | Some i when line.[0] <> '#' &&
-              (i = lang_len && aux lang line (lang_len - 1) ) -> (
-              let f_lang = String.sub line (i + 1) (String.length line - i - 1) in
-              fallback := (lang, f_lang) :: !fallback;
-              one_line ())
-          | _ -> one_line ())
-    in one_line ()
-  | None -> fallback := [("co", "fr"); ("oc", "fr"); ("br", "fr"); ("bg", "ru"); ]
+      let rec one_line () =
+        match input_line ic with
+        | exception End_of_file -> close_in ic
+        | line -> (
+            let lang_len = String.length lang in
+            match String.index_opt line ':' with
+            | Some i
+              when line.[0] <> '#'
+                   && i = lang_len
+                   && aux lang line (lang_len - 1) ->
+                let f_lang =
+                  String.sub line (i + 1) (String.length line - i - 1)
+                in
+                fallback := (lang, f_lang) :: !fallback;
+                one_line ()
+            | _ -> one_line ())
+      in
+      one_line ()
+  | None ->
+      fallback := [ ("co", "fr"); ("oc", "fr"); ("br", "fr"); ("bg", "ru") ]
 
 let input_lexicon lang ht open_fname =
   read_fallback lang "lexicon.gwf";
@@ -477,16 +480,14 @@ let input_lexicon lang ht open_fname =
   let derived_lang =
     match String.index_opt lang '-' with
     | Some i -> String.sub lang 0 i
-    | None ->
-      match String.index_opt lang '_' with
-      | Some i -> String.sub lang 0 i
-      | None -> ""
+    | None -> (
+        match String.index_opt lang '_' with
+        | Some i -> String.sub lang 0 i
+        | None -> "")
   in
   let derived_lang_len = String.length derived_lang in
   let rec aux a b i =
-    i = -1
-    || (String.unsafe_get a i = String.unsafe_get b i
-        && aux a b (i - 1) )
+    i = -1 || (String.unsafe_get a i = String.unsafe_get b i && aux a b (i - 1))
   in
   (* find header *)
   let tmp = Hashtbl.create 0 in
@@ -494,118 +495,119 @@ let input_lexicon lang ht open_fname =
     match input_line ic with
     | exception End_of_file -> close_in ic
     | line ->
-      let len = String.length line in
-      if len < 4 then key ()
-      else if String.unsafe_get line 0 = ' '
-           && String.unsafe_get line 1 = ' '
-           && String.unsafe_get line 2 = ' '
-           && String.unsafe_get line 3 = ' '
-      then trad (String.sub line 4 (len - 4))
-      else key ()
+        let len = String.length line in
+        if len < 4 then key ()
+        else if
+          String.unsafe_get line 0 = ' '
+          && String.unsafe_get line 1 = ' '
+          && String.unsafe_get line 2 = ' '
+          && String.unsafe_get line 3 = ' '
+        then trad (String.sub line 4 (len - 4))
+        else key ()
   (* find a line corresponding to a language *)
   and trad k =
     hold := "";
     match input_line ic with
     | exception End_of_file -> close_in ic
-    | line ->
-      match String.index_opt line ':' with
-      | Some i when (i = lang_len && aux lang line (lang_len - 1) )
-        || (i = derived_lang_len && aux derived_lang line (derived_lang_len - 1) ) ->
-          let v =
-            if i + 1 = String.length line then ""
-            else String.sub line (i + 2) (String.length line - i - 2)
-          in
-          Hashtbl.replace ht k v;
-          trad k
-      | Some i when List.mem_assoc lang !fallback &&
-          (i = (String.length (List.assoc lang !fallback))) &&
-          (aux (List.assoc lang !fallback) line (String.length (List.assoc lang !fallback) - 1 )) ->
-          let v =
-            if i + 1 = String.length line then ""
-            else String.sub line (i + 2) (String.length line - i - 2)
-          in
-          hold := v;
-          trad k
-      | Some _i when String.length line > 4
-             && String.unsafe_get line 0 = '-'
-             && String.unsafe_get line 1 = '>'
-             && String.unsafe_get line 2 = ':'
-             && String.unsafe_get line 3 = ' ' ->
-          (* defining alias names for existing entries in the lexicon *)
-          (*     alias_name *)
-          (* ->: real_entry *)
-          let k2 = String.sub line 4 (String.length line - 4) in
-          Hashtbl.replace tmp k k2;
-          trad k
-      | Some _i ->
-          trad k
-      | None -> (
-          if (not (Hashtbl.mem ht k)) && !hold <> "" then
-            Hashtbl.add ht k !hold;
-          key ())
+    | line -> (
+        match String.index_opt line ':' with
+        | Some i
+          when (i = lang_len && aux lang line (lang_len - 1))
+               || i = derived_lang_len
+                  && aux derived_lang line (derived_lang_len - 1) ->
+            let v =
+              if i + 1 = String.length line then ""
+              else String.sub line (i + 2) (String.length line - i - 2)
+            in
+            Hashtbl.replace ht k v;
+            trad k
+        | Some i
+          when List.mem_assoc lang !fallback
+               && i = String.length (List.assoc lang !fallback)
+               && aux
+                    (List.assoc lang !fallback)
+                    line
+                    (String.length (List.assoc lang !fallback) - 1) ->
+            let v =
+              if i + 1 = String.length line then ""
+              else String.sub line (i + 2) (String.length line - i - 2)
+            in
+            hold := v;
+            trad k
+        | Some _i
+          when String.length line > 4
+               && String.unsafe_get line 0 = '-'
+               && String.unsafe_get line 1 = '>'
+               && String.unsafe_get line 2 = ':'
+               && String.unsafe_get line 3 = ' ' ->
+            (* defining alias names for existing entries in the lexicon *)
+            (*     alias_name *)
+            (* ->: real_entry *)
+            let k2 = String.sub line 4 (String.length line - 4) in
+            Hashtbl.replace tmp k k2;
+            trad k
+        | Some _i -> trad k
+        | None ->
+            if (not (Hashtbl.mem ht k)) && !hold <> "" then
+              Hashtbl.add ht k !hold;
+            key ())
   in
-  key () ;
-  Hashtbl.iter (fun k k2 ->
+  key ();
+  Hashtbl.iter
+    (fun k k2 ->
       match Hashtbl.find_opt ht k2 with
       | Some entry -> Hashtbl.replace ht k entry
-      | None -> ()) tmp
+      | None -> ())
+    tmp
 
-
-let array_to_list_map fn a =
-  Array.fold_right (fun x acc -> fn x :: acc) a []
-
-let array_to_list_rev_map fn a =
-  Array.fold_left (fun acc x -> fn x :: acc) [] a
+let array_to_list_map fn a = Array.fold_right (fun x acc -> fn x :: acc) a []
+let array_to_list_rev_map fn a = Array.fold_left (fun acc x -> fn x :: acc) [] a
 
 let array_assoc k a =
   let len = Array.length a in
   let rec loop i =
     if i = len then raise Not_found
     else
-      let (k', v) = Array.unsafe_get a i in
-      if k' = k then v
-      else loop (i + 1)
-  in loop 0
+      let k', v = Array.unsafe_get a i in
+      if k' = k then v else loop (i + 1)
+  in
+  loop 0
 
 let string_of_int_sep sep x =
   let digits, len =
     let rec loop (d, l) x =
-      if x = 0 then (d, l) else loop (Char.chr (Char.code '0' + x mod 10) :: d, l + 1) (x / 10)
+      if x = 0 then (d, l)
+      else loop (Char.chr (Char.code '0' + (x mod 10)) :: d, l + 1) (x / 10)
     in
     loop ([], 0) x
   in
-  let digits, len = if digits = [] then ['0'], 1 else digits, len in
+  let digits, len = if digits = [] then ([ '0' ], 1) else (digits, len) in
   let slen = String.length sep in
-  let s = Bytes.create (len + (len - 1) / 3 * slen) in
+  let s = Bytes.create (len + ((len - 1) / 3 * slen)) in
   let _ =
     List.fold_left
       (fun (i, j) c ->
-         Bytes.set s j c ;
-         if i < len - 1 && (len - 1 - i) mod 3 = 0 then
-           begin String.blit sep 0 s (j + 1) slen; i + 1, j + 1 + slen end
-         else i + 1, j + 1)
+        Bytes.set s j c;
+        if i < len - 1 && (len - 1 - i) mod 3 = 0 then (
+          String.blit sep 0 s (j + 1) slen;
+          (i + 1, j + 1 + slen))
+        else (i + 1, j + 1))
       (0, 0) digits
   in
   Bytes.unsafe_to_string s
 
 let rec list_compare cmp l1 l2 =
-  match l1, l2 with
-  | x1 :: l1, x2 :: l2 -> begin
-      match cmp x1 x2 with
-      | 0 -> list_compare cmp l1 l2
-      | x -> x
-    end
+  match (l1, l2) with
+  | x1 :: l1, x2 :: l2 -> (
+      match cmp x1 x2 with 0 -> list_compare cmp l1 l2 | x -> x)
   | [], [] -> 0
   | [], _ -> -1
   | _, [] -> 1
 
 let rec list_find_map f = function
   | [] -> None
-  | x :: l ->
-    begin match f x with
-      | Some _ as result -> result
-      | None -> list_find_map f l
-    end
+  | x :: l -> (
+      match f x with Some _ as result -> result | None -> list_find_map f l)
 
 let array_find_map f a =
   let n = Array.length a in
@@ -619,7 +621,7 @@ let array_find_map f a =
   loop 0
 
 let rec list_last = function
-  | [ ] -> raise (Failure "list_last")
+  | [] -> raise (Failure "list_last")
   | [ x ] -> x
   | _ :: tl -> list_last tl
 
@@ -631,7 +633,7 @@ let executable_magic =
   | None -> Digest.file Sys.executable_name
 
 let random_magic =
-  Random.self_init () ;
+  Random.self_init ();
   Random.bits () |> string_of_int
 
 let check_magic magic ic =
@@ -639,7 +641,9 @@ let check_magic magic ic =
   let pos = pos_in ic in
   if in_channel_length ic - pos < len then false
   else if magic = really_input_string ic len then true
-  else begin seek_in ic pos ; false end
+  else (
+    seek_in ic pos;
+    false)
 
 let array_except v a =
   let rec loop i =
@@ -664,16 +668,12 @@ let array_forall2 f a1 a2 =
 let rec list_replace old_v new_v = function
   | [] -> []
   | hd :: tl ->
-    if hd = old_v
-    then new_v :: tl
-    else hd :: list_replace old_v new_v tl
+      if hd = old_v then new_v :: tl else hd :: list_replace old_v new_v tl
 
 let list_except x =
   let rec loop acc = function
     | [] -> []
-    | hd :: tl ->
-      if hd = x then List.rev_append acc tl
-      else loop (hd :: acc) tl
+    | hd :: tl -> if hd = x then List.rev_append acc tl else loop (hd :: acc) tl
   in
   loop []
 
@@ -681,52 +681,60 @@ let list_index x list =
   let rec loop i = function
     | [] -> raise Not_found
     | hd :: tl -> if hd = x then i else loop (succ i) tl
-  in loop 0 list
+  in
+  loop 0 list
 
 let list_slice a b list =
-  let rec list_slice a b =  function
-  | [] -> []
-  | hd :: tl ->
-    if a <> 0 then list_slice (pred a) b tl
-    else if b <> 0 then hd :: list_slice 0 (pred b) tl
-    else []
-  in list_slice a (b - a) list
+  let rec list_slice a b = function
+    | [] -> []
+    | hd :: tl ->
+        if a <> 0 then list_slice (pred a) b tl
+        else if b <> 0 then hd :: list_slice 0 (pred b) tl
+        else []
+  in
+  list_slice a (b - a) list
 
 let input_file_ic ic =
   let len = in_channel_length ic in
-  if Sys.unix then
+  if Sys.unix then (
     let bytes = Bytes.create len in
-    really_input ic bytes 0 len ;
-    Bytes.unsafe_to_string bytes
+    really_input ic bytes 0 len;
+    Bytes.unsafe_to_string bytes)
+  else if len = 0 then ""
   else
-    if len = 0 then ""
-    else
-      let buffer = Buffer.create len in
-      let rec loop () =
-        match input_line ic with
-        | line ->
-          Buffer.add_string buffer line ;
+    let buffer = Buffer.create len in
+    let rec loop () =
+      match input_line ic with
+      | line ->
+          Buffer.add_string buffer line;
           let pos = pos_in ic in
-          if pos < len
-          || (seek_in ic @@ pos - 1 ; input_char ic) = '\n'
-          then Buffer.add_char buffer '\n' ;
+          if
+            pos < len
+            || (seek_in ic @@ (pos - 1);
+                input_char ic)
+               = '\n'
+          then Buffer.add_char buffer '\n';
           loop ()
-        | exception End_of_file -> Buffer.contents buffer
-      in loop ()
+      | exception End_of_file -> Buffer.contents buffer
+    in
+    loop ()
 
 let normalize_utf_8 s =
   let b = Buffer.create (String.length s * 3) in
   let n = Uunf.create `NFC in
-  let rec add v = match Uunf.add n v with
-    | `Uchar u -> Uutf.Buffer.add_utf_8 b u; add `Await
+  let rec add v =
+    match Uunf.add n v with
+    | `Uchar u ->
+        Uutf.Buffer.add_utf_8 b u;
+        add `Await
     | `Await | `End -> ()
   in
   let add_uchar _ _ = function
     | `Malformed _ -> add (`Uchar Uutf.u_rep)
     | `Uchar _ as u -> add u
   in
-  Uutf.String.fold_utf_8 add_uchar () s ;
-  add `End ;
+  Uutf.String.fold_utf_8 add_uchar () s;
+  add `End;
   Buffer.contents b
 
 (* Copied from OCaml's List.sort_uniq and adapted to our needs
@@ -734,196 +742,198 @@ let normalize_utf_8 s =
 let list_map_sort_uniq (fn : 'a -> 'b) l =
   let open List in
   let rec rev_merge l1 l2 accu =
-    match l1, l2 with
+    match (l1, l2) with
     | [], l2 -> rev_append l2 accu
     | l1, [] -> rev_append l1 accu
-    | h1::t1, h2::t2 ->
-      let c = Stdlib.compare h1 h2 in
-      if c = 0 then rev_merge t1 t2 (h1::accu)
-      else if c < 0
-      then rev_merge t1 l2 (h1::accu)
-      else rev_merge l1 t2 (h2::accu)
+    | h1 :: t1, h2 :: t2 ->
+        let c = Stdlib.compare h1 h2 in
+        if c = 0 then rev_merge t1 t2 (h1 :: accu)
+        else if c < 0 then rev_merge t1 l2 (h1 :: accu)
+        else rev_merge l1 t2 (h2 :: accu)
   in
   let rec rev_merge_rev l1 l2 accu =
-    match l1, l2 with
+    match (l1, l2) with
     | [], l2 -> rev_append l2 accu
     | l1, [] -> rev_append l1 accu
-    | h1::t1, h2::t2 ->
-      let c = Stdlib.compare h1 h2 in
-      if c = 0 then rev_merge_rev t1 t2 (h1::accu)
-      else if c > 0
-      then rev_merge_rev t1 l2 (h1::accu)
-      else rev_merge_rev l1 t2 (h2::accu)
+    | h1 :: t1, h2 :: t2 ->
+        let c = Stdlib.compare h1 h2 in
+        if c = 0 then rev_merge_rev t1 t2 (h1 :: accu)
+        else if c > 0 then rev_merge_rev t1 l2 (h1 :: accu)
+        else rev_merge_rev l1 t2 (h2 :: accu)
   in
   let rec sort n l =
-    match n, l with
+    match (n, l) with
     | 2, x1 :: x2 :: tl ->
-      let x1 = fn x1 in
-      let x2 = fn x2 in
-      let s =
-        let c = Stdlib.compare x1 x2 in
-        if c = 0 then [x1] else if c < 0 then [x1; x2] else [x2; x1]
-      in
-      (s, tl)
+        let x1 = fn x1 in
+        let x2 = fn x2 in
+        let s =
+          let c = Stdlib.compare x1 x2 in
+          if c = 0 then [ x1 ] else if c < 0 then [ x1; x2 ] else [ x2; x1 ]
+        in
+        (s, tl)
     | 3, x1 :: x2 :: x3 :: tl ->
-      let x1 = fn x1 in
-      let x2 = fn x2 in
-      let x3 = fn x3 in
-      let s =
-        let c = Stdlib.compare x1 x2 in
-        if c = 0 then
-          let c = Stdlib.compare x2 x3 in
-          if c = 0 then [x2] else if c < 0 then [x2; x3] else [x3; x2]
-        else if c < 0 then
-          let c = Stdlib.compare x2 x3 in
-          if c = 0 then [x1; x2]
-          else if c < 0 then [x1; x2; x3]
+        let x1 = fn x1 in
+        let x2 = fn x2 in
+        let x3 = fn x3 in
+        let s =
+          let c = Stdlib.compare x1 x2 in
+          if c = 0 then
+            let c = Stdlib.compare x2 x3 in
+            if c = 0 then [ x2 ] else if c < 0 then [ x2; x3 ] else [ x3; x2 ]
+          else if c < 0 then
+            let c = Stdlib.compare x2 x3 in
+            if c = 0 then [ x1; x2 ]
+            else if c < 0 then [ x1; x2; x3 ]
+            else
+              let c = Stdlib.compare x1 x3 in
+              if c = 0 then [ x1; x2 ]
+              else if c < 0 then [ x1; x3; x2 ]
+              else [ x3; x1; x2 ]
           else
             let c = Stdlib.compare x1 x3 in
-            if c = 0 then [x1; x2]
-            else if c < 0 then [x1; x3; x2]
-            else [x3; x1; x2]
-        else
-          let c = Stdlib.compare x1 x3 in
-          if c = 0 then [x2; x1]
-          else if c < 0 then [x2; x1; x3]
-          else
-            let c = Stdlib.compare x2 x3 in
-            if c = 0 then [x2; x1]
-            else if c < 0 then [x2; x3; x1]
-            else [x3; x2; x1]
-      in
-      (s, tl)
+            if c = 0 then [ x2; x1 ]
+            else if c < 0 then [ x2; x1; x3 ]
+            else
+              let c = Stdlib.compare x2 x3 in
+              if c = 0 then [ x2; x1 ]
+              else if c < 0 then [ x2; x3; x1 ]
+              else [ x3; x2; x1 ]
+        in
+        (s, tl)
     | n, l ->
-      let n1 = n asr 1 in
-      let n2 = n - n1 in
-      let s1, l2 = rev_sort n1 l in
-      let s2, tl = rev_sort n2 l2 in
-      (rev_merge_rev s1 s2 [], tl)
+        let n1 = n asr 1 in
+        let n2 = n - n1 in
+        let s1, l2 = rev_sort n1 l in
+        let s2, tl = rev_sort n2 l2 in
+        (rev_merge_rev s1 s2 [], tl)
   and rev_sort n l =
-    match n, l with
+    match (n, l) with
     | 2, x1 :: x2 :: tl ->
-      let x1 = fn x1 in
-      let x2 = fn x2 in
-      let s =
-        let c = Stdlib.compare x1 x2 in
-        if c = 0 then [x1] else if c > 0 then [x1; x2] else [x2; x1]
-      in
-      (s, tl)
+        let x1 = fn x1 in
+        let x2 = fn x2 in
+        let s =
+          let c = Stdlib.compare x1 x2 in
+          if c = 0 then [ x1 ] else if c > 0 then [ x1; x2 ] else [ x2; x1 ]
+        in
+        (s, tl)
     | 3, x1 :: x2 :: x3 :: tl ->
-      let x1 = fn x1 in
-      let x2 = fn x2 in
-      let x3 = fn x3 in
-      let s =
-        let c = Stdlib.compare x1 x2 in
-        if c = 0 then
-          let c = Stdlib.compare x2 x3 in
-          if c = 0 then [x2] else if c > 0 then [x2; x3] else [x3; x2]
-        else if c > 0 then
-          let c = Stdlib.compare x2 x3 in
-          if c = 0 then [x1; x2]
-          else if c > 0 then [x1; x2; x3]
+        let x1 = fn x1 in
+        let x2 = fn x2 in
+        let x3 = fn x3 in
+        let s =
+          let c = Stdlib.compare x1 x2 in
+          if c = 0 then
+            let c = Stdlib.compare x2 x3 in
+            if c = 0 then [ x2 ] else if c > 0 then [ x2; x3 ] else [ x3; x2 ]
+          else if c > 0 then
+            let c = Stdlib.compare x2 x3 in
+            if c = 0 then [ x1; x2 ]
+            else if c > 0 then [ x1; x2; x3 ]
+            else
+              let c = Stdlib.compare x1 x3 in
+              if c = 0 then [ x1; x2 ]
+              else if c > 0 then [ x1; x3; x2 ]
+              else [ x3; x1; x2 ]
           else
             let c = Stdlib.compare x1 x3 in
-            if c = 0 then [x1; x2]
-            else if c > 0 then [x1; x3; x2]
-            else [x3; x1; x2]
-        else
-          let c = Stdlib.compare x1 x3 in
-          if c = 0 then [x2; x1]
-          else if c > 0 then [x2; x1; x3]
-          else
-            let c = Stdlib.compare x2 x3 in
-            if c = 0 then [x2; x1]
-            else if c > 0 then [x2; x3; x1]
-            else [x3; x2; x1]
-      in
-      (s, tl)
+            if c = 0 then [ x2; x1 ]
+            else if c > 0 then [ x2; x1; x3 ]
+            else
+              let c = Stdlib.compare x2 x3 in
+              if c = 0 then [ x2; x1 ]
+              else if c > 0 then [ x2; x3; x1 ]
+              else [ x3; x2; x1 ]
+        in
+        (s, tl)
     | n, l ->
-      let n1 = n asr 1 in
-      let n2 = n - n1 in
-      let s1, l2 = sort n1 l in
-      let s2, tl = sort n2 l2 in
-      (rev_merge s1 s2 [], tl)
+        let n1 = n asr 1 in
+        let n2 = n - n1 in
+        let s1, l2 = sort n1 l in
+        let s2, tl = sort n2 l2 in
+        (rev_merge s1 s2 [], tl)
   in
   let len = length l in
   if len < 2 then List.map fn l else fst (sort len l)
 
 let list_rev_map_append f l1 l2 =
-  let rec aux acc = function
-    | [] -> acc
-    | hd :: tl -> aux (f hd :: acc) tl
-  in
+  let rec aux acc = function [] -> acc | hd :: tl -> aux (f hd :: acc) tl in
   aux l2 l1
 
 let rec list_rev_iter f = function
   | [] -> ()
-  | hd :: tl -> list_rev_iter f tl ; f hd
+  | hd :: tl ->
+      list_rev_iter f tl;
+      f hd
 
 (* POSIX lockf(3), and fcntl(2), releases its locks when the process
    that holds the locks closes ANY file descriptor that was open on that file.
 *)
 let read_or_create_channel ?magic ?(wait = false) fname read write =
   if not Sys.unix then ignore wait;
-  
+
   assert (Secure.check fname);
-  let fd = Unix.openfile fname [ Unix.O_RDWR ; Unix.O_CREAT ] 0o666 in
-  
-  if Sys.unix then begin
-    try
-      Unix.lockf fd (if wait then Unix.F_LOCK else Unix.F_TLOCK) 0
-    with e -> Unix.close fd; raise e
-  end;
-  
+  let fd = Unix.openfile fname [ Unix.O_RDWR; Unix.O_CREAT ] 0o666 in
+
+  if Sys.unix then (
+    try Unix.lockf fd (if wait then Unix.F_LOCK else Unix.F_TLOCK) 0
+    with e ->
+      Unix.close fd;
+      raise e);
+
   let ic = Unix.in_channel_of_descr fd in
   let read () =
     seek_in ic 0;
     try
       match magic with
       | Some m when check_magic m ic ->
-         let r = Some (read ic) in
-         let _ = seek_in ic (in_channel_length ic - (String.length m)) in
-         assert (check_magic m ic);
-         r
+          let r = Some (read ic) in
+          let _ = seek_in ic (in_channel_length ic - String.length m) in
+          assert (check_magic m ic);
+          r
       | Some _ -> None
       | None -> Some (read ic)
     with _ -> None
   in
   match read () with
   | Some v ->
-     if Sys.unix then Unix.lockf fd Unix.F_ULOCK 0;
-     close_in ic;
-     v
+      if Sys.unix then Unix.lockf fd Unix.F_ULOCK 0;
+      close_in ic;
+      v
   | None ->
-     Unix.ftruncate fd 0;
-     let oc = Unix.out_channel_of_descr fd in
-     seek_out oc 0;
-     begin match magic with Some m -> seek_out oc (String.length m) | None -> () end;
-     let v = write oc in
-     flush oc;
-     let _ = seek_out oc (out_channel_length oc) in
-     begin match magic with Some m -> output_string oc m | None -> () end;
-     begin match magic with Some m -> seek_out oc 0; output_string oc m | None -> () end;
-     flush oc;
-     if Sys.unix then Unix.lockf fd Unix.F_ULOCK 0;
-     close_out oc;
-     v
+      Unix.ftruncate fd 0;
+      let oc = Unix.out_channel_of_descr fd in
+      seek_out oc 0;
+      (match magic with Some m -> seek_out oc (String.length m) | None -> ());
+      let v = write oc in
+      flush oc;
+      let _ = seek_out oc (out_channel_length oc) in
+      (match magic with Some m -> output_string oc m | None -> ());
+      (match magic with
+      | Some m ->
+          seek_out oc 0;
+          output_string oc m
+      | None -> ());
+      flush oc;
+      if Sys.unix then Unix.lockf fd Unix.F_ULOCK 0;
+      close_out oc;
+      v
 
 let read_or_create_value ?magic ?wait fname create =
   let read ic = Marshal.from_channel ic in
   let write oc =
     let v = create () in
-    Marshal.to_channel oc v [ Marshal.No_sharing ; Marshal.Closures ];
+    Marshal.to_channel oc v [ Marshal.No_sharing; Marshal.Closures ];
     v
   in
-  try read_or_create_channel ?magic ?wait fname read write
-  with _ -> create ()
+  try read_or_create_channel ?magic ?wait fname read write with _ -> create ()
 
 let encode s : Adef.encoded_string =
   let special = function
-    | '\000'..'\031' | '\127'..'\255' | '<' | '>' | '"' | '#' | '%' | '{'
-    | '}' | '|' | '\\' | '^' | '~' | '[' | ']' | '`' | ';' | '/' | '?' | ':'
-    | '@' | '=' | '&' | '+' -> true
+    | '\000' .. '\031'
+    | '\127' .. '\255'
+    | '<' | '>' | '"' | '#' | '%' | '{' | '}' | '|' | '\\' | '^' | '~' | '['
+    | ']' | '`' | ';' | '/' | '?' | ':' | '@' | '=' | '&' | '+' ->
+        true
     | _ -> false
   in
   let hexa_digit x =
@@ -933,7 +943,7 @@ let encode s : Adef.encoded_string =
   let rec need_code i =
     if i < String.length s then
       match s.[i] with
-        ' ' -> true
+      | ' ' -> true
       | x -> if special x then true else need_code (succ i)
     else false
   in
@@ -947,16 +957,18 @@ let encode s : Adef.encoded_string =
     if i < String.length s then
       let i1 =
         match s.[i] with
-          ' ' -> Bytes.set s1 i1 '+'; succ i1
+        | ' ' ->
+            Bytes.set s1 i1 '+';
+            succ i1
         | c ->
-            if special c then
-              begin
-                Bytes.set s1 i1 '%';
-                Bytes.set s1 (i1 + 1) (hexa_digit (Char.code c / 16));
-                Bytes.set s1 (i1 + 2) (hexa_digit (Char.code c mod 16));
-                i1 + 3
-              end
-            else begin Bytes.set s1 i1 c; succ i1 end
+            if special c then (
+              Bytes.set s1 i1 '%';
+              Bytes.set s1 (i1 + 1) (hexa_digit (Char.code c / 16));
+              Bytes.set s1 (i1 + 2) (hexa_digit (Char.code c mod 16));
+              i1 + 3)
+            else (
+              Bytes.set s1 i1 c;
+              succ i1)
       in
       copy_code_in s1 (succ i) i1
     else Bytes.unsafe_to_string s1
@@ -970,23 +982,21 @@ let gen_decode strip_spaces (s : Adef.encoded_string) : string =
   let s = (s :> string) in
   let hexa_val conf =
     match conf with
-    | '0'..'9' -> Char.code conf - Char.code '0'
-    | 'a'..'f' -> Char.code conf - Char.code 'a' + 10
-    | 'A'..'F' -> Char.code conf - Char.code 'A' + 10
+    | '0' .. '9' -> Char.code conf - Char.code '0'
+    | 'a' .. 'f' -> Char.code conf - Char.code 'a' + 10
+    | 'A' .. 'F' -> Char.code conf - Char.code 'A' + 10
     | _ -> 0
   in
   let rec need_decode i =
     if i < String.length s then
-      match s.[i] with
-      | '%' | '+' -> true
-      | _ -> need_decode (succ i)
+      match s.[i] with '%' | '+' -> true | _ -> need_decode (succ i)
     else false
   in
   let rec compute_len i i1 =
     if i < String.length s then
       let i =
         match s.[i] with
-        '%' when i + 2 < String.length s -> i + 3
+        | '%' when i + 2 < String.length s -> i + 3
         | _ -> succ i
       in
       compute_len i (succ i1)
@@ -996,11 +1006,16 @@ let gen_decode strip_spaces (s : Adef.encoded_string) : string =
     if i < String.length s then
       let i =
         match s.[i] with
-        '%' when i + 2 < String.length s ->
-          let v = hexa_val s.[i+1] * 16 + hexa_val s.[i+2] in
-          Bytes.set s1 i1 (Char.chr v); i + 3
-        | '+' -> Bytes.set s1 i1 ' '; succ i
-        | x -> Bytes.set s1 i1 x; succ i
+        | '%' when i + 2 < String.length s ->
+            let v = (hexa_val s.[i + 1] * 16) + hexa_val s.[i + 2] in
+            Bytes.set s1 i1 (Char.chr v);
+            i + 3
+        | '+' ->
+            Bytes.set s1 i1 ' ';
+            succ i
+        | x ->
+            Bytes.set s1 i1 x;
+            succ i
       in
       copy_decode_in s1 i (succ i1)
     else Bytes.unsafe_to_string s1
@@ -1008,11 +1023,9 @@ let gen_decode strip_spaces (s : Adef.encoded_string) : string =
   let rec strip_heading_and_trailing_spaces s =
     if String.length s > 0 then
       if s.[0] = ' ' then
-        strip_heading_and_trailing_spaces
-          (String.sub s 1 (String.length s - 1))
+        strip_heading_and_trailing_spaces (String.sub s 1 (String.length s - 1))
       else if s.[String.length s - 1] = ' ' then
-        strip_heading_and_trailing_spaces
-          (String.sub s 0 (String.length s - 1))
+        strip_heading_and_trailing_spaces (String.sub s 0 (String.length s - 1))
       else s
     else s
   in
@@ -1031,42 +1044,39 @@ let rec extract_param name stop_char =
   in
   function
   | x :: l ->
-    if String.length x >= String.length name &&
-       case_unsensitive_eq (String.sub x 0 (String.length name)) name
-    then
-      let i =
-        match String.index_from_opt x (String.length name) stop_char with
-        | Some i -> i
-        | None -> String.length x
-      in
-      String.sub x (String.length name) (i - String.length name)
-    else extract_param name stop_char l
+      if
+        String.length x >= String.length name
+        && case_unsensitive_eq (String.sub x 0 (String.length name)) name
+      then
+        let i =
+          match String.index_from_opt x (String.length name) stop_char with
+          | Some i -> i
+          | None -> String.length x
+        in
+        String.sub x (String.length name) (i - String.length name)
+      else extract_param name stop_char l
   | [] -> ""
 
 let sprintf_date tm =
-  Adef.safe @@
-  Printf.sprintf
-    "%04d-%02d-%02d %02d:%02d:%02d"
-    (1900 + tm.Unix.tm_year)
-    (succ tm.Unix.tm_mon)
-    tm.Unix.tm_mday
-    tm.Unix.tm_hour
-    tm.Unix.tm_min
-    tm.Unix.tm_sec
+  Adef.safe
+  @@ Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d" (1900 + tm.Unix.tm_year)
+       (succ tm.Unix.tm_mon) tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min
+       tm.Unix.tm_sec
 
 let rev_input_line ic pos (rbuff, rpos) =
   let rev = Buffer.create 256 in
   let rev_input_char pos =
-    if !rpos = 0 then begin
-      if Bytes.length !rbuff < 65536
-      then rbuff := Bytes.create @@ if Bytes.length !rbuff = 0 then 1024 else 2 * Bytes.length !rbuff ;
+    if !rpos = 0 then (
+      if Bytes.length !rbuff < 65536 then
+        rbuff :=
+          Bytes.create
+          @@ if Bytes.length !rbuff = 0 then 1024 else 2 * Bytes.length !rbuff;
 
       let ppos = max (pos - Bytes.length !rbuff) 0 in
       seek_in ic ppos;
       let len = pos - ppos in
       really_input ic !rbuff 0 len;
-      rpos := len
-    end;
+      rpos := len);
     decr rpos;
     Bytes.unsafe_get !rbuff !rpos
   in
@@ -1076,9 +1086,9 @@ let rev_input_line ic pos (rbuff, rpos) =
     let n = Bytes.length s in
     for i = 0 to (n - 1) / 2 do
       let c = Bytes.unsafe_get s i in
-      Bytes.unsafe_set s i @@ Bytes.unsafe_get s (n - i - 1) ;
-      Bytes.unsafe_set s (n - i - 1) c;
-    done ;
+      Bytes.unsafe_set s i @@ Bytes.unsafe_get s (n - i - 1);
+      Bytes.unsafe_set s (n - i - 1) c
+    done;
     Bytes.unsafe_to_string s
   in
   let rev_input_line pos =
@@ -1086,14 +1096,14 @@ let rev_input_line ic pos (rbuff, rpos) =
     else
       let _ = seek_in ic pos in
       let rec loop pos =
-        if pos <= 0 then get_n_reset (), pos
+        if pos <= 0 then (get_n_reset (), pos)
         else
           match rev_input_char pos with
-          | '\n' -> get_n_reset (), pos
-          | '\r' -> get_n_reset (), (pos - 1)
+          | '\n' -> (get_n_reset (), pos)
+          | '\r' -> (get_n_reset (), pos - 1)
           | c ->
-            Buffer.add_char rev c ;
-            loop (pos - 1)
+              Buffer.add_char rev c;
+              loop (pos - 1)
       in
       loop pos
   in
@@ -1102,13 +1112,13 @@ let rev_input_line ic pos (rbuff, rpos) =
 let search_file_opt directories fname =
   let rec loop = function
     | hd :: tl ->
-      let f = Filename.concat hd fname in
-      if Sys.file_exists f then Some f else loop tl
+        let f = Filename.concat hd fname in
+        if Sys.file_exists f then Some f else loop tl
     | [] -> None
-  in loop directories
+  in
+  loop directories
 
-let search_asset_opt fname =
-  search_file_opt (Secure.assets ()) fname
+let search_asset_opt fname = search_file_opt (Secure.assets ()) fname
 
 let eq_key (fn1, sn1, oc1) (fn2, sn2, oc2) =
   let s x = x |> nominative |> Name.lower in
@@ -1121,15 +1131,19 @@ let ls_r dirs =
         if Sys.file_exists dir then
           if Sys.is_directory dir then
             let contents =
-              try Sys.readdir dir |> Array.to_list |> List.map (Filename.concat dir)
+              try
+                Sys.readdir dir |> Array.to_list
+                |> List.map (Filename.concat dir)
               with e ->
-                Printf.eprintf "Error reading directory %s: %s\n" dir (Printexc.to_string e);
+                Printf.eprintf "Error reading directory %s: %s\n" dir
+                  (Printexc.to_string e);
                 []
             in
             loop (dir :: acc) (contents @ rest)
           else loop (dir :: acc) rest
-        else
-          (Printf.eprintf "Path does not exist: %s\n" dir; loop acc rest)
+        else (
+          Printf.eprintf "Path does not exist: %s\n" dir;
+          loop acc rest)
   in
   loop [] dirs
 
@@ -1139,109 +1153,116 @@ let check_permissions path =
     let perms = stats.Unix.st_perm in
     if perms land 0o200 = 0 then
       Printf.eprintf "File is not writable: %s\n" path;
-    (try Unix.access path [Unix.W_OK]
-     with Unix.Unix_error _ ->
-       Printf.eprintf "Current process does not have write permission: %s\n" path)
+    try Unix.access path [ Unix.W_OK ]
+    with Unix.Unix_error _ ->
+      Printf.eprintf "Current process does not have write permission: %s\n" path
   with e ->
-    Printf.eprintf "Error checking permissions for %s: %s\n" path (Printexc.to_string e)
+    Printf.eprintf "Error checking permissions for %s: %s\n" path
+      (Printexc.to_string e)
 
 let rm_rf f =
-  if Sys.file_exists f then
-    let all_paths = ls_r [f] in
+  if Sys.file_exists f then (
+    let all_paths = ls_r [ f ] in
     List.iter check_permissions all_paths;
-    let (directories, files) = List.partition Sys.is_directory all_paths in
-    List.iter (fun file ->
-      try
-        let ic = open_in_bin file in
-        close_in ic;
-        Sys.remove file
-      with e ->
-        Printf.eprintf "Error handling file %s: %s\n" file (Printexc.to_string e)
-    ) files;
-    List.iter (fun dir ->
-      try Unix.rmdir dir
-      with e ->
-        Printf.eprintf "Error deleting directory %s: %s\n" dir (Printexc.to_string e)
-    ) (List.rev directories)
-  else
-    Printf.eprintf "Path does not exist: %s\n" f
+    let directories, files = List.partition Sys.is_directory all_paths in
+    List.iter
+      (fun file ->
+        try
+          let ic = open_in_bin file in
+          close_in ic;
+          Sys.remove file
+        with e ->
+          Printf.eprintf "Error handling file %s: %s\n" file
+            (Printexc.to_string e))
+      files;
+    List.iter
+      (fun dir ->
+        try Unix.rmdir dir
+        with e ->
+          Printf.eprintf "Error deleting directory %s: %s\n" dir
+            (Printexc.to_string e))
+      (List.rev directories))
+  else Printf.eprintf "Path does not exist: %s\n" f
 
 let rec filter_map fn = function
   | [] -> []
-  | hd :: tl ->
-    match fn hd with
-    | Some x -> x :: filter_map fn tl
-    | None -> filter_map fn tl
+  | hd :: tl -> (
+      match fn hd with
+      | Some x -> x :: filter_map fn tl
+      | None -> filter_map fn tl)
 
 let rec rev_iter fn = function
   | [] -> ()
-  | hd :: tl -> let () = rev_iter fn tl in fn hd
+  | hd :: tl ->
+      let () = rev_iter fn tl in
+      fn hd
 
 let groupby ~key ~value list =
   let h = Hashtbl.create (List.length list) in
   List.iter
     (fun x ->
-       let k = key x in
-       let v = value x in
-       if Hashtbl.mem h k then Hashtbl.replace h k (v :: Hashtbl.find h k)
-       else Hashtbl.add h k [v])
-    list ;
+      let k = key x in
+      let v = value x in
+      if Hashtbl.mem h k then Hashtbl.replace h k (v :: Hashtbl.find h k)
+      else Hashtbl.add h k [ v ])
+    list;
   Hashtbl.fold (fun k v acc -> (k, v) :: acc) h []
 
-let digest s =
-  Digest.string s |> Digest.to_hex
+let digest s = Digest.string s |> Digest.to_hex
 
 let empty_person empty what =
-  { Def.first_name = what
-  ; surname = what
-  ; occ = 0
-  ; public_name = empty
-  ; image = empty
-  ; qualifiers = []
-  ; aliases = []
-  ; first_names_aliases = []
-  ; surnames_aliases = []
-  ; titles = []
-  ; rparents = []
-  ; related = []
-  ; occupation = empty
-  ; sex = Neuter
-  ; access = IfTitles
-  ; birth = Date.cdate_None
-  ; birth_place = empty
-  ; birth_note = empty
-  ; birth_src = empty
-  ; baptism = Date.cdate_None
-  ; baptism_place = empty
-  ; baptism_note = empty
-  ; baptism_src = empty
-  ; death = DontKnowIfDead
-  ; death_place = empty
-  ; death_note = empty
-  ; death_src = empty
-  ; burial = UnknownBurial
-  ; burial_place = empty
-  ; burial_note = empty
-  ; burial_src = empty
-  ; pevents = []
-  ; notes = empty
-  ; psources = empty
-  ; key_index = ()
+  {
+    Def.first_name = what;
+    surname = what;
+    occ = 0;
+    public_name = empty;
+    image = empty;
+    qualifiers = [];
+    aliases = [];
+    first_names_aliases = [];
+    surnames_aliases = [];
+    titles = [];
+    rparents = [];
+    related = [];
+    occupation = empty;
+    sex = Neuter;
+    access = IfTitles;
+    birth = Date.cdate_None;
+    birth_place = empty;
+    birth_note = empty;
+    birth_src = empty;
+    baptism = Date.cdate_None;
+    baptism_place = empty;
+    baptism_note = empty;
+    baptism_src = empty;
+    death = DontKnowIfDead;
+    death_place = empty;
+    death_note = empty;
+    death_src = empty;
+    burial = UnknownBurial;
+    burial_place = empty;
+    burial_note = empty;
+    burial_src = empty;
+    pevents = [];
+    notes = empty;
+    psources = empty;
+    key_index = ();
   }
 
 let empty_family empty =
-  { Def.marriage = Date.cdate_None
-  ; marriage_place = empty
-  ; marriage_note = empty
-  ; marriage_src = empty
-  ; witnesses = [||]
-  ; relation = Def.NoMention
-  ; divorce = Def.NotDivorced
-  ; fevents = []
-  ; comment = empty
-  ; origin_file = empty
-  ; fsources = empty
-  ; fam_index = ()
+  {
+    Def.marriage = Date.cdate_None;
+    marriage_place = empty;
+    marriage_note = empty;
+    marriage_src = empty;
+    witnesses = [||];
+    relation = Def.NoMention;
+    divorce = Def.NotDivorced;
+    fevents = [];
+    comment = empty;
+    origin_file = empty;
+    fsources = empty;
+    fam_index = ();
   }
 
 let good_name s =
@@ -1249,7 +1270,7 @@ let good_name s =
     if i = String.length s then true
     else
       match s.[i] with
-        'a'..'z' | 'A'..'Z' | '0'..'9' | '-' -> loop (i + 1)
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' -> loop (i + 1)
       | _ -> false
   in
   loop 0


### PR DESCRIPTION

I have reverted the two #ifdef SYSLOG but it should be fixed so both gwdLog.ml and GWPARAM.ml can also be also removed from the ocamlformat-ignore file.

The last ignored file would be ged2gwb.ml because of it's old camlp4 stream parser syntax. Around 15-20% of the file need to be changed because there are numerous stream parser patterns: skip_eol, get_to_eoln, skip_to_eoln, get_ident, parse_address, parse_text, get_lev_list and the EXTEND grammar sections.