### PR TITLE
Add blasons managment in carrousel

### DIFF
--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -563,7 +563,7 @@ let ged_psource opts base per =
       | s -> print_sour opts 1 (encode opts s))
 
 let has_image_file opts base p =
-  let s = Image.default_portrait_filename base p in
+  let s = Image.default_image_filename "portraits" base p in
   let f = Filename.concat opts.Gwexport.img_base_path s in
   if Sys.file_exists (f ^ ".gif") then Some (f ^ ".gif")
   else if Sys.file_exists (f ^ ".jpg") then Some (f ^ ".jpg")

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1672,7 +1672,7 @@ let image_request conf script_name env =
         if fname.[0] = '/' then String.sub fname 1 (String.length fname - 1)
         else fname
       in
-      let (`Path fname) = Image.path_of_filename conf fname in
+      let fname = Image.path_of_filename conf fname in
       let _ = ImageDisplay.print_image_file conf fname in
       true
   | _ ->
@@ -1684,7 +1684,7 @@ let image_request conf script_name env =
         (* empeche d'avoir des images qui se trouvent dans le dossier   *)
         (* image. Si on ne fait pas de basename, alors ça marche.       *)
         (* let fname = Filename.basename fname in *)
-        let (`Path fname) = Image.path_of_filename conf fname in
+        let fname = Image.path_of_filename conf fname in
         let _ = ImageDisplay.print_image_file conf fname in
         true
       else false
@@ -1823,7 +1823,7 @@ let extract_multipart boundary str =
   let str = (str : Adef.encoded_string :> string) in
   let rec skip_nl i =
     if i < String.length str && str.[i] = '\r' then skip_nl (i + 1)
-    else if i < String.length str && str.[i] = '\n' then i + 1
+    else if i < String.length str && str.[i] = '\n' then skip_nl (i + 1)
     else i
   in
   let next_line i =
@@ -1869,11 +1869,24 @@ let extract_multipart boundary str =
             :: loop i1
         | Some var, None ->
             let var = strip_quotes var in
-            let s, i = next_line i in
-            if s = "" then
-              let s, i = next_line i in
-              (var, Adef.encoded s) :: loop i
-            else loop i
+            let i = skip_nl i in
+            let i1 =
+              let rec loop i =
+                if i < String.length str then
+                  if
+                    i > String.length boundary
+                    && String.sub str
+                         (i - String.length boundary)
+                         (String.length boundary)
+                       = boundary
+                  then i - String.length boundary
+                  else loop (i + 1)
+                else i
+              in
+              loop i
+            in
+            let v = String.sub str i (i1 - i) |> String.trim in
+            (var, Adef.encoded v) :: loop i
         | _ -> loop i
       else if s = boundary ^ "--" then []
       else loop i

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -836,7 +836,6 @@ let treat_request =
              | "PS" -> w_base @@ PlaceDisplay.print_all_places_surnames
              | "PPS" -> w_base @@ Place.print_all_places_surnames
              | "R" -> w_base @@ w_person @@ relation_print
-             | "REFRESH" -> w_base @@ w_person @@ Perso.interp_templ "carrousel"
              | "REQUEST" ->
                  w_wizard @@ fun _ _ ->
                  Output.status conf Def.OK;

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -606,9 +606,14 @@ let treat_request =
                  w_base @@ fun conf base ->
                  SrcfileDisplay.print conf base "advanced"
              | "AS_OK" -> w_base @@ AdvSearchOkDisplay.print
+             | "BLASON_MOVE_TO_ANC" -> w_base @@ ImageCarrousel.print_main_c
+             | "BLASON_STOP" -> w_base @@ ImageCarrousel.print_main_c
              | "C" -> w_base @@ w_person @@ CousinsDisplay.print
              | "CHK_DATA" -> w_base @@ CheckDataDisplay.print
              | "CAL" -> w_base @@ Hutil.print_calendar
+             | "CHANGE_WIZ_VIS" ->
+                 w_wizard @@ w_lock @@ w_base
+                 @@ WiznotesDisplay.change_wizard_visibility
              | "CHG_CHN" when conf.wizard ->
                  w_wizard @@ w_base @@ ChangeChildrenDisplay.print
              | "CHG_CHN_OK" ->
@@ -652,6 +657,7 @@ let treat_request =
                  doc_aux conf base (fun conf _base ->
                      ImageDisplay.print_html conf)
              | "F" -> w_base @@ w_person @@ Perso.interp_templ "family"
+             | "FIM" -> w_base @@ ImageDisplay.print_blason
              | "H" -> (
                  w_base @@ fun conf base ->
                  match p_getenv conf.env "v" with
@@ -670,6 +676,7 @@ let treat_request =
              | "IM_C" -> w_base @@ ImageCarrousel.print_c ~saved:false
              | "IM_C_S" -> w_base @@ ImageCarrousel.print_c ~saved:true
              | "IM" -> w_base @@ ImageDisplay.print
+             | "IMAGE_TO_BLASON" -> w_base @@ ImageCarrousel.print_main_c
              | "IMH" -> w_base @@ fun conf _ -> ImageDisplay.print_html conf
              | "INV_FAM" -> w_wizard @@ w_base @@ UpdateFam.print_inv
              | "INV_FAM_OK" ->
@@ -825,6 +832,7 @@ let treat_request =
                  w_base @@ w_person @@ Geneweb.Perso.interp_templ "perso"
              | "POP_PYR" when conf.wizard || conf.friend ->
                  w_base @@ BirthDeathDisplay.print_population_pyramid
+             | "PORTRAIT_TO_BLASON" -> w_base @@ ImageCarrousel.print_main_c
              | "PS" -> w_base @@ PlaceDisplay.print_all_places_surnames
              | "PPS" -> w_base @@ Place.print_all_places_surnames
              | "R" -> w_base @@ w_person @@ relation_print
@@ -861,9 +869,6 @@ let treat_request =
                  )
              | "STAT" ->
                  w_base @@ fun conf _ -> BirthDeathDisplay.print_statistics conf
-             | "CHANGE_WIZ_VIS" ->
-                 w_wizard @@ w_lock @@ w_base
-                 @@ WiznotesDisplay.change_wizard_visibility
              | "TP" -> (
                  w_base @@ fun conf base ->
                  match Util.p_getenv conf.env "v" with

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -446,86 +446,60 @@
 %include;js
 %define;input_snd(xxx,yyy)
 $('.xxx').change(function() {
-   %(replace input label with file name, then enable send button if input is non empty%)
-   let fileName = $(this).val().split('\\').pop();
-   $(this).next('.custom-file-label').addClass("selected").html(fileName);
-   $('.yyy').attr('disabled', false);
-   %if;("yyy"="snd-btn-others")
-     $('textarea').attr('disabled', false);
-     $('textarea').focus();
-   %end;
+  let fileName = $(this).val().split('\\').pop();
+  $(this).next('.custom-file-label').addClass("selected").html(fileName);
+  $('.yyy').prop('disabled', false);
+  %if;("yyy"="snd-btn-others")
+    $('textarea').prop('disabled', false).focus();
+  %end;
 });
 %end;
 <script>
-%apply;input_snd("custom-portrait","snd-btn-portrait")
-%apply;input_snd("custom-others","snd-btn-others")
-$('#image_note').bind('input propertychange', function() {
-  if(this.value.length){
-  $('.btn-update-note-source').attr('disabled', false);
-  }
-});
-$('#image_source').bind('input propertychange', function() {
-  if(this.value.length){
-  $('.btn-update-note-source').attr('disabled', false);
-  }
-});
-$('.fa-file-lines').click(function() {
-  $('.custom-others').attr('disabled', true);
-  $('#image_note').attr('disabled', false);
-  $('#image_note').focus();4
-});
-$('.fa-file-zipper').click(function() {
-  $('.custom-others').attr('disabled', true);
-  $('#image_source').attr('disabled', false);
-  $('#image_source').focus();1
-});
-%( Initialize Bootstrap toast, tooltip and popover component, dismiss on next click function,
-  TODO: choose one and delete the other %)
-$(function () {
-  $('[data-toggle="tooltip"]').tooltip()
-})
-%($(function () {
-  $('[data-toggle="popover"]').popover()
-})
-$('.popover-dismiss').popover({
-  trigger: 'focus'
-})
-$( document).ready(function () {
- $('.toast').toast('show');
-})
-$(function () {
-  $('.toast').toast()
-})%)
-function get_note (cnt, name) {
-var item = document.getElementById("note_"+cnt);
-document.getElementById("image_note").value=item.dataset.note;
-document.getElementById("which_img_show").textContent="[*update image note] "+name;
-document.getElementById("file_name_2").value=name;
-document.getElementById("mode_2").value="note";
-%(var ta = document.getElementById("image_note");
-autosize.update(ta);%)
-}
-function get_source (cnt, name) {
-var item = document.getElementById("source_"+cnt);
-document.getElementById("image_source").value=item.dataset.source;
-document.getElementById("which_img_show").textContent="[*update image source] "+name;
-document.getElementById("file_name_2").value=name;
-document.getElementById("mode_2").value="source";
-%(var ta = document.getElementById("image_source");
-autosize.update(ta);%)
-}
-function toggle_url_on () {
-console.log("trace");
-var state = document.getElementById("image_name").disable;
-console.log(state);
-document.getElementById("image_name").disable = !state;
-document.getElementById("image_name").focus();
-}
-</script>
-%( Possible heavier futur script to manage multiple files inputs
-   https://github.com/Johann-S/bs-custom-file-input/blob/master/dist/bs-custom-file-input.min.js
-<script src=%etc_prefix;js/bs-custom-file-input.min.js></script>
-<script>$(document).ready(function(){bsCustomFileInput.init()})</script> %)
+// Clic pour les icônes de note et source
+const setupFieldEditor = (iconSelector, fieldSelector) => {
+  $(iconSelector).click(function() {
+    $('.custom-others').prop('disabled', true);
+    $(fieldSelector).prop('disabled', false).focus();
+  });
+};
+$(function() {
+  %apply;input_snd("custom-portrait","snd-btn-portrait")
+  %apply;input_snd("custom-others","snd-btn-others")
 
+  setupFieldEditor('.fa-file-lines', '#image_note');
+  setupFieldEditor('.fa-file-zipper', '#image_source');
+
+  $('#image_note, #image_source').on('input', function() {
+    if(this.value.length) {
+      $('.btn-update-note-source').prop('disabled', false);
+    }
+  });
+
+  $('[data-toggle="tooltip"]').tooltip();
+});
+
+// Fonction d'édition de métadonnées
+const updateImageMetadata = (type, cnt, name) => {
+  const $typeField = $(`#${type}_${cnt}`);
+  const $textField = $(`#image_${type}`);
+  
+  $textField.val($typeField.data(type));
+  $('#file_name_2').val(name);
+  $('#mode_2').val(type);
+  $('#which_img_show').text(`[*update image ${type}] ${name}`);
+};
+
+// Fonctions pour les notes et sources
+const get_note = (cnt, name) => updateImageMetadata('note', cnt, name);
+const get_source = (cnt, name) => updateImageMetadata('source', cnt, name);
+
+// Basculer l'état du champ URL
+const toggle_url_on = () => {
+  const $imageNameField = $('#image_name');
+  $imageNameField
+    .prop('disabled', !$imageNameField.prop('disabled'))
+    .focus();
+};
+</script>
 </body>
 </html>

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="%lang;">
 <head>
-  <!-- $Id: carrousel.txt v7.1 04/05/2023 18:19:02 $ -->
+  <!-- $Id: carrousel.txt v7.1 17/01/2025 07:39:24 $ -->
   <title>[*add]/[delete::image/images]0 #%index;</title>
   <meta name="robots" content="none">
   <meta charset="UTF-8">
@@ -21,53 +21,83 @@
 %random.init;
 %let;random_bits;%if;predictable_mode;123456%else;%random.bits;%end;%in;
 %define;alert_header()
-  %if;("http" in portrait or "http" in portrait_saved)
+  %if;("http" in portrait or "http" in old_portrait)
     WARNING
-  %elseif;(evar.mode="others")
-    %if;(evar.em="SND_IMAGE_C_OK")[*image received]%if;(evar.notes!="") [with note]%end;
-    %elseif;(evar.em="DEL_IMAGE_C_OK")[*image deleted]%sp;
-      %if;(evar.delete!="on")[and] [saved]1%end;
-    %elseif;(evar.em="RESET_IMAGE_C_OK")[*image/images]0 [restored]1%nn;
-    %end;
-  %else;
-    %if;(evar.em="SND_IMAGE_C_OK")%if;(evar.mode="note")[*note] [update::]%else;[*portrait] [uploaded]0%end;%nn;
-    %elseif;(evar.em="DEL_IMAGE_C_OK")[*portrait] [deleted]0%if;(evar.delete!="on") [and] [saved]0%end;%nn;
-    %elseif;(evar.em="RESET_IMAGE_C_OK")[*portrait] [restored]0%nn;
+  %elseif;(e.mode="carrousel")
+    %if;(e.em="SND_IMAGE_C_OK")[*image received]%if;(e.notes!="") [with note]%end;
+    %elseif;(e.em="DEL_IMAGE_C_OK")[*image deleted]%if;(e.delete!="on") [and] [saved]1%end;
+    %elseif;(e.em="RESET_IMAGE_C_OK")[*image/images]0 [restored]1%nn;
+    %end;%nn;
+  %elseif;(e.mode="blasons")
+    %if;(e.em="SND_IMAGE_C_OK")[*coat of arms] [uploaded]0%nn;
+    %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest=e.idigest)[*coat of arms] [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest=e.idigest)[*coat of arms] [restored]0%nn;
+    %end;%nn;
+  %elseif;(e.mode="portraits")
+    %if;(e.em="SND_IMAGE_C_OK")%if;(e.mode="note")[*note] [update]%else;[*portrait] [uploaded]0%end;%nn;
+    %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest!=e.idigest)[*portrait] [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest!=e.idigest)[*portrait] [restored]0%nn;
+    %end;%nn;
+  %elseif;(e.mode="note")
+    %if;(e.em="SND_IMAGE_C_OK")[*note/notes]0 [update::]%nn;
     %end;%nn;
   %end;
 %end;
 %define;alert_content()
-  %if;("http" in portrait or "http" in portrait_saved)
+  %if;("http" in portrait or "http" in old_portrait)
     Update image field with <a href="%prefix;m=MOD_IND;i=%index;">MOD_IND</a>
-  %elseif;(evar.mode="others" or evar.mode="note")
-    <samp>%if;(evar.em="RESET_IMAGE_C_OK")images%X;%carrousel;%X;saved%X;%evar.file_name; <strong>></strong> %end;images%X;%carrousel;%if;(evar.delete="on")%X;saved%end;%X;%nn;
-    %if;(evar.notes!="")%evar.file_name_2;.txt%else;%evar.file_name;%end;</samp>
-  %else;
-    %if;(evar.em="SND_IMAGE_C_OK" or evar.em="RESET_IMAGE_C_OK")
-      <samp>%evar.file_name;</samp> %if;(evar.em="RESET_IMAGE_C_OK")<samp>%portraits_store;%X;saved%X;%portrait_saved;</samp>
-      <strong> <</strong>%end;<strong>> </strong><samp>%portraits_store;%X;%portrait;</samp>%nn;
-      %(%if;(evar.em="DEL IMAGE_C_OK" or evar.em="RESET_IMAGE_C_OK")%portrait;%else;%evar.file_name;%end;</samp>%)
-    %elseif;(evar.em="DEL_IMAGE_C_OK")
-      %if;(evar.delete!="on")<samp>portrait%X;%portrait_saved;</samp> <strong>></strong> <samp>portraits%X;saved%X;%portrait_saved;</samp>
-      %else;<samp>portraits%X;saved%X;%carrousel;(.gif/jpg/png)</samp>%end;
+  %elseif;(e.mode="note")
+    <strong>></strong> %images_store;%X;%e.file_name_2;
+  %elseif;(e.mode="carrousel")<samp>
+    %if;(e.em="SND_IMAGE_C_OK")
+      <strong>></strong> %images_store;%X;%e.file_name;
+    %elseif;(e.em="DEL_IMAGE_C_OK")
+      %if;(e.delete="on")%images_store;%X;%keydir;%X;%e.file_name;%else;%nn;
+        %images_store;%X;%carrousel;%X;%e.file_name; <strong>></strong> %images_store;%X;%keydir;%X;%e.file_name;%nn;
+      %end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK")%images_store;%X;%keydir;%X;%e.file_name; <strong><></strong> %images_store;%X;%e.file_name;%nn;
+    %else;bad command %e.em; (%e.mode;)
     %end;
+    </samp>
+  %elseif;(e.mode="portraits")<samp>
+    %if;(e.em="SND_IMAGE_C_OK")%portraits_store;%X;%portrait_name;
+    %elseif;(e.em="DEL_IMAGE_C_OK")
+      %if;(e.delete="on")%old_portraits_store;%X;%e.file_name;%else;%nn;
+        %( attention, %portrait_name; may be gone!! %)
+        %portraits_store;%X;%e.file_name; <strong>></strong> %old_portraits_store;%X;%e.file_name;%nn;
+      %end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK")%portraits_store;%X;%carrousel;%X;saved%X;%e.file_name; <strong><></strong> %portraits_store;%X;%carrousel;%X;%e.file_name;%nn;
+    %else;bad command %e.em; (%e.mode;)%end;
+    </samp>
+  %elseif;(e.mode="blasons")<samp>
+    %if;(e.em="SND_IMAGE_C_OK")
+      %portraits_store;%X;%carrousel;%X;%blason_name;
+    %elseif;(e.em="DEL_IMAGE_C_OK")
+      %if;(e.delete="on")%portraits_store;%X;saved%X;%e.file_name;%else;%nn;
+        %( attention, %blason_name; may be gone!! %)
+        %portraits_store;%X;%e.file_name; <strong>></strong> %old_portraits_store;%X;%e.file_name;%nn;
+      %end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK")%old_portraits_store;%X;%e.file_name; <strong><></strong> %portraits_store;%X;%e.file_name;%nn;
+    %else;bad command %e.em; %e.mode;%end;
+    </samp>
+  %else;
+    bad command: %e.em; (%e.mode;)
   %end;
 %end;
 %define;alert_color()
-  %if;("http" in portrait or "http" in portrait_saved)danger
-  %elseif;(evar.mode="note")primary
-  %elseif;(evar.em="SND_IMAGE_C_OK" or evar.em="RESET_IMAGE_C_OK")success
-  %elseif;(evar.em="DEL_IMAGE_C_OK" and evar.delete="on")danger
+  %if;("http" in portrait or "http" in old_portrait)danger
+  %elseif;(e.mode="note")primary
+  %elseif;(e.em="SND_IMAGE_C_OK" or e.em="RESET_IMAGE_C_OK")success
+  %elseif;(e.em="DEL_IMAGE_C_OK" and e.delete="on")danger
   %else;warning
   %end;
 %end;
-
 %let;portraits_store;
   %if;reorg;%base.name;.gwb%X;documents%X;portraits%nn;
   %else;images%X;%base.name;%nn;
   %end;%nn;
 %in;
-%let;saved_portraits_store;
+%let;old_portraits_store;
   %if;reorg;%base.name;.gwb%X;documents%X;portraits%X;saved%nn;
   %else;images%X;%base.name;%X;saved%nn;
   %end;%nn;
@@ -77,19 +107,19 @@
   %else;src%X;%base.name;%X;images%nn;
   %end;%nn;
 %in;
-
+%define;anc_name(lll)[cousin.lll.0]0%end;
 %if;(wizard)
   <div class="row mb-1">
     %( *** Col 1 *** %)
     <div class="col-6 border border-bottom-0 border-top-0 border-left-0">
-      <h1 class="display-4">
-        %(<i class="fa fa-image-portrait fa-fw mr-1"></i>%)
+      <h1 class="display-5">%nn;
         %if;(has_portrait)[*modify portrait]%else;[*add portrait]%end;</h1>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
         %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
         <input type="hidden" name="m" value="SND_IMAGE_C_OK">
         <input type="hidden" name="i" value="%index;">
         <input type="hidden" name="notes" value="">
+        <input type="hidden" name="mode" value="portraits">
         <input type="hidden" name="idigest" value=%idigest;>
         <div class="custom-file col">
           <input type="file" name="file"
@@ -106,20 +136,41 @@
           %if;(has_portrait and has_old_portrait)[*previous portrait]%end;
         %end;
       </div>
-      <h1 class="display-4">
-      %(<i class="far fa-file-image fa-fw mr-1"></i>%)[*add image]</h1>
+      <h1 class="display-5">%nn;
+        %if;(has_blason)[*modify coat of arms]%else;[*add coat of arms]%end;</h1>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
         %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
         <input type="hidden" name="m" value="SND_IMAGE_C_OK">
         <input type="hidden" name="i" value="%index;">
-        <input type="hidden" name="mode" id="mode_2" value="others">
+        <input type="hidden" name="notes" value="">
+        <input type="hidden" name="mode" value="blasons">
+        <input type="hidden" name="idigest" value=%idigest;>
+        <input type="hidden" name="fdigest" value=%idigest;>
+        <div class="custom-file col">
+          <input type="file" name="file"
+            class="custom-file-input custom-portrait"
+              id="portrait_file" accept="image/*"%if;(not has_blason) autofocus%end;>
+          <label class="custom-file-label text-truncate" data-browse="[*browse]"
+            for="portrait_file">[*select] [blason/blasons]0</label>
+        </div>
+        <button class="btn btn-primary ml-2 col-2 snd-btn-portrait"
+          type="submit" disabled>[*send::]</button>
+      </form>
+      <div class="small mt-2">%nn;
+        %if;(has_blason and has_old_blason)[*previous::blason/blasons]%end;
+      </div>
+      <h1 class="display-5">[*add image]</h1>
+      <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
+        %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
+        <input type="hidden" name="m" value="SND_IMAGE_C_OK">
+        <input type="hidden" name="i" value="%index;">
+        <input type="hidden" name="mode" id="mode_2" value="carrousel">
         <input type="hidden" name="idigest" value=%idigest;>
         %( file_name is automatically provided by the type="file" item %)
         %( file_name_2 is used when updating the note file after selection %)
-        %( with the radiobutton of the old folder content (right column) %)
+        %( with the radiobutton of the saved folder content (right column) %)
         <input type="hidden" name="file_name_2" id="file_name_2" value="">
-
-        <div class="custom-file col">
+        <div class="custom-file col-9">
           <input type="file" name="file" class="custom-file-input custom-others"
             id="others_file" accept="image/*"%if;has_portrait; autofocus%end;%( multiple%)>
           <label class="custom-file-label text-truncate" for="others_file"  data-browse="[*browse]">%nn;
@@ -127,35 +178,23 @@
           </label>
         </div>
         <button class="btn btn-primary ml-2 col-2 snd-btn-others" type="submit" >[*send::]</button>
-        %(TODO: print only if old img already exists%)
-        <div class="small col-12 mt-1">
-          [*previous image]
-        </div>
-        <textarea class="form-control col-10 mr-2" id="image_url"
-          type="input" name="image_url" rows="1" placeholder="[*url]">
-        </textarea>
-        <textarea class="form-control col-10 mr-2" id="image_name"
-          type="input" name="image_name" rows="1" placeholder="[*name]">
-        </textarea>
-        
-        <div class="d-flex col">
-          <h1 class="display-4">
-            %(<i class="far fa-file-image fa-fw mr-1"></i>%)[*source/sources]0</h1>
-        </div>
-        %( TODO re-activate disable for send, source and note %)
-        <textarea class="form-control col-12" id="image_source"
-          name="source" rows="1" placeholder="[*source/sources]0">
-        </textarea>
-
-        <div class="d-flex col">
-          <h1 class="display-4">
-            %(<i class="far fa-file-image fa-fw mr-1"></i>%)[*note/notes]0</h1>
-          <span class="mb-1 px-0 ml-auto align-self-end col-2">
-            %include;toolbar
+        %(TODO: print only if saved img already exists%)
+          <span class="col-1 align-self-center ml-3">[or]</span>
+          <span class="col">
+          <input type="text" class="form-control mt-1" id="image_url" name="image_url"
+            placeholder="%apply;a_of_b%with;[URL]%and;[image/images]0%end;">
           </span>
-        </div>
-        <textarea class="form-control col-12" id="image_note"
-          name="note" rows="5" placeholder="[*note/notes]0">
+        %( long message about image with same name being deleted %)
+        <div class="small col-12 mt-1">[*previous image]</div>
+        %( TODO expliciter que le nom peut rester vide, gardera celui fourni %)
+        <input type="text" class="form-control col-12 mt-3" id="image_name"
+          name="image_name" placeholder="[*name] ([optionnal])">
+        %( TODO re-activate disable for send, source and note %)
+        <textarea class="form-control col-12 mt-1" id="image_source"
+          name="source" rows="1" placeholder="[*source/sources]0 ([optionnal])">
+        </textarea>
+        <textarea class="form-control col-12 mt-1" id="image_note"
+          name="note" rows="4" placeholder="[*note/notes]0 ([optionnal])">
         </textarea>
         <button class="btn btn-primary mt-2 col-12 btn-update-note-source" type="submit" disabled>
           <span id="which_img_show">[*send image with note and source]</span></button>
@@ -168,101 +207,178 @@
         %if;has_portrait;
           <div class="d-flex mt-1">
             <a role="button" 
-              href="%if;has_portrait_url;%portrait;%else;%prefix;kch=%random_bits;&m=IM_C&i=%index;%end;"%sp;
-              target="_blank" rel="noopener"%sp;
+              href="%portrait_url;" target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
-              title='<strong>[*see portrait]</strong><br><span class="small">%portrait;</span>
-                   <br><img class="rounded my-1"
-              src="%if;has_portrait_url;%portrait;%else;%prefix;kch=%random_bits;&m=IM_C&i=%index;%end;"%sp;
-                   width="185px">'>
+              title='<strong>[*see portrait]</strong><br><span class="small">%portrait;</span><br>
+                <img class="rounded my-1" src="%portrait_url;" width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-          <span class="invisible"><i class="fas fa-retweet fa-rotate-90 fa-fw text-primary"></i></span>
-          %if;has_portrait_url;%portrait;%else;
-            <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong>%nn;
-            <samp>%portrait_name;</samp>
-            <a role="button" class="ml-auto col-1"  href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&idigest=%idigest;"
-               data-toggle="tooltip" data-html="true" data-placement="left"
-               title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete portrait]</strong><br><span class="small">%portrait;</span>
-                      <br><img class="rounded my-1" src="%prefix;m=IM_C&i=%index;"
-                      width="185px">'>
-              <i class="far fa-trash-can text-warning"></i>%nn;</a>
-          %end;
+            <a href="%prefix;m=PORTRAIT_TO_BLASON&i=%index;" class="mx-1"
+               title="[*copy portrait to blason]">
+                 <i class="fa-solid fa-user-shield"></i></a>
+            %if;has_portrait_url;%portrait_name;%else;
+              <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%portrait_name;%end;</samp>
+            <a role="button" class="ml-auto mt-1"
+              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&idigest=%idigest;&file_name=%portrait_name;"
+              data-toggle="tooltip" data-html="true" data-placement="left"
+              title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete portrait]</strong><br><span class="small">%portrait;</span><br>
+                <img class="rounded my-1" src="%portrait_url;" width="185px">'>
+              <i class="far fa-trash-can text-warning mr-1"></i>%nn;</a>
           </div>
         %end;
         %if;has_old_portrait;
           <div class="d-flex mt-1">
             <a role="button" 
-              href="%if;has_old_portrait_url;%portrait;%else;%prefix;kch=%random_bits;&m=IM_C_S&i=%index;%end;"
-              target="_blank" rel="noopener"%sp;
+              href="%old_portrait_url;" target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
-              title='<strong>[*see portrait]</strong><br><span class="small">%portrait_saved</span>
-                   <br><img class="rounded my-1"
-              src="%if;has_old_portrait_url;%portrait_saved;%else;%prefix;kch=%random_bits;&m=IM_C_S&i=%index;%end;"
-                   width="185px">'>
+              title='<strong>[*see portrait]</strong><br><span class="small">%old_portrait;</span><br>
+                <img class="rounded my-1" src="%old_portrait_url;" width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait_name;&idigest=%idigest;"
-               title="[*restore portrait saved]">
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait;&idigest=%idigest;"
+              title="[*restore portrait saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
-            <strong><samp class="text-truncate">%saved_portraits_store;%X;</samp></strong><samp>
-            %if;has_old_portrait_url;%carrousel;.url%else;%portrait_saved_name;%end;</samp>
-            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&idigest=%idigest;&delete=on"
+            %if;has_old_portrait_url;<strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong>%old_portrait_name;%else;
+            <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%portrait_url;%end;</samp>
+            <a role="button" class="ml-auto col-1"
+              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&idigest=%idigest;&delete=on&file_name=%old_portrait_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"
-               title='<i class="far fa-trash-can text-danger mr-1"></i><strong>[*delete portrait saved]0</strong><br><span class="small">%portrait_saved;</span>
-                      <br><img class="rounded my-1" src="%prefix;m=IM_C_S&i=%index;"
-                      width="185px">'>
+              title='<i class="far fa-trash-can text-danger mr-1"></i><strong>[*delete saved portrait]0</strong><br><span class="small">%old_portrait;</span><br>
+                <img class="rounded my-1" src="%old_portrait_url;" width="185px">'>
               <i class="far fa-trash-can text-danger"></i></a>
           </div>
         %end;
-        <table style="line-height:0.8;" class="mt-2"><tr>
-        <td style="vertical-align:top"><a class="d_flex mt-1" href="%prefix;&m=REFRESH&i=%index;" title="[*add image]">
-          <span class="fa fa-image fa-fw" aria-hidden="true"></span>%nn;
-        </a></td><td>&nbsp;</td>
-        <td><small>[*warning refresh]</small>%nn;</td>
-        </tr></table>
+        %( TODO: table removed, restore formating %)
+        <i class="fas fa-retweet fa-rotate-90 fa-fw mr-1"></i>
+        <a href="%prefix;&m=REFRESH&i=%index;">
+          <i class="fa fa-image fa-fw" aria-hidden="true"></i>%nn;
+        </a>
+        <small>[*warning refresh]</small>
       %end;
-      %if;(has_carrousel)
+      %if;(has_blason or has_blason_stop or has_old_blason)
+      <h1 class="display-4 mt-2">[*blason/blasons]0</h1>
+      %if;has_blason_self;
+        <div class="d-flex align-self-center mt-1">
+          <a role="button" href="%blason_url;" target="_blank" rel="noopener"
+            data-toggle="tooltip" data-html="true" data-placement="left"
+            title='<strong>[*see coat of arms]</strong><br><span class="small">%blason_url;</span><br>
+              <img class="rounded my-1" src="%blason_url;" width="185px">'>
+            <i class="far fa-file-image fa-fw text-primary"></i></a>
+          <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%blason_name;</samp>
+          <a role="button" class="ml-auto col-1"
+            href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_name;"
+            data-toggle="tooltip" data-html="true" data-placement="left"
+            title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete coat of arms]</strong><br><span class="small">%blason;</span><br>
+              <img class="rounded my-1" src="%blason_url;" width="185px">'>
+            <i class="far fa-trash-can text-warning"></i></a>
+          <div class="dropdown">
+            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="dropdownMenuButton"
+              title="[*move coat of arms to]1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <i class="fa fa-person-arrow-up-from-line pb-0"></i>
+            </button>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+              %foreach;ancestor_level;
+                %foreach;ancestor;
+                  %for;i;1;12;
+                    %if;(ancestor.anc_sosa.v=2^i)
+                      <a class="dropdown-item small" href="%prefix;m=BLASON_MOVE_TO_ANC&i=%index;&ia=%ancestor.index;"
+                        title="[*move coat of arms to]0 %ancestor; %ancestor.dates_notag; (Sosa %ancestor.anc_sosa.v;),
+                               %apply;a_of_b%with;%apply;anc_name(i)%and;%self;%end;">%ancestor; %ancestor.dates;</a>
+                    %end;
+                  %end;
+                %end;
+              %end;
+            </div>
+          </div>
+        </div>
+      %elseif;has_blason_stop;
+        <div class="d-flex mt-1">
+          <span>%self; [stop using the coat of arms of]1 <a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>%nn;
+          <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_stop_name;"
+            data-toggle="tooltip" data-html="true" data-placement="left">
+            <i class="far fa-trash-can text-warning"></i>%nn;</a>
+        </div>
+      %elseif;has_blason;
+        <div class="d-flex mt-1">
+          <a role="button" href="%blason_url;"
+            target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
+            title='<strong>[*see coat of arms]</strong><br><span class="small">
+              %blason_name;</span><br><img class="rounded my-1"%sp;
+              src="%blason_url;" width="185px">'>
+            <i class="far fa-file-image fa-fw text-primary"></i></a>
+          <span>[*use coat of arms of]0%sp;<a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>
+          <a role="button" class="ml-auto" href="%prefix;m=BLASON_STOP&i=%index;&mode=blasons" title="[stop using the coat of arms of]0 %blason_owner;"
+            data-toggle="tooltip" data-html="true" data-placement="left">
+            <i class="fa-solid fa-xmark fa-fw fa-xl text-danger"></i></a>
+        </div>
+      %end;
+      %if;has_old_blason;
+        <div class="d-flex mt-1">
+          <a role="button" href="%old_blason_url;"
+            target="_blank" rel="noopener"
+            data-toggle="tooltip" data-html="true" data-placement="left"
+            title='<strong>[*see coat of arms]</strong><br><span class="small">%blason;</span><br>
+              <img class="rounded my-1" width="185px" src="%old_blason_url;">'>
+            <i class="far fa-file-image fa-fw text-primary"></i></a>
+          <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%portrait;&fdigest=%idigest;"
+            title="[*restore coat of arms saved]">
+            <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
+          <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%old_blason_name;</samp>
+          <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&delete=on&fdigest=%idigest;&file_name=%old_blason_name;"
+            data-toggle="tooltip" data-html="true" data-placement="left"%sp;
+            title='<strong>[*delete saved coat of arms]0</strong><br><span class="small">%old_blason;</span><br>
+              <img class="rounded my-1" src="%old_blason_url;" width="185px">'>
+            <i class="far fa-trash-can text-danger"></i></a>
+        </div>
+      %end;
+      <div>
+      %( TODO: table removed, restore formating %)
+        <i class="fas fa-retweet fa-rotate-90 fa-fw mr-1"></i>
+        <a href="%prefix;&m=REFRESH&i=%index;">
+          <i class="fa fa-image fa-fw" aria-hidden="true"></i></a>
+        <small>[*warning refresh]</small>
+      </div>
+    %end;
+      %if;(carrousel_img_nbr>0)
         <h1 class="display-4">[*image/images]1</h1>
         <div class="d-flex align-items-center">
           <i class="fa fa-folder-open fa-lg text-warning mx-2" aria-hidden="true"></i>
           <strong><samp class="text-truncate" title="%images_store;%X;%carrousel;">%images_store;%X;%carrousel;%X;</samp></strong>
-          <div class="ml-auto">(%carrousel_img_nbr; %if;(carrousel_img_nbr>1)[image/images]1%else;[image/images]0%end;)</div>
+          <div class="ml-auto">(%carrousel_img_nbr;)</div>
         </div>
         %foreach;img_in_carrousel;
           <div class="d-flex mt-1">
             <a role="button"
               href="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
               target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
-              title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [image/images]0</strong>
-                     <br><span class="small">%carrousel_img_raw;</span>
-                     <br><img class="rounded my-1"
-              src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
-                     width="185px">
-                     '>
+              title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [image/images]0</strong><br>
+                <span class="small">%carrousel_img_raw;</span><br>
+                <img class="rounded my-1"
+                  src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
+                  width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
             <a role="button" href="#" id="source_%img_cnt;" class="text-%if;(carrousel_img_src="")danger%else;primary%end;"
               onclick='get_source(%img_cnt;, "%carrousel_img_raw;"); return false;' data-source="%carrousel_img_src;"
               data-toggle="tooltip" data-html="true" data-placement="bottom"
               title='<strong><i class="far fa-file fa-fw mr-1"></i>
-                     %if;(carrousel_img_src="")[*add source]%else;[*modify source]%end;</strong>
-                     <br><span class="small"><br>%carrousel_img_src;</span>'>
+                 %if;(carrousel_img_src="")[*add source]%else;[*modify source]%end;</strong>
+                 <br><span class="small"><br>%carrousel_img_src;</span>'>
               <i class="far fa-file-zipper fa-fw"></i></a>
             <a role="button" href="#" id="note_%img_cnt;" class="text-%if;(carrousel_img_note="")danger%else;primary%end;"
               onclick='get_note(%img_cnt;, "%carrousel_img_raw;"); return false;' data-note="%carrousel_img_note;"
               data-toggle="tooltip" data-html="true" data-placement="bottom"
               title='<strong><i class="far fa-file fa-fw mr-1"></i>
-                     %if;(carrousel_img_note="")[*add note]%else;[*modify note]%end;</strong>
-                     <br><span class="small"><br>%carrousel_img_note;</span>'>
+                 %if;(carrousel_img_note="")[*add note]%else;[*modify note]%end;</strong>
+                 <br><span class="small"><br>%carrousel_img_note;</span>'>
               <i class="far fa-file-lines fa-fw"></i></a>
-            <samp class="text-truncate ml-1" title="%images_store;%X;%carrousel;%X;%carrousel_img;">%carrousel_img_raw;</samp>
-            <div class="ml-auto col-1">
+            <samp class="text-truncate ml-1" title="%images_store;%X;%carrousel;%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
+            <div class="ml-auto">
               <a role="button"
-                href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&file_name=%carrousel_img;&mode=others&idigest=%idigest;"
+                href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=carrousel&idigest=%idigest;&file_name=%carrousel_img;"
                 data-toggle="tooltip" data-html="true" data-placement="left"
-                title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete image]</strong>
-                       <br><span class="small">%carrousel_img_raw;</span>
-                       <br><img class="rounded my-1"
-                src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
-                width="185px">'>
+                title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete image]</strong><br>
+                  <span class="small">%carrousel_img;</span><br>
+                  <img class="rounded my-1"
+                    src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
+                    width="185px">'>
                 <i class="far fa-trash-can text-warning"></i></a>
             </div>
           </div>
@@ -273,49 +389,48 @@
         <div class="d-flex align-items-center">
           <i class="fa fa-folder-open fa-lg text-warning mx-2" aria-hidden="true"></i>
           <strong><samp class="text-truncate" title="%images_store;%X;%carrousel;%X;saved%X;">%images_store%X;%carrousel;%X;saved%X;</samp></strong>
-          <div class="ml-auto">(%carrousel_old_img_nbr; %if;(carrousel_old_img_nbr>1)[image/images]1%else;[image/images]0%end;)</div>
+          <div class="ml-auto">(%carrousel_old_img_nbr;)</div>
         </div>
         %foreach;img_in_carrousel_old;
           <div class="d-flex mt-1">
             <a role="button"
               href="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
               target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
-              title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [saved images]0</strong>
-                     <br><span class="small">%carrousel_img_raw;</span>
-                     <br><img class="rounded my-1"
-              src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
-              width="185px">'>
+              title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [saved images]0</strong><br>
+                <span class="small">%carrousel_img_raw;</span><br>
+                <img class="rounded my-1"
+                  src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
+                  width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=others&file_name=%carrousel_img;&idigest=%idigest;"
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=carrousel&delete=on&file_name=%carrousel_img;&idigest=%idigest;"
                %if;(url_in_env!="")%else;data-toggle="tooltip" data-html="true" data-placement="top"%end;
                title="[*restore image saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i></a>
-            <samp class="text-truncate ml-1" title="%images_store;%X;saved%X;%carrousel_img;">%carrousel_img_raw;</samp>
-            <div class="ml-auto col-1">
-              <a role="button"
+            <a href="%prefix;m=IMAGE_TO_BLASON&i=%index;&file_name=%carrousel_img;"
+            title="[*copy image to blason]"><i class="fa-solid fa-user-shield text-success"></i></a>
+            <samp class="text-truncate ml-1" title="%images_store;%X;saved%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
+            <a role="button" class="ml-auto"
                 href="%prefix;m=DEL_IMAGE_C_OK&i=%index%nn;
-                  &idigest=%idigest;&file_name=%carrousel_img;&mode=others%nn;
-                  &delete=on"%sp;
+                  &idigest=%idigest;&mode=carrousel&delete=on&file_name=%carrousel_img;"%sp;
                 data-toggle="tooltip" data-html="true" data-placement="left"
-                title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete image saved]</strong>
-                         <br><span class="small">%carrousel_img_raw;</span>
-                         <br><img class="rounded my-1"
-                src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
-                width="185px">'>
+                title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete saved image]</strong><br>
+                  <span class="small">%carrousel_img;</span><br>
+                  <img class="rounded my-1"
+                    src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
+                    width="185px">'>
                 <i class="far fa-trash-can text-danger fa-fw text-primary"></i></a>
-            </div>
           </div>
         %end;
-        <table style="line-height:0.8;" class="mt-2"><tr>
-        <td style="vertical-align:top"><a class="d_flex mt-1" href="%prefix;&m=REFRESH&i=%index;" title="[*add image]/[delete image]">
-          <span class="fa fa-image fa-fw" aria-hidden="true"></span>%nn;
-        </a></td><td>&nbsp;</td>
-        <td><small>[*warning refresh]</small>%nn;</td>
-        </tr></table>
+        %( TODO: table removed, restore formating + fix/remove this %)
+        <i class="fas fa-retweet fa-rotate-90 fa-fw mr-1"></i>
+        <a href="%prefix;&m=REFRESH&i=%index;">
+          <i class="fa fa-image fa-fw" aria-hidden="true"></i>%nn;
+        </a>
+        <small>[*warning refresh]</small>
       %end;
     </div>
   </div>
-  %if;(evar.em!="")
+  %if;(e.em!="")
     <div role="alert" class="alert alert-dismissible fade show alert-%apply;alert_color() mt-3">
       <strong>%apply;alert_header()[:]</strong> %apply;alert_content()
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -20,6 +20,14 @@
   carrousel is “on” if we are dealing with “others” images %)
 %random.init;
 %let;random_bits;%if;predictable_mode;123456%else;%random.bits;%end;%in;
+%define;refresh()
+  %if;(e.m!="REFRESH")
+    <div class="d-flex align-items-center small mt-2">
+      <a href="%prefix;&m=REFRESH&i=%index;" class="btn btn-sm btn-danger mr-2">
+        <i class="fas fa-retweet fa-rotate-90 fa-fw"></i></a> [*warning refresh]
+    </div>
+  %end;
+%end;
 %define;alert_header()
   %if;("http" in portrait or "http" in old_portrait)
     WARNING
@@ -29,9 +37,9 @@
     %elseif;(e.em="RESET_IMAGE_C_OK")[*image/images]0 [restored]1%nn;
     %end;%nn;
   %elseif;(e.mode="blasons")
-    %if;(e.em="SND_IMAGE_C_OK")[*coat of arms] [uploaded]0%nn;
-    %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest=e.idigest)[*coat of arms] [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
-    %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest=e.idigest)[*coat of arms] [restored]0%nn;
+    %if;(e.em="SND_IMAGE_C_OK")[*blason/blasons]0 [uploaded]0%nn;
+    %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest=e.idigest)[*blason/blasons]0 [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest=e.idigest)[*blason/blasons]0 [restored]0%nn;
     %end;%nn;
   %elseif;(e.mode="portraits")
     %if;(e.em="SND_IMAGE_C_OK")%if;(e.mode="note")[*note] [update]%else;[*portrait] [uploaded]0%end;%nn;
@@ -112,8 +120,14 @@
   <div class="row mb-1">
     %( *** Col 1 *** %)
     <div class="col-6 border border-bottom-0 border-top-0 border-left-0">
+      <div class="d-inline-flex">
       <h1 class="display-5">%nn;
         %if;(has_portrait)[*modify portrait]%else;[*add portrait]%end;</h1>
+        <a class="ml-2 mt-2 text-primary small" data-toggle="tooltip" data-html="true" data-placement="top"
+          title="%if;has_portrait_url;[*must use MOD_IND]%else;
+          %if;(has_portrait and has_old_portrait)[*previous portrait]%end;%end;">
+          (<i class="fa fa-info fa-xs"></i>)</a>
+      </div>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
         %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
         <input type="hidden" name="m" value="SND_IMAGE_C_OK">
@@ -131,11 +145,6 @@
         <button class="btn btn-primary ml-2 col-2 snd-btn-portrait"
           type="submit" disabled>[*send::]</button>
       </form>
-      <div class="small mt-2">%nn;
-        %if;has_portrait_url;[*must use MOD_IND]%else;
-          %if;(has_portrait and has_old_portrait)[*previous portrait]%end;
-        %end;
-      </div>
       <h1 class="display-5">%nn;
         %if;(has_blason)[*modify coat of arms]%else;[*add coat of arms]%end;</h1>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
@@ -147,66 +156,68 @@
         <input type="hidden" name="idigest" value=%idigest;>
         <input type="hidden" name="fdigest" value=%idigest;>
         <div class="custom-file col">
-          <input type="file" name="file"
-            class="custom-file-input custom-portrait"
+          <input type="file" name="file" class="custom-file-input custom-blason"
               id="portrait_file" accept="image/*"%if;(not has_blason) autofocus%end;>
           <label class="custom-file-label text-truncate" data-browse="[*browse]"
             for="portrait_file">[*select] [blason/blasons]0</label>
         </div>
-        <button class="btn btn-primary ml-2 col-2 snd-btn-portrait"
+        <button class="btn btn-primary ml-2 col-2 snd-btn-blason"
           type="submit" disabled>[*send::]</button>
       </form>
       <div class="small mt-2">%nn;
-        %if;(has_blason and has_old_blason)[*previous::blason/blasons]%end;
+        %if;(has_blason and has_old_blason)[*previous::blason/blasons]0%end;
       </div>
-      <h1 class="display-5">[*add image]</h1>
+      <div class="d-inline-flex">
+        <h1 class="display-5">[*add image]</h1>
+        <a class="ml-2 mt-2 text-primary small" data-toggle="tooltip" data-html="true" data-placement="top"
+          title="[*previous image]">(<i class="fa fa-info fa-xs"></i>)</a>
+      </div>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
         %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
         <input type="hidden" name="m" value="SND_IMAGE_C_OK">
         <input type="hidden" name="i" value="%index;">
         <input type="hidden" name="mode" id="mode_2" value="carrousel">
         <input type="hidden" name="idigest" value=%idigest;>
-        %( file_name is automatically provided by the type="file" item %)
-        %( file_name_2 is used when updating the note file after selection %)
-        %( with the radiobutton of the saved folder content (right column) %)
         <input type="hidden" name="file_name_2" id="file_name_2" value="">
-        <div class="custom-file col-9">
+        <div class="custom-file col">
           <input type="file" name="file" class="custom-file-input custom-others"
-            id="others_file" accept="image/*"%if;has_portrait; autofocus%end;%( multiple%)>
-          <label class="custom-file-label text-truncate" for="others_file"  data-browse="[*browse]">%nn;
-            [*select] [image/images]0%nn;
-          </label>
+            id="others_file" accept="image/*"%if;has_portrait; autofocus%end;>
+          <label class="custom-file-label text-truncate" data-browse="[*browse]"
+            for="others_file">[*select] [image/images]0</label>
         </div>
-        <button class="btn btn-primary ml-2 col-2 snd-btn-others" type="submit" >[*send::]</button>
-        %(TODO: print only if saved img already exists%)
-          <span class="col-1 align-self-center ml-3">[or]</span>
-          <span class="col">
-          <input type="text" class="form-control mt-1" id="image_url" name="image_url"
+        <button type="button" class="btn btn-primary ml-2 col-2 btn-quick-upload" disabled>[*send::]</button>
+        <div class="col-12 d-flex align-items-center mt-2">
+          <span class="mr-2">[or]</span>
+          <input type="text" class="form-control" id="image_url" name="image_url"
             placeholder="%apply;a_of_b%with;[URL]%and;[image/images]0%end;">
-          </span>
-        %( long message about image with same name being deleted %)
-        <div class="small col-12 mt-1">[*previous image]</div>
-        %( TODO expliciter que le nom peut rester vide, gardera celui fourni %)
+        </div>
         <input type="text" class="form-control col-12 mt-3" id="image_name"
-          name="image_name" placeholder="[*name] ([optionnal])">
-        %( TODO re-activate disable for send, source and note %)
-        <textarea class="form-control col-12 mt-1" id="image_source"
-          name="source" rows="1" placeholder="[*source/sources]0 ([optionnal])">
+          name="image_name" placeholder="[*name] ([optional]) TODO: FIXME!">
+        <textarea class="form-control col-12 mt-2" id="image_note" disabled
+          name="note" rows="2" placeholder="[*note/notes]0 ([optional])">
         </textarea>
-        <textarea class="form-control col-12 mt-1" id="image_note"
-          name="note" rows="4" placeholder="[*note/notes]0 ([optionnal])">
+        <textarea class="form-control col-12 mt-2" id="image_source" disabled
+          name="source" rows="1" placeholder="[*source/sources]0 ([optional])">
         </textarea>
-        <button class="btn btn-primary mt-2 col-12 btn-update-note-source" type="submit" disabled>
-          <span id="which_img_show">[*send image with note and source]</span></button>
+        <div class="col-12 mt-2">
+          <div class="d-flex">
+            <button type="submit" class="flex-grow-1 btn btn-primary text-wrap text-left py-2 submit-button" disabled>
+              <span id="which_img_show" class="d-inline-block">[*send image with note and source]</span>
+            </button>
+            <button type="button" class="btn btn-secondary ml-2 d-none" id="btn-cancel-edit">
+                [*user/password/cancel]2
+            </button>
+          </div>
+        </div>
       </form>
     </div>
     %( *** Col 2 *** image cache disabled with a kch=%random_bits; %)
     <div class="col-6">
       %if;(has_portrait or has_old_portrait)
-        <h1 class="display-4">[*portrait]0</h1>
+        <h1 class="display-5">[*portrait]0</h1>
         %if;has_portrait;
           <div class="d-flex mt-1">
-            <a role="button" 
+            <a role="button"
               href="%portrait_url;" target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong>[*see portrait]</strong><br><span class="small">%portrait;</span><br>
@@ -217,7 +228,7 @@
                  <i class="fa-solid fa-user-shield"></i></a>
             %if;has_portrait_url;%portrait_name;%else;
               <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%portrait_name;%end;</samp>
-            <a role="button" class="ml-auto mt-1"
+            <a role="button" class="ml-auto"
               href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&idigest=%idigest;&file_name=%portrait_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete portrait]</strong><br><span class="small">%portrait;</span><br>
@@ -226,8 +237,8 @@
           </div>
         %end;
         %if;has_old_portrait;
-          <div class="d-flex mt-1">
-            <a role="button" 
+          <div class="d-flex">
+            <a role="button"
               href="%old_portrait_url;" target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong>[*see portrait]</strong><br><span class="small">%old_portrait;</span><br>
@@ -237,8 +248,8 @@
               title="[*restore portrait saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
             %if;has_old_portrait_url;<strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong>%old_portrait_name;%else;
-            <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%portrait_url;%end;</samp>
-            <a role="button" class="ml-auto col-1"
+            <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%old_portrait_name;%end;</samp>
+            <a role="button" class="ml-auto"
               href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&idigest=%idigest;&delete=on&file_name=%old_portrait_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<i class="far fa-trash-can text-danger mr-1"></i><strong>[*delete saved portrait]0</strong><br><span class="small">%old_portrait;</span><br>
@@ -246,30 +257,12 @@
               <i class="far fa-trash-can text-danger"></i></a>
           </div>
         %end;
-        %( TODO: table removed, restore formating %)
-        <i class="fas fa-retweet fa-rotate-90 fa-fw mr-1"></i>
-        <a href="%prefix;&m=REFRESH&i=%index;">
-          <i class="fa fa-image fa-fw" aria-hidden="true"></i>%nn;
-        </a>
-        <small>[*warning refresh]</small>
+        %apply;refresh()
       %end;
       %if;(has_blason or has_blason_stop or has_old_blason)
-      <h1 class="display-4 mt-2">[*blason/blasons]0</h1>
-      %if;has_blason_self;
-        <div class="d-flex align-self-center mt-1">
-          <a role="button" href="%blason_url;" target="_blank" rel="noopener"
-            data-toggle="tooltip" data-html="true" data-placement="left"
-            title='<strong>[*see coat of arms]</strong><br><span class="small">%blason_url;</span><br>
-              <img class="rounded my-1" src="%blason_url;" width="185px">'>
-            <i class="far fa-file-image fa-fw text-primary"></i></a>
-          <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%blason_name;</samp>
-          <a role="button" class="ml-auto col-1"
-            href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_name;"
-            data-toggle="tooltip" data-html="true" data-placement="left"
-            title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete coat of arms]</strong><br><span class="small">%blason;</span><br>
-              <img class="rounded my-1" src="%blason_url;" width="185px">'>
-            <i class="far fa-trash-can text-warning"></i></a>
-          <div class="dropdown">
+        <div class="d-flex justify-content-between">
+          <h1 class="display-5">[*blason/blasons]0</h1>
+          <div class="dropdown align-self-center">
             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="dropdownMenuButton"
               title="[*move coat of arms to]1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="fa fa-person-arrow-up-from-line pb-0"></i>
@@ -289,56 +282,65 @@
             </div>
           </div>
         </div>
-      %elseif;has_blason_stop;
-        <div class="d-flex mt-1">
-          <span>%self; [stop using the coat of arms of]1 <a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>%nn;
-          <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_stop_name;"
-            data-toggle="tooltip" data-html="true" data-placement="left">
-            <i class="far fa-trash-can text-warning"></i>%nn;</a>
-        </div>
-      %elseif;has_blason;
-        <div class="d-flex mt-1">
-          <a role="button" href="%blason_url;"
-            target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
-            title='<strong>[*see coat of arms]</strong><br><span class="small">
-              %blason_name;</span><br><img class="rounded my-1"%sp;
-              src="%blason_url;" width="185px">'>
-            <i class="far fa-file-image fa-fw text-primary"></i></a>
-          <span>[*use coat of arms of]0%sp;<a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>
-          <a role="button" class="ml-auto" href="%prefix;m=BLASON_STOP&i=%index;&mode=blasons" title="[stop using the coat of arms of]0 %blason_owner;"
-            data-toggle="tooltip" data-html="true" data-placement="left">
-            <i class="fa-solid fa-xmark fa-fw fa-xl text-danger"></i></a>
-        </div>
+        %if;has_blason_self;
+          <div class="d-flex align-self-center mt-1">
+            <a role="button" href="%blason_url;" target="_blank" rel="noopener"
+              data-toggle="tooltip" data-html="true" data-placement="left"
+              title='<strong>[*see coat of arms]</strong><br><span class="small">%blason_url;</span><br>
+                <img class="rounded my-1" src="%blason_url;" width="185px">'>
+              <i class="far fa-file-image fa-fw text-primary"></i></a>
+            <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%blason_name;</samp>
+            <a role="button" class="ml-auto col-1"
+              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_name;"
+              data-toggle="tooltip" data-html="true" data-placement="left"
+              title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete coat of arms]</strong><br><span class="small">%blason;</span><br>
+                <img class="rounded my-1" src="%blason_url;" width="185px">'>
+              <i class="far fa-trash-can text-warning"></i></a>
+          </div>
+        %elseif;has_blason_stop;
+          <div class="d-flex mt-1">
+            <span>%self; [stop using the coat of arms of]1 <a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>%nn;
+            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_stop_name;"
+              data-toggle="tooltip" data-html="true" data-placement="left">
+              <i class="far fa-trash-can text-warning"></i>%nn;</a>
+          </div>
+        %elseif;has_blason;
+          <div class="d-flex mt-1">
+            <a role="button" href="%blason_url;"
+              target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
+              title='<strong>[*see coat of arms]</strong><br><span class="small">
+                %blason_name;</span><br><img class="rounded my-1"%sp;
+                src="%blason_url;" width="185px">'>
+              <i class="far fa-file-image fa-fw text-primary"></i></a>
+            <span>[*use coat of arms of]0%sp;<a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>
+            <a role="button" class="ml-auto" href="%prefix;m=BLASON_STOP&i=%index;&mode=blasons" title="[stop using the coat of arms of]0 %blason_owner;"
+              data-toggle="tooltip" data-html="true" data-placement="left">
+              <i class="fa-solid fa-xmark fa-fw fa-xl text-danger"></i></a>
+          </div>
+        %end;
+        %if;has_old_blason;
+          <div class="d-flex mt-1">
+            <a role="button" href="%old_blason_url;"
+              target="_blank" rel="noopener"
+              data-toggle="tooltip" data-html="true" data-placement="left"
+              title='<strong>[*see coat of arms]</strong><br><span class="small">%blason;</span><br>
+                <img class="rounded my-1" width="185px" src="%old_blason_url;">'>
+              <i class="far fa-file-image fa-fw text-primary"></i></a>
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%portrait;&fdigest=%idigest;"
+              title="[*restore coat of arms saved]">
+              <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
+            <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%old_blason_name;</samp>
+            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&delete=on&fdigest=%idigest;&file_name=%old_blason_name;"
+              data-toggle="tooltip" data-html="true" data-placement="left"%sp;
+              title='<strong>[*delete saved coat of arms]0</strong><br><span class="small">%old_blason;</span><br>
+                <img class="rounded my-1" src="%old_blason_url;" width="185px">'>
+              <i class="far fa-trash-can text-danger"></i></a>
+          </div>
+        %end;
+        %apply;refresh()
       %end;
-      %if;has_old_blason;
-        <div class="d-flex mt-1">
-          <a role="button" href="%old_blason_url;"
-            target="_blank" rel="noopener"
-            data-toggle="tooltip" data-html="true" data-placement="left"
-            title='<strong>[*see coat of arms]</strong><br><span class="small">%blason;</span><br>
-              <img class="rounded my-1" width="185px" src="%old_blason_url;">'>
-            <i class="far fa-file-image fa-fw text-primary"></i></a>
-          <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%portrait;&fdigest=%idigest;"
-            title="[*restore coat of arms saved]">
-            <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
-          <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%old_blason_name;</samp>
-          <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&delete=on&fdigest=%idigest;&file_name=%old_blason_name;"
-            data-toggle="tooltip" data-html="true" data-placement="left"%sp;
-            title='<strong>[*delete saved coat of arms]0</strong><br><span class="small">%old_blason;</span><br>
-              <img class="rounded my-1" src="%old_blason_url;" width="185px">'>
-            <i class="far fa-trash-can text-danger"></i></a>
-        </div>
-      %end;
-      <div>
-      %( TODO: table removed, restore formating %)
-        <i class="fas fa-retweet fa-rotate-90 fa-fw mr-1"></i>
-        <a href="%prefix;&m=REFRESH&i=%index;">
-          <i class="fa fa-image fa-fw" aria-hidden="true"></i></a>
-        <small>[*warning refresh]</small>
-      </div>
-    %end;
       %if;(carrousel_img_nbr>0)
-        <h1 class="display-4">[*image/images]1</h1>
+        <h1 class="display-5">[*image/images]1</h1>
         <div class="d-flex align-items-center">
           <i class="fa fa-folder-open fa-lg text-warning mx-2" aria-hidden="true"></i>
           <strong><samp class="text-truncate" title="%images_store;%X;%carrousel;">%images_store;%X;%carrousel;%X;</samp></strong>
@@ -346,29 +348,18 @@
         </div>
         %foreach;img_in_carrousel;
           <div class="d-flex mt-1">
-            <a role="button"
-              href="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
-              target="_blank" rel="noopener" data-toggle="tooltip" data-html="true" data-placement="left"
+            <a role="button" href="#" id="source_%img_cnt;" 
+              onclick='editImageNote(%img_cnt;, "%carrousel_img_raw;"); return false;' 
+              data-source="%carrousel_img_src;" data-note="%carrousel_img_note;"
+              data-toggle="tooltip" data-html="true" data-placement="left"
               title='<strong><i class="fas fa-images fa-xs mr-1"></i>[*see] [image/images]0</strong><br>
                 <span class="small">%carrousel_img_raw;</span><br>
                 <img class="rounded my-1"
                   src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C&i=%index;&s=%carrousel_img;%end;"
-                  width="185px">'>
+                  width="185px">
+                %if;(carrousel_img_note!="")<br><strong>[*note/notes]0[:]</strong> %carrousel_img_note;%end;
+                %if;(carrousel_img_src!="")<br><strong>[*source/sources]0[:]</strong> %carrousel_img_src;%end;'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="#" id="source_%img_cnt;" class="text-%if;(carrousel_img_src="")danger%else;primary%end;"
-              onclick='get_source(%img_cnt;, "%carrousel_img_raw;"); return false;' data-source="%carrousel_img_src;"
-              data-toggle="tooltip" data-html="true" data-placement="bottom"
-              title='<strong><i class="far fa-file fa-fw mr-1"></i>
-                 %if;(carrousel_img_src="")[*add source]%else;[*modify source]%end;</strong>
-                 <br><span class="small"><br>%carrousel_img_src;</span>'>
-              <i class="far fa-file-zipper fa-fw"></i></a>
-            <a role="button" href="#" id="note_%img_cnt;" class="text-%if;(carrousel_img_note="")danger%else;primary%end;"
-              onclick='get_note(%img_cnt;, "%carrousel_img_raw;"); return false;' data-note="%carrousel_img_note;"
-              data-toggle="tooltip" data-html="true" data-placement="bottom"
-              title='<strong><i class="far fa-file fa-fw mr-1"></i>
-                 %if;(carrousel_img_note="")[*add note]%else;[*modify note]%end;</strong>
-                 <br><span class="small"><br>%carrousel_img_note;</span>'>
-              <i class="far fa-file-lines fa-fw"></i></a>
             <samp class="text-truncate ml-1" title="%images_store;%X;%carrousel;%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
             <div class="ml-auto">
               <a role="button"
@@ -385,7 +376,7 @@
         %end;
       %end;
       %if;(carrousel_old_img_nbr>0)
-        <h1 class="display-4">[*saved images]1</h1>
+        <h1 class="display-5">[*saved images]1</h1>
         <div class="d-flex align-items-center">
           <i class="fa fa-folder-open fa-lg text-warning mx-2" aria-hidden="true"></i>
           <strong><samp class="text-truncate" title="%images_store;%X;%carrousel;%X;saved%X;">%images_store%X;%carrousel;%X;saved%X;</samp></strong>
@@ -421,12 +412,7 @@
                 <i class="far fa-trash-can text-danger fa-fw text-primary"></i></a>
           </div>
         %end;
-        %( TODO: table removed, restore formating + fix/remove this %)
-        <i class="fas fa-retweet fa-rotate-90 fa-fw mr-1"></i>
-        <a href="%prefix;&m=REFRESH&i=%index;">
-          <i class="fa fa-image fa-fw" aria-hidden="true"></i>%nn;
-        </a>
-        <small>[*warning refresh]</small>
+        %apply;refresh()
       %end;
     </div>
   </div>
@@ -449,57 +435,155 @@ $('.xxx').change(function() {
   let fileName = $(this).val().split('\\').pop();
   $(this).next('.custom-file-label').addClass("selected").html(fileName);
   $('.yyy').prop('disabled', false);
-  %if;("yyy"="snd-btn-others")
-    $('textarea').prop('disabled', false).focus();
+  %if;("yyy"="btn-quick-upload")
+    $('#image_note, #image_source').prop('disabled', false);
+    $('.submit-button').prop('disabled', false);
+    $('#image_url').prop('disabled', true).val('');
+    $('#btn-cancel-edit').removeClass('d-none').addClass('d-flex align-items-center');
+    $('#image_note').focus();
   %end;
 });
 %end;
 <script>
-// Clic pour les icônes de note et source
-const setupFieldEditor = (iconSelector, fieldSelector) => {
-  $(iconSelector).click(function() {
-    $('.custom-others').prop('disabled', true);
-    $(fieldSelector).prop('disabled', false).focus();
-  });
-};
 $(function() {
   %apply;input_snd("custom-portrait","snd-btn-portrait")
-  %apply;input_snd("custom-others","snd-btn-others")
+  %apply;input_snd("custom-blason","snd-btn-blason")
+  %apply;input_snd("custom-others","btn-quick-upload")
 
-  setupFieldEditor('.fa-file-lines', '#image_note');
-  setupFieldEditor('.fa-file-zipper', '#image_source');
-
-  $('#image_note, #image_source').on('input', function() {
-    if(this.value.length) {
-      $('.btn-update-note-source').prop('disabled', false);
+  $('[data-toggle="tooltip"]').tooltip({
+    html: true,
+    boundary: 'window'
+  });
+  
+  // Gestion du bouton d'envoi rapide (le premier bouton)
+  $('.btn-quick-upload').click(function() {
+    if($('#others_file').val()) {
+      $('form').submit();
     }
   });
-
-  $('[data-toggle="tooltip"]').tooltip();
+  
+  // Gestion de l'URL d'image 
+  $('#image_url').on('input', function() {
+    if(this.value.length) {
+      // Si une URL est saisie
+      $('.btn-quick-upload').prop('disabled', false);
+      $('#image_note, #image_source').prop('disabled', false);
+      $('.submit-button').prop('disabled', false);
+      
+      // Désactiver l'input de fichier puisqu'une URL est saisie
+      $('#others_file').prop('disabled', true);
+      $('.custom-file-label').html('[*select] [image/images]0');
+      
+      // Afficher le bouton d'annulation
+      $('#btn-cancel-edit').removeClass('d-none').addClass('d-flex align-items-center');
+    } else {
+      // Si l'URL est vidée et qu'il n'y a pas de fichier
+      if (!$('#others_file').prop('disabled')) {
+        $('.btn-quick-upload').prop('disabled', true);
+        $('#image_note, #image_source').prop('disabled', true);
+        $('.submit-button').prop('disabled', true);
+        
+        // Cacher le bouton d'annulation si on est revenu à l'état initial
+        $('#btn-cancel-edit').addClass('d-none');
+      }
+    }
+  });
+  
+  // Activer le bouton du bas si des métadonnées sont saisies
+  $('#image_name, #image_note, #image_source').on('input', function() {
+    if($('#others_file').val() || $('#image_url').val().trim() !== '' || $(this).val().trim() !== '') {
+      $('.submit-button').prop('disabled', false);
+    }
+  });
+  
+  // Désactiver les champs après l'envoi
+  $('form').on('submit', function() {
+    // Ne pas réinitialiser tout de suite si on est en mode édition
+    if($('#mode_2').val() !== 'note') {
+      setTimeout(function() {
+        $('#image_note, #image_source').prop('disabled', true);
+      }, 100);
+    }
+  });
+  
+ // Annuler l'édition
+  $('#btn-cancel-edit').click(function() {
+    // Réinitialiser les champs
+    $('#image_note, #image_source').val('').prop('disabled', true);
+    $('#file_name_2').val('');
+    $('#mode_2').val('carrousel');
+    $('#which_img_show').text('[*send image with note and source]');
+    $('.submit-button').prop('disabled', true);
+    
+    // Réinitialiser les champs spécifiques
+    $('#others_file').val('').prop('disabled', false);
+    $('.custom-file-label').html('[*select] [image/images]0');
+    $('#image_url').val('').prop('disabled', false);
+    $('.btn-quick-upload').prop('disabled', true);
+    
+    // Cacher le bouton d'annulation
+    $(this).addClass('d-none').removeClass('d-flex');
+  });
 });
 
-// Fonction d'édition de métadonnées
-const updateImageMetadata = (type, cnt, name) => {
-  const $typeField = $(`#${type}_${cnt}`);
-  const $textField = $(`#image_${type}`);
+const updateTextareaSize = () => {
+  setTimeout(() => {
+    autosize.update($('textarea'));
+  }, 0);
+};
+
+function formatButtonText(noteText, imageName, maxLen = 37) {
+  const ext = imageName.lastIndexOf('.');
+  const name = ext !== -1 ? imageName.slice(0, ext) : imageName;
+  const truncName = name.length > maxLen 
+    ? name.slice(0, maxLen - 3) + '[…]'
+    : name;
+  const fullText = `${noteText}\n${truncName}${ext !== -1 ? imageName.slice(ext) : ''}`;
+  if (name.length > maxLen) {
+    $('#which_img_show').css('white-space', 'pre-line');
+  } else {
+    $('#which_img_show').css('white-space', 'normal');
+  }
+
+  return fullText;
+}
+
+const editImageNote = (cnt, name) => {
+  const noteData = $(`#source_${cnt}`).data('note');
+  const sourceData = $(`#source_${cnt}`).data('source');
   
-  $textField.val($typeField.data(type));
+  // Désactiver l'input de fichier et l'URL pendant l'édition
+  $('#others_file').prop('disabled', true);
+  $('#image_url').prop('disabled', true);
+  
+  // Désactiver le bouton d'envoi rapide pendant l'édition
+  $('.btn-quick-upload').prop('disabled', true);
+  
+  // Afficher le bouton d'annulation
+  $('#btn-cancel-edit').removeClass('d-none').addClass('d-flex align-items-center');
+  
+  $('#image_note').val(noteData || '').prop('disabled', false).focus();
+  $('#image_source').val(sourceData || '').prop('disabled', false);
+  
+  updateTextareaSize();
+  $('#image_note').focus();
+
   $('#file_name_2').val(name);
-  $('#mode_2').val(type);
-  $('#which_img_show').text(`[*update image ${type}] ${name}`);
+  $('#mode_2').val('note');
+  const buttonText = noteData 
+    ? formatButtonText(`[*update image note]`, name)
+    : formatButtonText(`[*add note]/[source/sources]0`, name);
+  $('#which_img_show').text(buttonText);
+  $('.submit-button').prop('disabled', false);
+  
+  $('#image_note, #image_source').off('input').on('input', function() {
+    $('.submit-button').prop('disabled', !this.value.length);
+    updateTextareaSize();
+  });
+  
+  return false;
 };
 
-// Fonctions pour les notes et sources
-const get_note = (cnt, name) => updateImageMetadata('note', cnt, name);
-const get_source = (cnt, name) => updateImageMetadata('source', cnt, name);
-
-// Basculer l'état du champ URL
-const toggle_url_on = () => {
-  const $imageNameField = $('#image_name');
-  $imageNameField
-    .prop('disabled', !$imageNameField.prop('disabled'))
-    .focus();
-};
 </script>
 </body>
 </html>

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -20,14 +20,6 @@
   carrousel is “on” if we are dealing with “others” images %)
 %random.init;
 %let;random_bits;%if;predictable_mode;123456%else;%random.bits;%end;%in;
-%define;refresh()
-  %if;(e.m!="REFRESH")
-    <div class="d-flex align-items-center small mt-2">
-      <a href="%prefix;&m=REFRESH&i=%index;" class="btn btn-sm btn-danger mr-2">
-        <i class="fas fa-retweet fa-rotate-90 fa-fw"></i></a> [*warning refresh]
-    </div>
-  %end;
-%end;
 %define;alert_header()
   %if;("http" in portrait or "http" in old_portrait)
     WARNING
@@ -38,14 +30,14 @@
     %end;%nn;
   %elseif;(e.mode="blasons")
     %if;(e.em="SND_IMAGE_C_OK")[*blason/blasons]0 [uploaded]0%nn;
-    %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest=e.idigest)[*blason/blasons]0 [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
-    %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest=e.idigest)[*blason/blasons]0 [restored]0%nn;
+    %elseif;(e.em="DEL_IMAGE_C_OK")[*blason/blasons]0 [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK")[*blason/blasons]0 [restored]0%nn;
     %elseif;(e.em="IMAGE_TO_BLASON")[*image/images]0 [copied/copied]1 [to] [blason/blasons]0%nn;
     %end;%nn;
   %elseif;(e.mode="portraits")
     %if;(e.em="SND_IMAGE_C_OK")%if;(e.mode="note")[*note] [update]%else;[*portrait] [uploaded]0%end;%nn;
-    %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest!=e.idigest)[*portrait] [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
-    %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest!=e.idigest)[*portrait] [restored]0%nn;
+    %elseif;(e.em="DEL_IMAGE_C_OK")[*portrait] [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK")[*portrait] [restored]0%nn;
     %end;%nn;
   %elseif;(e.mode="note")
     %if;(e.em="SND_IMAGE_C_OK")[*note/notes]0 [update::]%nn;
@@ -62,7 +54,8 @@
       <strong>></strong> %images_store;%X;%e.file_name;
     %elseif;(e.em="DEL_IMAGE_C_OK")
       %if;(e.delete="on")%images_store;%X;%keydir;%X;%e.file_name;%else;%nn;
-        %images_store;%X;%carrousel;%X;%e.file_name; <strong>></strong> %images_store;%X;%keydir;%X;%e.file_name;%nn;
+        %images_store;|%X;|%carrousel;|%X;|%e.file_name; <strong>></strong>
+        %images_store;%X;%keydir;%X;%e.file_name;%nn;
       %end;%nn;
     %elseif;(e.em="RESET_IMAGE_C_OK")%images_store;%X;%keydir;%X;%e.file_name; <strong><></strong> %images_store;%X;%e.file_name;%nn;
     %else;bad command %e.em; (%e.mode;)
@@ -125,10 +118,11 @@
       <div class="d-inline-flex">
       <h1 class="display-5">%nn;
         %if;(has_portrait)[*modify portrait]%else;[*add portrait]%end;</h1>
-        <a class="ml-2 mt-2 text-primary small" data-toggle="tooltip" data-html="true" data-placement="top"
+        %if;(has_portrait or has_portrait_url)<abbr class="ml-2 mt-2 text-primary small" data-toggle="tooltip" data-html="true" data-placement="top"
           title="%if;has_portrait_url;[*must use MOD_IND]%else;
-          %if;(has_portrait and has_old_portrait)[*previous portrait]%end;%end;">
-          (<i class="fa fa-info fa-xs"></i>)</a>
+          %if;has_portrait;[*previous portrait]%end;%end;">
+          (<i class="fa fa-info fa-xs"></i>)</abbr>
+        %end;
       </div>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
         %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
@@ -136,7 +130,6 @@
         <input type="hidden" name="i" value="%index;">
         <input type="hidden" name="notes" value="">
         <input type="hidden" name="mode" value="portraits">
-        <input type="hidden" name="idigest" value=%idigest;>
         <div class="custom-file col">
           <input type="file" name="file"
             class="custom-file-input custom-portrait"
@@ -155,8 +148,6 @@
         <input type="hidden" name="i" value="%index;">
         <input type="hidden" name="notes" value="">
         <input type="hidden" name="mode" value="blasons">
-        <input type="hidden" name="idigest" value=%idigest;>
-        <input type="hidden" name="fdigest" value=%idigest;>
         <div class="custom-file col">
           <input type="file" name="file" class="custom-file-input custom-blason"
               id="portrait_file" accept="image/*"%if;(not has_blason) autofocus%end;>
@@ -171,15 +162,14 @@
       </div>
       <div class="d-inline-flex">
         <h1 class="display-5">[*add image]</h1>
-        <a class="ml-2 mt-2 text-primary small" data-toggle="tooltip" data-html="true" data-placement="top"
-          title="[*previous image]">(<i class="fa fa-info fa-xs"></i>)</a>
+        <abbr class="ml-2 mt-2 text-primary small" data-toggle="tooltip" data-html="true" data-placement="top"
+          title="[*previous image]">(<i class="fa fa-info fa-xs"></i>)</abbr>
       </div>
       <form class="form-row" method="post" action="%action;" enctype="multipart/form-data">
         %if;(cgi)<input type="hidden" name="b" value="%e.b;">%end;
         <input type="hidden" name="m" value="SND_IMAGE_C_OK">
         <input type="hidden" name="i" value="%index;">
         <input type="hidden" name="mode" id="mode_2" value="carrousel">
-        <input type="hidden" name="idigest" value=%idigest;>
         <input type="hidden" name="file_name_2" id="file_name_2" value="">
         <div class="custom-file col">
           <input type="file" name="file" class="custom-file-input custom-others"
@@ -188,22 +178,24 @@
             for="others_file">[*select] [image/images]0</label>
         </div>
         <button type="button" class="btn btn-primary ml-2 col-2 btn-quick-upload" disabled>[*send::]</button>
-        <div class="col-12 d-flex align-items-center mt-2">
-          <span class="mr-2">[or]</span>
-          <div class="col">
-          <input type="text" class="form-control" id="image_url" name="image_url"
-            placeholder="%apply;a_of_b%with;[URL]%and;[image/images]0%end;">
-          <input type="text" class="form-control col-12 mt-3" id="image_name"
-            name="image_name" placeholder="[*name] ([for url only])">
+        <div class="col-12 mt-2 px-0">
+          <div class="d-flex align-items-center">
+            <span class="mr-2">[or]</span>
+              <input type="text" class="form-control" id="image_url" name="image_url"
+                placeholder="%apply;a_of_b%with;[URL]%and;[image/images]0%end;">
+              <input type="text" class="form-control ml-1" id="image_name" name="image_name"
+                placeholder="[*name]" disabled>
           </div>
         </div>
-        <textarea class="form-control col-12 mt-2" id="image_note" disabled
+        <div class="mt-3 mb-2 w-100">
+        <textarea class="form-control" id="image_note" disabled
           name="note" rows="2" placeholder="[*note/notes]0 ([optional])">
         </textarea>
-        <textarea class="form-control col-12 mt-2" id="image_source" disabled
+        </div>
+        <textarea class="form-control w-100" id="image_source" disabled
           name="source" rows="1" placeholder="[*source/sources]0 ([optional])">
         </textarea>
-        <div class="col-12 mt-2">
+        <div class="col-12 mt-2 px-0">
           <div class="d-flex">
             <button type="submit" class="flex-grow-1 btn btn-primary text-wrap text-left py-2 submit-button" disabled>
               <span id="which_img_show" class="d-inline-block">[*send image with note and source]</span>
@@ -233,7 +225,7 @@
             %if;has_portrait_url;%portrait_name;%else;
               <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%portrait_name;%end;</samp>
             <a role="button" class="ml-auto"
-              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&idigest=%idigest;&file_name=%portrait_name;"
+              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete portrait]</strong><br><span class="small">%portrait;</span><br>
                 <img class="rounded my-1" src="%portrait_url;" width="185px">'>
@@ -248,20 +240,19 @@
               title='<strong>[*see portrait]</strong><br><span class="small">%old_portrait;</span><br>
                 <img class="rounded my-1" src="%old_portrait_url;" width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait;&idigest=%idigest;"
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=portraits&file_name=%portrait;"
               title="[*restore portrait saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
             %if;has_old_portrait_url;<strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong>%old_portrait_name;%else;
             <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%old_portrait_name;%end;</samp>
             <a role="button" class="ml-auto"
-              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&idigest=%idigest;&delete=on&file_name=%old_portrait_name;"
+              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=portraits&delete=on&file_name=%old_portrait_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<i class="far fa-trash-can text-danger mr-1"></i><strong>[*delete saved portrait]0</strong><br><span class="small">%old_portrait;</span><br>
                 <img class="rounded my-1" src="%old_portrait_url;" width="185px">'>
               <i class="far fa-trash-can text-danger"></i></a>
           </div>
         %end;
-        %apply;refresh()
       %end;
       %if;(has_blason or has_blason_stop or has_old_blason)
         <div class="d-flex justify-content-between">
@@ -310,7 +301,7 @@
               <i class="far fa-file-image fa-fw text-primary"></i></a>
             <strong><samp class="text-truncate">%portraits_store;%X;</samp></strong><samp>%blason_name;</samp>
             <a role="button" class="ml-auto col-1"
-              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_name;"
+              href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%blason_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"
               title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete coat of arms]</strong><br><span class="small">%blason;</span><br>
                 <img class="rounded my-1" src="%blason_url;" width="185px">'>
@@ -318,8 +309,8 @@
           </div>
         %elseif;has_blason_stop;
           <div class="d-flex mt-1">
-            <span>%self; [stop using the coat of arms of]1 <a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>%nn;
-            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&fdigest=%idigest;&file_name=%blason_stop_name;"
+            <span>%self; [*stop using the coat of arms of]1 <a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>%nn;
+            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%blason_stop_name;"
               data-toggle="tooltip" data-html="true" data-placement="left">
               <i class="far fa-trash-can text-warning"></i>%nn;</a>
           </div>
@@ -332,7 +323,7 @@
                 src="%blason_url;" width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
             <span>[*use coat of arms of]0%sp;<a href="%prefix;%blason_owner.access;">%blason_owner;</a></span>
-            <a role="button" class="ml-auto" href="%prefix;m=BLASON_STOP&i=%index;&mode=blasons" title="[stop using the coat of arms of]0 %blason_owner;"
+            <a role="button" class="ml-auto" href="%prefix;m=BLASON_STOP&i=%index;&mode=blasons" title="[*stop using the coat of arms of]0 %blason_owner;"
               data-toggle="tooltip" data-html="true" data-placement="left">
               <i class="fa-solid fa-xmark fa-fw fa-xl text-danger"></i></a>
           </div>
@@ -345,18 +336,17 @@
               title='<strong>[*see coat of arms]</strong><br><span class="small">%blason;</span><br>
                 <img class="rounded my-1" width="185px" src="%old_blason_url;">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%portrait;&fdigest=%idigest;"
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=blasons&file_name=%portrait;"
               title="[*restore coat of arms saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i>%nn;</a>
             <strong><samp class="text-truncate">%old_portraits_store;%X;</samp></strong><samp>%old_blason_name;</samp>
-            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&delete=on&fdigest=%idigest;&file_name=%old_blason_name;"
+            <a role="button" class="ml-auto col-1" href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=blasons&delete=on&file_name=%old_blason_name;"
               data-toggle="tooltip" data-html="true" data-placement="left"%sp;
               title='<strong>[*delete saved coat of arms]0</strong><br><span class="small">%old_blason;</span><br>
                 <img class="rounded my-1" src="%old_blason_url;" width="185px">'>
               <i class="far fa-trash-can text-danger"></i></a>
           </div>
         %end;
-        %apply;refresh()
       %end;
       %if;(carrousel_img_nbr>0)
         <h1 class="display-5">[*image/images]1</h1>
@@ -384,7 +374,7 @@
             <samp class="text-truncate ml-1" title="%images_store;%X;%carrousel;%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
             <div class="ml-auto">
               <a role="button"
-                href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=carrousel&idigest=%idigest;&file_name=%carrousel_img;"
+                href="%prefix;m=DEL_IMAGE_C_OK&i=%index;&mode=carrousel&file_name=%carrousel_img;"
                 data-toggle="tooltip" data-html="true" data-placement="left"
                 title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete image]</strong><br>
                   <span class="small">%carrousel_img;</span><br>
@@ -414,14 +404,14 @@
                   src="%if;(url_in_env!="")%url_in_env;%else;%prefix;m=IM_C_S&i=%index;&s=%carrousel_img;%end;"
                   width="185px">'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
-            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=carrousel&delete=on&file_name=%carrousel_img;&idigest=%idigest;"
+            <a role="button" href="%prefix;m=RESET_IMAGE_C_OK&i=%index;&mode=carrousel&delete=on&file_name=%carrousel_img;"
                %if;(url_in_env!="")%else;data-toggle="tooltip" data-html="true" data-placement="top"%end;
                title="[*restore image saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i></a>
             <samp class="text-truncate ml-1" title="%images_store;%X;saved%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
             <a role="button" class="ml-auto"
                 href="%prefix;m=DEL_IMAGE_C_OK&i=%index%nn;
-                  &idigest=%idigest;&mode=carrousel&delete=on&file_name=%carrousel_img;"%sp;
+                  &mode=carrousel&delete=on&file_name=%carrousel_img;"%sp;
                 data-toggle="tooltip" data-html="true" data-placement="left"
                 title='<i class="far fa-trash-can text-warning mr-1"></i><strong>[*delete saved image]</strong><br>
                   <span class="small">%carrousel_img;</span><br>
@@ -431,7 +421,6 @@
                 <i class="far fa-trash-can text-danger fa-fw text-primary"></i></a>
           </div>
         %end;
-        %apply;refresh()
       %end;
     </div>
   </div>
@@ -457,7 +446,7 @@ $('.xxx').change(function() {
   %if;("yyy"="btn-quick-upload")
     $('#image_note, #image_source').prop('disabled', false);
     $('.submit-button').prop('disabled', false);
-    $('#image_url').prop('disabled', true).val('');
+    $('#image_url, #image_name').prop('disabled', true).val('');
     $('#btn-cancel-edit').removeClass('d-none').addClass('d-flex align-items-center');
     $('#image_note').focus();
   %end;
@@ -492,6 +481,7 @@ $(function() {
       // Désactiver l'input de fichier puisqu'une URL est saisie
       $('#others_file').prop('disabled', true);
       $('.custom-file-label').html('[*select] [image/images]0');
+      $('#image_name').prop('disabled', false);
       
       // Afficher le bouton d'annulation
       $('#btn-cancel-edit').removeClass('d-none').addClass('d-flex align-items-center');
@@ -504,6 +494,7 @@ $(function() {
         
         // Cacher le bouton d'annulation si on est revenu à l'état initial
         $('#btn-cancel-edit').addClass('d-none');
+        $('#image_name').prop('disabled', true).val('');
       }
     }
   });
@@ -538,6 +529,7 @@ $(function() {
     $('#others_file').val('').prop('disabled', false);
     $('.custom-file-label').html('[*select] [image/images]0');
     $('#image_url').val('').prop('disabled', false);
+    $('#image_name').val('').prop('disabled', true);
     $('.btn-quick-upload').prop('disabled', true);
     
     // Cacher le bouton d'annulation
@@ -573,7 +565,7 @@ const editImageNote = (cnt, name) => {
   
   // Désactiver l'input de fichier et l'URL pendant l'édition
   $('#others_file').prop('disabled', true);
-  $('#image_url').prop('disabled', true);
+  $('#image_url, #image_name').prop('disabled', true);
   
   // Désactiver le bouton d'envoi rapide pendant l'édition
   $('.btn-quick-upload').prop('disabled', true);
@@ -603,6 +595,18 @@ const editImageNote = (cnt, name) => {
   return false;
 };
 
+$('#image_url').on('input', function() {
+  const url = this.value.trim();
+  const nameField = $('#image_name');
+  
+  if (url && !nameField.val()) {
+    // Extraire le nom depuis l'URL pour prévisualisation
+    const filename = url.split('/').pop().split('?')[0];
+    if (filename && filename.includes('.')) {
+      nameField.attr('placeholder', filename + ' (auto)');
+    }
+  }
+});
 </script>
 </body>
 </html>

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -34,12 +34,13 @@
   %elseif;(e.mode="carrousel")
     %if;(e.em="SND_IMAGE_C_OK")[*image received]%if;(e.notes!="") [with note]%end;
     %elseif;(e.em="DEL_IMAGE_C_OK")[*image deleted]%if;(e.delete!="on") [and] [saved]1%end;
-    %elseif;(e.em="RESET_IMAGE_C_OK")[*image/images]0 [restored]1%nn;
+    %elseif;(e.em="RESET_IMAGE_C_OK")[*image/images]0 [copied/copied]1%nn;
     %end;%nn;
   %elseif;(e.mode="blasons")
     %if;(e.em="SND_IMAGE_C_OK")[*blason/blasons]0 [uploaded]0%nn;
     %elseif;(e.em="DEL_IMAGE_C_OK" and e.fdigest=e.idigest)[*blason/blasons]0 [deleted]0%if;(e.delete!="on") [and] [saved]0%end;%nn;
     %elseif;(e.em="RESET_IMAGE_C_OK" and e.fdigest=e.idigest)[*blason/blasons]0 [restored]0%nn;
+    %elseif;(e.em="IMAGE_TO_BLASON")[*image/images]0 [copied/copied]1 [to] [blason/blasons]0%nn;
     %end;%nn;
   %elseif;(e.mode="portraits")
     %if;(e.em="SND_IMAGE_C_OK")%if;(e.mode="note")[*note] [update]%else;[*portrait] [uploaded]0%end;%nn;
@@ -86,6 +87,7 @@
         %portraits_store;%X;%e.file_name; <strong>></strong> %old_portraits_store;%X;%e.file_name;%nn;
       %end;%nn;
     %elseif;(e.em="RESET_IMAGE_C_OK")%old_portraits_store;%X;%e.file_name; <strong><></strong> %portraits_store;%X;%e.file_name;%nn;
+    %elseif;(e.em="IMAGE_TO_BLASON")%images_store;%X%e.file_name; <strong><></strong> %portraits_store;%X;%keydir;.blason%ext;%nn;
     %else;bad command %e.em; %e.mode;%end;
     </samp>
   %else;
@@ -377,6 +379,8 @@
                 %if;(carrousel_img_note!="")<br><strong>[*note/notes]0[:]</strong> %carrousel_img_note;%end;
                 %if;(carrousel_img_src!="")<br><strong>[*source/sources]0[:]</strong> %carrousel_img_src;%end;'>
               <i class="far fa-file-image fa-fw text-primary"></i></a>
+            <a href="%prefix;m=IMAGE_TO_BLASON&i=%index;&mode=blasons&file_name=%carrousel_img;"
+            title="[*copy image to blason]"><i class="fa-solid fa-user-shield text-success"></i></a>
             <samp class="text-truncate ml-1" title="%images_store;%X;%carrousel;%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
             <div class="ml-auto">
               <a role="button"
@@ -414,8 +418,6 @@
                %if;(url_in_env!="")%else;data-toggle="tooltip" data-html="true" data-placement="top"%end;
                title="[*restore image saved]">
               <i class="fa fa-retweet fa-rotate-90 fa-fw text-success"></i></a>
-            <a href="%prefix;m=IMAGE_TO_BLASON&i=%index;&file_name=%carrousel_img;"
-            title="[*copy image to blason]"><i class="fa-solid fa-user-shield text-success"></i></a>
             <samp class="text-truncate ml-1" title="%images_store;%X;saved%X;%carrousel_img_raw;">%carrousel_img_raw;</samp>
             <a role="button" class="ml-auto"
                 href="%prefix;m=DEL_IMAGE_C_OK&i=%index%nn;

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -188,11 +188,13 @@
         <button type="button" class="btn btn-primary ml-2 col-2 btn-quick-upload" disabled>[*send::]</button>
         <div class="col-12 d-flex align-items-center mt-2">
           <span class="mr-2">[or]</span>
+          <div class="col">
           <input type="text" class="form-control" id="image_url" name="image_url"
             placeholder="%apply;a_of_b%with;[URL]%and;[image/images]0%end;">
+          <input type="text" class="form-control col-12 mt-3" id="image_name"
+            name="image_name" placeholder="[*name] ([for url only])">
+          </div>
         </div>
-        <input type="text" class="form-control col-12 mt-3" id="image_name"
-          name="image_name" placeholder="[*name] ([optional]) TODO: FIXME!">
         <textarea class="form-control col-12 mt-2" id="image_note" disabled
           name="note" rows="2" placeholder="[*note/notes]0 ([optional])">
         </textarea>

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -262,16 +262,30 @@
       %if;(has_blason or has_blason_stop or has_old_blason)
         <div class="d-flex justify-content-between">
           <h1 class="display-5">[*blason/blasons]0</h1>
+          %reset_count;
+          %reset_count1;
+          %foreach;ancestor_level;
+            %foreach;ancestor;
+              %for;i;1;12;
+                %if;(ancestor.anc_sosa.v=2^i and ancestor.has_blason_stop)%incr_count;%end;
+                %if;(ancestor.anc_sosa.v=2^i and count=0)%incr_count1;
+                %end;
+              %end;
+            %end;
+          %end;
           <div class="dropdown align-self-center">
+            %if;(has_blason_self and count1>0)
             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="dropdownMenuButton"
               title="[*move coat of arms to]1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="fa fa-person-arrow-up-from-line pb-0"></i>
             </button>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+              %reset_count;
               %foreach;ancestor_level;
                 %foreach;ancestor;
                   %for;i;1;12;
-                    %if;(ancestor.anc_sosa.v=2^i)
+                    %if;(ancestor.anc_sosa.v=2^i and ancestor.has_blason_stop)%incr_count;%end;
+                    %if;(ancestor.anc_sosa.v=2^i and count=0)
                       <a class="dropdown-item small" href="%prefix;m=BLASON_MOVE_TO_ANC&i=%index;&ia=%ancestor.index;"
                         title="[*move coat of arms to]0 %ancestor; %ancestor.dates_notag; (Sosa %ancestor.anc_sosa.v;),
                                %apply;a_of_b%with;%apply;anc_name(i)%and;%self;%end;">%ancestor; %ancestor.dates;</a>
@@ -280,6 +294,7 @@
                 %end;
               %end;
             </div>
+            %end;
           </div>
         </div>
         %if;has_blason_self;

--- a/hd/etc/carrousel_display.txt
+++ b/hd/etc/carrousel_display.txt
@@ -28,7 +28,7 @@
       </h5>
       <div class="modal-body d-flex justify-content-center">
         <div id="carousel" class="carousel slide" data-ride="carousel" data-interval="5000">
-        %(%let;maximg;%if;has_portrait;%expr(carrousel_img_nbr+1)%else;%carrousel_img_nbr;%end;%in;
+        %(%let;maximg;%if;has_portrait and has_blason;%expr(carrousel_img_nbr+2)%else;%if;has_portrait or has_blason;%expr(carrousel_img_nbr+1)%else;%carrousel_img_nbr;%end;%end;%in;
             <ol class="carousel-indicators">
             %for;i;0;maximg;
             <li %if;(i=0)class="active"%end; data-target="#carousel" data-slide-to="%i;"></li>
@@ -46,12 +46,28 @@
                 </div>
               </div>
             %end;
-            %if;has_carrousel;
+            %if;(has_blason_self)
+              <div class="carousel-item%if;(not has_portrait)active%end;">
+                %if;("http" in blason_self)
+                  <a href="%blason;" target="_blank" rel="noopener">
+                    <img class="img-fluid" src="%blason;" alt="[*blason/blasons]0 yy">
+                  </a>
+                %else;
+                  <a href="%prefix;m=FIM&i=%index;" target="_blank" rel="noopener">
+                    <img class="img-fluid" src="%prefix;m=FIM&i=%index;" alt="[*blason/blasons] xx">
+                  </a>
+                %end;
+                <div class="position-relative d-none d-md-block">
+                  <span>[blason/blasons]0</span>
+                </div>
+              </div>
+            %end;
+            %if;(carrousel_img_nbr>0)
               %foreach;img_in_carrousel;%incr_count;
-                <div class="carousel-item%if;(not has_portrait and is_first) active%end;">
-                  %if;(url_in_env!="")
+                <div class="carousel-item%if;(not has_portrait and not has_blason and is_first) active%end;">
+                  %if;("http" in url_in_env)
                     <a href="%url_in_env;" target="_blank" rel="noopener">
-                      url_in_env image
+                      <img class="img-fluid" src="%url_in_env;" alt="%count; slide">
                     </a>
                   %else;
                     <a href="%prefix;m=IM_C&i=%index;&s=%carrousel_img;" target="_blank" rel="noopener">
@@ -65,7 +81,6 @@
                     <span><strong>[*source/sources]0[:] </strong>%carrousel_img_src;</span>%end;
                     %if;(carrousel_img_note!="")<br>
                     <span><strong>[*note/notes]0[:] </strong>%carrousel_img_note;</span>%end;
-                    
                   </div>
                 </div>
               %end;

--- a/hd/etc/css/css.css
+++ b/hd/etc/css/css.css
@@ -138,7 +138,7 @@ html {
   margin-top:0.2rem;
 }
 /* grey empty inputs with placeholder to better see empty fields in forms */
-#updform textarea:placeholder-shown, input:placeholder-shown, select.custom-select {
+#updform textarea:placeholder-shown, #updform input:placeholder-shown, #updform select.custom-select {
   background-color: #f2f2f2;
 }
 
@@ -150,6 +150,11 @@ html {
 /* Ascendant table by couple anchor fix */
 #scrollfix {
   scroll-padding-top: 48px;
+}
+
+/* Carrousel */
+.text-pre-line {
+  white-space: pre-line;
 }
 
 /* Books */

--- a/hd/etc/js.txt
+++ b/hd/etc/js.txt
@@ -86,8 +86,7 @@
     %end;
   %end;
 %end;
-%if;(e.m="MOD_IND" or e.m="MOD_IND_OK"
-    or e.m="MOD_FAM" or e.m="MOD_FAM_OK"
+%if;("MOD_IND" in e.m or "MOD_FAM" in e.m or "SND_IMAGE_C" in e.m or "REFRESH" in e.m
     or e.m="ADD_FAM" or e.m="ADD_PAR" or e.m="ADD_FAM_OK" or e.m="MOD_NOTES"
     or (e.m="MOD_DATA" and (e.data="src" or e.data="occu")))
   %if;(b.use_cdn="yes")

--- a/hd/etc/modules/arbre_3gen_photo.txt
+++ b/hd/etc/modules/arbre_3gen_photo.txt
@@ -14,11 +14,11 @@
 %end;
 %define;ttl(ss,gg)
   %if;(ss=0)
-    %if;(gg=2)[a grandfather/a grandmother/a grandparent]0
-    %else;[father/mother]0%end;
+    %if;(gg=2)([a grandfather/a grandmother/a grandparent]0)
+    %else;([father/mother]0)%end;
   %else;
-    %if;(gg=2)[a grandfather/a grandmother/a grandparent]1
-    %else;[father/mother]1%end;
+    %if;(gg=2)([a grandfather/a grandmother/a grandparent]1)
+    %else;([father/mother]1)%end;
   %end;
 %end;
 %( vtbr will show 2 vertical bars if one grandparents’ couple is divorced or separated
@@ -41,11 +41,18 @@
 %let;marriage_sep_check;%get_var.mar_father;%get_var.mar_mother;%in;
 %let;vtbr;%if;("-" in marriage_sep_check)2%else;1%end;%in;
 %define;ind(xx,gg)
-  %if;xx.has_image;
-    %if;(not cancel_links)<a href="%xx.image_url;" target="_blank">%end;
-    <img class="rounded" %xx.image_small_size; src="%xx.image_url;"
-      alt="[image/images]0" title="%xx; (%apply;ttl(xx.sex,gg))">
-    %if;(not cancel_links)</a>%end;
+  %if;(xx.has_image or xx.has_blason)
+    %if;xx.has_image;
+      %if;(not cancel_links)<a href="%xx.image_url;" target="_blank">%end;
+      <img class="rounded" %xx.image_small_size; src="%xx.image_url;"
+        alt="[image/images]0" title="%xx; %apply;ttl(xx.sex,gg)">
+      %if;(not cancel_links)</a>%end;
+    %elseif;xx.has_blason;
+      %if;(not cancel_links)<a href="%xx.blason_url;" target="_blank">%end;
+      <img class="rounded" %xx.blason_small_size; src="%xx.blason_url;"
+        alt="[image/images]0" title="%xx; %apply;ttl(xx.sex,gg)">
+      %if;(not cancel_links)</a>%end;
+    %end;
   %elseif;(b.default_image="yes")
     <img height="75" src="%images_prefix;img_unknown_%if;(xx.sex=1)wo%end;man.png" alt="[missing image]">
   %(%else;

--- a/hd/etc/modules/arbre_vertical.txt
+++ b/hd/etc/modules/arbre_vertical.txt
@@ -1,5 +1,6 @@
 <!-- $Id: modules/arbre_vertical.txt v7.1 04/03/2023 10:39:16 $ -->
 %( Arbre ascendant vertical %)
+
 %define;a_tree_line()
   %if;(not is_first)
     <tr>
@@ -21,10 +22,22 @@
       <td colspan="%expr(cell.colspan)" class="text-center align-bottom p-0 fix_size">%nn;
         %if;(cell.is_empty)%nn;
         %else;
-          %if;(e.im="" and cell.person.has_image)
-            %if;not cancel_links;<a href="%cell.person.image_html_url;">%end;
-            <img class="rounded mb-1" src="%cell.person.image_url;"%cell.person.image_small_size;%sp;%nn;
-             alt="[image/images]0" title="[image/images]0">%nn;
+          %if;(e.im="" and (cell.person.has_image or cell.person.has_blason))
+            %if;(cell.person.has_image and cell.person.has_blason)
+              %if;not cancel_links;<a
+                href="%cell.person.blason_url;">%end;
+              <img class="rounded mb-1"
+                src="%cell.person.blason_url;"%nn;
+                %cell.person.blason_extra_small_size;%sp;%nn;
+                alt="[blason]0 " title="[blason]0">%nn;
+              %if;not cancel_links;</a>%end;
+            %end;
+            %if;not cancel_links;<a
+              href="%if;cell.person.has_image;%cell.person.image_url;%else;%cell.person.blason_url;%end;">%end;
+            <img class="rounded mb-1"
+              src="%if;cell.person.has_image;%cell.person.image_url;%else;%cell.person.blason_url;%end;"%nn;
+              %if;cell.person.has_image;%cell.person.image_small_size;%else;%cell.person.blason_small_size;%end;%sp;%nn;
+              alt="[image/images]0 " title="[image/images]0">%nn;
             %if;not cancel_links;</a>%end;<br>
           %end;
           %( Checking if the ancestors are falsly alive by verifying three first generations (self/parents/grand-parents births)

--- a/hd/etc/modules/individu.txt
+++ b/hd/etc/modules/individu.txt
@@ -1,4 +1,4 @@
-<!-- $Id: modules/individu.txt v7.1 27/03/2024 07:42:02 $ -->
+<!-- $Id: modules/individu.txt v7.1 19/06/2024 06:41:02 $ -->
 %( options
 0: skip
 1: standard
@@ -375,16 +375,16 @@
   </ul>
 %end;
 %define;portrait()
-  %if;(has_image or b.default_image="yes")
+  %if;(has_image or has_blason or b.default_image="yes")
     <div class="d-flex align-items-center">
       %if;has_image;
-        %if;(e.cgl!="on") 
-          <a href="%image_url;" target="_blank">
-            <img src="%image_url;"%image_size; class=" %if;(op_m=3)align-self-center mx-1%end; rounded" alt="[image/images]0">%nn;
-          </a>%nn;
-        %else;
-          <img src="%image_url;"%image_size; class="%if;(op_m=3)align-self-center mx-1%end; rounded" alt="[image/images]0">%nn;
-        %end;
+        %if;not cancel_links;<a href="%image_url;" target="_blank">%end;
+          <img src="%image_url;"%image_size; class=" %if;(op_m=3)align-self-center mx-1%end; rounded" alt="[image/images]0" title="[him/her]s">%nn;
+        %if;not cancel_links;</a>%end;
+      %elseif;has_blason;
+        %if;not cancel_links;<a href="%blason_url;" target="_blank">%end;
+            <img src="%blason_url;"%blason_size; class="%if;(op_m=3)align-self-center mx-1%end;" alt="[blason/blasons]0">%nn;
+        %if;not cancel_links</a>%end;
       %elseif;(b.default_image="yes")
         <img class="%if;(op_m=3)d-flex align-self-center mx-1%end; rounded" src="%images_prefix;img_unknown_%if;(is_female)wo%elseif;(is_male)%else;u_%end;man.png"%image_size; alt="[missing image]">
       %end;
@@ -398,7 +398,12 @@
 %let;prefx;%if;(e.m="F")%prefix_set.pmod;%else;%prefix;%end;%in;
 %if;(e.m!="MOD_IND")
   <div class="col-12">
-  <h1 class="%if;(op_m=2)text-center%else;text-xs-center text-md-left%end; ml-1 ml-md-3">
+  <h1 class="%if;(op_m=2)text-center%else;text-xs-center text-md-left%end;">
+    %if;(has_portrait and has_blason) %(has_portrait is false if no portrait !! TODO: FIXME!%)
+      %if;not cancel_links;<a href="%blason_url;" target="_blank">%end;
+       <img src="%blason_url;"%blason_small_size; class="%if;(op_m=3)align-self-center mx-1%end; mx-2" alt="[blason/blasons]0">%nn;
+      %if;not cancel_links;</a>%end;
+    %end;
     %if;has_public_name;
       %if;has_qualifiers;%public_name; <em>%qualifier;</em>
       %else;%public_name; %surname;%end;

--- a/hd/etc/modules/unions.txt
+++ b/hd/etc/modules/unions.txt
@@ -80,6 +80,15 @@
     %end;
   %end;
 %end;
+%define;picture(xxx,yyy)
+  %if;not cancel_links;<a href="%xxx.yyy_url;" class="align-self-start" target="_blank">%end;
+    <img class="%if;("xxx"="spouse")big%else;small%end;_image fade_image mx-1 rounded" src="%xxx.yyy_url;" alt="[xxx/xxxs]0 [yyy/yyys]0"
+      title="%if;("xxx"="spouse")%xxx; ([spouse/spouses]0)
+             %elseif;("xxx"="parent")%xxx; (%if;(parent.is_male)[father-in-law/mother-in-law]0%else;[father-in-law/mother-in-law]1%end;)
+             %elseif;("xxx"="child")%count1;. %xxx; (%if;child.is_male;[son/daughter/child]0%elseif;child.is_female;[son/daughter/child]1%else;[son/daughter/child]2%end;)
+             %end;">
+  %if;not cancel_links;</a>%end;
+%end;
 %( ATTENTION: on n'utilise pas max_desc_level parce que c'est extremement
    gourmand sur les gros arbre puisqu'on calcule toute la descendance.
    or on n’a besoin de seulement savoir s’il y a des arrière-petits-
@@ -213,7 +222,12 @@
       %if;(child.has_image)%incr_count2;%end;
     %end;
     <ul class="pl-4 py-0%if;(wizard and not cancel_links) fa-ul ml-0%end; mb-0">
-    %if;not (wizard and not cancel_links)%apply;li_SD("spouse")%else;<li><span class="fa-li">%apply;marr_wrench_to_bullet("spouse")</span>%end;
+    %if;not (wizard and not cancel_links)%apply;li_SD("spouse")
+    %else;<li><span class="fa-li%if;(spouse.has_blason and spouse.has_portrait) pt-1%end;">%apply;marr_wrench_to_bullet("spouse")</span>%end;
+    %if;(spouse.has_blason and spouse.has_portrait)
+      <img src="%spouse.blason_url;" %blason_extra_small_size; alt="[blason/blasons]0 [spouse/spouses]0"
+        class="%if;(op_m=3)align-self-center mx-1%end; mr-2" title="[*blason/blasons]0 [spouse/spouses]0">%nn;
+    %end;
     <span %apply;getvar%with;ns[marriage event]%count;%end;>%apply;married_to("self", 1)</span>%sp;
     %apply;short_display_person("spouse")
     %if;((wizard or friend or bvar.no_note_for_visitor!="yes") and has_comment)
@@ -258,17 +272,11 @@
               <div class="d-inline-flex">
                 <div class="align-self-center">
                   %if;spouse.has_image;
-                    %if;(not cancel_links)
-                      <a href="%spouse.image_url;" class="align-self-start" target="_blank">%nn;
-                        <img class="big_image fade_image mx-1 rounded" src="%spouse.image_url;" alt="[image/images]0" title="%spouse; ([spouse/spouses]0)">%nn;
-                      </a>%nn;
-                    %else;
-                      <img class="big_image fade_image mx-1 rounded align-self-start" src="%spouse.image_url;" alt="[image/images]0" title="%spouse; ([spouse/spouses]0)">%nn;
-                    %end;
-                  %elseif;(bvar.default_image="yes")
+                    %apply;picture("spouse","image")
+                  %elseif;spouse.has_blason;
+                    %apply;picture("spouse","blason")
+                  %elseif;(b.default_image="yes")
                     <img class="align-self-start mx-1 my-4" src="%images_prefix;img_unknown_%if;(spouse.is_female)wo%elseif;(spouse.is_male)%else;u_%end;man.png" alt="[missing image]">%nn;
-                  %(%else;
-                    <div class="big_image noimage rounded align-text-center display-1 text-center text-muted px-5 mx-2 pt-1 pb-4">&nbsp;</div>%nn;%)
                   %end;
                 </div>
               <div class="flex-column align-self-center ml-1">
@@ -283,19 +291,11 @@
                       %foreach;spouse.parent;
                         <div class="d-flex %if;(parent.is_male)mb-3%end; px-1">
                           %if;parent.has_image;
-                            %if;(not cancel_links)
-                              <a href="%parent.image_url;" class="align-self-center" target="_blank">%nn;
-                                <img class="small_image fade_image rounded align-self-center" src="%parent.image_url;"
-                                  alt="[image/images]0 %if;(parent.is_male)[father/mother]0%else;[father/mother]1 %end;" title="%parent; (%if;(parent.is_male)[father-in-law/mother-in-law]0%else;[father-in-law/mother-in-law]1%end;)">%nn;
-                              </a>%nn;
-                            %else;
-                              <img class="small_image fade_image rounded align-self-center" src="%parent.image_url;"
-                               alt="[image/images]0 %if;(parent.is_male)[father/mother]0%else;[father/mother]1 %end;" title="%parent; (%if;(parent.is_male)[father-in-law/mother-in-law]0%else;[father-in-law/mother-in-law]1%end;)">%nn;
-                            %end;
-                          %elseif;(bvar.default_image="yes")
+                            %apply;picture("parent","image")
+                          %elseif;parent.has_blason;
+                            %apply;picture("parent","blason")
+                          %elseif;(b.default_image="yes")
                             <img class="small_image rounded align-self-center" src="%images_prefix;img_unknown_%if;(parent.is_female)wo%elseif;(parent.is_male)%else;u_%end;man.png" alt="[missing image]" title="%if;(parent.is_male)[father-in-law/mother-in-law]0%else;[father-in-law/mother-in-law]1%end;">%nn;
-                          %else;
-                            <span class="small_image noimage rounded align-self-center display-3 text-center text-muted ml-2 pb-2">&nbsp;</span>%nn;
                           %end;
                           <div class="ml-2 align-self-center">
                             %apply;short_display_person_tree("parent")
@@ -317,20 +317,12 @@
                 %incr_count1;
                 <div class="d-flex flex-row mt-1">%count1;.
                   %if;child.has_image;
-                    %if;(not cancel_links)
-                      <a href="%child.image_url;" class="align-self-center" target="_blank">%nn;
-                        <img class="small_image fade_image rounded ml-2" src="%child.image_url;" alt="[image/images]0"
-                          title="%count1;. %child; (%if;child.is_male;[son/daughter/child]0%elseif;child.is_female;[son/daughter/child]1%else;[son/daughter/child]2%end;)">%nn;
-                      </a>%nn;
-                    %else;
-                      <img class="small_image fade_image rounded ml-2 align-self-center" src="%child.image_url;" alt="[image/images]0"
-                        title="%count1;. %child; (%if;child.is_male;[son/daughter/child]0%elseif;child.is_female;[son/daughter/child]1%else;[son/daughter/child]2%end;)">%nn;
-                    %end;
-                  %elseif;(bvar.default_image="yes")
+                    %apply;picture("child","image")
+                  %elseif;child.has_blason_self;
+                    %apply;picture("child","blason")
+                  %elseif;(b.default_image="yes")
                     <img class="small_image align-self-center rounded ml-2" src="%images_prefix;img_unknown_%if;(is_female)wo%elseif;(is_male)%else;u_%end;man.png" alt="[missing image]"
                       title="%if;child.is_male;[son/daughter/child]0%elseif;child.is_female;[son/daughter/child]1%else;[son/daughter/child]2%end;">%nn;
-                  %else;
-                    <span class="small_image noimage align-self-center rounded display-3 text-center text-muted ml-2 pb-2">&nbsp;</span>
                   %end;
                   <div class="ml-2 align-self-center">
                     %if;(count2=0)<ul>%apply;li_SDC("child")%end;%nn;

--- a/hd/etc/notes_gallery.txt
+++ b/hd/etc/notes_gallery.txt
@@ -1,4 +1,4 @@
-<!-- $Id: notes_upd.txt v7.1 06/06/2024 05:51:09 $ -->
+<!-- $Id: notes_gallery.txt v7.1 06/06/2024 05:51:09 $ -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -201,7 +201,7 @@ function displayByGroup(images_l) {
           old_grp = group;
         };
 
-        $("#legend").append( "<li class='legend' id='a" + cnt + "'><span><a href='" + href + "' target='_blank'>" + txt + "</a></span></li>" );
+        $("#legend").append( "<li class='legend' id='a" + cnt + "'><span><a href=\"" + href + "\" target='_blank'>" + txt + "</a></span></li>" );
         $("#div_legend").removeClass( "d-none" );
         $("#rlm").attr( "href", $("#rlm").attr("href") + "&p" + cnt_rlm + "=" + r.fn + "&n" + cnt_rlm + "=" + r.sn + (get(r.oc) == "" ? "" : "&oc" + cnt_rlm + "=" + r.oc ) );
         cnt_rlm++;
@@ -230,14 +230,15 @@ function displayByIndi(images_l) {
     if( get(r.fn) != "" && get(r.sn) != "" ) {
         href = "%prefix;&p=" + r.fn + "&n=" + r.sn + oc;
         txt = r.fn + " " + r.sn;
-        $("#legend").append( "<li class='legend' id='a" + cnt + "'><span><a href='" + href + "' target='_blank'>" + txt + "</a></span></li>" );
+        $("#legend").append( "<li class='legend' id='a" + cnt + "'><span><a href=\"" + href + "\" target='_blank'>" + txt + "</a>" + (get(r.alt) != "" ? " (" + r.alt + ")" : "") + "</span></li>" );
         $("#div_legend").removeClass( "d-none" );
         $("#rlm").attr( "href", $("#rlm").attr("href") + "&p" + cnt_rlm + "=" + r.fn + "&n" + cnt_rlm + "=" + r.sn + (get(r.oc) == "" ? "" : "&oc" + cnt_rlm + "=" + r.oc ) );
         cnt_rlm++;
     }
 
+    if( get(r.alt) != "") { txt += " (" + r.alt + ")"; }
     maps.forEach( function (item) {
-        $("#map").append( "<area class='area" + cnt + "' shape='" + get(item.shape) + "' coords='" + get(item.coords) + "' alt='" + txt + "' title='" + txt + "' href='" + href + "' target='_blank'>" );
+        $("#map").append( "<area class='area" + cnt + "' shape='" + get(item.shape) + "' coords='" + get(item.coords) + "' alt=\"" + txt + "\" title=\"" + txt + "\" href=\"" + href + "\" target='_blank'>" );
     });
     cnt++;
   });

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -19640,8 +19640,8 @@ tr: aileyi Düzenle
     update image note
 co: mudificà a nota di a fiura
 de: Bildnotiz aktualisieren
-en: update image note
-fr: mettre à jour la note de l’image
+en: update image
+fr: mettre à jour l’image
 
     update image source
 co: mudificà a fonte di a fiura

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -5089,6 +5089,10 @@ sl: nadaljevano
 sv: forts
 tr: devam eden
 
+    copied/copied
+en: copied/copied
+fr: copié/copiée
+
     copy link %s
 co: cupià u liame %s in u preme’papei
 de: kopiere den %s Link in die Zwischenablage
@@ -18778,6 +18782,10 @@ sk: titul/tituly
 sl: naziv/nazivi
 sv: titel/titlar
 tr: konu başlığı/başlıkları
+
+    to
+en: to
+fr: vers
 
     to add a child to a family, use "%s"
 af: om 'n kind by te voeg by 'n familie, gebruik "%s"

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -1881,8 +1881,8 @@ tr: resim ekle
     must use MOD_IND
 co: u ritrattu hè un indirizzu web. Impiegà MOD_IND per mudificallu o squassallu.
 de: Das Bild ist eine URL. Nutze MOD_IND zum korrigieren oder löschen.
-en: portrait is a url. Use MOD_IND to delete or update.
-fr: le portrait est une Url. Utiliser MOD_IND pour le corriger ou le supprimer.
+en: portrait is a URL. Use MOD_IND to delete or update.
+fr: le portrait est une URL. Utiliser MOD_IND pour le corriger ou le supprimer.
 
     add portrait
 co: aghjunghje un ritrattu
@@ -8660,6 +8660,10 @@ sk: pre zoznam podľa dátumu poslednej zmeny
 sl: za seznam razvrščen po datumu zadnje spremembe
 sv: för listan över sista ändringsdatum
 tr: son değişiklik tarihine göre sıralanmış liste için
+
+    for url only
+en: for URL defined images
+fr: pour les images définies par une URL
 
     for/since
 co: durante/dapoi

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -1826,6 +1826,10 @@ sl: dodaj zapiski
 sv: lägg till noteringar
 tr: not ekle
 
+    add coat of arms
+en: add a coat of arms
+fr: ajouter un blason
+
     add filter
 co: aghjunghje un filtru
 de: Filter hinzufügen
@@ -4662,6 +4666,10 @@ pt: familiar próximo
 sv: en släkting
 tr: bir ebeveyn
 
+    blason/blasons
+en: coat of arms/coats of arms
+fr: blason/blasons
+
     coefficient of relationship
 co: U <a href="https://en.wikipedia.org/wiki/Coefficient_of_relationship">cuefficiente di e rilazioni</a> indicheghja u percentuale medianu minimu di geni spartiti trà dui individui.
 de: Der <a href="https://de.wikipedia.org/wiki/Verwandtschaftskoeffizient">Verwandtschaftskoeffizient</a> berechnet den minimalen Prozentsatz der Übereinstimmung der DNA zwischen zwei Personen.
@@ -6959,13 +6967,21 @@ sl: izbriši
 sv: ta bort
 tr: sil
 
+    delete coat of arms
+en: delete the coat of arms
+fr: supprimer le blason
+
+    delete saved coat of arms
+en: delete the saved coat of arms
+fr: supprimer le blason sauvegardé
+
     delete image
 co: squassà a fiura
 de: Bild löschen
 en: delete image
 fr: supprimer une image
 
-    delete image saved
+    delete saved image
 co: squassà a fiura arregistrata
 de: das gespeicherte Bild löschen
 en: delete saved image
@@ -6977,7 +6993,7 @@ de: Porträt löschen
 en: delete portrait
 fr: supprimer le portrait
 
-    delete portrait saved
+    delete saved portrait
 co: squassà u ritrattu arregistratu
 de: das gespeicherte Porträt löschen
 en: delete saved portrait
@@ -12384,6 +12400,10 @@ sl: spremeni
 sv: ändra
 tr: güncelleme
 
+    modify coat of arms
+en: modify the coat of arms
+fr: modifier le blason
+
     modify family %s event order
 co: intervertisce l’evenimenti di a famiglia %s
 de: vertauschen Sie die Ereignisse der Familie %s
@@ -12459,6 +12479,14 @@ co: mudificà u ritrattu
 de: Porträt ändern
 en: modify the portrait
 fr: modifier le portrait
+
+    copy portrait to blason
+en: use portrait as coats of arme
+fr: utiliser le portrait comme blason
+
+    copy image to blason
+en: use image as coats of arme
+fr: utiliser l'image comme blason
 
     modify source
 co: mudificà a fonte
@@ -12577,6 +12605,10 @@ sk: viac ako %d odpovedí
 sl: več kot %d zadetkov
 sv: fler än %d svar
 tr: %d cevaptan daha fazla
+
+    move coat of arms to
+en: move the coat of arms to/raise the coat of arms to first known holder who bored it
+fr: déplacer le blason vers/remonter le blason au premier ancêtre connu l’ayant porté
 
     move union comments to notes
 co: trasferisce u campu storicu « cummenti d’unione » versu quellu cuntiguu di e « note d’unione ».
@@ -14926,11 +14958,15 @@ de: vorher
 en: previous
 fr: précédent
 
+    previous coat of arms
+en: a possible previous version of the saved coat of arms will be deleted.
+fr: une sauvegarde pré-existante du blason sera supprimée.
+
     previous image
 co: s’è una fiura cù u listessu nome esiste dighjà in u cartulare di salvaguardia, sta fiura serà squassata.
 de: wenn schon ein gespeichertes Bild mit dem gleichen Namen existiert, wird es gelöscht.
 en: if an image with the same name already exists in the saved, it will be deleted.
-fr: si une image du même nom existe déjà dans le sous-répertoire de sauvegarde, elle sera supprimée.
+fr: si une image du même nom existe déjà, elle sera supprimée.
 
     previous portrait
 co: un arregistramentu precedente di u ritrattu, s’ellu esiste, serà squassatu. Impiegà MOD_IND ùn arregistreghja micca u ritrattu.
@@ -15725,6 +15761,10 @@ de: wiederherstellen
 en: restore
 fr: restaurer
 
+    restore coat of arms saved
+en: restore coat of arms
+fr: restaurer le blason
+
     restore image saved
 co: risturà una fiura arregistrata
 de: das gespeicherte Bild wiederherstellen
@@ -15915,7 +15955,7 @@ fr: sauvegardé/sauvegardée
 co: fiura arregistrata/fiure arregistrate
 de: gespeichertes Bild/gespeicherte Bilder
 en: saved image/saved images
-fr: image sauvegardée/images sauvegardées
+fr: sauvegarde/sauvegardes
 
     scale
 co: anni à a generazione
@@ -16229,6 +16269,10 @@ pt: ver fotos
 ru: смотри изображения предков
 sv: se bilder
 tr: resimleri görüntüle
+
+    see coat of arms
+en: see the coat of arms
+fr: voir le blason
 
     see descendants notes/sources
 co: fighjà e note è e fonte
@@ -17325,6 +17369,10 @@ sl: medtem ko ostajaš na tem orodju
 sv: medan du stannar på detta verktyg
 tr: bu araç üzerinde kalırken
 zh: 在此工具上停留时
+
+    stop using the coat of arms of
+en: stop using the coat of arms of/this individual stopped using his ancestor coat of arms
+fr: arrêter d’utiliser le blason de/cet individu a arrêté d’utiliser le blason de son ancêtre
 
     store image
 co: a fiura selezziunata serà piazzata in
@@ -19607,11 +19655,12 @@ de: hochgeladen
 en: uploaded
 fr: envoyé/envoyée
 
-    url
+    URL
 co: indirizzu web
-de: Url
-en: url
-fr: url
+de: URL
+en: URL
+es: LRU
+fr: URL
 
     restore default_sosa_ref
 co: risturà Sosa 1 predefinitu
@@ -19650,6 +19699,10 @@ sk: použi "spojenie" namiesto "vytvorenia"
 sl: uporabite "povezava" namesto "ustvari"
 sv: använd "länk" istället för "skapa"
 tr: "oluştur" yerine "bağlantı" kullanın
+
+    use coat of arms of
+en: use the coat of arms of
+fr: utilise le blason de
 
     user and language variables
 af: gebruiker- en taalveranderlikes

--- a/lib/changeChildren.ml
+++ b/lib/changeChildren.ml
@@ -65,7 +65,8 @@ let change_child conf base parent_surname changed ip =
     let key = new_first_name ^ " " ^ new_surname in
     let ipl = Gutil.person_ht_find_all base key in
     check_conflict base p key new_occ ipl;
-    Image.rename_portrait conf base p (new_first_name, new_surname, new_occ);
+    Image.rename_portrait_and_blason conf base p
+      (new_first_name, new_surname, new_occ);
     (* On ajoute les enfants dans le type Change_children_name       *)
     (* pour la future mise à jour de l'historique et du fichier gwf. *)
     let changed =

--- a/lib/dagDisplay.ml
+++ b/lib/dagDisplay.ml
@@ -10,7 +10,7 @@ module Logs = Geneweb_logs.Logs
 let image_normal_txt conf base p fname width height =
   let image_txt = Utf8.capitalize_fst (transl_nth conf "image/images" 0) in
   let s = Unix.stat fname in
-  let k = Image.default_portrait_filename base p in
+  let k = Image.default_image_filename "portraits" base p in
   let r =
     Format.sprintf
       {|<img src="%sm=IM&d=%s&%s&k=%s"%s%s alt="%s" title="%s"

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -3,28 +3,42 @@ open Gwdb
 
 val portrait_folder : config -> string
 val carrousel_folder : config -> string
-val authorized_image_file_extension : string array
+val ext_list_1 : string array
+val ext_list_2 : string array
+val find_file_without_ext : string -> string
+val is_url : string -> bool
+
+val src_of_string :
+  config ->
+  string ->
+  [ `Src_with_size_info of string | `Path of string | `Url of string | `Empty ]
 
 val scale_to_fit : max_w:int -> max_h:int -> w:int -> h:int -> int * int
-(** [scale_to_fit ~max_w ~max_h ~w ~h] is the [width, height] of a proportionally scaled [w, h] rectangle so it can fit in a [max_w, max_h] rectangle *)
+(** [scale_to_fit ~max_w ~max_h ~w ~h] is the {(width, height)} of a proportionally scaled {(w, h)} rectangle so it can fit in a {(max_w, max_h)} rectangle *)
+
+val parse_src_with_size_info :
+  config ->
+  [< `Src_with_size_info of string ] ->
+  ([> `Path of string | `Url of string ] * (int * int), string) result
 
 (* TODO this should be removed *)
-val default_portrait_filename : base -> person -> string
-(** [default_portrait_filename base p] is the default filename of [p]'s portrait. Without it's file extension.
- e.g: default_portrait_filename_of_key "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond"
+val default_image_filename : string -> base -> person -> string
+(** [default_image_filename mode base p] is the default filename of [p]'s portrait or blason. Without it's file extension.
+ e.g: default_image_filename "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond" or "jean_claude.3.dupond.blason"
  *)
 
-val size_from_path : [ `Path of string ] -> (int * int, unit) result
+val size_from_path : string -> (int * int, unit) result
 (** [size_from_path path]
     - Error () if failed to read or parse file
     - Ok (width, height) of the file.
 It works by opening the file and reading magic numbers *)
 
-val path_of_filename : config -> string -> [> `Path of string ]
+val path_of_filename : config -> string -> string
 (** [path_of_filename fname] search for image {i images/fname} inside the base and assets directories.
     Return the path to found file or [fname] if file isn't found.  *)
 
-val rename_portrait : config -> base -> person -> string * string * int -> unit
+val rename_portrait_and_blason :
+  config -> base -> person -> string * string * int -> unit
 (** Rename portrait to match updated name *)
 
 val src_to_string : [< `Path of string | `Url of string ] -> string
@@ -47,6 +61,26 @@ val get_portrait_with_size :
     - [None] if we don't have access to [p]'s portrait or it doesn't exist.
     - [Some (src, size_opt)] with [src] the url or path of [p]'s portrait. [size_opt] is the (width,height) of the portrait if we could recover them *)
 
+val get_blason_with_size :
+  config ->
+  base ->
+  person ->
+  bool ->
+  ([> `Path of string | `Url of string ] * (int * int) option) option
+(** [get_blason_with_size conf base p] is
+        - [None] if we don't have access to [p]'s family portrait or it doesn't exist.
+        - [Some (src, size_opt)] with [src] the url or path of [p]'s family portrait. [size_opt] is the (width,height) of the family portrait if we could recover them *)
+
+val has_blason : config -> base -> person -> bool -> bool
+(** [has_blason conf base p self] is
+      - [true] if [p] has coat of  arms. If Self is true it checks only for its own coat of arms
+      - [false] if [p] has not *)
+
+val has_blason_stop : config -> base -> person -> bool
+(** [has_blason_stop conf base p] is
+              - [true] if [p] stops to use coat of  arms of his ancestors
+              - [false] if [p] did not stop or has no coat of arms *)
+
 val get_portrait :
   config -> base -> person -> [> `Path of string | `Url of string ] option
 (** [get_portrait conf base p] is
@@ -56,9 +90,53 @@ val get_portrait :
 
 val get_old_portrait :
   config -> base -> person -> [> `Path of string | `Url of string ] option
+
+val get_blason_aux :
+  config ->
+  base ->
+  person ->
+  bool ->
+  bool ->
+  [> `Path of string | `Url of string ] option
+(** [get_blason conf base p self saved] is
+    - [None] if we don't have access to [p]'s blason or it doesn't exist.
+    - [Some src] with [src] the url or path of [p]'s blason.
+*)
+
+val get_blason :
+  config ->
+  base ->
+  person ->
+  bool ->
+  [> `Path of string | `Url of string ] option
+
+val get_old_blason :
+  config ->
+  base ->
+  person ->
+  bool ->
+  [> `Path of string | `Url of string ] option
+
+val get_portrait_name : config -> base -> person -> string
+val get_old_portrait_name : config -> base -> person -> string
+val get_blason_name : config -> base -> person -> string
+val get_old_blason_name : config -> base -> person -> string
+
+val get_old_portrait_or_blason :
+  config ->
+  base ->
+  string ->
+  person ->
+  [> `Path of string | `Url of string ] option
 (** [get_portrait conf base p] is
     - [None] if we don't have access to [p]'s portrait or it doesn't exist.
     - [Some src] with [src] the url or path of [p]'s portrait.
+*)
+
+val get_blason_owner : config -> base -> person -> iper option
+(** [get_blason_owner conf base p] is
+    - [None] if we do not find blason owner.
+    - [Some fa_iper] with [fa_iper] the owner [p]'s blason.
 *)
 
 (* -- Carrousel -- *)

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -621,7 +621,7 @@ let effective_delete_ok conf base p =
   let ext = get_extension conf fname mode false fname in
   let dir = !GWPARAM.portraits_d conf.bname in
   if move_file_to_save (fname ^ ext) dir = 0 then
-    incorrect conf "effective delete";
+    incorrect conf "effective delete (ok)";
   let changed =
     U_Delete_image (Util.string_gen_person base (gen_person_of_person p))
   in
@@ -674,13 +674,16 @@ let effective_delete_c_ok conf base ?(f_name = "") p =
     if delete then String.concat Filename.dir_sep [ dir; "saved"; fname ]
     else Filename.concat dir fname
   in
-  let orig_file = Image.find_file_without_ext orig_file in
+  let orig_file =
+    Filename.remove_extension orig_file |> Image.find_file_without_ext
+  in
   (* FIXME basename *)
   let file = Filename.basename orig_file in
   if orig_file = "" then incorrect conf "empty file name"
     (* if delete is on, we are talking about saved files *)
   else if delete then Mutil.rm orig_file (* is it needed ?, move should do it *)
-  else if move_file_to_save dir file = 0 then incorrect conf "effective delete";
+  else if move_file_to_save dir file = 0 then
+    incorrect conf "effective delete (c_ok)";
   let changed =
     U_Delete_image (Util.string_gen_person base (gen_person_of_person p))
   in
@@ -762,10 +765,9 @@ let effective_copy_image_to_blason conf base p =
     else "OK")
     <> ""
   in
-  (* la fonction image_to_blason part des images sauvegardées *)
   let fname =
     String.concat Filename.dir_sep
-      [ Image.carrousel_folder conf; keydir; "saved"; fname ]
+      [ Image.carrousel_folder conf; keydir; fname ]
   in
   cp fname blason_filename;
   History.record conf base
@@ -944,10 +946,13 @@ let print_main_c conf base =
                   failwith
                     (__FILE__ ^ " idigest error, line " ^ string_of_int __LINE__
                       :> string)
-              | "incorrect request" -> Hutil.incorrect_request conf
+              | "incorrect request" ->
+                  Hutil.incorrect_request conf
+                    ~comment:"incorrect request, report"
               | _ -> print_confirm_c conf base save_m report)
-          | None -> Hutil.incorrect_request conf)
-      | None -> Hutil.incorrect_request conf)
+          | None -> Hutil.incorrect_request conf ~comment:"incorrect, None ip")
+      | None ->
+          Hutil.incorrect_request conf ~comment:"incorrect request, None m")
   (* em!="" second pass, ignore *)
   | Some _ -> print_confirm_c conf base "REFRESH" ""
 

--- a/lib/imageDisplay.mli
+++ b/lib/imageDisplay.mli
@@ -11,9 +11,15 @@ val print_source : config -> string -> unit
     Filename may contain sub-folders, but cannot point outside images *)
 
 val print : config -> Gwdb.base -> unit
+
 (** Searches image's filename in the environement [conf.env] and sends
     HTTP response with its content on the socket. If filename isn't presented,
     looks up personal image (portrait) for person mentionned in [conf.env] *)
+
+val print_blason : config -> Gwdb.base -> unit
+(** Searches blason filename in the environement [conf.env] and sends
+        HTTP response with its content on the socket. If filename isn't presented,
+        looks up family image (blason) for person mentionned in [conf.env] *)
 
 val print_html : config -> unit
 (** Sends HTTP response with HTML page containg just image specified in

--- a/lib/mergeIndDisplay.ml
+++ b/lib/mergeIndDisplay.ml
@@ -99,7 +99,7 @@ let print_differences conf base branches p1 p2 =
            ^>^ {|" style="max-width:75px;max-height:100px">|} ^ url
             :> Adef.safe_string)
       | Some (`Path path) ->
-          let k = Image.default_portrait_filename base p in
+          let k = Image.default_image_filename "portraits" base p in
           let s = Unix.stat path in
           Printf.sprintf
             {|<img src="%sm=IM&d=%s&%s&k=%s" \

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -559,7 +559,7 @@ let person_note conf base p str =
   let env =
     [
       ('i', fun () -> string_of_iper (get_iper p));
-      ('k', fun () -> Image.default_portrait_filename base p);
+      ('k', fun () -> Image.default_image_filename "portraits" base p);
     ]
   in
   note conf base env str
@@ -568,7 +568,7 @@ let source_note conf base p str =
   let env =
     [
       ('i', fun () -> string_of_iper (get_iper p));
-      ('k', fun () -> Image.default_portrait_filename base p);
+      ('k', fun () -> Image.default_image_filename "portraits" base p);
     ]
   in
   wiki_aux (function [ "<p>"; x; "</p>" ] -> [ x ] | x -> x) conf base env str

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1274,9 +1274,22 @@ let gen_string_of_img_sz max_w max_h conf base (p, p_auth) =
     | None -> ""
   else ""
 
+let gen_string_of_fimg_sz max_w max_h conf base (p, p_auth) =
+  if p_auth then
+    match Image.get_blason_with_size conf base p false with
+    | Some (_, Some (w, h)) ->
+        let w, h = Image.scale_to_fit ~max_w ~max_h ~w ~h in
+        Format.sprintf " width=\"%d\" height=\"%d\"" w h
+    | Some (_, None) | None -> Format.sprintf " height=\"%d\"" max_h
+  else ""
+
 let string_of_image_size = gen_string_of_img_sz max_im_wid max_im_wid
 let string_of_image_medium_size = gen_string_of_img_sz 160 120
 let string_of_image_small_size = gen_string_of_img_sz 100 75
+let string_of_blason_size = gen_string_of_fimg_sz max_im_wid max_im_wid
+let string_of_blason_medium_size = gen_string_of_fimg_sz 160 120
+let string_of_blason_small_size = gen_string_of_fimg_sz 100 75
+let string_of_blason_extra_small_size = gen_string_of_fimg_sz 50 37
 
 let get_sosa conf base env r p =
   try List.assoc (get_iper p) !r
@@ -1345,7 +1358,7 @@ let get_note_or_source conf base ?(p = Gwdb.empty_person base Gwdb.dummy_iper)
     let env =
       [
         ('i', fun () -> string_of_iper (get_iper p));
-        ('k', fun () -> Image.default_portrait_filename base p);
+        ('k', fun () -> Image.default_image_filename "portraits" base p);
       ]
     in
     let s = string_with_macros conf env note_or_source in
@@ -1734,7 +1747,7 @@ and eval_simple_str_var conf base env (p, p_auth) = function
           null_val
       | _ -> null_val)
   (* carrousel *)
-  | "idigest" -> Image.default_portrait_filename base p |> str_val
+  | "idigest" -> Image.default_image_filename "portraits" base p |> str_val
   | "img_cnt" -> (
       match get_env "img_cnt" env with
       | Vint cnt -> VVstring (string_of_int cnt)
@@ -2335,6 +2348,12 @@ and eval_compound_var conf base env ((a, _) as ep) loc = function
           eval_relation_field_var conf base env (0, rt, ip, true) loc sl
       | _ -> raise Not_found)
   | "self" :: sl -> eval_person_field_var conf base env ep loc sl
+  | "blason_owner" :: sl -> (
+      match Image.get_blason_owner conf base a with
+      | Some fa_iper ->
+          let ep = make_ep conf base fa_iper in
+          eval_person_field_var conf base env ep loc sl
+      | None -> null_val)
   | "sosa_ref" :: sl -> (
       match get_env "sosa_ref" env with
       | Vsosa_ref (Some p) ->
@@ -3484,21 +3503,29 @@ and eval_bool_person_field conf base env (p, p_auth) = function
   | "has_first_names_aliases" ->
       if hide_person conf base p then false else get_first_names_aliases p <> []
   | "has_history" -> has_history conf base p p_auth
+  (* Beware: lots of confusion between image and portrait *)
   | "has_image" | "has_portrait" ->
       Image.get_portrait conf base p |> Option.is_some
+  | "has_blason" -> Image.has_blason conf base p false
+  | "has_blason_self" -> Image.has_blason conf base p true
+  | "has_blason_stop" -> Image.has_blason_stop conf base p
   | "has_image_url" | "has_portrait_url" -> (
       match Image.get_portrait conf base p with
       | Some (`Url _url) -> true
       | _ -> false)
+  | "has_c_image_url" -> (
+      match get_env "carrousel_img" env with
+      | Vstring s -> Image.is_url s
+      | _ -> false)
   | "has_old_image_url" | "has_old_portrait_url" -> (
-      match Image.get_old_portrait conf base p with
+      match Image.get_old_portrait_or_blason conf base "portraits" p with
       | Some (`Url _url) -> true
       | _ -> false)
   (* carrousel *)
-  | "has_carrousel" -> Image.get_carrousel_imgs conf base p <> []
-  | "has_old_carrousel" -> Image.get_carrousel_old_imgs conf base p <> []
   | "has_old_image" | "has_old_portrait" ->
-      Image.get_old_portrait conf base p |> Option.is_some
+      Image.get_old_portrait_or_blason conf base "portraits" p |> Option.is_some
+  | "has_old_blason" ->
+      Image.get_old_portrait_or_blason conf base "blasons" p |> Option.is_some
   | "has_nephews_or_nieces" -> has_nephews_or_nieces conf base p
   | "has_nobility_titles" -> p_auth && Util.nobtit conf base p <> []
   | "has_notes" | "has_pnotes" ->
@@ -3734,21 +3761,41 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
         let sn = sou base (get_surname p) in
         let occ = get_occ p in
         HistoryDiff.history_file fn sn occ |> str_val
-  | "image" -> (
+  | "image" | "portrait" -> (
       match Image.get_portrait conf base p with
       | Some src -> Image.src_to_string src |> str_val
       | None -> null_val)
-  | "image_html_url" -> string_of_image_url conf base ep true |> safe_val
-  | "image_size" -> string_of_image_size conf base ep |> str_val
-  | "image_medium_size" -> string_of_image_medium_size conf base ep |> str_val
-  | "image_small_size" -> string_of_image_small_size conf base ep |> str_val
-  | "image_url" -> string_of_image_url conf base ep false |> safe_val
+  | "old_image" | "old_portrait" -> (
+      match Image.get_old_portrait conf base p with
+      | Some (`Path s) -> str_val s
+      | Some (`Url u) -> str_val u
+      | None -> null_val)
+  | "image_html_url" | "portrait_html_url" ->
+      string_of_image_url conf base ep true false |> safe_val
+  | "image_size" | "portrait_size" ->
+      string_of_image_size conf base ep |> str_val
+  | "blason_size" -> string_of_blason_size conf base ep |> str_val
+  | "image_medium_size" | "portrait_medium_size" ->
+      string_of_image_medium_size conf base ep |> str_val
+  | "blason_medium_size" -> string_of_blason_medium_size conf base ep |> str_val
+  | "image_small_size" | "portrait_small_size" ->
+      string_of_image_small_size conf base ep |> str_val
+  | "blason_small_size" -> string_of_blason_small_size conf base ep |> str_val
+  | "blason_extra_small_size" ->
+      string_of_blason_extra_small_size conf base ep |> str_val
+  | "image_url" | "portrait_url" ->
+      string_of_image_url conf base ep false false |> safe_val
+  | "old_image_url" | "old_portrait_url" ->
+      string_of_image_url conf base ep false true |> safe_val
+  | "blason_url" -> string_of_blason_url conf base ep false false |> safe_val
+  | "old_blason_url" -> string_of_blason_url conf base ep false true |> safe_val
   | "index" -> (
       match get_env "p_link" env with
       | Vbool _ -> null_val
       | _ -> get_iper p |> string_of_iper |> Mutil.encode |> safe_val)
-  (* carrousel functions *)
-  | "carrousel" -> Image.default_portrait_filename base p |> str_val
+  | "carrousel" -> Image.default_image_filename "portraits" base p |> str_val
+  | "blason_carrousel" ->
+      Image.default_image_filename "blasons" base p |> str_val
   | "carrousel_img_nbr" ->
       string_of_int (List.length (Image.get_carrousel_imgs conf base p))
       |> str_val
@@ -3763,32 +3810,40 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
       match get_env "carrousel_img_src" env with
       | Vstring source -> str_val source
       | _ -> raise Not_found)
-  | "portrait" -> (
-      (* TODO what do we want here? can we remove this? *)
-      match Image.get_portrait conf base p with
-      | Some (`Path s) -> str_val s
-      | Some (`Url u) -> str_val u
+  | "blason" -> (
+      match Image.get_blason conf base p false with
+      | Some (`Path p) when Filename.extension p = ".stop" -> null_val
+      | Some src -> Image.src_to_string src |> str_val
       | None -> null_val)
-  | "portrait_name" -> (
-      match Image.get_portrait conf base p with
-      | Some (`Path s) -> str_val (Filename.basename s)
-      | Some (`Url u) -> str_val u (* ?? *)
+  | "old_blason" -> (
+      match Image.get_old_blason conf base p false with
+      | Some (`Path p) when Filename.extension p = ".stop" -> null_val
+      | Some src -> Image.src_to_string src |> str_val
       | None -> null_val)
-  | "portrait_saved" -> (
-      match Image.get_old_portrait conf base p with
-      | Some (`Path s) -> str_val s
-      | Some (`Url u) -> str_val u
+  | "blason_self" -> (
+      match Image.get_blason conf base p true with
+      | Some (`Path p) when Filename.extension p = ".stop" -> null_val
+      | Some src -> Image.src_to_string src |> str_val
       | None -> null_val)
-  | "portrait_saved_name" -> (
-      match Image.get_old_portrait conf base p with
-      | Some (`Path s) -> str_val (Filename.basename s)
-      | Some (`Url u) -> str_val u (* ?? *)
-      | None -> null_val)
+  | "portrait_name" -> str_val (Image.get_portrait_name conf base p)
+  | "blason_name" -> str_val (Image.get_blason_name conf base p)
+  | "old_portrait_name" -> str_val (Image.get_old_portrait_name conf base p)
+  | "old_blason_name" -> str_val (Image.get_old_blason_name conf base p)
+  | "blason_stop_name" ->
+      str_val (Image.default_image_filename "blasons" base p ^ ".stop")
   | "X" -> str_val Filename.dir_sep (* end carrousel functions *)
   | "key" ->
       if hide_person conf base p then null_val
       else
         Format.sprintf "%s.%d %s"
+          (p_first_name base p |> Name.lower)
+          (get_occ p)
+          (p_surname base p |> Name.lower)
+        |> str_val
+  | "keydir" ->
+      if is_hide_names conf p && not p_auth then null_val
+      else
+        Format.sprintf "%s.%d.%s"
           (p_first_name base p |> Name.lower)
           (get_occ p)
           (p_surname base p |> Name.lower)
@@ -4017,7 +4072,7 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
           let env =
             [
               ('i', fun () -> string_of_iper (get_iper p));
-              ('k', fun () -> Image.default_portrait_filename base p);
+              ('k', fun () -> Image.default_image_filename "portraits" base p);
             ]
           in
           let s =
@@ -4186,13 +4241,20 @@ and string_of_died conf p p_auth =
     | NotDead | DontKnowIfDead | OfCourseDead -> ""
   else ""
 
-and string_of_image_url conf base (p, p_auth) html : Adef.escaped_string =
+and string_of_image_url conf base (p, p_auth) html saved : Adef.escaped_string =
   if p_auth then
-    match Image.get_portrait conf base p with
+    match
+      if saved then Image.get_old_portrait conf base p
+      else Image.get_portrait conf base p
+    with
+    | Some (`Path fname) when Filename.extension fname = ".url" -> (
+        match Some (Secure.open_in fname) with
+        | Some ic -> Adef.escaped (input_line ic)
+        | None -> Adef.escaped "")
     | Some (`Path fname) ->
         let s = Unix.stat fname in
         let b = acces conf base p in
-        let k = Image.default_portrait_filename base p in
+        let k = Image.default_image_filename "portraits" base p in
         Format.sprintf "%sm=IM%s&d=%d&%s&k=/%s"
           (commd conf :> string)
           (if html then "H" else "")
@@ -4203,6 +4265,34 @@ and string_of_image_url conf base (p, p_auth) html : Adef.escaped_string =
     | Some (`Url url) -> Adef.escaped url (* FIXME *)
     | None -> Adef.escaped ""
   else Adef.escaped ""
+
+and string_of_blason_url conf base (p, p_auth) html saved : Adef.escaped_string
+    =
+  if p_auth then
+    match Image.get_blason_aux conf base p false saved with
+    | Some (`Path fname) when Filename.extension fname = ".url" -> (
+        match Some (Secure.open_in fname) with
+        | Some ic -> Adef.escaped (input_line ic)
+        | None -> Adef.escaped "")
+    | Some (`Path fname) ->
+        (* p is not the blason owner *)
+        let s = Unix.stat fname in
+        let k = Filename.basename fname |> Filename.chop_extension in
+        (* k is first_name.occ.surname.blason *)
+        let parts = String.split_on_char '.' k in
+        let access =
+          Format.sprintf "p=%s&n=%s&oc=%s" (List.nth parts 0) (List.nth parts 2)
+            (List.nth parts 1)
+        in
+        Format.sprintf "%sm=FIM%s&d=%d&%s&k=/%s"
+          (commd conf :> string)
+          (if html then "H" else "")
+          (int_of_float (mod_float s.Unix.st_mtime (float_of_int max_int)))
+          access k
+        |> Adef.escaped
+    | Some (`Url url) -> Adef.escaped url (* FIXME *)
+    | None -> Adef.escaped ""
+  else Adef.escaped "xz"
 
 and string_of_parent_age conf base (p, p_auth) parent : Adef.safe_string =
   match get_parents p with

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3831,7 +3831,12 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
   | "old_blason_name" -> str_val (Image.get_old_blason_name conf base p)
   | "blason_stop_name" ->
       str_val (Image.default_image_filename "blasons" base p ^ ".stop")
-  | "X" -> str_val Filename.dir_sep (* end carrousel functions *)
+  | "X" -> str_val Filename.dir_sep
+  | "ext" -> (
+      match p_getenv conf.env "file_name" with
+      | Some f -> str_val (Filename.extension f)
+      | None -> str_val "no_ext")
+  (* end carrousel functions *)
   | "key" ->
       if hide_person conf base p then null_val
       else

--- a/lib/perso.mli
+++ b/lib/perso.mli
@@ -55,7 +55,8 @@ val string_of_parent_age :
   config -> base -> person * bool -> (family -> iper) -> Adef.safe_string
 
 val string_of_image_url :
-  config -> base -> person * bool -> bool -> Adef.escaped_string
+  config -> base -> person * bool -> bool -> bool -> Adef.escaped_string
+(** [string_of_image_url conf base p html saved] *)
 
 val round_2_dec : float -> float
 

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -816,7 +816,9 @@ let effective_mod ?prerr ?skip_conflict conf base sp =
    match Gwdb.person_of_key base sp.first_name sp.surname sp.occ with
    | Some p' when p' <> pi && Some p' <> skip_conflict ->
        Update.print_create_conflict conf base (poi base p') ""
-   | _ -> Image.rename_portrait conf base op (sp.first_name, sp.surname, sp.occ));
+   | _ ->
+       Image.rename_portrait_and_blason conf base op
+         (sp.first_name, sp.surname, sp.occ));
   if (List.assoc_opt "nsck" conf.env :> string option) <> Some "on" then
     check_sex_married ?prerr conf base sp op;
   let created_p = ref [] in


### PR DESCRIPTION
This PR mainly adds a support for coat of arms in the carrousel. It allows to avoid to duplicate images: A coat of arm can be added from an individual to one of his descendant instead of adding the same coat of arms as portrait to each individuals. The original idea and work was done last year by @mdelambilly (thank you very much again!) It was later reworked and also rebased three times to master (to support image map, base reorganisation and other changes…) by @hgouraud and myself during the year. It should be nearly usable as it is yet but I add it as a temporary draft because it needs far more testings.

Note as reminder that the last work on `notes_album.txt` is not present. It should be added back and merged with `notes_gallery.txt`.

