### PR TITLE
For legacy properly create cnt dir

### DIFF
--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -16,7 +16,6 @@ let force = ref false
 let cnt_dir = ref ""
 let sock_dir = ref ""
 let bases = ref (Secure.base_dir ())
-let oc : out_channel option ref = ref None
 
 type init_s = { status : bool; bname : string }
 

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -446,8 +446,6 @@ let p_auth conf base p =
 let p_auth_sp conf base p =
   p_auth conf base p || (conf.Config.friend && Gwdb.get_access p <> Private)
 
-let log fn = match !oc with Some oc -> fn oc | None -> ()
-
 (** [wrap_output conf title content]
   Plugins defining a page content but not a complete UI
   may want to wrap their page using [wrap_output].

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -571,12 +571,13 @@ let init_etc bname =
      with Unix.Unix_error (_, _, _) ->
        Logs.syslog `LOG_WARNING (Printf.sprintf "Failure when creating lang"));
 
-    (if not (Sys.file_exists "cnt") then
+    (if not (Sys.file_exists (!cnt_d bname)) then
      try
-       Unix.mkdir "cnt" 0o755;
+       Unix.mkdir (!cnt_d bname) 0o755;
        force := true
      with Unix.Unix_error (_, _, _) ->
-       Logs.syslog `LOG_WARNING (Printf.sprintf "Failure when creating cnt"));
+       Logs.syslog `LOG_WARNING
+         (Printf.sprintf "Failure when creating cnt_dir: %s" (!cnt_d bname)));
 
     if not (Sys.file_exists (!etc_d bname)) then
       try

--- a/lib/gwdb-legacy/database.ml
+++ b/lib/gwdb-legacy/database.ml
@@ -729,7 +729,7 @@ let make_immut_record_access ~read_only ic ic_acc shift array_pos len name
           cleared := true;
           match !tab with
           | None -> ()
-          | Some a ->
+          | Some _a ->
               (* We could call [Gw_ancient.delete] here to
                  free the memory allocated with Ancient. Unfortunately,
                  [Ancient.delete] is buggy and cannot be used without causing


### PR DESCRIPTION
fix issue #2142

Use Case: gwd started with -bd specifying a directory that is not current working dir (cwd)

Without this commit, each request reports warning in gwd.log "WARNING Failure when creating cnt"

git bisect identified cid ca2ebd7a4 as the first bad commit 
```
Author: Henri83 <henri.gouraud@laposte.net>
Date:   Sat Mar 1 15:33:06 2025 +0100
    dont create init files (cache, etc, cnt, ...) if base.gwb does not exist
```

In same commit remove lines creating etc in cwd,
that badly duplicate lines using etc_d.