### PR TITLE
Do not catching the exception in `w_base`

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -420,33 +420,27 @@ let w_lock ~onerror fn conf (base_name : string option) =
 let w_base ~none fn conf (bfile : string option) =
   match bfile with
   | None -> none conf
-  | Some bfile -> (
-      try
-        Gwdb.with_database bfile (fun base ->
-            let conf = make_henv conf base in
-            let conf = make_senv conf base in
-            let conf =
-              match Util.default_sosa_ref conf base with
-              | Some p ->
-                  {
-                    conf with
-                    default_sosa_ref = (get_iper p, Some p);
-                    nb_of_persons = Gwdb.nb_of_persons base;
-                    nb_of_families = Gwdb.nb_of_families base;
-                  }
-              | None ->
-                  {
-                    conf with
-                    nb_of_persons = Gwdb.nb_of_persons base;
-                    nb_of_families = Gwdb.nb_of_families base;
-                  }
-            in
-            fn conf base)
-      with _ ->
-        (* FIXME: If the exception is raised after printing the HTTP header,
-           the function [none] fails and raises an exception with a cryptic
-           backtrace. *)
-        none conf)
+  | Some bfile ->
+      Gwdb.with_database bfile (fun base ->
+          let conf = make_henv conf base in
+          let conf = make_senv conf base in
+          let conf =
+            match Util.default_sosa_ref conf base with
+            | Some p ->
+                {
+                  conf with
+                  default_sosa_ref = (get_iper p, Some p);
+                  nb_of_persons = Gwdb.nb_of_persons base;
+                  nb_of_families = Gwdb.nb_of_families base;
+                }
+            | None ->
+                {
+                  conf with
+                  nb_of_persons = Gwdb.nb_of_persons base;
+                  nb_of_families = Gwdb.nb_of_families base;
+                }
+          in
+          fn conf base)
 
 let w_person ~none fn conf base =
   match find_person_in_env conf base "" with


### PR DESCRIPTION
As my comment explained, catching exceptions here makes the code harder to debug. If the base is missing or something fails during the request process, it is a fatal error if we don't catch it in the request handler.

The previous code tried to output a 404 Not found error on the socket but most of the time, it is too late as the HTTP header can be emitted in the template engine.

For small pages, we could prepare the page in memory and, if everything works as expected, we print the HTTP header and the page after. For large page, users expect to get a partial result. These changes are too extensive and complicated for the current code base.

This PR only removes the exception handler. As a result, the worker die with such exceptions. I believe that this design is acceptable and we can implement a better patch when the code base will be better.