### PR TITLE
Do not use `--package geneweb` to build GeneWeb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ unpatch_files:
 	  mv bin/ged2gwb/ged2gwb.ml.bak bin/ged2gwb/ged2gwb.ml; \
 	fi
 
-BUILD = dune build -p geneweb
+BUILD = dune build
 UNPATCH = $(MAKE) --no-print-directory unpatch_files
 
 unpatch_after = (($(1) && $(UNPATCH)) || ($(UNPATCH) && false))


### PR DESCRIPTION
The target `build` of the Makefile runs the command:
```sh
dune build -p geneweb
```
As the man of `dune build` explains, the option `--package` is equivalent to `--only-package` AND `--release`. In the release profile, the warnings are not fatals and it seems that some of them are not printed at all!

Nowadays, compiling is quick and there is no reason to limit the scope of `make build` to the `geneweb` package.

This PR changes the Makefile as follows:
1. `make build` builds everything.
2. Remove `gwd` as `build` builds everything.