### PR TITLE
Specify the modules list for the executable `client`

### DIFF
--- a/rpc/test/dune
+++ b/rpc/test/dune
@@ -15,6 +15,8 @@
 (executable
   (name client)
   (modes js)
+  (modules
+    client)
   (libraries
     geneweb_rpc
     js_of_ocaml


### PR DESCRIPTION
It is a mandatory on old dune versions.