### PR TITLE
Do not call Printexc.print_backtrace outside an exception handler

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1,9 +1,6 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
 module Logs = Geneweb_logs.Logs
-
-let () = if Sys.getenv_opt "DEBUG" <> None then Sys.enable_runtime_warnings true
-
 open Geneweb
 open Config
 open Def
@@ -2178,7 +2175,8 @@ let print_version_commit () =
 let set_debug_flag () =
   debug := true;
   Logs.debug_flag := true;
-  Printexc.record_backtrace true
+  Printexc.record_backtrace true;
+  Sys.enable_runtime_warnings true
 
 let set_verbosity_level lvl = Logs.verbosity_level := lvl
 
@@ -2434,7 +2432,6 @@ let main () =
     try (Sys.getenv "QUERY_STRING" |> Adef.encoded, true)
     with Not_found -> ("" |> Adef.encoded, !force_cgi)
   in
-  if not !debug then Sys.enable_runtime_warnings false;
   Util.is_welcome := false;
   if cgi then (
     Wserver.cgi := true;

--- a/lib/logs/logs.ml
+++ b/lib/logs/logs.ml
@@ -48,8 +48,7 @@ let syslog (level : level) msg =
   then begin
     let log = Syslog.openlog ~flags @@ Filename.basename @@ Sys.executable_name in
     Syslog.syslog log level msg ;
-    Syslog.closelog log ;
-    if !debug_flag then Printexc.print_backtrace stderr ;
+    Syslog.closelog log
   end
 #else
   let () = () in
@@ -68,14 +67,12 @@ let syslog (level : level) msg =
       | `LOG_DEBUG -> "DEBUG"
     in
     let print oc = Printf.fprintf oc "%a %s %s\n%!" pp_tm tm level msg in
-    begin match Sys.getenv_opt "GW_SYSLOG_FILE" with
-      | Some fn ->
-          Compat.Out_channel.with_open_gen
-            [ Open_wronly ; Open_creat ; Open_append ] 0o644 fn print
-      | None ->
-          print stderr
-    end ;
-    if !debug_flag then Printexc.print_backtrace stderr ;
+    match Sys.getenv_opt "GW_SYSLOG_FILE" with
+    | Some fn ->
+        Compat.Out_channel.with_open_gen
+          [ Open_wronly ; Open_creat ; Open_append ] 0o644 fn print
+    | None ->
+        print stderr
   end
 #endif
 


### PR DESCRIPTION
This function cannot be used outside exception handlers. We called it our Logs module if the debug flag was set. As a result, we got an irrelevant backtraces, even if there is no uncaught exceptions in workers.

This commit also `enable_runtime_warnings` in debug mode. These warnings are disabled by default.

Fix issue #2233 