### PR TITLE
Clean up workers if the master process is done

### DIFF
--- a/lib/util/my_unix.ml
+++ b/lib/util/my_unix.ml
@@ -1,0 +1,11 @@
+let rec waitpid_noeintr flags pid =
+  try Unix.waitpid [] (-1)
+  with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_noeintr flags pid
+
+let rec accept_noeintr ?cloexec fd =
+  try Unix.accept ?cloexec fd
+  with Unix.Unix_error (Unix.EINTR, _, _) -> accept_noeintr ?cloexec fd
+
+let rec listen_noeintr fd n =
+  try Unix.listen fd n
+  with Unix.Unix_error (Unix.EINTR, _, _) -> listen_noeintr fd n

--- a/lib/util/my_unix.mli
+++ b/lib/util/my_unix.mli
@@ -1,0 +1,16 @@
+(* As the SA_RESTART flag is no support in Unix OCaml library, the following
+   functions provide variants of system calls that automatically restart after
+   being interrupted by signals. *)
+
+val waitpid_noeintr : Unix.wait_flag list -> int -> int * Unix.process_status
+(** Equivalent to [Unix.waitpid], but this variant restart upon interruption
+    by signals. *)
+
+val accept_noeintr :
+  ?cloexec:bool -> Unix.file_descr -> Unix.file_descr * Unix.sockaddr
+(** Equivalent to [Unix.accept], but this variant restart upon interruption
+    by signals. *)
+
+val listen_noeintr : Unix.file_descr -> int -> unit
+(** Equivalent to [Unix.listen], but this variant restart upon interruption
+    by signals. *)


### PR DESCRIPTION
This PR fixes several bugs in the worker pool during the clean up phase:
1. `Unix.kill` didn't work because I accidentaly swapped its arguments!
2. The finalizer of the `Fun.protect` could be executed within workers. This occurs when an uncaught exception is raised in a child process. As a result, the child kills some of its siblings. As new workers can spawn after starting the server, we cannot install the finalizer only in the master process. To resolve this, the cleanup function contains a guard to prevent from executing its code in children.
3. Many system calls of `Unix` won't automatically restart after being interrupted by a signal. This is the default behavior on Unix and the usual SA_RESTART option is not available on OCaml because it is hard to implement it. A new module `My_unix` contains appropriate wrappers for system calls.