### PR TITLE
Use `nread` to copy notes

### DIFF
--- a/lib/gwdb-legacy/outbase.ml
+++ b/lib/gwdb-legacy/outbase.ml
@@ -188,7 +188,11 @@ let ( // ) = Filename.concat
 
 let notes_dir base = base.data.bdir // "notes_d"
 let notes_file base = base.data.bdir // "notes"
-let output_notes base dst = Filesystem.copy_file (notes_file base) dst
+
+let output_notes base dst =
+  let content = base.Dbdisk.data.bnotes.nread "" Def.RnAll in
+  Compat.Out_channel.with_open_text dst (fun oc ->
+    output_string oc content)
 
 (* Copy all the notes from "notes_d" of the database [base] into the
    destination directory [dst_dir]. *)

--- a/lib/util/filesystem.ml
+++ b/lib/util/filesystem.ml
@@ -102,10 +102,10 @@ let walk_folder ?(recursive = false) f path acc =
   traverse [ path ] acc
 
 let copy_file src dst =
-  Compat.In_channel.with_open_bin src @@ fun ic ->
-  Compat.Out_channel.with_open_bin dst @@ fun oc ->
   let sz = 8192 in
   let buf = Bytes.create sz in
+  Compat.In_channel.with_open_bin src @@ fun ic ->
+  Compat.Out_channel.with_open_bin dst @@ fun oc ->
   let rec loop () =
     let r = Compat.In_channel.input ic buf 0 sz in
     if r > 0 then (


### PR DESCRIPTION
In PR #2131, I wrote a new function to copy files on disk. This function should be used to synchronize files in `outbase` but notes can be in memory only. A proper fix requires a complete refactoring of the notes, which is to expensive.

This PR restores the previous code and fixes the issue #2168.