### PR TITLE
Create gw_tmp in bdir not in cwd

### DIFF
--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -1642,7 +1642,7 @@ let output_command_line bdir =
 
 (** Link .gwo files and create a database. *)
 let link next_family_fun bdir =
-  let tmp_dir = Filename.concat "gw_tmp" bdir in
+  let tmp_dir = Filename.concat bdir "gw_tmp" in
   Mutil.mkdir_p tmp_dir;
   let tmp_per_index = Filename.concat tmp_dir "gwc_per_index" in
   let tmp_per = Filename.concat tmp_dir "gwc_per" in

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -233,7 +233,7 @@ let main () =
           Printf.eprintf "*** database not created\n";
           flush stderr;
           exit 2));
-    let tmp_file = Filename.concat Filename.current_dir_name "gw_tmp" in
+    let tmp_file = Filename.concat bdir "gw_tmp" in
     Mutil.rm_rf tmp_file)
 
 let _ = main ()


### PR DESCRIPTION
Create gw_tmp in bdir not in cwd

This is a fix for issue #2153

@hgouraud,  for your review.