### PR TITLE
Small prs

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2396,10 +2396,17 @@ let main () =
     speclist anonfun usage;
   Arg.parse speclist anonfun usage;
   let gwd_cmd =
-    Array.fold_left
-      (fun acc arg ->
-        if arg.[0] = '-' then acc ^ "<br><b>" ^ arg ^ "</b> " else acc ^ arg)
-      "" Sys.argv
+    let rec process acc skip_next = function
+      | [] -> acc
+      | arg :: rest ->
+          if skip_next then process (acc ^ "xxx") false rest
+          else if arg = "-cgi_secret_salt" then
+            process (acc ^ "<br><b>" ^ arg ^ "</b> ") true rest
+          else if arg.[0] = '-' then
+            process (acc ^ "<br><b>" ^ arg ^ "</b> ") false rest
+          else process (acc ^ arg) false rest
+    in
+    process "" false (Array.to_list Sys.argv)
   in
   Geneweb.GWPARAM.gwd_cmd := gwd_cmd;
   List.iter register_plugin !plugins;

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -685,7 +685,7 @@ let treat_request =
                  w_base @@ BirthDeathDisplay.print_birth
              | "LD" when conf.wizard || conf.friend ->
                  w_base @@ BirthDeathDisplay.print_death
-             | "LINKED" -> w_base @@ w_person @@ Perso.print_what_links
+             | "LINKED" -> w_base @@ w_person @@ NotesDisplay.print_what_links_p
              | "LL" -> w_base @@ BirthDeathDisplay.print_longest_lived
              | "LM" when conf.wizard || conf.friend ->
                  w_base @@ BirthDeathDisplay.print_marriage
@@ -803,7 +803,15 @@ let treat_request =
                      match
                        (p_getenv conf.env "ref", p_getenv conf.env "ajax")
                      with
-                     | Some "on", _ -> NotesDisplay.print_what_links conf base
+                     | Some "on", _ ->
+                         let fnotes =
+                           match p_getenv conf.env "f" with
+                           | Some f ->
+                               if NotesLinks.check_file_name f <> None then f
+                               else ""
+                           | None -> ""
+                         in
+                         NotesDisplay.print_what_links conf base fnotes
                      | _, Some "on" ->
                          let charset =
                            if conf.charset = "" then "utf-8" else conf.charset

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -972,6 +972,9 @@ let treat_request =
 let treat_request conf =
   GWPARAM.init_etc conf.bname;
   (* TODO verify if we need init_etc here *)
+  GWPARAM.nb_errors := 0;
+  GWPARAM.errors_undef := [];
+  GWPARAM.errors_other := [];
   let conf =
     {
       conf with

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -64,7 +64,6 @@ let relation_print conf base p =
   RelationDisplay.print conf base p p1
 
 let specify conf base n pl1 pl2 pl3 =
-  Printf.eprintf "specify\n";
   let title _ = Output.printf conf "%s : %s" n (transl conf "specify") in
   let n = Name.crush_lower n in
   let ptll pl =
@@ -119,7 +118,6 @@ let specify conf base n pl1 pl2 pl3 =
       l
     |> List.rev_map (fun (p, v, _) -> (p, v))
   in
-  Printf.eprintf "sort ptll\n";
   let ptll1 = ptll pl1 |> sort_ptll in
   let ptll2 = ptll pl2 |> sort_ptll in
   let ptll3 = ptll pl3 |> sort_ptll in

--- a/hd/etc/notes_gallery.txt
+++ b/hd/etc/notes_gallery.txt
@@ -15,7 +15,8 @@
 <div class="container-fluid">
   %include;home
   <div class="small float-right mr-2 mt-2">
-    (<a href="%url;&ref=on">[linked pages]</a>)
+    (<a href="%url;&ref=on"
+        title="[pages where page appears]"><-</a>)
   </div>
   <h1 id="h1" class="ml-3 mb-0">Chargement en cours…</h1>
   %if(wizard)

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -11025,19 +11025,27 @@ sv: länkade bilder
 tr: bağlantılı resimler
 zh: 关联图像
 
-    linked pages
+    pages where page appears
+en: pages or notes where page is referenced
+fr: pages ou notes où la page est citée
+
+    albums galleries where person appears
+en: albums or galleries where person is referenced
+fr: albums ou galleries où la personne est citée
+
+    pages where person appears
 bg: свързани страници
 ca: enllaços
 co: pagine ligate
 cs: spojený stránky
 da: lænkede sider
 de: verknüpfte Seiten
-en: linked pages
+en: pages or notes where person is referenced
 eo: linkitaj paĝoj
 es: páginas enlazadas
 et: seotud leheküljed
 fi: linkitettyjä sivuja
-fr: pages liées
+fr: pages ou notes où la personne est citée
 he: דפים מקושרים
 it: pagine collegate
 lt: susieti puslapiai
@@ -16068,6 +16076,10 @@ fr: partiel
     not exact hlp
 en: partial matching (exact matching by default)
 fr: correspondance partielle (correspondance exacte par défaut)
+
+    note is restricted
+en: access to this page is restricted
+fr: l'accès à cette page est restreint
 
     optional/mandatory
 en: optional/mandatory

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -12406,6 +12406,10 @@ de: die ganze Notiz bearbeiten/vorheriger Abschnitt/nächster Abschnitt
 en: modify all the note/previous section/next section
 fr: éditer toute la note/section précédente/section suivante
 
+    visualize
+en: display
+fr: afficher
+
     modify note
 co: mudificà a nota
 de: Notiz bearbeiten

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -153,8 +153,22 @@ let json_extract_img conf s =
   | Some img -> ((Util.commd conf :> string) ^ "m=DOC&s=" ^ img, img)
   | None -> ("", "")
 
-let safe_gallery conf s =
-  let html s = Util.string_with_macros conf [] s in
+let safe_gallery conf base s =
+  let html s = 
+    let s =
+      let wi =
+        {
+          Wiki.wi_mode = "NOTES";
+          Wiki.wi_file_path = file_path conf base;
+          Wiki.wi_person_exists = person_exists conf base;
+          Wiki.wi_mark_if_not_public = mark_if_not_public conf base;
+          Wiki.wi_always_show_link = conf.wizard || conf.friend;
+        }
+      in
+      Wiki.syntax_links conf wi s
+    in
+  Util.string_with_macros conf [] s in
+
   let safe_map e =
     match e with
     | `Assoc l ->

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -154,7 +154,7 @@ let json_extract_img conf s =
   | None -> ("", "")
 
 let safe_gallery conf base s =
-  let html s = 
+  let html s =
     let s =
       let wi =
         {
@@ -167,7 +167,8 @@ let safe_gallery conf base s =
       in
       Wiki.syntax_links conf wi s
     in
-  Util.string_with_macros conf [] s in
+    Util.string_with_macros conf [] s
+  in
 
   let safe_map e =
     match e with

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -103,4 +103,4 @@ val update_cache_linked_pages :
   Config.config -> mode -> Def.NLDB.key -> Def.NLDB.key -> int -> unit
 
 val json_extract_img : Config.config -> string -> string * string
-val safe_gallery : Config.config -> string -> string
+val safe_gallery : Config.config -> Gwdb.base -> string -> string

--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -485,7 +485,7 @@ let print_json conf base =
   let nenv, s = read_notes_from_conf conf base in
   let s =
     match List.assoc "TYPE" nenv with
-    | "album" | "gallery" -> Notes.safe_gallery conf s
+    | "album" | "gallery" -> Notes.safe_gallery conf base s
     | (exception Not_found) | _ -> s
   in
   Output.print_sstring conf s

--- a/lib/notesDisplay.mli
+++ b/lib/notesDisplay.mli
@@ -5,7 +5,7 @@ val print_linked_list :
   unit
 (** Displays the page list in argument *)
 
-val print_what_links : Config.config -> Gwdb.base -> unit
+val print_what_links : Config.config -> Gwdb.base -> string -> unit
 
 val print : Config.config -> Gwdb.base -> unit
 (** Displays the base notes *)
@@ -25,3 +25,6 @@ val print_misc_notes : Config.config -> Gwdb.base -> unit
 
 val print_misc_notes_search : Config.config -> Gwdb.base -> unit
 (** Same as `print_misc_notes`, with a default search *)
+
+val print_what_links_p : Config.config -> Gwdb.base -> Gwdb.person -> unit
+(** Displays links to pages associated to the person *)

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -37,7 +37,9 @@ let misc_notes_link s i =
     (* assume no link up to [j] and find next link position *)
     if j < slen then
       match s.[j] with
-      | '%' -> wlnone (j + 2)
+      | '%' -> WLnone (j, cut j)
+      | '\'' -> WLnone (j, cut j)
+      | '{' -> WLnone (j, cut j)
       | '[' ->
           if j > i && j + 1 < slen && s.[j + 1] = '[' then WLnone (j, cut j)
           else wlnone (j + 1)

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -5685,37 +5685,3 @@ let print ?no_headers conf base p =
     when is_that_user_and_password conf.auth_scheme "" passwd = false ->
       Util.unauthorized conf src
   | Some _ | None -> interp_templ ?no_headers "perso" conf base p
-
-let print_what_links conf base p =
-  if authorized_age conf base p then (
-    let key =
-      let fn = Name.lower (sou base (get_first_name p)) in
-      let sn = Name.lower (sou base (get_surname p)) in
-      (fn, sn, get_occ p)
-    in
-    let db = Gwdb.read_nldb base in
-    let db = Notes.merge_possible_aliases conf db in
-    let pgl = Notes.links_to_ind conf base db key None in
-    let title h =
-      let lnkd_typ =
-        match p_getenv conf.env "type" with
-        | Some "gallery" -> "linked images"
-        | Some "album" -> "linked images"
-        | _ -> "linked pages"
-      in
-      transl conf lnkd_typ |> Utf8.capitalize_fst |> Output.print_sstring conf;
-      Util.transl conf ":" |> Output.print_sstring conf;
-      Output.print_sstring conf " ";
-      if h then Output.print_string conf (simple_person_text conf base p true)
-      else (
-        Output.print_sstring conf {|<a href="|};
-        Output.print_string conf (commd conf);
-        Output.print_string conf (acces conf base p);
-        Output.print_sstring conf {|">|};
-        Output.print_string conf (simple_person_text conf base p true);
-        Output.print_sstring conf {|</a>|})
-    in
-    Hutil.header conf title;
-    NotesDisplay.print_linked_list conf base pgl;
-    Hutil.trailer conf)
-  else Hutil.incorrect_request conf

--- a/lib/perso.mli
+++ b/lib/perso.mli
@@ -28,9 +28,6 @@ val interp_notempl_with_menu :
 val print : ?no_headers:bool -> config -> base -> person -> unit
 (** Displays the HTML page of a person *)
 
-val print_what_links : config -> base -> person -> unit
-(** Displays links to pages associated to the person *)
-
 val get_linked_page : config -> base -> person -> string -> Adef.safe_string
 val get_birth_text : config -> person -> bool -> Adef.safe_string
 val get_baptism_text : config -> person -> bool -> Adef.safe_string

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -786,6 +786,7 @@ let print_sub_part_links conf edit_mode sfn cnt0 is_empty =
     Output.print_sstring conf
       (Utf8.capitalize_fst (transl_nth conf "modify all note" 1));
     Output.print_sstring conf "</a>");
+
   Output.print_sstring conf {|<a href="|};
   Output.print_string conf (commd conf);
   Output.print_sstring conf {|m=|};
@@ -796,6 +797,17 @@ let print_sub_part_links conf edit_mode sfn cnt0 is_empty =
   Output.print_sstring conf
     (Utf8.capitalize_fst (transl_nth conf "modify all note" 0));
   Output.print_sstring conf "</a>";
+
+  Output.print_sstring conf {|<a href="|};
+  Output.print_string conf (commd conf);
+  Output.print_sstring conf {|m=|};
+  Output.print_sstring conf "NOTES";
+  Output.print_string conf sfn;
+  Output.print_sstring conf {|" class="btn btn-sm btn-outline-primary">|};
+  Output.print_sstring conf {|<i class="fa fa-image fa-fw"></i> |};
+  Output.print_sstring conf (Utf8.capitalize_fst (transl conf "visualize"));
+  Output.print_sstring conf "</a>";
+
   if not is_empty then (
     Output.print_sstring conf {|<a href="|};
     Output.print_string conf (commd conf);

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -235,7 +235,6 @@ let bold_italic_syntax s =
 
 let syntax_links conf wi s =
   let buff = Buffer.create 80 in
-  let chars = [ '{'; '%'; '\''; '[' ] in
   let cancel_links = Util.p_getenv conf.env "cgl" = Some "on" in
   let slen = String.length s in
   let rec loop quot_lev pos i =
@@ -254,12 +253,9 @@ let syntax_links conf wi s =
          || s.[i + 1] = '{'
          || s.[i + 1] = '}'
          || s.[i + 1] = '\'')
-      && List.mem s.[i + 1] [ '['; ']'; '{'; '}'; '\'' ]
     then (
       Buffer.add_char buff s.[i + 1];
       loop quot_lev pos (i + 2))
-    else if s.[i] = '%' && i < slen - 1 && s.[i + 1] = '/' then
-      loop quot_lev pos (i + 2) (* ignore !!?? *)
     else if s.[i] = '%' then (
       Buffer.add_char buff '%';
       loop quot_lev pos (i + 1))
@@ -378,16 +374,8 @@ let syntax_links conf wi s =
           Buffer.add_string buff t;
           loop quot_lev (pos + 1) j
       | NotesLinks.WLnone (j, none_s) -> (
-          match find_first_char_from_list none_s 0 chars with
-          | None ->
-              Buffer.add_string buff none_s;
-              loop quot_lev pos j
-          | Some k when none_s.[k] <> '[' ->
-              Buffer.add_string buff (String.sub none_s 0 k);
-              loop quot_lev pos (j - String.length none_s + k)
-          | Some k ->
-              Buffer.add_char buff '[';
-              loop quot_lev pos (j - String.length none_s + k + 1))
+          Buffer.add_string buff none_s;
+          loop quot_lev pos j)
   in
   loop Zero 1 0;
   Buffer.contents buff

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -373,9 +373,9 @@ let syntax_links conf wi s =
           in
           Buffer.add_string buff t;
           loop quot_lev (pos + 1) j
-      | NotesLinks.WLnone (j, none_s) -> (
+      | NotesLinks.WLnone (j, none_s) ->
           Buffer.add_string buff none_s;
-          loop quot_lev pos j)
+          loop quot_lev pos j
   in
   loop Zero 1 0;
   Buffer.contents buff


### PR DESCRIPTION
* restrict access to notes according to a list of ancestors 
  RESTRICT= [[p1/n1/oc1]],[[p2\n2/oc2]],... at the head of the note (after TITLE)
  oci is mandatory
* add back refs to notes and albums (where is this note/album mentionned)
* in notes, the %i and %k syntax expands to index and key
* allow wiki link in description field of album/gallery
* hide secret-salt value in gwd launch parameters (conf.txt)
* reset fir each request the nbr of errors reported in the hourglass (home.txt)
* fix some wiki syntax formatting in notes (pending a major rehaul)
* set initial value of nb_persons in the base to 0 rather than -1 