### PR TITLE
Restore `Util.is_welcome` after treating the welcome request

### DIFF
--- a/lib/srcfileDisplay.ml
+++ b/lib/srcfileDisplay.ml
@@ -553,6 +553,7 @@ let eval_predefined_apply conf _env f vl =
 
 let print_welcome conf base =
   Util.is_welcome := true;
+  Fun.protect ~finally:(fun () -> Util.is_welcome := false) @@ fun () ->
   let env =
     let sosa_ref_l =
       let sosa_ref () = Util.find_sosa_ref conf base in


### PR DESCRIPTION
In https://github.com/geneweb/geneweb/commit/68cc7fc40d8a9d2d28c6812595590de87cbff59a a new variable `is_welcome` was introduced to allow templates to determine if they are included into the welcome page. At this time, the hack worked because each client request launched a new gwd fork, and nothing was written to the socket after calling `print_welcome`.

The new fork pool changes the situation. Now, after calling `print_welcome`, the same fork can treat another request. The fix consists in restoring the value of `Util.is_welcome` after treating a request.

This fix is another hack... Ideally, we would store the variable in the template environment without using reference. The current template engine does not allow this because templates using the `is_welcome` variable are included within other templates and the template engine does not propagate variables from outer to inner templates. Changing this behavior would be really expensive.

This PR fixes #2191.