### PR TITLE
Do not choose the output format in views

### DIFF
--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -330,11 +330,19 @@ let print conf base =
     | None -> ""
   in
   let nenv, s = read_notes base fnotes in
-  let title = try List.assoc "TITLE" nenv with Not_found -> "" in
-  let title = Util.safe_html title in
-  match p_getint conf.env "v" with
-  | Some cnt0 -> print_notes_part conf base fnotes title s cnt0
-  | None -> print_whole_notes conf base fnotes title s None
+  let templ =
+    match List.assoc "TYPE" nenv with
+    | "album" | "gallery" -> Util.open_etc_file conf "notes_gallery"
+    | exception Not_found | _ -> None
+  in
+  match templ with
+  | Some (ic, _) -> Templ.copy_from_templ conf Templ.Env.empty ic
+  | None ->
+    let title = try List.assoc "TITLE" nenv with Not_found -> "" in
+    let title = Util.safe_html title in
+    match p_getint conf.env "v" with
+    | Some cnt0 -> print_notes_part conf base fnotes title s cnt0
+    | None -> print_whole_notes conf base fnotes title s None
 
 let print_mod_json conf base =
   let nenv, s = read_notes_from_conf conf base in

--- a/lib/notesDisplay.mli
+++ b/lib/notesDisplay.mli
@@ -5,11 +5,17 @@ val print_linked_list :
   unit
 (** Displays the page list in argument *)
 
+val print_what_links : Config.config -> Gwdb.base -> unit
+
 val print : Config.config -> Gwdb.base -> unit
 (** Displays the base notes *)
 
+val print_json : Config.config -> Gwdb.base -> unit
+
 val print_mod : Config.config -> Gwdb.base -> unit
 (** Displays a text form for notes creation/edition *)
+
+val print_mod_json : Config.config -> Gwdb.base -> unit
 
 val print_mod_ok : Config.config -> Gwdb.base -> unit
 (** Updates notes *)


### PR DESCRIPTION
The views `NotesDisplay.print` and `NotesDisplay.print_mod` can output HTML or JSON content on the socket. If the user asks for JSON result, these printers outputs a HTTP header with the appropriate MIME format. This design breaks the separation between the dispatcher in `gwd/request.ml` and views. In other words, a single request should always output in the same format.

Changes in this PR:
1. Use different views according to the output format.
2. Change the output format in `request` itself.
3. Refactor a bit the code of views in `NotesDisplay`.