### PR TITLE
Restrict access to notes/gallery/album to descendants of some persons

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -685,7 +685,7 @@ let treat_request =
                  w_base @@ BirthDeathDisplay.print_birth
              | "LD" when conf.wizard || conf.friend ->
                  w_base @@ BirthDeathDisplay.print_death
-             | "LINKED" -> w_base @@ w_person @@ Perso.print_what_links
+             | "LINKED" -> w_base @@ w_person @@ NotesDisplay.print_what_links_p
              | "LL" -> w_base @@ BirthDeathDisplay.print_longest_lived
              | "LM" when conf.wizard || conf.friend ->
                  w_base @@ BirthDeathDisplay.print_marriage
@@ -803,7 +803,15 @@ let treat_request =
                      match
                        (p_getenv conf.env "ref", p_getenv conf.env "ajax")
                      with
-                     | Some "on", _ -> NotesDisplay.print_what_links conf base
+                     | Some "on", _ ->
+                         let fnotes =
+                           match p_getenv conf.env "f" with
+                           | Some f ->
+                               if NotesLinks.check_file_name f <> None then f
+                               else ""
+                           | None -> ""
+                         in
+                         NotesDisplay.print_what_links conf base fnotes
                      | _, Some "on" ->
                          let charset =
                            if conf.charset = "" then "utf-8" else conf.charset

--- a/hd/etc/notes_gallery.txt
+++ b/hd/etc/notes_gallery.txt
@@ -15,7 +15,8 @@
 <div class="container-fluid">
   %include;home
   <div class="small float-right mr-2 mt-2">
-    (<a href="%url;&ref=on">[linked pages]</a>)
+    (<a href="%url;&ref=on"
+        title="[pages where page appears]"><-</a>)
   </div>
   <h1 id="h1" class="ml-3 mb-0">Chargement en cours…</h1>
   %if(wizard)

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -11025,19 +11025,27 @@ sv: länkade bilder
 tr: bağlantılı resimler
 zh: 关联图像
 
-    linked pages
+    pages where page appears
+en: pages or notes where page is referenced
+fr: pages ou notes où la page est citée
+
+    albums galleries where person appears
+en: albums or galleries where person is referenced
+fr: albums ou galleries où la personne est citée
+
+    pages where person appears
 bg: свързани страници
 ca: enllaços
 co: pagine ligate
 cs: spojený stránky
 da: lænkede sider
 de: verknüpfte Seiten
-en: linked pages
+en: pages or notes where person is referenced
 eo: linkitaj paĝoj
 es: páginas enlazadas
 et: seotud leheküljed
 fi: linkitettyjä sivuja
-fr: pages liées
+fr: pages ou notes où la personne est citée
 he: דפים מקושרים
 it: pagine collegate
 lt: susieti puslapiai
@@ -16068,6 +16076,10 @@ fr: partiel
     not exact hlp
 en: partial matching (exact matching by default)
 fr: correspondance partielle (correspondance exacte par défaut)
+
+    note is restricted
+en: access to this page is restricted
+fr: l'accès à cette page est restreint
 
     optional/mandatory
 en: optional/mandatory

--- a/lib/notesDisplay.mli
+++ b/lib/notesDisplay.mli
@@ -5,7 +5,7 @@ val print_linked_list :
   unit
 (** Displays the page list in argument *)
 
-val print_what_links : Config.config -> Gwdb.base -> unit
+val print_what_links : Config.config -> Gwdb.base -> string -> unit
 
 val print : Config.config -> Gwdb.base -> unit
 (** Displays the base notes *)
@@ -25,3 +25,6 @@ val print_misc_notes : Config.config -> Gwdb.base -> unit
 
 val print_misc_notes_search : Config.config -> Gwdb.base -> unit
 (** Same as `print_misc_notes`, with a default search *)
+
+val print_what_links_p : Config.config -> Gwdb.base -> Gwdb.person -> unit
+(** Displays links to pages associated to the person *)

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -5685,37 +5685,3 @@ let print ?no_headers conf base p =
     when is_that_user_and_password conf.auth_scheme "" passwd = false ->
       Util.unauthorized conf src
   | Some _ | None -> interp_templ ?no_headers "perso" conf base p
-
-let print_what_links conf base p =
-  if authorized_age conf base p then (
-    let key =
-      let fn = Name.lower (sou base (get_first_name p)) in
-      let sn = Name.lower (sou base (get_surname p)) in
-      (fn, sn, get_occ p)
-    in
-    let db = Gwdb.read_nldb base in
-    let db = Notes.merge_possible_aliases conf db in
-    let pgl = Notes.links_to_ind conf base db key None in
-    let title h =
-      let lnkd_typ =
-        match p_getenv conf.env "type" with
-        | Some "gallery" -> "linked images"
-        | Some "album" -> "linked images"
-        | _ -> "linked pages"
-      in
-      transl conf lnkd_typ |> Utf8.capitalize_fst |> Output.print_sstring conf;
-      Util.transl conf ":" |> Output.print_sstring conf;
-      Output.print_sstring conf " ";
-      if h then Output.print_string conf (simple_person_text conf base p true)
-      else (
-        Output.print_sstring conf {|<a href="|};
-        Output.print_string conf (commd conf);
-        Output.print_string conf (acces conf base p);
-        Output.print_sstring conf {|">|};
-        Output.print_string conf (simple_person_text conf base p true);
-        Output.print_sstring conf {|</a>|})
-    in
-    Hutil.header conf title;
-    NotesDisplay.print_linked_list conf base pgl;
-    Hutil.trailer conf)
-  else Hutil.incorrect_request conf

--- a/lib/perso.mli
+++ b/lib/perso.mli
@@ -28,9 +28,6 @@ val interp_notempl_with_menu :
 val print : ?no_headers:bool -> config -> base -> person -> unit
 (** Displays the HTML page of a person *)
 
-val print_what_links : config -> base -> person -> unit
-(** Displays links to pages associated to the person *)
-
 val get_linked_page : config -> base -> person -> string -> Adef.safe_string
 val get_birth_text : config -> person -> bool -> Adef.safe_string
 val get_baptism_text : config -> person -> bool -> Adef.safe_string


### PR DESCRIPTION
The content of a note is augmented with
`RESTRICT=[[fn1/sn1/oc1]],[[fn2/sn2/oc2]]...`
oc is mandatory
When pnoc changes, the RESTRICT list is updated

When accessing a note, authentified users (friends) verify that one of [[fn/sn/oc]] is an ancestor.

In .gwf,
`restrict_note_max=n`  # defines the number of generations to search for ancestors (default 4)
`restrict_for_spouses=yes` # the restrict policy is extended to spouses (default no)