### PR TITLE
Remove `base_header`, `base_trailer` and `copyright` template variables

### DIFF
--- a/hd/etc/advanced.txt
+++ b/hd/etc/advanced.txt
@@ -181,7 +181,7 @@
     <button type="submit" class="btn btn-outline-primary btn-lg">[*search/case sensitive]0</button>
   </div>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/anclist.txt
+++ b/hd/etc/anclist.txt
@@ -435,7 +435,7 @@
     </table>
   %end;
 %end;
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/ancmenu.txt
+++ b/hd/etc/ancmenu.txt
@@ -586,7 +586,7 @@ function missing_events_options () {
     </div>
   </div>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js
@@ -604,7 +604,7 @@ $(document).ready(function() {
   }).maximizeSelect2Height();
 });
   $("body").on('change', '#only', function() {
-   ($('#only').is(':checked')) ? ($('.onlycheck').text("[only]"), $('.noa').addClass("d-none"), $('.noa_l').removeClass("d-none")) 
+   ($('#only').is(':checked')) ? ($('.onlycheck').text("[only]"), $('.noa').addClass("d-none"), $('.noa_l').removeClass("d-none"))
                                : ($('.onlycheck').text("[up to]"), $('.noa').removeClass("d-none"), $('.noa_l').addClass("d-none"))
   });
 </script>

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1904,7 +1904,7 @@ TODO: obtenir les secondes valeurs valeurs jj/mm/aaaa pour les cas « ou | » 
     </div>
   %end;
 %end;
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/anctree.txt
+++ b/hd/etc/anctree.txt
@@ -50,7 +50,7 @@
 %else;
   This should not happen (probably a bad variable in URL: check t=/t1=)
 %end;
-%base_trailer;
+%include;trl
 %if;(e.t!="T" and e.t!="A" and e.t!="C" and e.t1="")
 %include;copyr
 %end;

--- a/hd/etc/annivmenu.txt
+++ b/hd/etc/annivmenu.txt
@@ -30,7 +30,7 @@
   </ul>
 </p>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/calendar.txt
+++ b/hd/etc/calendar.txt
@@ -144,7 +144,7 @@
   </div>
 </div>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/carrousel.txt
+++ b/hd/etc/carrousel.txt
@@ -137,7 +137,7 @@
         <textarea class="form-control col-10 mr-2" id="image_name"
           type="input" name="image_name" rows="1" placeholder="[*name]">
         </textarea>
-        
+
         <div class="d-flex col">
           <h1 class="display-4">
             %(<i class="far fa-file-image fa-fw mr-1"></i>%)[*source/sources]0</h1>
@@ -167,7 +167,7 @@
         <h1 class="display-4">[*portrait]0</h1>
         %if;has_portrait;
           <div class="d-flex mt-1">
-            <a role="button" 
+            <a role="button"
               href="%if;has_portrait_url;%portrait;%else;%prefix;kch=%random_bits;&m=IM_C&i=%index;%end;"%sp;
               target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
@@ -191,7 +191,7 @@
         %end;
         %if;has_old_portrait;
           <div class="d-flex mt-1">
-            <a role="button" 
+            <a role="button"
               href="%if;has_old_portrait_url;%portrait;%else;%prefix;kch=%random_bits;&m=IM_C_S&i=%index;%end;"
               target="_blank" rel="noopener"%sp;
               data-toggle="tooltip" data-html="true" data-placement="left"
@@ -325,7 +325,7 @@
   %end;
 %end;
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/conf.txt
+++ b/hd/etc/conf.txt
@@ -62,7 +62,7 @@
   </div>
 </section>
 
-%base_trailer;
+%include;trl
 %include;copyr
 %include;js
 </div>

--- a/hd/etc/cousins.txt
+++ b/hd/etc/cousins.txt
@@ -165,7 +165,7 @@
 %end;
 
 <div class="my-3">Total[:] %if;(evar.v2=0)%expr(count-count2)%else;%count;%end; %if;(count=0 or count=1)[person/persons]0%else;[person/persons]1%end;.</div>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/cousmenu.txt
+++ b/hd/etc/cousmenu.txt
@@ -36,7 +36,7 @@
 %end;
 %if;(max!=0 and not (max=1 and not has_children))
   <div class="d-flex flex-wrap align-self-center btn-toolbar py-0 mx-3 mt-1" role="toolbar" aria-label="buttons to select maximum ascending level v">
-    
+
     <span>%for;i;min;maxp;%if;(i=13)<span class="high-lev d-none">%end;%apply;picklvl(i)%if;(i=max and max>12)</span>%end;%end;
       %if;(max>12)
         <span class="toggle-lev ml-1" data-caution=". [*high generation caution]">
@@ -210,7 +210,7 @@
                       <button type="button" class="btn btn-sm py-0 mt-1 btn-light%if;(cousdown=0) disabled%end;" data-dismiss="modal" data-toggle="modal" data-target="#modal_vvv_%expr(www+1)"><span title="vvv/%expr(www+1)" data-toggle="tooltip" data-html="true"><i class="fa-solid fa-arrow-down-long fa-fw"></i>www</span></button>
                     </div>
                   </div>
-                  <a role="button" href="%prefix;%access;&m=C&v1=vvv&v2=www" 
+                  <a role="button" href="%prefix;%access;&m=C&v1=vvv&v2=www"
                     class="btn btn-lg btn-light p-2 mr-2 align-self-center">
                       <span data-toggle="tooltip" data-html="true" title="%expr(vvv+www) %if;(vvv+www<2)[degree of kinship]0%else;[degree of kinship]1%end; ([show all] [relationship link/relationship links]1)">
                         <i class="fa-solid fa-person-arrow-up-from-line"></i>
@@ -376,7 +376,7 @@
       </div>
     </div>
   </div>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/dag.txt
+++ b/hd/etc/dag.txt
@@ -175,7 +175,7 @@
         %if;dag_cell.is_nothing;&nbsp;%nn;
         %elseif;dag_cell.is_bar;
           %if;(dag_cell.bar_link!="" and not cancel_links)
-             %( added em!=R here condition because first button_rel is static and does the same 
+             %( added em!=R here condition because first button_rel is static and does the same
                No! each vbar has a different action, suppressing a particular path %)
             <a href="%dag_cell.bar_link;" title="[*suppress this path]">│</a>%nn;
           %else;│%end;
@@ -212,7 +212,7 @@
     </table>
   %end;
 %end;
-%base_trailer;
+%include;trl
 </div>
 %include;js
 </body>

--- a/hd/etc/deslist.txt
+++ b/hd/etc/deslist.txt
@@ -503,7 +503,7 @@
   %else;%apply;min(evarv, max_desc_level, bvar.max_desc_level)%end;
 %end;
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/deslist_hr.txt
+++ b/hd/etc/deslist_hr.txt
@@ -318,7 +318,7 @@
   <div id="total" class="mt-2 ml-2" title="[unfiltered total]">[*total][:]
     %apply;desc_count(max_desc_level) [descendants] (%count; [person/persons]1 [with] [spouse/spouses]1)</div>
 %end;
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/desmenu.txt
+++ b/hd/etc/desmenu.txt
@@ -252,7 +252,7 @@ function table_spouse_disabled () {
             <div class="custom-control custom-checkbox custom-control-inline">
               <input type="checkbox" class="custom-control-input" id="t_nowrap" name="nowrap">
               <label class="custom-control-label" for="t_nowrap">[*no line break in names]</label>
-            </div>  
+            </div>
             <div class="custom-control custom-checkbox custom-control-inline">
               <input type="checkbox" class="custom-control-input" id="t_tt" name="tt" value="1">
               <label class="custom-control-label" for="t_tt">[*title/titles]1</label>
@@ -395,7 +395,7 @@ function table_spouse_disabled () {
     </div>
   </div>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/destable.txt
+++ b/hd/etc/destable.txt
@@ -622,7 +622,7 @@
     %apply;desc_count(max_desc_level,0,1,1,list_size)
   %end;.
 </div>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/destree.txt
+++ b/hd/etc/destree.txt
@@ -19,7 +19,7 @@
 %include;perso_utils
 %include;menubar
 %include;modules/arbre_descendants
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/family.txt
+++ b/hd/etc/family.txt
@@ -29,7 +29,7 @@
     %include;modules/arbre_famille
   </div>
   %if;(not cancel_links)
-    %base_trailer;
+    %include;trl
     %include;copyr
   %end;
 </div>

--- a/hd/etc/list.txt
+++ b/hd/etc/list.txt
@@ -216,7 +216,7 @@
     %end;
   %end;
 </div>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/moved.txt
+++ b/hd/etc/moved.txt
@@ -22,7 +22,7 @@ fr: La base de données "%bname;" se trouve maintenant à l'adresse:
 </dd></dt></dl>
 </p>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 </body>

--- a/hd/etc/notes_gallery.txt
+++ b/hd/etc/notes_gallery.txt
@@ -41,7 +41,7 @@
     <a id="rlm" href="%prefix;m=RLM" title="[*relations tree]"><img src="%image_prefix;/gui_create.png" height="18" alt="Tree"></a>
     <div id="legend" class="list-comma list-unstyled pl-1"></div>
   </div>
- 
+
   <div class="d-none" id="div_unknown">%nn;
     [*unknown person][:]%nn; <ul id="unknown" class="d-inline list-comma list-unstyled pl-0"></ul>
   </div>

--- a/hd/etc/perso.txt
+++ b/hd/etc/perso.txt
@@ -68,7 +68,7 @@
   %misc_names;<p>
 %end;
 %if;(not cancel_links)
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </div>

--- a/hd/etc/redirect.txt
+++ b/hd/etc/redirect.txt
@@ -30,7 +30,7 @@ it: L'indirizzo di questo service è cambiato.
 </ul>
 </p>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 </body>

--- a/hd/etc/relmenu.txt
+++ b/hd/etc/relmenu.txt
@@ -164,7 +164,7 @@
     </div>
   </div>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 <script>

--- a/hd/etc/renamed.txt
+++ b/hd/etc/renamed.txt
@@ -27,7 +27,7 @@ it: La base di dati "%old;" ha cambiato nome "%new;".
 </ul>
 </p>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 </body>

--- a/hd/etc/stats.txt
+++ b/hd/etc/stats.txt
@@ -46,7 +46,7 @@
   </ul>
 %end;
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/templm/advanced.txt
+++ b/hd/etc/templm/advanced.txt
@@ -103,7 +103,7 @@
     %apply;event("burial")
   </fieldset>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/anclist.txt
+++ b/hd/etc/templm/anclist.txt
@@ -155,7 +155,7 @@
   %if;not cancel_links;
     %include;tools
     %apply;tools_anclist()
-    %base_trailer;
+    %include;trl
     %include;copyr
   %end;
 %end;

--- a/hd/etc/templm/ancmenu.txt
+++ b/hd/etc/templm/ancmenu.txt
@@ -315,7 +315,7 @@
 </form>
 <div style="clear:both;"></div>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/ancsosa.txt
+++ b/hd/etc/templm/ancsosa.txt
@@ -118,7 +118,7 @@
   %include;tools
 
   %apply;tools_ancsosa()
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </body>

--- a/hd/etc/templm/anctree.txt
+++ b/hd/etc/templm/anctree.txt
@@ -1,4 +1,4 @@
-﻿%doctype;
+%doctype;
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <!-- $Id: templm/anctree.txt v7.0 2015/12/10 21:34:32 $ -->
@@ -244,7 +244,7 @@
   %include;tools
   %apply;tools_anctree()
   <div style="clear:both;"></div>
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </body>

--- a/hd/etc/templm/calendar.txt
+++ b/hd/etc/templm/calendar.txt
@@ -287,7 +287,7 @@
 </td>
 </tr>
 </table>
-%base_trailer;
+%include;trl
 %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/dag.txt
+++ b/hd/etc/templm/dag.txt
@@ -144,7 +144,7 @@
 %if;not cancel_links;
   %include;tools
   %apply;tools_dag()
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </body>

--- a/hd/etc/templm/deslist.txt
+++ b/hd/etc/templm/deslist.txt
@@ -98,7 +98,7 @@
     %if;not cancel_links;
       %include;tools
       %apply;tools_deslist()
-      %base_trailer;
+      %include;trl
       %include;copyr
     %end;
   %end;

--- a/hd/etc/templm/desmenu.txt
+++ b/hd/etc/templm/desmenu.txt
@@ -222,7 +222,7 @@
 </form>
 <div style="clear:both;"></div>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/doc_templm.txt
+++ b/hd/etc/templm/doc_templm.txt
@@ -170,7 +170,7 @@
   </td>
 </tr>
 </table>
-%base_trailer;
+%include;trl
 %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/perso.txt
+++ b/hd/etc/templm/perso.txt
@@ -1354,7 +1354,7 @@
         %apply;content_family("self","spouse")
         %if;(evar.opt = "from" and wizard)<em>(%origin_file;)</em>%nl;%end;
         %if;(evar.image="on" and nb_families > 1)<hr style="clear:both;">%end;
-      
+
     %end;
     </div>
   %else;
@@ -1390,7 +1390,7 @@
 %if;(not cancel_links)
   %apply;menu()
   %apply;buttons()
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </div>

--- a/hd/etc/templm/relmenu.txt
+++ b/hd/etc/templm/relmenu.txt
@@ -256,7 +256,7 @@
   </fieldset>
 </form>
 
-%base_trailer;
+%include;trl
 %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/upddag.txt
+++ b/hd/etc/templm/upddag.txt
@@ -178,7 +178,7 @@
 %end;
 
 <div style="height:300px;clear:both;"> </div>
-  %base_trailer;
+  %include;trl
   %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/upddata1.txt
+++ b/hd/etc/templm/upddata1.txt
@@ -148,7 +148,7 @@
 %else;
   %apply;print_long()
 %end;
-%base_trailer;
+%include;trl
 %include;copyr
 
 </body>

--- a/hd/etc/templm/updfam.txt
+++ b/hd/etc/templm/updfam.txt
@@ -259,7 +259,7 @@
     %end;
 </fieldset>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 %include;js
 </body>

--- a/hd/etc/templm/updind.txt
+++ b/hd/etc/templm/updind.txt
@@ -292,7 +292,7 @@
   </table>
 </fieldset>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/templm/updmenu1.txt
+++ b/hd/etc/templm/updmenu1.txt
@@ -108,7 +108,7 @@
     <br>
   </p>
 %end;
-  %base_trailer;
+  %include;trl
   %include;copyr
 </body>
 </html>

--- a/hd/etc/templm/welcome.txt
+++ b/hd/etc/templm/welcome.txt
@@ -255,7 +255,7 @@ zh: 网络家谱
      </td></tr>
   </table>
 <br>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 </div>

--- a/hd/etc/tp0_updDAG.txt
+++ b/hd/etc/tp0_updDAG.txt
@@ -125,7 +125,7 @@
   </table>
 </form>
 %if;(not cancel_links)
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </div>

--- a/hd/etc/tp0_updRLM.txt
+++ b/hd/etc/tp0_updRLM.txt
@@ -86,7 +86,7 @@
   </table>
 </form>
 %if;(not cancel_links)
-  %base_trailer;
+  %include;trl
   %include;copyr
 %end;
 </div>

--- a/hd/etc/upddata.txt
+++ b/hd/etc/upddata.txt
@@ -279,7 +279,7 @@
       (> %if;(b.book_max_results!="")<abbr title="book_max_results">%b.book_max_results;</abbr>%else;%nb_max%end;).
       %if;(e.s!="")[*specify]%else;[*select a letter]%end;.</div>
   %end;
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/upddatamenu.txt
+++ b/hd/etc/upddatamenu.txt
@@ -17,7 +17,7 @@
 
 
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -407,7 +407,7 @@
     <div class="row">
       <label for="excnt_witnwcnt_fn" class="col-sm-2 col-form-label">[*first name/first names]0</label>
       <div class="col-sm-6">
-        <input type="text" class="form-control" name="excnt_witnwcnt_fn" id="excnt_witnwcnt_fn" 
+        <input type="text" class="form-control" name="excnt_witnwcnt_fn" id="excnt_witnwcnt_fn"
           value="%fwitness.first_name;" placeholder="[*first name/first names]0"%datalist_fnames;>
       </div>
       <label for="excnt_witnwcnt_occ" class="col-sm-auto col-form-label">[*number]0</label>
@@ -807,7 +807,7 @@
     </div>
   </div>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/updfamevt.txt
+++ b/hd/etc/updfamevt.txt
@@ -44,7 +44,7 @@
 
 %apply;print_event()
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/updhist.txt
+++ b/hd/etc/updhist.txt
@@ -193,7 +193,7 @@
   </div>
 %end;
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/updhist_diff.txt
+++ b/hd/etc/updhist_diff.txt
@@ -351,7 +351,7 @@ function update_old () {
 %else;
   %apply;print_diff()
 %end;
-%base_trailer;
+%include;trl
 %include;copyr
 
 </div>

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -360,7 +360,7 @@
         <input type="text" name="excnt_ins_witnwcnt_n" size="1" maxlength="1" value="1" onkeydown= "if(event.keyCode == 13) document.getElementById('excnt_ins_witnwcnt').value = 'on';">
         </label>[nouveau(x)::witness/witnesses]0 %if;("evt_name" = "#bapt")/ [godfather/godmother/godparents]2%end;
         <input type="hidden" name="excnt_ins_witnwcnt" id="excnt_ins_witnwcnt" readonly>
-        <input type="submit" 
+        <input type="submit"
           onclick="%if;("evt_name" = "buri_or_crem")set_buri(xcnt);%end;
                    %if;("evt_name" = "#deat")set_insert_death(xcnt);%end; document.forms['form_pers'].action += '#witn';document.getElementById('excnt_ins_witnwcnt').value = 'on'" value="ok" readonly>
       </td>
@@ -395,7 +395,7 @@
     <div class="row">
       <label for="excnt_witnwcnt_fn" class="col-2 col-form-label">[*first name/first names]0</label>
       <div class="col-6">
-        <input type="text" class="form-control" name="excnt_witnwcnt_fn" id="excnt_witnwcnt_fn" 
+        <input type="text" class="form-control" name="excnt_witnwcnt_fn" id="excnt_witnwcnt_fn"
           value="%witness.first_name;"placeholder="[*first name/first names]0"%datalist_fnames;>
       </div>
       <label for="excnt_witnwcnt_occ" class="col-2 col-form-label">[*number]0</label>
@@ -743,7 +743,7 @@
       <input type="hidden" name="m" value="ADD_IND_OK">
     %end;
   </div>
-  
+
   <div class="card">
     <h2 class="card-header%if;(mrg=1) mt-5%end;">%nn;
       %if;(mrg=1)[*merge::person/persons]1%nn;
@@ -956,7 +956,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="card">
     %apply;card_header("birth","birth")
     <div class="card-body">
@@ -1313,7 +1313,7 @@
     </div>
   </div>
 </form>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/updindevt.txt
+++ b/hd/etc/updindevt.txt
@@ -43,7 +43,7 @@
 
 %apply;print_event()
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/updmenu1.txt
+++ b/hd/etc/updmenu1.txt
@@ -221,7 +221,7 @@
   </p>
 %end;
 
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -241,7 +241,7 @@ fr: Les <strong>droits des magiciens</strong> sont actuellement <strong>suspendu
                             2. [*surname/surnames]0 ¹[:] <i class='font-weight-lighter'>Doe</i><br><br>
                             3. [*public name][:] <i class='font-weight-lighter'>James Smith</i><br><br>
                             4. [*alias][:] <i class='font-weight-lighter'>Jimmy</i><br><br>
-                            
+
                             5. [*key]0[:] [first name/first names]2.[occ]1 [surname/surnames]0 ²<br>
                                    <i class='font-weight-lighter'>James William.2 Smith-Johnson<br>       james william.2 smith johnson</i><br>
                             <br><div class='font-weight-lighter small'>¹ [word/words]0<br>² [word/words]1<br>³ [optional/mandatory]0</div></div>">
@@ -575,7 +575,7 @@ zh: 已经有 %nb_accesses; 次访问数据库，其中 %nb_accesses_to_welcome;
 %end;
   </div>
 </div>
-%base_trailer;
+%include;trl
 %include;copyr
 </div>
 %include;js

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1469,7 +1469,6 @@ and print_var print_ast_list conf ifun env ep loc sl =
 and print_simple_variable dummy conf = function
   | "base_trailer" -> include_hed_trl dummy conf "trl"
   | "body_prop" -> print_body_prop conf
-  | "copyright" -> print_copyright dummy conf
   | "number_of_bases" ->
       Output.print_sstring conf
         (string_of_int (List.length (Util.get_bases_list ())))

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1467,7 +1467,6 @@ and print_var print_ast_list conf ifun env ep loc sl =
   print_var1 eval_var sl
 
 and print_simple_variable dummy conf = function
-  | "base_header" -> include_hed_trl dummy conf "hed"
   | "base_trailer" -> include_hed_trl dummy conf "trl"
   | "body_prop" -> print_body_prop conf
   | "copyright" -> print_copyright dummy conf

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1461,12 +1461,12 @@ and print_var print_ast_list conf ifun env ep loc sl =
                 Format.sprintf "%%%s?" (String.concat "." sl)
                 :: !GWPARAM.errors_other;
               Output.printf conf " %%%s?" (String.concat "." sl))
-      | sl -> print_variable ep conf sl)
+      | sl -> print_variable conf sl)
   in
   let eval_var = eval_var conf ifun env ep loc in
   print_var1 eval_var sl
 
-and print_simple_variable dummy conf = function
+and print_simple_variable conf = function
   | "body_prop" -> print_body_prop conf
   | "number_of_bases" ->
       Output.print_sstring conf
@@ -1503,58 +1503,17 @@ and print_simple_variable dummy conf = function
       Output.print_sstring conf res
   | _ -> raise Not_found
 
-and print_variable dummy conf sl =
+and print_variable conf sl : unit =
   try Output.print_sstring conf (eval_variable conf sl)
   with Not_found -> (
     try
       match sl with
-      | [ s ] -> print_simple_variable dummy conf s
+      | [ s ] -> print_simple_variable conf s
       | _ -> raise Not_found
     with Not_found ->
       GWPARAM.errors_undef :=
         Format.sprintf "%%%s?" (String.concat "." sl) :: !GWPARAM.errors_undef;
       Output.printf conf " %%%s?" (String.concat "." sl))
-
-and include_hed_trl dummy conf name =
-  match name with
-  | "hed" -> include_template_without_env dummy conf name (fun () -> ())
-  | "trl" ->
-      include_template_without_env dummy conf name (fun () -> ());
-      let query_time = Unix.gettimeofday () -. conf.query_start in
-      Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
-        !GWPARAM.errors_other !GWPARAM.set_vars
-  | _ -> ()
-
-and include_template_without_env dummy conf fname failure =
-  match Util.open_etc_file conf fname with
-  | Some (ic, fname) ->
-      include_begin conf @@ Adef.safe fname;
-      let astl = Templ_parser.parse_templ conf (Lexing.from_channel ic) in
-      close_in ic;
-      let ifun =
-        {
-          eval_var = (fun _ _ _ -> raise Not_found);
-          eval_transl = (fun _ -> eval_transl conf);
-          eval_predefined_apply = (fun _ -> raise Not_found);
-          get_vother = (fun _ -> None);
-          set_vother = (fun _ -> assert false);
-          print_foreach = (fun _ -> raise Not_found);
-        }
-      in
-      Templ_parser.wrap "" (fun () -> interp_ast conf ifun Env.empty dummy astl);
-      include_end conf @@ Adef.safe fname
-  | None -> failure ()
-
-and print_copyright dummy conf =
-  include_template_without_env dummy conf "copyr" (fun () ->
-      Output.print_sstring conf "<hr style=\"margin:0\">\n";
-      Output.print_sstring conf "<div style=\"font-size: 80%\">\n";
-      Output.print_sstring conf "<em>";
-      Output.print_sstring conf "Copyright (c) 1998-2007 INRIA - GeneWeb ";
-      Output.print_sstring conf Version.ver;
-      Output.print_sstring conf "</em>";
-      Output.print_sstring conf "</div>\n";
-      Output.print_sstring conf "<br>\n")
 
 let copy_from_templ conf env ic =
   let astl = Templ_parser.parse_templ conf (Lexing.from_channel ic) in
@@ -1582,5 +1541,23 @@ let include_template conf env fname failure =
       include_end conf @@ Adef.safe fname
   | None -> failure ()
 
-let include_hed_trl = include_hed_trl ()
-let print_copyright = print_copyright ()
+let include_hed_trl conf name =
+  match name with
+  | "hed" -> include_template conf Env.empty name (fun () -> ())
+  | "trl" ->
+      include_template conf Env.empty name (fun () -> ());
+      let query_time = Unix.gettimeofday () -. conf.query_start in
+      Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
+        !GWPARAM.errors_other !GWPARAM.set_vars
+  | _ -> ()
+
+let print_copyright conf =
+  include_template conf Env.empty "copyr" (fun () ->
+      Output.print_sstring conf "<hr style=\"margin:0\">\n";
+      Output.print_sstring conf "<div style=\"font-size: 80%\">\n";
+      Output.print_sstring conf "<em>";
+      Output.print_sstring conf "Copyright (c) 1998-2007 INRIA - GeneWeb ";
+      Output.print_sstring conf Version.ver;
+      Output.print_sstring conf "</em>";
+      Output.print_sstring conf "</div>\n";
+      Output.print_sstring conf "<br>\n")

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1467,7 +1467,6 @@ and print_var print_ast_list conf ifun env ep loc sl =
   print_var1 eval_var sl
 
 and print_simple_variable dummy conf = function
-  | "base_trailer" -> include_hed_trl dummy conf "trl"
   | "body_prop" -> print_body_prop conf
   | "number_of_bases" ->
       Output.print_sstring conf


### PR DESCRIPTION
These variables are not used or using `%include` has a similar effect. 
1. `base_header` and `copyright` have been already removed in templates by @hgouraud.
2. `base_trailer` was still used by the template `trl.txt` is empty! 

This PR has been tested using the new script of @hgouraud that produce reference outputs for the web server. 

The motivation of this PR is to remove properly the polymorphic recursion in `Templ.interp_ast`. This 
recursion didn't type correctly with old OCaml version (because of a bug in the compiler itself). 