### PR TITLE
Add predictable mode

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -118,6 +118,7 @@ type config = {
   forced_plugins : string list;
   plugins : string list;
   secret_salt : string option;
+  predictable_mode : bool;
 }
 
 (**/**)
@@ -195,6 +196,7 @@ let empty =
     forced_plugins = [];
     plugins = [];
     secret_salt = None;
+    predictable_mode = false;
   }
 
 (**/**)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -125,6 +125,9 @@ type config = {
   secret_salt : string option;
       (** Secret salt generated at the server startup. The salt is used in form's
       digests to enhance security. *)
+  predictable_mode : bool;
+  (** Determine if we are in predictable mode. In this mode, output must not
+      depend on random state. *)
 }
 (** Geneweb configuration data type *)
 

--- a/lib/logs/logs.ml
+++ b/lib/logs/logs.ml
@@ -84,4 +84,5 @@ type 'a msgf = (('a, Format.formatter, unit, unit) format4 -> 'a) -> unit
 let report level fmt = Fmt.kstr (syslog level) ("@[" ^^ fmt ^^ "@]@?")
 let info (msgf : 'a msgf) = msgf @@ report `LOG_INFO
 let debug (msgf : 'a msgf) = msgf @@ report `LOG_DEBUG
+let warn (msgf : 'a msgf) = msgf @@ report `LOG_WARNING
 let err (msgf : 'a msgf) = msgf @@ report `LOG_ERR

--- a/lib/logs/logs.mli
+++ b/lib/logs/logs.mli
@@ -57,4 +57,5 @@ type 'a msgf = (('a, Format.formatter, unit, unit) format4 -> 'a) -> unit
 
 val info : 'a msgf -> unit
 val debug : 'a msgf -> unit
+val warn : 'a msgf -> unit
 val err : 'a msgf -> unit

--- a/lib/wserver/wserver.ml
+++ b/lib/wserver/wserver.ml
@@ -325,17 +325,20 @@ let accept_connections ~timeout ~n_workers callback socket =
   if Sys.unix then accept_connections_unix ~timeout ~n_workers callback socket
   else accept_connections_windows socket
 
-let generate_secret_salt () =
-  Random.self_init ();
-  string_of_int @@ Random.bits ()
+let generate_secret_salt with_salt =
+  if with_salt then (
+    Random.self_init ();
+    string_of_int @@ Random.bits ())
+  else
+    ""
 
-let start ?addr ~port ?timeout ~max_pending_requests ~n_workers callback =
+let start ?(with_salt = true) ?addr ~port ?timeout ~max_pending_requests ~n_workers callback =
   let timeout = match timeout with None -> 0 | Some t -> t in
   match Sys.getenv "WSERVER" with
   | exception Not_found ->
       (* A secret salt is added to the environment to ensure that workers
          use the same salt for digests on both Unix and Windows platforms. *)
-      Unix.putenv "SECRET_SALT" @@ generate_secret_salt ();
+      Unix.putenv "SECRET_SALT" @@ generate_secret_salt with_salt;
       check_stopping ();
       let addr =
         match addr with

--- a/lib/wserver/wserver.mli
+++ b/lib/wserver/wserver.mli
@@ -3,6 +3,7 @@
 (* module [Wserver]: elementary web service *)
 
 val start :
+  ?with_salt:bool ->
   ?addr:string ->
   port:int ->
   ?timeout:int ->
@@ -27,7 +28,9 @@ val start :
       - [path] is the path of the request,
       - [query] is the query content.
 
-    Listening on ports < 1024 may require root privileges. *)
+    Listening on ports < 1024 may require root privileges.
+
+    The flag [with_salt] can be used to disable salt generation. *)
 
 val close_connection : unit -> unit
 (** Closes the current socket *)

--- a/test/run_gw_test.sh
+++ b/test/run_gw_test.sh
@@ -138,6 +138,8 @@ OCAMLRUNPARAM=b $SUDOPRFX $BIN_DIR/gwd \
   -blang \
   -log "<stderr>" \
   -plugins -unsafe $BIN_DIR/plugins \
+  -predictable_mode \
+  -n_workers 0 \
   2>> $GWDLOG &
 
 # give some time for gwd to start


### PR DESCRIPTION
This PR introduces a new option `-predictable_mode` for `gwd`. This option is
intented for debugging or testing. In this mode, the behavior of GeneWeb must
be predictable.

In particular, we do not generate a random secret salt in this mode.