### PR TITLE
Fix salt digests in cgi mode

### DIFF
--- a/lib/wserver/wserver.mli
+++ b/lib/wserver/wserver.mli
@@ -2,20 +2,22 @@
 
 (* module [Wserver]: elementary web service *)
 
+type handler =
+  Unix.sockaddr * string list -> string -> Adef.encoded_string -> unit
+
 val start :
-  ?with_salt:bool ->
   ?addr:string ->
   port:int ->
   ?timeout:int ->
   max_pending_requests:int ->
   n_workers:int ->
-  (Unix.sockaddr * string list -> string -> Adef.encoded_string -> unit) ->
+  handler ->
   unit
-(** [Wserver.start ?addr ~port ?timeout ~n_workers callback]
+(** [Wserver.start ~secret_salt ?addr ~port ?timeout ~n_workers callback]
     starts a HTTP 1.1 server that listens on the address [addr] and port [port].
 
     On Unix, worker jobs managed by [n_workers] workers have a time limit of
-    [timeout]. If [timeout] is [Some 0] or [None], there is no limit.
+    [timeout]. If [timeout] is [0], there is no limit. This is the default.
 
     The [max_pending_requests] argument specified the maximum number of
     pending requests that the server can store. If the queue is full, new
@@ -28,12 +30,7 @@ val start :
       - [path] is the path of the request,
       - [query] is the query content.
 
-    Listening on ports < 1024 may require root privileges.
-
-    The flag [with_salt] can be used to disable salt generation. *)
-
-val generate_secret_salt : bool -> string
-(** generate secret salt if [with_salt] is requested *)
+    Listening on ports < 1024 may require root privileges. *)
 
 val close_connection : unit -> unit
 (** Closes the current socket *)


### PR DESCRIPTION
The cgi mode calls gwd for each request, which means the secret salt is generated for each request and cannot work properly. This PR fixes this issue:
1. Add a new option `-cgi_secret_salt` that must be set by the user in its cgi script. The way the salt is generated/stored is up to the user. I strongly recommend to not store the salt into an environment variable or a file that can be read by `gwd`.
2. Move and refactor a bit the way the secret salt is given to GeneWeb. Actually, the function `Wserver.start` does not need to manage the salt at all as its value is only read by its `callback` argument. I add a new argument to this callback and now the secret salt is entirely managed in `bin/gwd/gwd.ml`.

Fix issue #2180 