### PR TITLE
fix SECRET_SALT problem in CGI mode

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2412,8 +2412,7 @@ let main () =
   Util.is_welcome := false;
   if cgi then (
     Wserver.cgi := true;
-    Unix.putenv "SECRET_SALT"
-      (Wserver.generate_secret_salt (not !predictable_mode));
+    Unix.putenv "SECRET_SALT" (Wserver.generate_secret_salt false);
     let query =
       if Sys.getenv_opt "REQUEST_METHOD" = Some "POST" then (
         let len =


### PR DESCRIPTION
Until a better solution is identified, no secret salt in CGI mode.
The current set-up modifies SECRET_SALT for each request. 
This results in different SECRET_SALT for MOD_IND and MOD_IND_OK triggering the "base has changed" message. 