### PR TITLE
Remove DUNE_PROFILE variable in configure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,13 @@ jobs:
       - name: Build Geneweb
         id: build
         shell: bash
+        run: opam exec -- make distrib
+
+      - name: Run tests
+        id: tests
+        shell: bash
         run: |
-          opam exec -- make ci distrib 2>&1 | tee build-output.log
+          opam exec -- make ci 2>&1 | tee build-output.log
 
           set +e
           PASSED=$(grep -c "\[OK\]" build-output.log)
@@ -168,10 +173,10 @@ jobs:
           os: ${{ matrix.os }}
           ocaml-version: ${{ matrix.ocaml-compiler }}
           cache-hit: ${{ runner.os != 'Windows' && steps.cache-opam-unix.outputs.cache-hit || steps.cache-opam-windows.outputs.cache-hit }}
-          tests-total: ${{ steps.build.outputs.tests_total }}
-          tests-passed: ${{ steps.build.outputs.tests_passed }}
-          tests-failed: ${{ steps.build.outputs.tests_failed }}
-          tests-skipped: ${{ steps.build.outputs.tests_skipped }}
+          tests-total: ${{ steps.tests.outputs.tests_total }}
+          tests-passed: ${{ steps.tests.outputs.tests_passed }}
+          tests-failed: ${{ steps.tests.outputs.tests_failed }}
+          tests-skipped: ${{ steps.tests.outputs.tests_skipped }}
 
   build-results:
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v**
 
+env:
+  DUNE_PROFILE: "release"
+
 jobs:
 
   release:
@@ -49,7 +52,7 @@ jobs:
       # Build the distribution
       - name: Build the distribution
         run: |
-          opam exec -- ocaml ./configure.ml --sosa-legacy --gwdb-legacy --release
+          opam exec -- ocaml ./configure.ml --sosa-legacy --gwdb-legacy
           opam exec -- make distrib
 
       # Archive distribution for release

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ Makefile.config: configure.ml
 	fi
 include Makefile.config
 
-# Ensure that all the dune commands run with the profile choosen with the script
-# ./configure
-export DUNE_PROFILE := $(DUNE_PROFILE)
-
 endif
 
 -include Makefile.local
@@ -24,10 +20,6 @@ ODOC_DIR=$(BUILD_DIR)/_doc/_html
 # [BEGIN] Generated files section
 
 CPPO_D=$(GWDB_D) $(OS_D) $(SYSLOG_D)
-
-ifeq ($(DUNE_PROFILE),dev)
-    CPPO_D+= -D DEBUG
-endif
 
 %/dune: %/dune.in Makefile.config
 	@printf "Generating $@…" \
@@ -230,7 +222,7 @@ opendoc: doc
 
 test: ## Run tests
 test: | $(GENERATED_FILES_DEP)
-	dune build @runtest
+	@$(call unpatch_after, dune build @runtest)
 .PHONY: test
 
 bench: ## Run benchmarks
@@ -264,12 +256,8 @@ clean:
 .PHONY: clean
 
 ci: ## Run tests, skip known failures
-ci:
-ifdef SKIP_BUILD
-	@GENEWEB_CI=on dune runtest
-else
-	@ocaml ./configure.ml && $(MAKE) -s build && GENEWEB_CI=on dune runtest
-endif
+ci: | $(GENERATED_FILES_DEP)
+	@$(call unpatch_after, GENEWEB_CI=on dune build @runtest)
 
 ocp-indent: ## Run ocp-indent (inplace edition)
 ocp-indent:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ FROM ocaml/opam:debian-ocaml-4.14-nnp AS builder
 
 ENV OPAMYES=yes
 ENV OPAMJOBS=2
+ENV DUNE_PROFILE=release
 
 USER root
 # Install required system dependencies
@@ -27,7 +28,7 @@ RUN eval "$(opam env)" && opam install . --deps-only --with-test && opam pin add
 # Clone repository and build Geneweb
 WORKDIR /home/opam/geneweb
 COPY --chown=opam:opam . .
-RUN eval "$(opam env)" && ocaml ./configure.ml --sosa-zarith --gwd-caching --release && make distrib
+RUN eval "$(opam env)" && ocaml ./configure.ml --sosa-zarith --gwd-caching && make distrib
 
 ###############################################################################
 #                                       STAGE 2: Export build via blank image

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -42,6 +42,8 @@ depends: [
 ]
 depopts: ["ocaml-option-nnp" "ancient" "zarith"]
 dev-repo: "git+https://github.com/geneweb/geneweb.git"
+build-env: DUNE_PROFILE = "release"
+
 build: [
   [ "ocaml" "./configure.ml" "--release" ]
   [ make "build" ]

--- a/geneweb.opam.template
+++ b/geneweb.opam.template
@@ -1,3 +1,5 @@
+build-env: DUNE_PROFILE = "release"
+
 build: [
   [ "ocaml" "./configure.ml" "--release" ]
   [ make "build" ]

--- a/geneweb_colab.ipynb
+++ b/geneweb_colab.ipynb
@@ -111,7 +111,7 @@
       "source": [
         "#Clone GeneWeb, checkout selected branch\n",
         "!git clone https://github.com/geneweb/geneweb\n",
-        "!cd geneweb && opam exec -- ocaml ./configure.ml --release && opam exec -- make distrib"
+        "!cd geneweb && opam exec -- ocaml ./configure.ml && DUNE_PROFILE=release opam exec -- make distrib"
       ]
     },
     {


### PR DESCRIPTION
This is not the appropriate way to ensure that dune runs with release profile. The `DUNE_PROFILE` environment variable is the right way to invoke the Makefile with a specific profile. For instance,
```console
DUNE_PROFILE=release make build
```
builds the project with release profile.