### PR TITLE
[WIP] New parser for TLSW

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -48,6 +48,10 @@
     digestif
     pp_loc
     dune-site
+    tyxml
+    cmdliner
+    progress
+    logs
     (utop :with-dev-setup)
     (ocamlformat (and :with-dev-setup (= "0.28.1")))
   )

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,9 @@
               logs
               yojson
               fmt
+              syslog-message # shouldn't be necessary
+              tyxml
+              progress
             ]);
           };
         };

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -42,6 +42,10 @@ depends: [
   "digestif"
   "pp_loc"
   "dune-site"
+  "tyxml"
+  "cmdliner"
+  "progress"
+  "logs"
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "odoc" {with-doc}

--- a/lib/compat/geneweb_compat.ml
+++ b/lib/compat/geneweb_compat.ml
@@ -34,6 +34,92 @@ module In_channel = struct
     match Stdlib.input_line ic with
     | s -> Some s
     | exception End_of_file -> None
+
+  (* Read up to [len] bytes into [buf], starting at [ofs]. Return total bytes
+     read. *)
+  let read_upto ic buf ofs len =
+    let rec loop ofs len =
+      if len = 0 then ofs
+      else
+        let r = Stdlib.input ic buf ofs len in
+        if r = 0 then ofs else loop (ofs + r) (len - r)
+    in
+    loop ofs len - ofs
+
+  (* Best effort attempt to return a buffer with >= (ofs + n) bytes of storage,
+     and such that it coincides with [buf] at indices < [ofs].
+
+     The returned buffer is equal to [buf] itself if it already has sufficient
+     free space.
+
+     The returned buffer may have *fewer* than [ofs + n] bytes of storage if this
+     number is > [Sys.max_string_length]. However the returned buffer will
+     *always* have > [ofs] bytes of storage. In the limiting case when [ofs = len
+     = Sys.max_string_length] (so that it is not possible to resize the buffer at
+     all), an exception is raised. *)
+
+  let ensure buf ofs n =
+    let len = Bytes.length buf in
+    if len >= ofs + n then buf
+    else
+      let new_len = ref len in
+      while !new_len < ofs + n do
+        new_len := (2 * !new_len) + 1
+      done;
+      let new_len = !new_len in
+      let new_len =
+        if new_len <= Sys.max_string_length then new_len
+        else if ofs < Sys.max_string_length then Sys.max_string_length
+        else
+          failwith
+            "In_channel.input_all: channel content is larger than maximum \
+             string length"
+      in
+      let new_buf = Bytes.create new_len in
+      Bytes.blit buf 0 new_buf 0 ofs;
+      new_buf
+
+  let input_all ic =
+    let chunk_size = 65536 in
+    (* IO_BUFFER_SIZE *)
+    let initial_size =
+      try Stdlib.in_channel_length ic - Stdlib.pos_in ic
+      with Sys_error _ -> -1
+    in
+    let initial_size = if initial_size < 0 then chunk_size else initial_size in
+    let initial_size =
+      if initial_size <= Sys.max_string_length then initial_size
+      else Sys.max_string_length
+    in
+    let buf = Bytes.create initial_size in
+    let nread = read_upto ic buf 0 initial_size in
+    if nread < initial_size then
+      (* EOF reached, buffer partially filled *)
+      Bytes.sub_string buf 0 nread
+    else
+      (* nread = initial_size, maybe EOF reached *)
+      match Stdlib.input_char ic with
+      | exception End_of_file ->
+          (* EOF reached, buffer is completely filled *)
+          Bytes.unsafe_to_string buf
+      | c ->
+          (* EOF not reached *)
+          let rec loop buf ofs =
+            let buf = ensure buf ofs chunk_size in
+            let rem = Bytes.length buf - ofs in
+            (* [rem] can be < [chunk_size] if buffer size close to
+               [Sys.max_string_length] *)
+            let r = read_upto ic buf ofs rem in
+            if r < rem then (* EOF reached *)
+              Bytes.sub_string buf 0 (ofs + r)
+            else (* r = rem *)
+              loop buf (ofs + rem)
+          in
+          let buf = ensure buf nread (chunk_size + 1) in
+          Bytes.set buf nread c;
+          loop buf (nread + 1)
+
+  external is_binary_mode : in_channel -> bool = "caml_ml_is_binary_mode"
 end
 
 module Out_channel = struct

--- a/lib/compat/geneweb_compat.mli
+++ b/lib/compat/geneweb_compat.mli
@@ -57,6 +57,19 @@ module In_channel : sig
       A newline is the character [\n] unless the file is open in text mode and
       {!Sys.win32} is [true] in which case it is the sequence of characters
       [\r\n]. *)
+
+  val input_all : t -> string
+  (** [input_all ic] reads all remaining data from [ic].
+
+      If the same channel is read concurrently by multiple threads, the returned
+      string is not guaranteed to contain contiguous characters from the input.
+  *)
+
+  val is_binary_mode : t -> bool
+  (** [is_binary_mode ic] returns whether the channel [ic] is in binary mode
+      (see {!set_binary_mode}).
+
+      @since 5.2 *)
 end
 
 module Out_channel : sig

--- a/lib/dune
+++ b/lib/dune
@@ -24,9 +24,11 @@
   geneweb_util
   geneweb_templ
   geneweb_logs
+  geneweb_tlsw
   yojson
   markup
   re
   uucp
   uri
-  digestif))
+  digestif
+  tyxml))

--- a/lib/loc/dune
+++ b/lib/loc/dune
@@ -1,0 +1,4 @@
+(library
+ (package geneweb)
+ (name geneweb_loc)
+ (libraries geneweb_compat fmt pp_loc))

--- a/lib/loc/geneweb_loc.ml
+++ b/lib/loc/geneweb_loc.ml
@@ -1,21 +1,29 @@
 module Compat = Geneweb_compat
 
-type source = [ `File of string | `Raw of string ]
+type source = [ `File of string | `In_channel of in_channel | `Raw of string ]
 
 let equal_source src1 src2 =
   match (src1, src2) with
   | `File f1, `File f2 -> String.equal f1 f2
   | `File _, _ | _, `File _ -> false
+  | `In_channel ic1, `In_channel ic2 -> ic1 = ic2
+  | `In_channel _, _ | _, `In_channel _ -> false
   | `Raw s1, `Raw s2 -> String.equal s1 s2
 
 let pp_source ppf src =
-  match src with `File f -> Fmt.string ppf f | `Raw _ -> Fmt.pf ppf "<raw>"
+  match src with
+  | `File f -> Fmt.string ppf f
+  | `In_channel _ -> Fmt.pf ppf "<in_channel>"
+  | `Raw _ -> Fmt.pf ppf "<raw>"
 
 type t = { src : source; start : int; stop : int }
 
 let dummy = { src = `File "<dummy>"; start = -1; stop = -1 }
 let[@inline] is_dummy t = t == dummy
-let[@inline] of_offsets src start stop = { src; start; stop }
+
+let[@inline always] mk src start stop =
+  assert (0 <= start && start <= stop);
+  { src; start; stop }
 
 let equal { src = s11; start = s12; stop = s13 }
     { src = s21; start = s22; stop = s23 } =
@@ -37,6 +45,9 @@ let with_pp_loc_input src k =
       Compat.In_channel.with_open_text f @@ fun ic ->
       k (Pp_loc.Input.in_channel ic)
   | `Raw s -> k (Pp_loc.Input.string s)
+  | `In_channel ic ->
+      assert (not @@ Compat.In_channel.is_binary_mode ic);
+      k (Pp_loc.Input.in_channel ic)
 
 let pp ppf ({ src; start; stop } as t) =
   if is_dummy t then Fmt.pf ppf "<dummy>"

--- a/lib/loc/geneweb_loc.mli
+++ b/lib/loc/geneweb_loc.mli
@@ -1,7 +1,7 @@
 type t
 (** Type of locations. *)
 
-type source = [ `File of string | `Raw of string ]
+type source = [ `File of string | `In_channel of in_channel | `Raw of string ]
 (** Type of sources. *)
 
 val equal_source : source -> source -> bool
@@ -17,9 +17,9 @@ val dummy : t
 val is_dummy : t -> bool
 (** [is_dummy t] checks if [t] is the dummy location. *)
 
-val of_offsets : source -> int -> int -> t
-(** [of_offsets src start stop] creates a location for the source [src] starting
-    at [start] and ending at [stop]. *)
+val mk : source -> int -> int -> t
+(** [mk src start stop] creates a location for the source [src] starting at
+    [start] and ending at [stop]. *)
 
 val equal : t -> t -> bool
 (** [equal t1 t2] checks if the locations [t1] and [t2] are equal. *)

--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -21,7 +21,7 @@ let read_notes base fnotes =
   Wiki.split_title_and_text s
 
 let merge_possible_aliases conf db =
-  let aliases = Wiki.notes_aliases conf in
+  let aliases = Wiki.parse_notes_aliases conf in
   let db =
     List.map
       (fun (pg, (sl, il)) ->

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1579,17 +1579,19 @@ let mode_local env =
 let get_note_or_source conf base
     ?(p = Driver.empty_person base Driver.Iper.dummy) auth no_note
     note_or_source =
+  let _ = p in
   let note_or_source = Driver.sou base note_or_source in
   if auth && not no_note then
     (* TODO investigate the use of i in env *)
     (* in notes, %i becomes index. Other use ??  *)
-    let env =
-      [
-        ('i', fun () -> Driver.Iper.to_string (Driver.get_iper p));
-        ('k', fun () -> Image.default_image_filename "portraits" base p);
-      ]
-    in
-    let lines = Wiki.html_of_tlsw conf note_or_source in
+    (* let env = *)
+    (*   [ *)
+    (*     ('i', fun () -> Driver.Iper.to_string (Driver.get_iper p)); *)
+    (*     ('k', fun () -> Image.default_image_filename "portraits" base p); *)
+    (*   ] *)
+    (* in *)
+    Wiki.html_of_tlsw2 conf base note_or_source |> Adef.safe |> safe_val
+    (* let lines = Wiki.html_of_tlsw conf note_or_source in
     let lines =
       (* remove enclosing <p> .. </p> if any *)
       if List.compare_length_with lines 2 > 0 then
@@ -1602,7 +1604,7 @@ let get_note_or_source conf base
       else lines
     in
     Notes.source_note_with_env conf base env (String.concat "\n" lines)
-    |> safe_val
+    |> safe_val *)
   else null_val
 
 let date_aux conf p_auth date =

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -8,7 +8,7 @@ let src = Logs.Src.create ~doc:"Perso" __MODULE__
 
 module Log = (val Logs.src_log src : Logs.LOG)
 module Sosa = Geneweb_sosa
-module Loc = Geneweb_templ.Loc
+module Loc = Geneweb_loc
 module Collection = Geneweb_db.Collection
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -4,7 +4,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Sosa = Geneweb_sosa
 module Parser = Geneweb_templ.Parser
 module Ast = Geneweb_templ.Ast
-module Loc = Geneweb_templ.Loc
+module Loc = Geneweb_loc
 module Driver = Geneweb_db.Driver
 
 exception UnboundVar

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -1,5 +1,5 @@
 module Ast = Geneweb_templ.Ast
-module Loc = Geneweb_templ.Loc
+module Loc = Geneweb_loc
 
 module Env : sig
   type 'a t

--- a/lib/templ/ast.ml
+++ b/lib/templ/ast.ml
@@ -1,4 +1,5 @@
 module Compat = Geneweb_compat
+module Loc = Geneweb_loc
 
 type desc =
   | Atext of string
@@ -17,7 +18,7 @@ type desc =
   | Ainclude of [ `File of string | `Raw of string ]
   | Apack of t list
 
-and t = { desc : desc; loc : Loc.t }
+and t = { desc : desc; loc : Geneweb_loc.t }
 
 let equal_pair eq1 eq2 (x1, y1) (x2, y2) = eq1 x1 x2 && eq2 y1 y2
 

--- a/lib/templ/ast.mli
+++ b/lib/templ/ast.mli
@@ -15,7 +15,7 @@ type desc = private
   | Ainclude of [ `File of string | `Raw of string ]
   | Apack of t list
 
-and t = private { desc : desc; loc : Loc.t }
+and t = private { desc : desc; loc : Geneweb_loc.t }
 
 val equal : t -> t -> bool
 (** [equal t1 t2] checks if the ast node [t1] and [t2] are equal. *)
@@ -24,27 +24,34 @@ val pp : t Fmt.t
 (** [pp ppf t] prints the ast node [t] on the formatter [ppf] for debugging
     purpose. *)
 
-val mk_text : ?loc:Loc.t -> string -> t
-val mk_var : ?loc:Loc.t -> string -> string list -> t
-val mk_transl : ?loc:Loc.t -> bool -> string -> string -> t
-val mk_wid_hei : ?loc:Loc.t -> string -> t
-val mk_if : ?loc:Loc.t -> t -> t list -> t list -> t
+val mk_text : ?loc:Geneweb_loc.t -> string -> t
+val mk_var : ?loc:Geneweb_loc.t -> string -> string list -> t
+val mk_transl : ?loc:Geneweb_loc.t -> bool -> string -> string -> t
+val mk_wid_hei : ?loc:Geneweb_loc.t -> string -> t
+val mk_if : ?loc:Geneweb_loc.t -> t -> t list -> t list -> t
 
 val mk_foreach :
-  ?loc:Loc.t -> string * string list -> t list list -> t list -> t
+  ?loc:Geneweb_loc.t -> string * string list -> t list list -> t list -> t
 
-val mk_for : ?loc:Loc.t -> string -> t -> t -> t list -> t
+val mk_for : ?loc:Geneweb_loc.t -> string -> t -> t -> t list -> t
 
 val mk_define :
-  ?loc:Loc.t -> string -> (string * t option) list -> t list -> t list -> t
+  ?loc:Geneweb_loc.t ->
+  string ->
+  (string * t option) list ->
+  t list ->
+  t list ->
+  t
 
-val mk_apply : ?loc:Loc.t -> string -> (string option * t list) list -> t
-val mk_let : ?loc:Loc.t -> string -> t list -> t list -> t
-val mk_op1 : ?loc:Loc.t -> string -> t -> t
-val mk_op2 : ?loc:Loc.t -> string -> t -> t -> t
-val mk_int : ?loc:Loc.t -> string -> t
-val mk_include : ?loc:Loc.t -> [ `File of string | `Raw of string ] -> t
-val mk_pack : ?loc:Loc.t -> t list -> t
+val mk_apply :
+  ?loc:Geneweb_loc.t -> string -> (string option * t list) list -> t
+
+val mk_let : ?loc:Geneweb_loc.t -> string -> t list -> t list -> t
+val mk_op1 : ?loc:Geneweb_loc.t -> string -> t -> t
+val mk_op2 : ?loc:Geneweb_loc.t -> string -> t -> t -> t
+val mk_int : ?loc:Geneweb_loc.t -> string -> t
+val mk_include : ?loc:Geneweb_loc.t -> [ `File of string | `Raw of string ] -> t
+val mk_pack : ?loc:Geneweb_loc.t -> t list -> t
 
 val subst : (string -> string) -> t -> t
 (** [subst f t] applies the substitution [f] on all variables of the ast node

--- a/lib/templ/dune
+++ b/lib/templ/dune
@@ -3,4 +3,4 @@
 (library
  (name geneweb_templ)
  (public_name geneweb.templ)
- (libraries geneweb_compat fmt pp_loc))
+ (libraries geneweb_compat geneweb_loc fmt))

--- a/lib/templ/lexer.mll
+++ b/lib/templ/lexer.mll
@@ -1,4 +1,5 @@
 {
+module Loc = Geneweb_loc
 
 module State : sig
   type t = private {
@@ -32,7 +33,7 @@ end = struct
 
   let current_loc (st : t) =
     let stop = st.lexbuf.Lexing.lex_abs_pos + st.lexbuf.Lexing.lex_curr_pos in
-    Loc.of_offsets st.src st.start stop
+    Loc.mk st.src st.start stop
 
   let push_token tk st =
     { st with tokens = tk :: st.tokens }

--- a/lib/templ/parser.ml
+++ b/lib/templ/parser.ml
@@ -14,8 +14,7 @@ let parse_ast ~src lexbuf =
   let st = Lexer.State.create ~src lexbuf in
   Lexer.parse_ast (Buffer.create 1024) [] st lexbuf |> fst
 
-let parse_file ~src fl =
-  Compat.In_channel.with_open_text fl @@ fun ic ->
+let parse_ic ~src ic =
   (* We do not use position feature of the Lexing module as our lexer does not
      produce a single token per call. Instead, we rely on
      `lex_abs_pos`, `lex_start_pos` and `lex_curr_pos` of [lexbuf] to compute
@@ -23,11 +22,14 @@ let parse_file ~src fl =
   let lexbuf = Lexing.from_channel ~with_positions:false ic in
   parse_ast ~src lexbuf
 
+let parse_file ~src fl = Compat.In_channel.with_open_text fl (parse_ic ~src)
+
 let parse_source ~cached src =
   match src with
   | `File fl ->
       if cached then with_cache (parse_file ~src) fl else parse_file ~src fl
   | `Raw s -> parse_ast ~src (Lexing.from_string ~with_positions:false s)
+  | `In_channel ic -> parse_ic ~src ic
 
 let comment fl =
   let s =

--- a/lib/templ/parser.mli
+++ b/lib/templ/parser.mli
@@ -1,8 +1,8 @@
 val parse :
   ?cached:bool ->
   on_exn:(exn -> Printexc.raw_backtrace -> unit) ->
-  resolve_include:(Loc.t -> string -> string) ->
-  Loc.source ->
+  resolve_include:(Geneweb_loc.t -> string -> string) ->
+  Geneweb_loc.source ->
   Ast.t list
 (** [parse ?cached ~on_exn ~find src] parses [src] and expands included
     templates.

--- a/lib/tlsw/ast.ml
+++ b/lib/tlsw/ast.ml
@@ -4,9 +4,9 @@ module Loc = Geneweb_loc
 type 'a located = { desc : 'a; loc : Geneweb_loc.t }
 
 type link_tag =
-  | Person of string * string * int option
-  | Note of string
-  | Wizard of string
+  | Person of { fn : string; sn : string; occ : int option }
+  | Note of { path : string }
+  | Wizard of { path : string }
   | Image of { path : string; width : string option }
 
 type link_desc = [ `Link of link_tag * string option ]
@@ -24,7 +24,7 @@ and node = node_desc located
 type size = One | Two | Three | Four | Five | Six
 type toc = Std | Short | No
 
-type block =
+type block_desc =
   [ `Header of size * string
   | `Toc of toc
   | `Newline
@@ -34,16 +34,16 @@ type block =
   | node_desc
   | text_desc ]
 
-and t = block located
+and block = block_desc located
 
 let equal t1 t2 = t1 = t2
 
 let pp_link_tag ppf t =
   match t with
-  | Person (fn, sn, occ) ->
+  | Person { fn; sn; occ } ->
       Fmt.pf ppf "Person (%S, %S, %a)" fn sn Fmt.(option int) occ
-  | Note fl -> Fmt.pf ppf "Note (%S)" fl
-  | Wizard fl -> Fmt.pf ppf "Wizard (%S)" fl
+  | Note { path } -> Fmt.pf ppf "Note (%S)" path
+  | Wizard { path } -> Fmt.pf ppf "Wizard (%S)" path
   | Image { path; width } ->
       Fmt.pf ppf "Image (%S, %a)" path Fmt.(option Dump.string) width
 
@@ -125,16 +125,16 @@ let[@inline always] mk_rule ?loc () = mk ?loc @@ `Rule
 
 let link_to_html (tag, s) =
   match tag with
-  | Person (fn, sn, occ) ->
+  | Person { fn; sn; occ } ->
       let s =
         Fmt.str "(%s/%s/%a) %a" fn sn Fmt.(option int) occ Fmt.(option string) s
       in
       Html.(span ~a:[ a_style "color: blue" ] [ txt s ])
-  | Note fl ->
-      let s = Fmt.str "(%s)%a" fl Fmt.(option string) s in
+  | Note { path } ->
+      let s = Fmt.str "(%s)%a" path Fmt.(option string) s in
       Html.(span ~a:[ a_style "color: red" ] [ txt s ])
-  | Wizard fl ->
-      let s = Fmt.str "(%s)%a" fl Fmt.(option string) s in
+  | Wizard { path } ->
+      let s = Fmt.str "(%s)%a" path Fmt.(option string) s in
       Html.(span ~a:[ a_style "color: green" ] [ txt s ])
   | Image { path; _ } ->
       let s = Fmt.str "(%s)%a" path Fmt.(option string) s in

--- a/lib/tlsw/ast.ml
+++ b/lib/tlsw/ast.ml
@@ -1,0 +1,194 @@
+module Html = Tyxml.Html
+module Loc = Geneweb_loc
+
+type 'a located = { desc : 'a; loc : Geneweb_loc.t }
+
+type link_tag =
+  | Person of string * string * int option
+  | Note of string
+  | Wizard of string
+  | Image of { path : string; width : string option }
+
+type link_desc = [ `Link of link_tag * string option ]
+type link = link_desc located
+type tag = Plain | Italic | Bold | BoldItalic | Strike | Underline | Highlight
+type span_desc = [ `Span of tag * string | link_desc ]
+type span = span_desc located
+type text_desc = [ `Text of span list ]
+type text = text_desc located
+type kind = Ordered | Unordered
+
+type node_desc = [ `Node of text option * kind * node list ]
+and node = node_desc located
+
+type size = One | Two | Three | Four | Five | Six
+type toc = Std | Short | No
+
+type block =
+  [ `Header of size * string
+  | `Toc of toc
+  | `Newline
+  | `Rule
+  | `Indent of int * text
+  | `Pre of string
+  | node_desc
+  | text_desc ]
+
+and t = block located
+
+let equal t1 t2 = t1 = t2
+
+let pp_link_tag ppf t =
+  match t with
+  | Person (fn, sn, occ) ->
+      Fmt.pf ppf "Person (%S, %S, %a)" fn sn Fmt.(option int) occ
+  | Note fl -> Fmt.pf ppf "Note (%S)" fl
+  | Wizard fl -> Fmt.pf ppf "Wizard (%S)" fl
+  | Image { path; width } ->
+      Fmt.pf ppf "Image (%S, %a)" path Fmt.(option Dump.string) width
+
+let pp_tag ppf t =
+  match t with
+  | Plain -> Fmt.pf ppf "Plain"
+  | Italic -> Fmt.pf ppf "Italic"
+  | Bold -> Fmt.pf ppf "Bold"
+  | BoldItalic -> Fmt.pf ppf "BoldItalic"
+  | Strike -> Fmt.pf ppf "Strike"
+  | Underline -> Fmt.pf ppf "Underline"
+  | Highlight -> Fmt.pf ppf "Highlight"
+
+let pp_size ppf sz =
+  match sz with
+  | One -> Fmt.pf ppf "One"
+  | Two -> Fmt.pf ppf "Two"
+  | Three -> Fmt.pf ppf "Three"
+  | Four -> Fmt.pf ppf "Four"
+  | Five -> Fmt.pf ppf "Five"
+  | Six -> Fmt.pf ppf "Six"
+
+let pp_toc ppf toc =
+  match toc with
+  | Std -> Fmt.pf ppf "Std"
+  | Short -> Fmt.pf ppf "Short"
+  | No -> Fmt.pf ppf "No"
+
+let pp_link_desc ppf (`Link (tag, s)) =
+  Fmt.pf ppf "Link (%a, %a)" pp_link_tag tag Fmt.(option Dump.string) s
+
+let pp_link ppf { desc; _ } = pp_link_desc ppf desc
+
+let pp_span ppf { desc; _ } =
+  match desc with
+  | #link_desc as t -> pp_link_desc ppf t
+  | `Span (tag, s) -> Fmt.pf ppf "Span (%a, %S)" pp_tag tag s
+
+let pp_text_desc ppf (`Text l) = Fmt.(list ~sep:comma pp_span) ppf l
+let pp_text ppf { desc; _ } = pp_text_desc ppf desc
+
+let pp_kind ppf k =
+  match k with
+  | Ordered -> Fmt.pf ppf "Ordered"
+  | Unordered -> Fmt.pf ppf "Unordered"
+
+let rec pp_node_desc ppf (`Node (t, k, l)) =
+  Fmt.pf ppf "Node (%a, %a, %a)"
+    Fmt.(option pp_text)
+    t pp_kind k
+    Fmt.(list ~sep:comma pp_node)
+    l
+
+and pp_node ppf { desc; _ } = pp_node_desc ppf desc
+
+let pp_block ppf t =
+  match t with
+  | `Header (sz, t) -> Fmt.pf ppf "Header (%a, %S)" pp_size sz t
+  | `Toc toc -> Fmt.pf ppf "Toc (%a)" pp_toc toc
+  | `Newline -> Fmt.pf ppf "Newline"
+  | `Rule -> Fmt.pf ppf "Rule"
+  | `Indent (c, t) -> Fmt.pf ppf "Indent (%d, %a)" c pp_text t
+  | `Pre s -> Fmt.pf ppf "Pre (%S)" s
+  | #node_desc as t -> pp_node_desc ppf t
+  | #text_desc as t -> pp_text_desc ppf t
+
+let pp ppf { desc; _ } = pp_block ppf desc
+let[@inline always] mk ?(loc = Loc.dummy) desc = { desc; loc }
+let[@inline always] mk_link ?loc x y = mk ?loc @@ `Link (x, y)
+let[@inline always] mk_span ?loc x y = mk ?loc @@ `Span (x, y)
+let[@inline always] mk_node ?loc x y z = mk ?loc @@ `Node (x, y, z)
+let[@inline always] mk_header ?loc x y = mk ?loc @@ `Header (x, y)
+let[@inline always] mk_toc ?loc x = mk ?loc @@ `Toc x
+let[@inline always] mk_text ?loc x = mk ?loc @@ `Text x
+let[@inline always] mk_indent ?loc x y = mk ?loc @@ `Indent (x, y)
+let[@inline always] mk_pre ?loc x = mk ?loc @@ `Pre x
+let[@inline always] mk_newline ?loc () = mk ?loc @@ `Newline
+let[@inline always] mk_rule ?loc () = mk ?loc @@ `Rule
+
+let link_to_html (tag, s) =
+  match tag with
+  | Person (fn, sn, occ) ->
+      let s =
+        Fmt.str "(%s/%s/%a) %a" fn sn Fmt.(option int) occ Fmt.(option string) s
+      in
+      Html.(span ~a:[ a_style "color: blue" ] [ txt s ])
+  | Note fl ->
+      let s = Fmt.str "(%s)%a" fl Fmt.(option string) s in
+      Html.(span ~a:[ a_style "color: red" ] [ txt s ])
+  | Wizard fl ->
+      let s = Fmt.str "(%s)%a" fl Fmt.(option string) s in
+      Html.(span ~a:[ a_style "color: green" ] [ txt s ])
+  | Image { path; _ } ->
+      let s = Fmt.str "(%s)%a" path Fmt.(option string) s in
+      Html.(span ~a:[ a_style "color: yellow" ] [ txt s ])
+
+let span_to_html { desc; _ } =
+  match desc with
+  | `Link l -> link_to_html l
+  | `Span (tag, s) -> (
+      match tag with
+      | Plain -> Html.txt s
+      | Italic -> Html.(i [ txt s ])
+      | Bold -> Html.(b [ txt s ])
+      | BoldItalic -> Html.(b [ i [ txt s ] ])
+      | Strike ->
+          Html.(span ~a:[ a_style "text-decoration: line-through" ] [ txt s ])
+      | Underline ->
+          Html.(span ~a:[ a_style "text-decoration: underline" ] [ txt s ])
+      | Highlight -> Html.(mark [ txt s ]))
+
+let text_desc_to_html (`Text l) = List.map span_to_html l
+let text_to_html { desc; _ } = text_desc_to_html desc
+
+let rec node_desc_to_html (`Node (t, k, l)) =
+  let l = node_list_to_html k l in
+  match t with
+  | Some t -> Html.(li (text_to_html t @ [ l ]))
+  | None -> Html.(li [ l ])
+
+and node_list_to_html k l =
+  let l = List.map (fun { desc; _ } -> node_desc_to_html desc) l in
+  match l with
+  | [] -> Html.(txt "")
+  | _ -> ( match k with Ordered -> Html.(ol l) | Unordered -> Html.(ul l))
+
+let to_html { desc; _ } =
+  match desc with
+  | `Header (One, s) -> Html.(h1 [ txt s ])
+  | `Header (Two, s) -> Html.(h2 [ txt s ])
+  | `Header (Three, s) -> Html.(h3 [ txt s ])
+  | `Header (Four, s) -> Html.(h4 [ txt s ])
+  | `Header (Five, s) -> Html.(h5 [ txt s ])
+  | `Header (Six, s) -> Html.(h6 [ txt s ])
+  | `Toc Std -> Html.(div [ txt "__TOC__" ])
+  | `Toc Short -> Html.(div [ txt "__SHORT_TOC__" ])
+  | `Toc No -> Html.(div [ txt "__NOTOC__" ])
+  | `Indent (lvl, t) ->
+      let s = Fmt.str "text-indent: %d%%;" (lvl * 5) in
+      Html.(p ~a:[ a_style s ] @@ text_to_html t)
+  | `Pre s -> Html.(pre [ txt s ])
+  | `Node (None, k, l) -> node_list_to_html k l
+  | `Node (Some _, _, _) ->
+      (* Top level lists never contain text. *)
+      assert false
+  | `Newline -> Html.br ()
+  | `Rule -> Html.hr ()
+  | #text_desc as t -> Html.(p @@ text_desc_to_html t)

--- a/lib/tlsw/ast.ml
+++ b/lib/tlsw/ast.ml
@@ -4,14 +4,23 @@ module Loc = Geneweb_loc
 type 'a located = { desc : 'a; loc : Geneweb_loc.t }
 
 type link_tag =
-  | Person of { fn : string; sn : string; occ : int option }
-  | Note of { path : string }
-  | Wizard of { path : string }
+  | Person of { fn : string; sn : string; oc : int option }
+  | Note of { path : string; anchor : string option; wizard : bool }
   | Image of { path : string; width : string option }
 
 type link_desc = [ `Link of link_tag * string option ]
 type link = link_desc located
-type tag = Plain | Italic | Bold | BoldItalic | Strike | Underline | Highlight
+
+type tag =
+  | Plain
+  | Italic
+  | Bold
+  | BoldItalic
+  | Strike
+  | Underline
+  | Highlight
+  | Error
+
 type span_desc = [ `Span of tag * string | link_desc ]
 type span = span_desc located
 type text_desc = [ `Text of span list ]
@@ -40,10 +49,10 @@ let equal t1 t2 = t1 = t2
 
 let pp_link_tag ppf t =
   match t with
-  | Person { fn; sn; occ } ->
-      Fmt.pf ppf "Person (%S, %S, %a)" fn sn Fmt.(option int) occ
-  | Note { path } -> Fmt.pf ppf "Note (%S)" path
-  | Wizard { path } -> Fmt.pf ppf "Wizard (%S)" path
+  | Person { fn; sn; oc } ->
+      Fmt.pf ppf "Person (%S, %S, %a)" fn sn Fmt.(option int) oc
+  | Note { path; anchor; wizard } ->
+      Fmt.pf ppf "Note (%S, %a, %b)" path Fmt.(option string) anchor wizard
   | Image { path; width } ->
       Fmt.pf ppf "Image (%S, %a)" path Fmt.(option Dump.string) width
 
@@ -56,6 +65,7 @@ let pp_tag ppf t =
   | Strike -> Fmt.pf ppf "Strike"
   | Underline -> Fmt.pf ppf "Underline"
   | Highlight -> Fmt.pf ppf "Highlight"
+  | Error -> Fmt.pf ppf "Error"
 
 let pp_size ppf sz =
   match sz with
@@ -111,31 +121,39 @@ let pp_block ppf t =
   | #text_desc as t -> pp_text_desc ppf t
 
 let pp ppf { desc; _ } = pp_block ppf desc
-let[@inline always] mk ?(loc = Loc.dummy) desc = { desc; loc }
-let[@inline always] mk_link ?loc x y = mk ?loc @@ `Link (x, y)
-let[@inline always] mk_span ?loc x y = mk ?loc @@ `Span (x, y)
-let[@inline always] mk_node ?loc x y z = mk ?loc @@ `Node (x, y, z)
-let[@inline always] mk_header ?loc x y = mk ?loc @@ `Header (x, y)
-let[@inline always] mk_toc ?loc x = mk ?loc @@ `Toc x
-let[@inline always] mk_text ?loc x = mk ?loc @@ `Text x
-let[@inline always] mk_indent ?loc x y = mk ?loc @@ `Indent (x, y)
-let[@inline always] mk_pre ?loc x = mk ?loc @@ `Pre x
-let[@inline always] mk_newline ?loc () = mk ?loc @@ `Newline
-let[@inline always] mk_rule ?loc () = mk ?loc @@ `Rule
+let[@inline] mk ?(loc = Loc.dummy) desc = { desc; loc }
+let[@inline] mk_link ?loc x y = mk ?loc @@ `Link (x, y)
+let[@inline] mk_span ?loc x y = mk ?loc @@ `Span (x, y)
+
+let[@inline] mk_person_link ?loc ~fn ~sn ?oc =
+  mk_link ?loc (Person { fn; sn; oc })
+
+let[@inline] mk_note_link ?loc ~path ?anchor ~wizard =
+  if wizard && Option.is_some anchor then failwith "mk_note_link";
+  mk_link ?loc (Note { path; anchor; wizard })
+
+let[@inline] mk_image_link ?loc ~path ?width =
+  mk_link ?loc (Image { path; width })
+
+let[@inline] mk_node ?loc x y z = mk ?loc @@ `Node (x, y, z)
+let[@inline] mk_header ?loc x y = mk ?loc @@ `Header (x, y)
+let[@inline] mk_toc ?loc x = mk ?loc @@ `Toc x
+let[@inline] mk_text ?loc x = mk ?loc @@ `Text x
+let[@inline] mk_indent ?loc x y = mk ?loc @@ `Indent (x, y)
+let[@inline] mk_pre ?loc x = mk ?loc @@ `Pre x
+let[@inline] mk_newline ?loc () = mk ?loc @@ `Newline
+let[@inline] mk_rule ?loc () = mk ?loc @@ `Rule
 
 let link_to_html (tag, s) =
   match tag with
-  | Person { fn; sn; occ } ->
+  | Person { fn; sn; oc } ->
       let s =
-        Fmt.str "(%s/%s/%a) %a" fn sn Fmt.(option int) occ Fmt.(option string) s
+        Fmt.str "(%s/%s/%a) %a" fn sn Fmt.(option int) oc Fmt.(option string) s
       in
       Html.(span ~a:[ a_style "color: blue" ] [ txt s ])
-  | Note { path } ->
+  | Note { path; anchor = _; wizard = _ } ->
       let s = Fmt.str "(%s)%a" path Fmt.(option string) s in
       Html.(span ~a:[ a_style "color: red" ] [ txt s ])
-  | Wizard { path } ->
-      let s = Fmt.str "(%s)%a" path Fmt.(option string) s in
-      Html.(span ~a:[ a_style "color: green" ] [ txt s ])
   | Image { path; _ } ->
       let s = Fmt.str "(%s)%a" path Fmt.(option string) s in
       Html.(span ~a:[ a_style "color: yellow" ] [ txt s ])
@@ -153,7 +171,8 @@ let span_to_html { desc; _ } =
           Html.(span ~a:[ a_style "text-decoration: line-through" ] [ txt s ])
       | Underline ->
           Html.(span ~a:[ a_style "text-decoration: underline" ] [ txt s ])
-      | Highlight -> Html.(mark [ txt s ]))
+      | Highlight -> Html.(mark [ txt s ])
+      | Error -> Html.(span ~a:[ a_style "color: red" ] [ txt s ]))
 
 let text_desc_to_html (`Text l) = List.map span_to_html l
 let text_to_html { desc; _ } = text_desc_to_html desc

--- a/lib/tlsw/ast.mli
+++ b/lib/tlsw/ast.mli
@@ -1,0 +1,67 @@
+type +'a located = { desc : 'a; loc : Geneweb_loc.t }
+
+(** {2 Span language} *)
+
+type link_tag =
+  | Person of string * string * int option
+  | Note of string
+  | Wizard of string
+  | Image of { path : string; width : string option }
+
+type link_desc = [ `Link of link_tag * string option ]
+type link = link_desc located
+
+val mk_link : ?loc:Geneweb_loc.t -> link_tag -> string option -> link
+val pp_link : link Fmt.t
+
+type tag = Plain | Italic | Bold | BoldItalic | Strike | Underline | Highlight
+type span_desc = [ `Span of tag * string | link_desc ]
+type span = span_desc located
+
+(** {2 Text language} *)
+
+type text_desc = [ `Text of span list ]
+type text = text_desc located
+
+val mk_span : ?loc:Geneweb_loc.t -> tag -> string -> span
+val mk_text : ?loc:Geneweb_loc.t -> span list -> text
+
+(** {2 List language} *)
+
+type kind = Ordered | Unordered
+
+type node_desc = [ `Node of text option * kind * node list ]
+and node = node_desc located
+
+val mk_node : ?loc:Geneweb_loc.t -> text option -> kind -> node list -> node
+
+type size = One | Two | Three | Four | Five | Six
+type toc = Std | Short | No
+
+type block =
+  [ `Header of size * string
+  | `Toc of toc
+  | `Newline
+  | `Rule
+  | `Indent of int * text
+  | `Pre of string
+  | node_desc
+  | text_desc ]
+
+and t = block located
+
+val equal : t -> t -> bool
+
+(** {2 Constructors for blocks} *)
+
+val mk_header : ?loc:Geneweb_loc.t -> size -> string -> t
+val mk_toc : ?loc:Geneweb_loc.t -> toc -> t
+val mk_indent : ?loc:Geneweb_loc.t -> int -> text -> t
+val mk_pre : ?loc:Geneweb_loc.t -> string -> t
+val mk_newline : ?loc:Geneweb_loc.t -> unit -> t
+val mk_rule : ?loc:Geneweb_loc.t -> unit -> t
+
+(** {2 Printers} *)
+
+val to_html : t -> Html_types.flow5 Tyxml.Html.elt
+val pp : t Fmt.t

--- a/lib/tlsw/ast.mli
+++ b/lib/tlsw/ast.mli
@@ -3,9 +3,9 @@ type +'a located = { desc : 'a; loc : Geneweb_loc.t }
 (** {2 Span language} *)
 
 type link_tag =
-  | Person of string * string * int option
-  | Note of string
-  | Wizard of string
+  | Person of { fn : string; sn : string; occ : int option }
+  | Note of { path : string }
+  | Wizard of { path : string }
   | Image of { path : string; width : string option }
 
 type link_desc = [ `Link of link_tag * string option ]
@@ -38,7 +38,7 @@ val mk_node : ?loc:Geneweb_loc.t -> text option -> kind -> node list -> node
 type size = One | Two | Three | Four | Five | Six
 type toc = Std | Short | No
 
-type block =
+type block_desc =
   [ `Header of size * string
   | `Toc of toc
   | `Newline
@@ -48,20 +48,20 @@ type block =
   | node_desc
   | text_desc ]
 
-and t = block located
+and block = block_desc located
 
-val equal : t -> t -> bool
+val equal : block -> block -> bool
 
 (** {2 Constructors for blocks} *)
 
-val mk_header : ?loc:Geneweb_loc.t -> size -> string -> t
-val mk_toc : ?loc:Geneweb_loc.t -> toc -> t
-val mk_indent : ?loc:Geneweb_loc.t -> int -> text -> t
-val mk_pre : ?loc:Geneweb_loc.t -> string -> t
-val mk_newline : ?loc:Geneweb_loc.t -> unit -> t
-val mk_rule : ?loc:Geneweb_loc.t -> unit -> t
+val mk_header : ?loc:Geneweb_loc.t -> size -> string -> block
+val mk_toc : ?loc:Geneweb_loc.t -> toc -> block
+val mk_indent : ?loc:Geneweb_loc.t -> int -> text -> block
+val mk_pre : ?loc:Geneweb_loc.t -> string -> block
+val mk_newline : ?loc:Geneweb_loc.t -> unit -> block
+val mk_rule : ?loc:Geneweb_loc.t -> unit -> block
 
 (** {2 Printers} *)
 
-val to_html : t -> Html_types.flow5 Tyxml.Html.elt
-val pp : t Fmt.t
+val to_html : block -> Html_types.flow5 Tyxml.Html.elt
+val pp : block Fmt.t

--- a/lib/tlsw/ast.mli
+++ b/lib/tlsw/ast.mli
@@ -3,9 +3,8 @@ type +'a located = { desc : 'a; loc : Geneweb_loc.t }
 (** {2 Span language} *)
 
 type link_tag =
-  | Person of { fn : string; sn : string; occ : int option }
-  | Note of { path : string }
-  | Wizard of { path : string }
+  | Person of { fn : string; sn : string; oc : int option }
+  | Note of { path : string; anchor : string option; wizard : bool }
   | Image of { path : string; width : string option }
 
 type link_desc = [ `Link of link_tag * string option ]
@@ -14,7 +13,16 @@ type link = link_desc located
 val mk_link : ?loc:Geneweb_loc.t -> link_tag -> string option -> link
 val pp_link : link Fmt.t
 
-type tag = Plain | Italic | Bold | BoldItalic | Strike | Underline | Highlight
+type tag =
+  | Plain
+  | Italic
+  | Bold
+  | BoldItalic
+  | Strike
+  | Underline
+  | Highlight
+  | Error
+
 type span_desc = [ `Span of tag * string | link_desc ]
 type span = span_desc located
 
@@ -23,7 +31,29 @@ type span = span_desc located
 type text_desc = [ `Text of span list ]
 type text = text_desc located
 
+(** {2 Constructors for spans} *)
+
 val mk_span : ?loc:Geneweb_loc.t -> tag -> string -> span
+
+val mk_person_link :
+  ?loc:Geneweb_loc.t ->
+  fn:string ->
+  sn:string ->
+  ?oc:int ->
+  string option ->
+  link
+
+val mk_note_link :
+  ?loc:Geneweb_loc.t ->
+  path:string ->
+  ?anchor:string ->
+  wizard:bool ->
+  string option ->
+  link
+
+val mk_image_link :
+  ?loc:Geneweb_loc.t -> path:string -> ?width:string -> string option -> link
+
 val mk_text : ?loc:Geneweb_loc.t -> span list -> text
 
 (** {2 List language} *)

--- a/lib/tlsw/combinator.ml
+++ b/lib/tlsw/combinator.ml
@@ -1,17 +1,18 @@
 module Loc = Geneweb_loc
 
-type ('a, 'st) res = Ok of 'a * 'st | Fail of (unit -> string) * 'st
-type 'a t = { run : Input.t -> ('a, Input.t) res } [@@unboxed]
+type 'a t = { run : Input.t -> ('a, unit -> string) result * Input.t }
+[@@unboxed]
 
 let[@inline always] run t st = t.run st
-let ret a = { run = (fun st -> Ok (a, st)) }
+let ret a = { run = (fun st -> (Ok a, st)) }
 
 let fail fmt =
-  Fmt.kstr (fun s -> { run = (fun st -> Fail ((fun () -> s), st)) }) fmt
+  Fmt.kstr (fun s -> { run = (fun st -> (Error (fun () -> s), st)) }) fmt
 
 let bind t f =
   let run st =
-    match t.run st with Ok (a, st') -> (f a).run st' | Fail _ as r -> r
+    let r, st' = t.run st in
+    match r with Ok a -> (f a).run st' | Error _ as r -> (r, st')
   in
   { run }
 
@@ -19,20 +20,64 @@ let choice l =
   let run st =
     let rec loop l =
       match l with
-      | [] -> Fail ((fun () -> "non-exhaustive choice combinator"), st)
-      | t :: tx -> ( match t.run st with Ok _ as r -> r | Fail _ -> loop tx)
+      | [] -> (Error (fun () -> "non-exhaustive choice combinator"), st)
+      | t :: tx -> (
+          let r, st' = t.run st in
+          match r with Ok _ as r -> (r, st') | Error _ -> loop tx)
     in
     loop l
   in
   { run }
 
-let case l =
+let case l t =
   let run st =
     let rec loop l =
       match l with
-      | [] -> Fail ((fun () -> "non-exhaustive case combinator"), st)
+      | [] -> t.run st
       | (t1, t2) :: tx -> (
-          match t1.run st with Ok _ -> t2.run st | Fail _ -> loop tx)
+          let r, _st' = t1.run st in
+          match r with Ok _ -> t2.run st | Error _ -> loop tx)
+    in
+    loop l
+  in
+  { run }
+
+let case_with_recover ~recover l t =
+  let run st =
+    let rec loop l =
+      match l with
+      | [] -> t.run st
+      | (t1, t2) :: tx -> (
+          let start = Input.offset st in
+          let r, st' = t1.run st in
+          match r with
+          | Ok _ -> (
+              let r, st'' = t2.run st in
+              match r with
+              | Ok _ as r -> (r, st'')
+              | Error _ ->
+                  let stop = Input.offset st' in
+                  let loc = Loc.mk (Input.to_source st) start stop in
+                  (Ok (recover loc), st'))
+          | Error _ -> loop tx)
+    in
+    loop l
+  in
+  { run }
+
+let case ?recover l t =
+  match recover with
+  | Some recover -> case_with_recover ~recover l t
+  | None -> case l t
+
+let case2 l =
+  let run st =
+    let rec loop l =
+      match l with
+      | [] -> (Error (fun () -> "non-exhaustive choice combinator"), st)
+      | (t1, t2) :: tx -> (
+          let r, _st' = t1.run st in
+          match r with Ok _ -> t2.run st | Error _ -> loop tx)
     in
     loop l
   in
@@ -41,7 +86,10 @@ let case l =
 let ( let* ) = bind
 
 let ( <|> ) t1 t2 =
-  let run st = match t1.run st with Ok _ as r -> r | Fail _ -> t2.run st in
+  let run st =
+    let r, st' = t1.run st in
+    match r with Ok _ -> (r, st') | Error _ -> t2.run st
+  in
   { run }
 
 let ( *> ) t1 t2 =
@@ -55,9 +103,10 @@ let ( <* ) t1 t2 =
 
 let many t =
   let rec loop acc st =
-    match t.run st with
-    | Ok (a, st') -> loop (a :: acc) st'
-    | Fail _ -> Ok (List.rev acc, st)
+    let r, st' = t.run st in
+    match r with
+    | Ok a -> loop (a :: acc) st'
+    | Error _ -> (Ok (List.rev acc), st)
   in
   { run = loop [] }
 
@@ -68,24 +117,24 @@ let many1 t =
 
 let count t =
   let rec loop acc st =
-    match t.run st with
-    | Ok (_, st') -> loop (acc + 1) st'
-    | Fail _ -> Ok (acc, st)
+    let r, st' = t.run st in
+    match r with Ok _ -> loop (acc + 1) st' | Error _ -> (Ok acc, st)
   in
   { run = loop 0 }
 
-let until a =
+let until t =
   let run st =
     let buf = Buffer.create 17 in
     let rec loop st =
-      match a.run st with
-      | Ok _ -> Ok (Buffer.contents buf, st)
-      | Fail _ -> (
+      let r, st' = t.run st in
+      match r with
+      | Ok _ -> (Ok (Buffer.contents buf), st)
+      | Error _ -> (
           match Input.peak st with
           | Some c ->
               Buffer.add_char buf c;
               loop (Input.next st)
-          | None -> Ok (Buffer.contents buf, st))
+          | None -> (Ok (Buffer.contents buf), st))
     in
     loop st
   in
@@ -94,15 +143,17 @@ let until a =
 let skip t =
   let run st =
     let rec loop st =
-      match t.run st with Ok (_, st') -> loop st' | Fail _ -> Ok ((), st)
+      let r, st' = t.run st in
+      match r with Ok _ -> loop st' | Error _ -> (Ok (), st)
     in
     loop st
   in
   { run }
 
-let option a =
+let option t =
   let run st =
-    match a.run st with Ok (r, st) -> Ok (Some r, st) | Fail _ -> Ok (None, st)
+    let r, st' = t.run st in
+    match r with Ok r -> (Ok (Some r), st') | Error _ -> (Ok None, st)
   in
   { run }
 
@@ -111,23 +162,23 @@ let char c =
     match Input.peak st with
     | Some c' ->
         let st' = Input.next st in
-        if Char.equal c c' then Ok (c, st')
-        else Fail ((fun () -> Fmt.str "expected %C, got %C" c c'), st')
-    | None -> Fail ((fun () -> "expected input, reached end of file"), st)
+        if Char.equal c c' then (Ok c, st')
+        else (Error (fun () -> Fmt.str "expected %C, got %C" c c'), st')
+    | None -> (Error (fun () -> "expected input, reached end of file"), st)
   in
   { run }
 
 let string s =
   let len = String.length s in
   let rec loop i st =
-    if i = len then Ok (s, st)
+    if i = len then (Ok s, st)
     else
       match Input.peak st with
       | Some c ->
           let st' = Input.next st in
           if Char.equal s.[i] c then loop (i + 1) st'
-          else Fail ((fun () -> Fmt.str "expected %C, got %C" s.[i] c), st')
-      | None -> Fail ((fun () -> "expected input, reached end of file"), st)
+          else (Error (fun () -> Fmt.str "expected %C, got %C" s.[i] c), st')
+      | None -> (Error (fun () -> "expected input, reached end of file"), st)
   in
   { run = loop 0 }
 
@@ -137,29 +188,29 @@ let digit =
     | Some c ->
         let st' = Input.next st in
         let cd = Char.code c in
-        if 48 <= cd && cd <= 57 then Ok (cd - 48, st')
-        else Fail ((fun () -> Fmt.str "expected digit, got %C" c), st')
-    | None -> Fail ((fun () -> "expected digit, reached end of file"), st)
+        if 48 <= cd && cd <= 57 then (Ok (cd - 48), st')
+        else (Error (fun () -> Fmt.str "expected digit, got %C" c), st')
+    | None -> (Error (fun () -> "expected digit, reached end of file"), st)
   in
   { run }
 
 let int =
-  let rec loop r st =
-    match digit.run st with
-    | Ok (d, st') -> loop ((r * 10) + d) st'
-    | Fail _ -> Ok (r, st)
+  let rec loop acc st =
+    let r, st' = digit.run st in
+    match r with Ok d -> loop ((acc * 10) + d) st' | Error _ -> (Ok acc, st)
   in
-  let* r = digit in
-  { run = loop r }
+  let* acc = digit in
+  { run = loop acc }
 
 let located t =
   let run st =
     let start = Input.offset st in
-    match t.run st with
-    | Ok (r, st') ->
+    let x, st' = t.run st in
+    match x with
+    | Ok r ->
         let stop = Input.offset st' in
         let src = Input.to_source st' in
-        Ok ((r, Loc.mk src start stop), st')
-    | Fail _ as r -> r
+        (Ok (r, Loc.mk src start stop), st')
+    | Error _ as r -> (r, st')
   in
   { run }

--- a/lib/tlsw/combinator.ml
+++ b/lib/tlsw/combinator.ml
@@ -3,8 +3,8 @@ module Loc = Geneweb_loc
 type 'a t = { run : Input.t -> ('a, unit -> string) result * Input.t }
 [@@unboxed]
 
-let[@inline always] run t st = t.run st
-let ret a = { run = (fun st -> (Ok a, st)) }
+let[@inline] run t st = t.run st
+let[@inline] ret a = { run = (fun st -> (Ok a, st)) }
 
 let fail fmt =
   Fmt.kstr (fun s -> { run = (fun st -> (Error (fun () -> s), st)) }) fmt
@@ -126,7 +126,7 @@ let until t =
   let run st =
     let buf = Buffer.create 17 in
     let rec loop st =
-      let r, st' = t.run st in
+      let r, _st' = t.run st in
       match r with
       | Ok _ -> (Ok (Buffer.contents buf), st)
       | Error _ -> (

--- a/lib/tlsw/combinator.ml
+++ b/lib/tlsw/combinator.ml
@@ -115,6 +115,37 @@ let many1 t =
   let* xs = many t in
   ret (x :: xs)
 
+let take_while p =
+  let run st =
+    let buf = Buffer.create 17 in
+    let rec loop st =
+      match Input.peak st with
+      | Some c when p c ->
+          Buffer.add_char buf c;
+          loop (Input.next st)
+      | Some _ | None -> (Ok (Buffer.contents buf), st)
+    in
+    loop st
+  in
+  { run }
+
+let take_while1 p =
+  let run st =
+    let buf = Buffer.create 17 in
+    let rec loop st =
+      match Input.peak st with
+      | Some c when p c ->
+          Buffer.add_char buf c;
+          loop (Input.next st)
+      | Some _ | None ->
+          if Buffer.length buf = 0 then
+            (Error (fun () -> Fmt.str "expect something"), st)
+          else (Ok (Buffer.contents buf), st)
+    in
+    loop st
+  in
+  { run }
+
 let count t =
   let rec loop acc st =
     let r, st' = t.run st in

--- a/lib/tlsw/combinator.ml
+++ b/lib/tlsw/combinator.ml
@@ -1,0 +1,165 @@
+module Loc = Geneweb_loc
+
+type ('a, 'st) res = Ok of 'a * 'st | Fail of (unit -> string) * 'st
+type 'a t = { run : Input.t -> ('a, Input.t) res } [@@unboxed]
+
+let[@inline always] run t st = t.run st
+let ret a = { run = (fun st -> Ok (a, st)) }
+
+let fail fmt =
+  Fmt.kstr (fun s -> { run = (fun st -> Fail ((fun () -> s), st)) }) fmt
+
+let bind t f =
+  let run st =
+    match t.run st with Ok (a, st') -> (f a).run st' | Fail _ as r -> r
+  in
+  { run }
+
+let choice l =
+  let run st =
+    let rec loop l =
+      match l with
+      | [] -> Fail ((fun () -> "non-exhaustive choice combinator"), st)
+      | t :: tx -> ( match t.run st with Ok _ as r -> r | Fail _ -> loop tx)
+    in
+    loop l
+  in
+  { run }
+
+let case l =
+  let run st =
+    let rec loop l =
+      match l with
+      | [] -> Fail ((fun () -> "non-exhaustive case combinator"), st)
+      | (t1, t2) :: tx -> (
+          match t1.run st with Ok _ -> t2.run st | Fail _ -> loop tx)
+    in
+    loop l
+  in
+  { run }
+
+let ( let* ) = bind
+
+let ( <|> ) t1 t2 =
+  let run st = match t1.run st with Ok _ as r -> r | Fail _ -> t2.run st in
+  { run }
+
+let ( *> ) t1 t2 =
+  let* _ = t1 in
+  t2
+
+let ( <* ) t1 t2 =
+  let* r = t1 in
+  let* _ = t2 in
+  ret r
+
+let many t =
+  let rec loop acc st =
+    match t.run st with
+    | Ok (a, st') -> loop (a :: acc) st'
+    | Fail _ -> Ok (List.rev acc, st)
+  in
+  { run = loop [] }
+
+let many1 t =
+  let* x = t in
+  let* xs = many t in
+  ret (x :: xs)
+
+let count t =
+  let rec loop acc st =
+    match t.run st with
+    | Ok (_, st') -> loop (acc + 1) st'
+    | Fail _ -> Ok (acc, st)
+  in
+  { run = loop 0 }
+
+let until a =
+  let run st =
+    let buf = Buffer.create 17 in
+    let rec loop st =
+      match a.run st with
+      | Ok _ -> Ok (Buffer.contents buf, st)
+      | Fail _ -> (
+          match Input.peak st with
+          | Some c ->
+              Buffer.add_char buf c;
+              loop (Input.next st)
+          | None -> Ok (Buffer.contents buf, st))
+    in
+    loop st
+  in
+  { run }
+
+let skip t =
+  let run st =
+    let rec loop st =
+      match t.run st with Ok (_, st') -> loop st' | Fail _ -> Ok ((), st)
+    in
+    loop st
+  in
+  { run }
+
+let option a =
+  let run st =
+    match a.run st with Ok (r, st) -> Ok (Some r, st) | Fail _ -> Ok (None, st)
+  in
+  { run }
+
+let char c =
+  let run st =
+    match Input.peak st with
+    | Some c' ->
+        let st' = Input.next st in
+        if Char.equal c c' then Ok (c, st')
+        else Fail ((fun () -> Fmt.str "expected %C, got %C" c c'), st')
+    | None -> Fail ((fun () -> "expected input, reached end of file"), st)
+  in
+  { run }
+
+let string s =
+  let len = String.length s in
+  let rec loop i st =
+    if i = len then Ok (s, st)
+    else
+      match Input.peak st with
+      | Some c ->
+          let st' = Input.next st in
+          if Char.equal s.[i] c then loop (i + 1) st'
+          else Fail ((fun () -> Fmt.str "expected %C, got %C" s.[i] c), st')
+      | None -> Fail ((fun () -> "expected input, reached end of file"), st)
+  in
+  { run = loop 0 }
+
+let digit =
+  let run st =
+    match Input.peak st with
+    | Some c ->
+        let st' = Input.next st in
+        let cd = Char.code c in
+        if 48 <= cd && cd <= 57 then Ok (cd - 48, st')
+        else Fail ((fun () -> Fmt.str "expected digit, got %C" c), st')
+    | None -> Fail ((fun () -> "expected digit, reached end of file"), st)
+  in
+  { run }
+
+let int =
+  let rec loop r st =
+    match digit.run st with
+    | Ok (d, st') -> loop ((r * 10) + d) st'
+    | Fail _ -> Ok (r, st)
+  in
+  let* r = digit in
+  { run = loop r }
+
+let located t =
+  let run st =
+    let start = Input.offset st in
+    match t.run st with
+    | Ok (r, st') ->
+        let stop = Input.offset st' in
+        let src = Input.to_source st' in
+        Ok ((r, Loc.mk src start stop), st')
+    | Fail _ as r -> r
+  in
+  { run }

--- a/lib/tlsw/combinator.mli
+++ b/lib/tlsw/combinator.mli
@@ -1,11 +1,9 @@
 type +'a t
 (** Type of parsers that produce values of type ['a]. *)
 
-type ('a, 'st) res = Ok of 'a * 'st | Fail of (unit -> string) * 'st
-
 (** {2 Monadic operators} *)
 
-val run : 'a t -> Input.t -> ('a, Input.t) res
+val run : 'a t -> Input.t -> ('a, unit -> string) result * Input.t
 (** [run t st] executes the parser [t] starting from the initial state [st]. *)
 
 val ret : 'a -> 'a t
@@ -51,16 +49,18 @@ val option : 'a t -> 'a option t
 (** [option t] attempts to execute parser [t]. If [t] succeeds, its result is
     wrapped in [Some]. If [t] fails, [option t] succeeds and returns [None]. *)
 
-val case : (_ t * 'a t) list -> 'a t
-(** [case l] runs in order the first element of the pairs until one succeed.
-    Then it runs the second element. *)
+val case : ?recover:(Geneweb_loc.t -> 'a) -> (_ t * 'a t) list -> 'a t -> 'a t
+(** [case ?recover l] runs in order the first element of the pairs until one
+    succeed. Then it runs the second element. *)
+
+val case2 : (_ t * 'a t) list -> 'a t
 
 val until : _ t -> string t
 (** [until t] accumulates the input until the parser [t] succeeds. *)
 
 val skip : _ t -> unit t
-(** [skip t] executes [t], consuming input as [t] would, but discards its result.
-*)
+(** [skip t] executes [t], consuming input as [t] would, but discards its
+    result. *)
 
 val count : 'a t -> int t
 (** [count t] executes [t] and returns the number of characters consumed by [t].

--- a/lib/tlsw/combinator.mli
+++ b/lib/tlsw/combinator.mli
@@ -1,0 +1,78 @@
+type +'a t
+(** Type of parsers that produce values of type ['a]. *)
+
+type ('a, 'st) res = Ok of 'a * 'st | Fail of (unit -> string) * 'st
+
+(** {2 Monadic operators} *)
+
+val run : 'a t -> Input.t -> ('a, Input.t) res
+(** [run t st] executes the parser [t] starting from the initial state [st]. *)
+
+val ret : 'a -> 'a t
+(** [ret a] creates a parser that always succeeds and returns the value [a]
+    without consuming any input. *)
+
+val fail : ('b, Format.formatter, unit, 'a t) format4 -> 'b
+(** [fail] creates a parser that always fails with consuming any input. *)
+
+val bind : 'a t -> ('a -> 'b t) -> 'b t
+(** [bind t f] executes the parser [t]. If [t] succeeds, its result is passed to
+    the function [f]. *)
+
+(* {2 Parsers for basic types} *)
+
+val char : char -> char t
+(** [char c] creates a parser that accepts exactly the character [c]. *)
+
+val string : string -> string t
+(** [string s] creates a parser that accepts exactly the string [s]. *)
+
+val digit : int t
+(** [digit] is a parser accepting a single decimal digit. *)
+
+val int : int t
+(** [int] is parser accepting decimal numbers. *)
+
+(** {2 Basic combinators} *)
+
+val choice : 'a t list -> 'a t
+(** [choice l] attemps to run the parsers in the list [l] in order. It succeeds
+    with the result of the first parser that succeeds. *)
+
+val many : 'a t -> 'a list t
+(** [many t] repeatedly executes [t] as long as it succeeds, accumulating all
+    results into a list. *)
+
+val many1 : 'a t -> 'a list t
+(** [many1 t] does the same as [many] but [t] must succeed at least once for
+    [many1 t] to succeed. *)
+
+val option : 'a t -> 'a option t
+(** [option t] attempts to execute parser [t]. If [t] succeeds, its result is
+    wrapped in [Some]. If [t] fails, [option t] succeeds and returns [None]. *)
+
+val case : (_ t * 'a t) list -> 'a t
+(** [case l] runs in order the first element of the pairs until one succeed.
+    Then it runs the second element. *)
+
+val until : _ t -> string t
+(** [until t] accumulates the input until the parser [t] succeeds. *)
+
+val skip : _ t -> unit t
+(** [skip t] executes [t], consuming input as [t] would, but discards its result.
+*)
+
+val count : 'a t -> int t
+(** [count t] executes [t] and returns the number of characters consumed by [t].
+    This combinator is more efficient than [List.length (many t)]. *)
+
+val located : 'a t -> ('a * Geneweb_loc.t) t
+(** [with_loc t] executes parser [t]. If [t] succeeds, it returns both the
+    result of [t] and the span of input consumed by [t]. *)
+
+(* {2 Syntax extension} *)
+
+val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+val ( <|> ) : 'a t -> 'a t -> 'a t
+val ( *> ) : _ t -> 'a t -> 'a t
+val ( <* ) : 'a t -> _ t -> 'a t

--- a/lib/tlsw/combinator.mli
+++ b/lib/tlsw/combinator.mli
@@ -33,6 +33,9 @@ val int : int t
 
 (** {2 Basic combinators} *)
 
+val take_while : (char -> bool) -> string t
+val take_while1 : (char -> bool) -> string t
+
 val choice : 'a t list -> 'a t
 (** [choice l] attemps to run the parsers in the list [l] in order. It succeeds
     with the result of the first parser that succeeds. *)

--- a/lib/tlsw/dune
+++ b/lib/tlsw/dune
@@ -1,0 +1,4 @@
+(library
+ (name geneweb_tlsw)
+ (public_name geneweb.tlsw)
+ (libraries geneweb_loc fmt tyxml))

--- a/lib/tlsw/input.ml
+++ b/lib/tlsw/input.ml
@@ -1,0 +1,14 @@
+type t = { input : string; offset : int }
+
+let[@inline always] of_string s = { input = s; offset = 0 }
+let[@inline always] of_file _s = assert false
+let[@inline always] of_channel _s = assert false
+let[@inline always] eof { input; offset } = offset >= String.length input
+let peak ({ input; offset } as t) = if eof t then None else Some input.[offset]
+let[@inline] offset { offset; _ } = offset
+
+let next ({ offset; _ } as t) =
+  let offset = if eof t then offset else offset + 1 in
+  { t with offset }
+
+let to_source { input; _ } = `Raw input

--- a/lib/tlsw/input.mli
+++ b/lib/tlsw/input.mli
@@ -1,0 +1,10 @@
+type t
+
+val of_string : string -> t
+val of_file : string -> t
+val of_channel : in_channel -> t
+val offset : t -> int
+val eof : t -> bool
+val peak : t -> char option
+val next : t -> t
+val to_source : t -> Geneweb_loc.source

--- a/lib/tlsw/parser.ml
+++ b/lib/tlsw/parser.ml
@@ -1,0 +1,350 @@
+module C = Combinator
+module Loc = Geneweb_loc
+
+let ws = C.(char ' ' <|> char '\t')
+let eol = C.(string "\n" <|> string "\r\n")
+let space = C.string " "
+let empty_line = C.(many ws *> eol)
+let std_toc_tk = C.string "__TOC__"
+let short_toc_tk = C.string "__SHORT_TOC__"
+let no_toc_tk = C.string "__NOTOC__"
+let rule_tk = C.string "----"
+let indent_tk = C.string ":"
+let ul_tk = C.string "*"
+let ol_tk = C.string "#"
+let h1_del = C.string "="
+let h2_del = C.string "=="
+let h3_del = C.string "==="
+let h4_del = C.string "===="
+let h5_del = C.string "====="
+let h6_del = C.string "======"
+let link_person_open = C.string "[["
+let link_person_close = C.string "]]"
+let link_note_open = C.string "[[["
+let link_note_close = C.string "]]]"
+let link_wizard_open = C.string "[[w:"
+let link_wizard_close = C.string "]]"
+let link_image_open = C.string "[[image:"
+let link_image_close = C.string "]]"
+let slash = C.string "/"
+let any = C.string ""
+
+(********** Parsing span *********)
+
+let italic_del = C.string "''"
+let bold_del = C.string "'''"
+let bold_italic_del = C.string "'''''"
+let underline_del = C.string "__"
+let strike_del = C.string "~~"
+let highlight_open = C.string "{"
+let highlight_close = C.string "}"
+
+(* Parse an input of the form `start s close` where `s` is any string
+   that does not contain `s`. Output a text block with the kind [k]. *)
+let span_text start close k =
+  C.(
+    let* s, loc = located (start *> until close <* close) in
+    if String.length s = 0 then fail "empty span"
+    else ret (Ast.mk_span ~loc k s))
+
+let italic = span_text italic_del italic_del Italic
+let bold = span_text bold_del bold_del Bold
+let bold_italic = span_text bold_italic_del bold_italic_del BoldItalic
+let strike = span_text strike_del strike_del Strike
+let underline = span_text underline_del underline_del Underline
+let highlight = span_text highlight_open highlight_close Highlight
+
+(********* Parsing links *********)
+
+let link_person =
+  C.(
+    let firstname = until (slash <|> link_person_close) in
+    let surname = until (slash <|> link_person_close) in
+    let occ = C.int in
+    let link_person_text = until link_person_close in
+    let content =
+      let* fn = firstname in
+      let* sn = slash *> surname in
+      let* occ_opt = option (slash *> occ) in
+      let* text_opt = option (slash *> link_person_text) in
+      ret (fn, sn, occ_opt, text_opt)
+    in
+    let* (fn, sn, occ_opt, text_opt), loc =
+      located (link_person_open *> content <* link_person_close)
+    in
+    ret (Ast.mk_link ~loc (Person (fn, sn, occ_opt)) text_opt))
+
+let link_note =
+  C.(
+    let content =
+      let* fl = until (slash <|> link_note_close) in
+      let* text_opt = option (slash *> until link_note_close) in
+      ret (fl, text_opt)
+    in
+    let* (fl, text_opt), loc =
+      located (link_note_open *> content <* link_note_close)
+    in
+    ret (Ast.mk_link ~loc (Note fl) text_opt))
+
+let link_wizard =
+  C.(
+    let content =
+      let* fl = until (slash <|> link_wizard_close) in
+      let* text_opt = option (slash *> until link_wizard_close) in
+      ret (fl, text_opt)
+    in
+    let* (fl, text_opt), loc =
+      located (link_wizard_open *> content <* link_wizard_close)
+    in
+    ret (Ast.mk_link ~loc (Wizard fl) text_opt))
+
+let link_image =
+  C.(
+    let content =
+      let* path = until (slash <|> link_image_close) in
+      let* alt_opt = option (slash *> until (slash <|> link_image_close)) in
+      let* width = option (slash *> until link_image_close) in
+      ret (path, width, alt_opt)
+    in
+    let* (path, width, alt_opt), loc =
+      located (link_image_open *> content <* link_image_close)
+    in
+    ret (Ast.mk_link ~loc (Image { path; width }) alt_opt))
+
+let link =
+  C.(
+    case [
+      link_wizard_open, link_wizard;
+      link_image_open, link_image;
+      link_note_open, link_note;
+      link_person_open, link_person;
+    ])
+    [@ocamlformat "disable"]
+
+(********* Parsing normal text *********)
+
+let special_nl =
+  C.choice [
+    empty_line;
+    rule_tk;
+    indent_tk;
+    h6_del;
+    h5_del;
+    h4_del;
+    h2_del;
+    h1_del;
+    std_toc_tk;
+    short_toc_tk;
+    no_toc_tk;
+    ul_tk;
+    ol_tk;
+  ]
+  [@ocamlformat "disable"]
+
+let special =
+  C.(
+  (eol *> special_nl)
+  <|> italic_del
+  <|> strike_del
+  <|> underline_del
+  <|> highlight_open
+  <|> link_person_open)
+  [@ocamlformat "disable"]
+
+let plain =
+  C.(
+    let* s, loc = located @@ until special in
+    if String.length s = 0 then fail "end of text block"
+    else ret (Ast.mk_span ~loc Plain s))
+
+(********* Parsing text *********)
+
+let span_coercion p =
+  C.(
+    let* r = p in
+    ret (r :> Ast.span))
+
+let span =
+  C.(
+    case [
+      bold_italic_del, bold_italic;
+      bold_del, bold;
+      italic_del, italic;
+      strike_del, strike;
+      underline_del, underline;
+      highlight_open, highlight;
+      link_image_open, span_coercion link_image;
+      link_wizard_open, span_coercion link_wizard;
+      link_note_open, span_coercion link_note;
+      link_person_open, span_coercion link_person;
+      any, plain
+    ])
+    [@ocamlformat "disable"]
+
+let text =
+  C.(
+    let* l, loc = located @@ many1 span <* option eol in
+    ret (Ast.mk_text ~loc l))
+
+(********* Parsing header *********)
+
+let header del sz =
+  C.(
+    let* s, loc = located (del *> until del <* del <* many ws <* eol) in
+    if String.length s = 0 then fail "empty header"
+    else ret (Ast.mk_header ~loc sz s))
+
+let h1 = header h1_del Ast.One
+let h2 = header h2_del Ast.Two
+let h3 = header h3_del Ast.Three
+let h4 = header h4_del Ast.Four
+let h5 = header h5_del Ast.Five
+let h6 = header h6_del Ast.Six
+
+(********* Parser toc *********)
+
+let toc tk k =
+  C.(
+    let* (), loc = located (tk *> skip ws <* eol) in
+    ret (Ast.mk_toc ~loc k))
+
+let std_toc = toc std_toc_tk Std
+let short_toc = toc short_toc_tk Short
+let no_toc = toc no_toc_tk No
+
+(********* Parser pre *********)
+
+let pre_open = C.(empty_line *> space)
+let pre_close = C.(eol *> empty_line)
+let pre_tk = C.(empty_line *> space *> until eol *> eol *> space)
+
+let pre =
+  C.(
+    let* s, loc = located (pre_open *> until pre_close <* pre_close) in
+    ret (Ast.mk_pre ~loc s))
+
+(********* Parser list *********)
+
+let rec ul_at_lvl lvl =
+  C.(
+    let* c = count ul_tk in
+    if c != lvl then fail "expected a unordered list of level %d" lvl
+    else
+      let* text_opt = option text in
+      let* nested, loc =
+        located @@ option
+        @@ case [ (ul_tk, ul_at_lvl (lvl + 1)); (ol_tk, ol_at_lvl 1) ]
+      in
+      let* tl = option @@ ul_at_lvl lvl in
+      let tl = match tl with None -> [] | Some (_, tl) -> tl in
+      match nested with
+      | None ->
+          let hd = Ast.mk_node ~loc text_opt Ast.Unordered [] in
+          ret (Ast.Unordered, hd :: tl)
+      | Some (nested_kind, nested) ->
+          let hd = Ast.mk_node ~loc text_opt nested_kind nested in
+          ret (Ast.Unordered, hd :: tl))
+
+and ol_at_lvl lvl =
+  C.(
+    let* c = count ol_tk in
+    if c != lvl then fail "expected an ordered list of level %d" lvl
+    else
+      let* text_opt = option text in
+      let* nested, loc =
+        located @@ option
+        @@ case [ (ol_tk, ol_at_lvl (lvl + 1)); (ul_tk, ul_at_lvl 1) ]
+      in
+      let* tl = option @@ ol_at_lvl lvl in
+      let tl = match tl with None -> [] | Some (_, tl) -> tl in
+      match nested with
+      | None ->
+          let hd = Ast.mk_node ~loc text_opt Ast.Unordered [] in
+          ret (Ast.Ordered, hd :: tl)
+      | Some (nested_kind, nested) ->
+          let hd = Ast.mk_node ~loc text_opt nested_kind nested in
+          ret (Ast.Ordered, hd :: tl))
+
+let ul =
+  C.(
+    let* (_, l), loc = located @@ ul_at_lvl 1 in
+    ret (Ast.mk_node ~loc None Unordered l))
+
+let ol =
+  C.(
+    let* (_, l), loc = located @@ ol_at_lvl 1 in
+    ret (Ast.mk_node ~loc None Ordered l))
+
+(********* Parser rule *********)
+
+let rule =
+  C.(
+    let* _, loc = located (rule_tk <* skip (char '-' <|> ws) <* eol) in
+    ret (Ast.mk_rule ~loc ()))
+
+(********* Parser indent *********)
+
+let indent =
+  C.(
+    let content =
+      let* c = count indent_tk in
+      let* t = text in
+      ret (c, t)
+    in
+    let* (c, t), loc = located content in
+    ret (Ast.mk_indent ~loc c t))
+
+(********* Parser block *********)
+
+let newline =
+  C.(
+    let* _, loc = located empty_line in
+    ret (Ast.mk_newline ~loc ()))
+
+let coercion p =
+  C.(
+    let* r = p in
+    ret (r :> Ast.t))
+
+let block =
+  C.(
+    case [
+      pre_tk, pre;
+      empty_line, newline;
+      rule_tk, rule;
+      indent_tk, indent;
+      h6_del, h6;
+      h5_del, h5;
+      h4_del, h4;
+      h3_del, h3;
+      h2_del, h2;
+      h1_del, h1;
+      std_toc_tk, std_toc;
+      short_toc_tk, short_toc;
+      no_toc_tk, no_toc;
+      ul_tk, coercion ul;
+      ol_tk, coercion ol;
+      any, coercion text
+    ])
+    [@ocamlformat "disable"]
+
+let parse parser ~on_err s =
+  let st = Input.of_string s in
+  let rec loop acc st =
+    let start = Input.offset st in
+    match C.run parser st with
+    | Ok (tk, st') -> loop (tk :: acc) st'
+    | Fail (err, st') ->
+        if Input.eof st then List.rev acc
+        else
+          let stop = Input.offset st' in
+          let loc = Loc.mk (Input.to_source st') start stop in
+          on_err ~loc (err ());
+          acc
+  in
+  loop [] st
+
+type error_handler = loc:Geneweb_loc.t -> string -> unit
+
+let parse_links = parse link
+let parse = parse block

--- a/lib/tlsw/parser.ml
+++ b/lib/tlsw/parser.ml
@@ -64,38 +64,38 @@ let link_person =
     let content =
       let* fn = firstname in
       let* sn = slash *> surname in
-      let* occ_opt = option (slash *> occ) in
-      let* text_opt = option (slash *> link_person_text) in
-      ret (fn, sn, occ_opt, text_opt)
+      let* occ = option (slash *> occ) in
+      let* text = option (slash *> link_person_text) in
+      ret (fn, sn, occ, text)
     in
-    let* (fn, sn, occ_opt, text_opt), loc =
+    let* (fn, sn, occ, text), loc =
       located (link_person_open *> content <* link_person_close)
     in
-    ret (Ast.mk_link ~loc (Person (fn, sn, occ_opt)) text_opt))
+    ret (Ast.mk_link ~loc Ast.(Person {fn; sn; occ}) text))
 
 let link_note =
   C.(
     let content =
-      let* fl = until (slash <|> link_note_close) in
+      let* path = until (slash <|> link_note_close) in
       let* text_opt = option (slash *> until link_note_close) in
-      ret (fl, text_opt)
+      ret (path, text_opt)
     in
-    let* (fl, text_opt), loc =
+    let* (path, text), loc =
       located (link_note_open *> content <* link_note_close)
     in
-    ret (Ast.mk_link ~loc (Note fl) text_opt))
+    ret (Ast.mk_link ~loc (Ast.Note { path }) text))
 
 let link_wizard =
   C.(
     let content =
-      let* fl = until (slash <|> link_wizard_close) in
-      let* text_opt = option (slash *> until link_wizard_close) in
-      ret (fl, text_opt)
+      let* path = until (slash <|> link_wizard_close) in
+      let* text = option (slash *> until link_wizard_close) in
+      ret (path, text)
     in
-    let* (fl, text_opt), loc =
+    let* (path, text), loc =
       located (link_wizard_open *> content <* link_wizard_close)
     in
-    ret (Ast.mk_link ~loc (Wizard fl) text_opt))
+    ret (Ast.mk_link ~loc (Ast.Wizard { path }) text))
 
 let link_image =
   C.(
@@ -314,12 +314,12 @@ let newline =
 let coercion p =
   C.(
     let* r = p in
-    ret (r :> Ast.t))
+    ret (r :> Ast.block))
 
 let block ~recover =
   let r =
     if recover then
-      Some (fun loc -> (Ast.(mk_text ~loc [ mk_span Plain "error" ]) :> Ast.t))
+      Some (fun loc -> (Ast.(mk_text ~loc [ mk_span Plain "error" ]) :> Ast.block))
     else None
   in
   C.(
@@ -342,11 +342,11 @@ let block ~recover =
     ] (coercion @@ text ~recover))
     [@ocamlformat "disable"]
 
-let parse parser ~on_err s =
+let parse t ~on_err s =
   let st = Input.of_string s in
   let rec loop acc st =
     let start = Input.offset st in
-    match C.run parser st with
+    match C.run t st with
     | Ok tk, st' -> loop (tk :: acc) st'
     | Error err, st' ->
         if Input.eof st then List.rev acc

--- a/lib/tlsw/parser.ml
+++ b/lib/tlsw/parser.ml
@@ -27,7 +27,6 @@ let link_wizard_close = C.string "]]"
 let link_image_open = C.string "[[image:"
 let link_image_close = C.string "]]"
 let slash = C.string "/"
-let any = C.string ""
 
 (********** Parsing span *********)
 
@@ -113,7 +112,7 @@ let link_image =
 
 let link =
   C.(
-    case [
+    case2 [
       link_wizard_open, link_wizard;
       link_image_open, link_image;
       link_note_open, link_note;
@@ -164,9 +163,13 @@ let span_coercion p =
     let* r = p in
     ret (r :> Ast.span))
 
-let span =
+let span ~recover =
+  let recover =
+    if recover then Some (fun loc -> Ast.mk_span ~loc Highlight "error")
+    else None
+  in
   C.(
-    case [
+    case ?recover [
       bold_italic_del, bold_italic;
       bold_del, bold;
       italic_del, italic;
@@ -177,13 +180,12 @@ let span =
       link_wizard_open, span_coercion link_wizard;
       link_note_open, span_coercion link_note;
       link_person_open, span_coercion link_person;
-      any, plain
-    ])
+    ] plain)
     [@ocamlformat "disable"]
 
-let text =
+let text ~recover =
   C.(
-    let* l, loc = located @@ many1 span <* option eol in
+    let* l, loc = located @@ many1 (span ~recover) <* option eol in
     ret (Ast.mk_text ~loc l))
 
 (********* Parsing header *********)
@@ -225,17 +227,21 @@ let pre =
 
 (********* Parser list *********)
 
-let rec ul_at_lvl lvl =
+let rec ul_at_lvl ~recover lvl =
   C.(
     let* c = count ul_tk in
     if c != lvl then fail "expected a unordered list of level %d" lvl
     else
-      let* text_opt = option text in
+      let* text_opt = option (text ~recover) in
       let* nested, loc =
         located @@ option
-        @@ case [ (ul_tk, ul_at_lvl (lvl + 1)); (ol_tk, ol_at_lvl 1) ]
+        @@ case2
+             [
+               (ul_tk, ul_at_lvl ~recover (lvl + 1));
+               (ol_tk, ol_at_lvl ~recover 1);
+             ]
       in
-      let* tl = option @@ ul_at_lvl lvl in
+      let* tl = option @@ ul_at_lvl ~recover lvl in
       let tl = match tl with None -> [] | Some (_, tl) -> tl in
       match nested with
       | None ->
@@ -245,17 +251,21 @@ let rec ul_at_lvl lvl =
           let hd = Ast.mk_node ~loc text_opt nested_kind nested in
           ret (Ast.Unordered, hd :: tl))
 
-and ol_at_lvl lvl =
+and ol_at_lvl ~recover lvl =
   C.(
     let* c = count ol_tk in
     if c != lvl then fail "expected an ordered list of level %d" lvl
     else
-      let* text_opt = option text in
+      let* text_opt = option (text ~recover) in
       let* nested, loc =
         located @@ option
-        @@ case [ (ol_tk, ol_at_lvl (lvl + 1)); (ul_tk, ul_at_lvl 1) ]
+        @@ case2
+             [
+               (ol_tk, ol_at_lvl ~recover (lvl + 1));
+               (ul_tk, ul_at_lvl ~recover 1);
+             ]
       in
-      let* tl = option @@ ol_at_lvl lvl in
+      let* tl = option @@ ol_at_lvl ~recover lvl in
       let tl = match tl with None -> [] | Some (_, tl) -> tl in
       match nested with
       | None ->
@@ -265,14 +275,14 @@ and ol_at_lvl lvl =
           let hd = Ast.mk_node ~loc text_opt nested_kind nested in
           ret (Ast.Ordered, hd :: tl))
 
-let ul =
+let ul ~recover =
   C.(
-    let* (_, l), loc = located @@ ul_at_lvl 1 in
+    let* (_, l), loc = located @@ ul_at_lvl ~recover 1 in
     ret (Ast.mk_node ~loc None Unordered l))
 
-let ol =
+let ol ~recover =
   C.(
-    let* (_, l), loc = located @@ ol_at_lvl 1 in
+    let* (_, l), loc = located @@ ol_at_lvl ~recover 1 in
     ret (Ast.mk_node ~loc None Ordered l))
 
 (********* Parser rule *********)
@@ -284,11 +294,11 @@ let rule =
 
 (********* Parser indent *********)
 
-let indent =
+let indent ~recover =
   C.(
     let content =
       let* c = count indent_tk in
-      let* t = text in
+      let* t = text ~recover in
       ret (c, t)
     in
     let* (c, t), loc = located content in
@@ -306,13 +316,18 @@ let coercion p =
     let* r = p in
     ret (r :> Ast.t))
 
-let block =
+let block ~recover =
+  let r =
+    if recover then
+      Some (fun loc -> (Ast.(mk_text ~loc [ mk_span Plain "error" ]) :> Ast.t))
+    else None
+  in
   C.(
-    case [
+    case ?recover:r [
       pre_tk, pre;
       empty_line, newline;
       rule_tk, rule;
-      indent_tk, indent;
+      indent_tk, (indent ~recover);
       h6_del, h6;
       h5_del, h5;
       h4_del, h4;
@@ -322,10 +337,9 @@ let block =
       std_toc_tk, std_toc;
       short_toc_tk, short_toc;
       no_toc_tk, no_toc;
-      ul_tk, coercion ul;
-      ol_tk, coercion ol;
-      any, coercion text
-    ])
+      ul_tk, coercion @@ ul ~recover;
+      ol_tk, coercion @@ ol ~recover;
+    ] (coercion @@ text ~recover))
     [@ocamlformat "disable"]
 
 let parse parser ~on_err s =
@@ -333,8 +347,8 @@ let parse parser ~on_err s =
   let rec loop acc st =
     let start = Input.offset st in
     match C.run parser st with
-    | Ok (tk, st') -> loop (tk :: acc) st'
-    | Fail (err, st') ->
+    | Ok tk, st' -> loop (tk :: acc) st'
+    | Error err, st' ->
         if Input.eof st then List.rev acc
         else
           let stop = Input.offset st' in
@@ -347,4 +361,4 @@ let parse parser ~on_err s =
 type error_handler = loc:Geneweb_loc.t -> string -> unit
 
 let parse_links = parse link
-let parse = parse block
+let parse ~recover = parse (block ~recover)

--- a/lib/tlsw/parser.ml
+++ b/lib/tlsw/parser.ml
@@ -18,14 +18,14 @@ let h3_del = C.string "==="
 let h4_del = C.string "===="
 let h5_del = C.string "====="
 let h6_del = C.string "======"
-let link_person_open = C.string "[["
-let link_person_close = C.string "]]"
-let link_note_open = C.string "[[["
-let link_note_close = C.string "]]]"
-let link_wizard_open = C.string "[[w:"
-let link_wizard_close = C.string "]]"
-let link_image_open = C.string "[[image:"
-let link_image_close = C.string "]]"
+let person_link_open = C.string "[["
+let person_link_close = C.string "]]"
+let note_link_open = C.string "[[["
+let note_link_close = C.string "]]]"
+let wizard_link_open = C.string "[[w:"
+let wizard_link_close = C.string "]]"
+let image_link_open = C.string "[[image:"
+let image_link_close = C.string "]]"
 let slash = C.string "/"
 
 (********** Parsing span *********)
@@ -53,70 +53,79 @@ let strike = span_text strike_del strike_del Strike
 let underline = span_text underline_del underline_del Underline
 let highlight = span_text highlight_open highlight_close Highlight
 
+(********* Parsing paths *********)
+
+let path =
+  C.(
+    take_while1 (fun c ->
+        match c with
+        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' | ':' -> true
+        | _ -> false))
+
 (********* Parsing links *********)
 
-let link_person =
+let person_link =
   C.(
-    let firstname = until (slash <|> link_person_close) in
-    let surname = until (slash <|> link_person_close) in
-    let occ = C.int in
-    let link_person_text = until link_person_close in
+    let firstname = until (slash <|> person_link_close) in
+    let surname = until (slash <|> person_link_close) in
+    let oc = C.int in
+    let link_person_text = until person_link_close in
     let content =
       let* fn = firstname in
       let* sn = slash *> surname in
-      let* occ = option (slash *> occ) in
+      let* oc = option (slash *> oc) in
       let* text = option (slash *> link_person_text) in
-      ret (fn, sn, occ, text)
+      ret (fn, sn, oc, text)
     in
-    let* (fn, sn, occ, text), loc =
-      located (link_person_open *> content <* link_person_close)
+    let* (fn, sn, oc, text), loc =
+      located (person_link_open *> content <* person_link_close)
     in
-    ret (Ast.mk_link ~loc Ast.(Person {fn; sn; occ}) text))
+    ret (Ast.mk_person_link ~loc ~fn ~sn ?oc text))
 
-let link_note =
+let note_link =
   C.(
     let content =
-      let* path = until (slash <|> link_note_close) in
-      let* text_opt = option (slash *> until link_note_close) in
-      ret (path, text_opt)
+      let* p = path in
+      let* text_opt = option (slash *> until note_link_close) in
+      ret (p, text_opt)
     in
-    let* (path, text), loc =
-      located (link_note_open *> content <* link_note_close)
+    let* (p, text), loc =
+      located (note_link_open *> content <* note_link_close)
     in
-    ret (Ast.mk_link ~loc (Ast.Note { path }) text))
+    ret (Ast.mk_note_link ~loc ~path:p ~wizard:false text))
 
-let link_wizard =
+let wizard_link =
   C.(
     let content =
-      let* path = until (slash <|> link_wizard_close) in
-      let* text = option (slash *> until link_wizard_close) in
-      ret (path, text)
+      let* p = path in
+      let* text = option (slash *> until wizard_link_close) in
+      ret (p, text)
     in
-    let* (path, text), loc =
-      located (link_wizard_open *> content <* link_wizard_close)
+    let* (p, text), loc =
+      located (wizard_link_open *> content <* wizard_link_close)
     in
-    ret (Ast.mk_link ~loc (Ast.Wizard { path }) text))
+    ret (Ast.mk_note_link ~loc ~path:p ~wizard:true text))
 
-let link_image =
+let image_link =
   C.(
     let content =
-      let* path = until (slash <|> link_image_close) in
-      let* alt_opt = option (slash *> until (slash <|> link_image_close)) in
-      let* width = option (slash *> until link_image_close) in
+      let* path = until (slash <|> image_link_close) in
+      let* alt_opt = option (slash *> until (slash <|> image_link_close)) in
+      let* width = option (slash *> until image_link_close) in
       ret (path, width, alt_opt)
     in
     let* (path, width, alt_opt), loc =
-      located (link_image_open *> content <* link_image_close)
+      located (image_link_open *> content <* image_link_close)
     in
-    ret (Ast.mk_link ~loc (Image { path; width }) alt_opt))
+    ret (Ast.mk_image_link ~loc ~path ?width alt_opt))
 
 let link =
   C.(
     case2 [
-      link_wizard_open, link_wizard;
-      link_image_open, link_image;
-      link_note_open, link_note;
-      link_person_open, link_person;
+      wizard_link_open, wizard_link;
+      image_link_open, image_link;
+      note_link_open, note_link;
+      person_link_open, person_link;
     ])
     [@ocamlformat "disable"]
 
@@ -147,7 +156,7 @@ let special =
   <|> strike_del
   <|> underline_del
   <|> highlight_open
-  <|> link_person_open)
+  <|> person_link_open)
   [@ocamlformat "disable"]
 
 let plain =
@@ -176,10 +185,10 @@ let span ~recover =
       strike_del, strike;
       underline_del, underline;
       highlight_open, highlight;
-      link_image_open, span_coercion link_image;
-      link_wizard_open, span_coercion link_wizard;
-      link_note_open, span_coercion link_note;
-      link_person_open, span_coercion link_person;
+      image_link_open, span_coercion image_link;
+      wizard_link_open, span_coercion wizard_link;
+      note_link_open, span_coercion note_link;
+      person_link_open, span_coercion person_link;
     ] plain)
     [@ocamlformat "disable"]
 
@@ -319,7 +328,8 @@ let coercion p =
 let block ~recover =
   let r =
     if recover then
-      Some (fun loc -> (Ast.(mk_text ~loc [ mk_span Plain "error" ]) :> Ast.block))
+      Some
+        (fun loc -> (Ast.(mk_text ~loc [ mk_span Plain "error" ]) :> Ast.block))
     else None
   in
   C.(
@@ -344,21 +354,26 @@ let block ~recover =
 
 let parse t ~on_err s =
   let st = Input.of_string s in
-  let rec loop acc st =
+  let rec loop st () =
     let start = Input.offset st in
     match C.run t st with
-    | Ok tk, st' -> loop (tk :: acc) st'
+    | Ok tk, st' -> Seq.Cons (tk, loop st')
     | Error err, st' ->
-        if Input.eof st then List.rev acc
+        if Input.eof st then Seq.Nil
         else
           let stop = Input.offset st' in
           let loc = Loc.mk (Input.to_source st') start stop in
           on_err ~loc (err ());
-          acc
+          Seq.Nil
   in
-  loop [] st
+  loop st
 
 type error_handler = loc:Geneweb_loc.t -> string -> unit
+
+let is_valid_path s =
+  match fst @@ C.run path @@ Input.of_string s with
+  | Ok _ -> true
+  | Error _ -> false
 
 let parse_links = parse link
 let parse ~recover = parse (block ~recover)

--- a/lib/tlsw/parser.mli
+++ b/lib/tlsw/parser.mli
@@ -111,7 +111,7 @@
 
 type error_handler = loc:Geneweb_loc.t -> string -> unit
 
-val parse : recover:bool -> on_err:error_handler -> string -> Ast.t list
+val parse : recover:bool -> on_err:error_handler -> string -> Ast.block list
 (** [parse ~on_err s] parses the input [s] for the TLSW syntax. *)
 
 val parse_links : on_err:error_handler -> string -> Ast.link list

--- a/lib/tlsw/parser.mli
+++ b/lib/tlsw/parser.mli
@@ -111,8 +111,12 @@
 
 type error_handler = loc:Geneweb_loc.t -> string -> unit
 
-val parse : recover:bool -> on_err:error_handler -> string -> Ast.block list
+val is_valid_path : string -> bool
+(** [is_valid_path s] checks if [s] is a path with colons as directory
+    delimitator. *)
+
+val parse : recover:bool -> on_err:error_handler -> string -> Ast.block Seq.t
 (** [parse ~on_err s] parses the input [s] for the TLSW syntax. *)
 
-val parse_links : on_err:error_handler -> string -> Ast.link list
+val parse_links : on_err:error_handler -> string -> Ast.link Seq.t
 (** [parse_links ~on_err s] *)

--- a/lib/tlsw/parser.mli
+++ b/lib/tlsw/parser.mli
@@ -111,7 +111,7 @@
 
 type error_handler = loc:Geneweb_loc.t -> string -> unit
 
-val parse : on_err:error_handler -> string -> Ast.t list
+val parse : recover:bool -> on_err:error_handler -> string -> Ast.t list
 (** [parse ~on_err s] parses the input [s] for the TLSW syntax. *)
 
 val parse_links : on_err:error_handler -> string -> Ast.link list

--- a/lib/tlsw/parser.mli
+++ b/lib/tlsw/parser.mli
@@ -1,0 +1,118 @@
+(** {1 TLSW: Text Language Stolen from Wikipedia}
+
+    This module provides a parser for the Wikipedia-inspired markup syntax used
+    by GeneWeb.
+
+    {2 Headers}
+    Use equal signs to denote section hierarchy. Six levels are supported.
+    {v
+    = Level 1 =
+    == Level 2 ==
+    ...
+    ====== Level 6 ======
+    v}
+
+    {2 Horizontal Rules}
+    Four or more hyphens create a horizontal rule.
+    {v
+    ----
+    ---------...
+    v}
+
+    {2 Tables of Contents}
+    Control the visibility and style of the Table of Contents:
+    {v
+    __TOC__
+    __SHORT_TOC__
+    __NOTOC__
+    v}
+
+    {2 Lists}
+    Use asterisks for unordered lists. Increase the number of asterisks for
+    nesting. For example:
+    {v
+    * item
+    * item
+    ** nested item
+    ** nested item
+    * item
+    v}
+
+    Use the hash symbol for ordered lists. Increase the number of hashes for
+    nesting. For example:
+    {v
+    # item
+    # item
+    ## nested item
+    ## nested item
+    # item
+    v}
+
+    Ordered and unordered lists can be mixed:
+    {v
+    # item
+    * item
+    ** nested item
+    * item
+    # item
+    ## nested item
+    # item
+    v}
+
+    {2 Text Formatting}
+    Apply styles using quotes, underscores, or curly braces:
+    {v
+    ''italic''
+    '''bold'''
+    '''''bold + italic'''''
+    __underline__
+    ~~strike~~
+    {highlight}
+    v}
+
+    {2 Links and References}
+
+    {3 Person Pages}
+    Link to a person's page using double brackets. The occurrence (occ) and
+    display text are optional.
+    {v
+    [[first name/surname]]
+    [[first name/surname/occ]]
+    [[first name/surname/occ/text]]
+    v}
+
+    {3 Bibliographic Notes}
+    Reference bibliographic notes using triple brackets. The display text is
+    optional.
+    {v
+    [[[dir1:dir2:file]]]
+    [[[dir1:dir2:file/text]]]
+    v}
+    {b Note:} Use the colon symbol [:] as a path separator instead of the
+    standard forward slash [/].
+
+    {3 Wizard Pages}
+    Reference wizard pages using the [w:] prefix:
+    {v
+    [[w:dir1:dir2:file]]
+    [[w:dir1:dir2:file/text]]
+    v}
+
+    {3 Images}
+    Embed images as follows. The display text is optional, and [width] must be a
+    valid CSS size.
+    {v
+    [[image:dir1:dir2:file]]
+    [[image:dir1:dir2:file/text]]
+    [[image:dir1:dir2:file/text/width]]
+    v}
+    As with notes, use the colon [:] as the path separator regardless of your
+    platform's native directory separator. *)
+
+type error_handler = loc:Geneweb_loc.t -> string -> unit
+
+val parse : on_err:error_handler -> string -> Ast.t list
+(** [parse ~on_err s] parses the input [s] for the TLSW syntax. *)
+
+val parse_links : on_err:error_handler -> string -> Ast.link list
+(** [parse_links ~on_err s] *)

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -182,52 +182,112 @@ end = struct
     Ast.{ desc; loc }
 end
 
-let pp_person_link conf ppf (fn, sn, oc) =
-  let fn = encode fn in
-  let sn = encode sn in
-  Fmt.pf ppf "%sp=%s;n=%s%a" (command conf) fn sn Fmt.(option ~none:nop int) oc
+module Printer = struct
+  let pp_person_link conf ppf (fn, sn, oc) =
+    let fn = encode fn in
+    let sn = encode sn in
+    let pp_oc ppf oc = Fmt.pf ppf "&oc=%d" oc in
+    Fmt.pf ppf "%sp=%s;n=%s%a" (command conf) fn sn Fmt.(option ~none:nop pp_oc) oc
 
-let pp_note_link conf ppf (path, anchor, wizard) =
-  let path = encode path in
-  if wizard then Fmt.pf ppf "%sm=WIZNOTES&f=%s" (command conf) path
-  else
-    match anchor with
-    | Some a ->
-        let a = encode a in
-        Fmt.pf ppf "%sm=WIZNOTES&f=%s#%s" (command conf) path a
-    | None -> Fmt.pf ppf "%sm=WIZNOTES&f=%s" (command conf) path
+  let pp_note_link conf ppf (path, anchor, wizard) =
+    let path = encode path in
+    if wizard then Fmt.pf ppf "%sm=WIZNOTES&f=%s" (command conf) path
+    else
+      match anchor with
+      | Some a ->
+          let a = encode a in
+          Fmt.pf ppf "%sm=WIZNOTES&f=%s#%s" (command conf) path a
+      | None -> Fmt.pf ppf "%sm=WIZNOTES&f=%s" (command conf) path
 
-let pp_image_link conf ppf path =
-  let path = encode path in
-  Fmt.pf ppf "%sm=IM&s=%s" (command conf) path
+  let pp_image_link conf ppf path =
+    let path = encode path in
+    Fmt.pf ppf "%sm=IM&s=%s" (command conf) path
 
-let _link_to_html conf (tag, text) =
-  let a ~cls ?text uri =
-    let s = Option.value ~default:uri text in
-    Html.(a ~a:[ a_href uri; a_class [ cls ] ] [ txt s ])
-  in
-  let img ~cls ?width ?alt src =
-    let alt = Option.value ~default:"" alt in
-    let attrs =
-      match width with
-      | Some w ->
-          let s = Fmt.str "max-width: %s" w in
-          [ Html.a_style s ]
-      | None -> []
+  let link_to_html conf (tag, text) =
+    let a ~cls ?text uri =
+      let s = Option.value ~default:uri text in
+      Html.(a ~a:[ a_href uri; a_class [ cls ] ] [ txt s ])
     in
-    let attrs = Html.a_class [ cls ] :: attrs in
-    Html.(img ~a:attrs ~src ~alt ())
-  in
-  match tag with
-  | Tlsw.Ast.Person { fn; sn; oc } ->
-      let lk = Fmt.str "%a" (pp_person_link conf) (fn, sn, oc) in
-      a ~cls:"person-link" ?text lk
-  | Note { path; anchor; wizard } ->
-      let lk = Fmt.str "%a" (pp_note_link conf) (path, anchor, wizard) in
-      a ~cls:"note-link" ?text lk
-  | Image { path; width; _ } ->
-      let src = Fmt.str "%a" (pp_image_link conf) path in
-      img ~cls:"image-link" ?width ?alt:text src
+    let img ~cls ?width ?alt src =
+      let alt = Option.value ~default:"" alt in
+      let attrs =
+        match width with
+        | Some w ->
+            let s = Fmt.str "max-width: %s" w in
+            [ Html.a_style s ]
+        | None -> []
+      in
+      let attrs = Html.a_class [ cls ] :: attrs in
+      Html.(img ~a:attrs ~src ~alt ())
+    in
+    match tag with
+    | Tlsw.Ast.Person { fn; sn; oc } ->
+        let lk = Fmt.str "%a" (pp_person_link conf) (fn, sn, oc) in
+        a ~cls:"person-link" ?text lk
+    | Note { path; anchor; wizard } ->
+        let lk = Fmt.str "%a" (pp_note_link conf) (path, anchor, wizard) in
+        a ~cls:"note-link" ?text lk
+    | Image { path; width; _ } ->
+        let src = Fmt.str "%a" (pp_image_link conf) path in
+        img ~cls:"image-link" ?width ?alt:text src
+
+  let span_to_html conf Tlsw.Ast.{ desc; _ } =
+    let open Tlsw.Ast in
+    match desc with
+    | `Link l -> link_to_html conf l
+    | `Span (tag, s) -> (
+        match tag with
+        | Plain -> Html.txt s
+        | Italic -> Html.(i [ txt s ])
+        | Bold -> Html.(b [ txt s ])
+        | BoldItalic -> Html.(b [ i [ txt s ] ])
+        | Strike ->
+            Html.(span ~a:[ a_style "text-decoration: line-through" ] [ txt s ])
+        | Underline ->
+            Html.(span ~a:[ a_style "text-decoration: underline" ] [ txt s ])
+        | Highlight -> Html.(mark [ txt s ])
+        | Error -> Html.(span ~a:[ a_style "color: red" ] [ txt s ]))
+
+  let text_desc_to_html conf (`Text l) = List.map (span_to_html conf) l
+  let text_to_html conf Tlsw.Ast.{ desc; _ } = text_desc_to_html conf desc
+
+  let rec node_desc_to_html conf (`Node (t, k, l)) =
+    let l = node_list_to_html conf k l in
+    match t with
+    | Some t -> Html.(li (text_to_html conf t @ [ l ]))
+    | None -> Html.(li [ l ])
+
+  and node_list_to_html conf k l =
+    let open Tlsw.Ast in
+    let l = List.map (fun { desc; _ } -> node_desc_to_html conf desc) l in
+    match l with
+    | [] -> Html.(txt "")
+    | _ -> ( match k with Ordered -> Html.(ol l) | Unordered -> Html.(ul l))
+
+  let to_html conf Tlsw.Ast.{ desc; _ } =
+    let open Tlsw.Ast in
+    match desc with
+    | `Header (One, s) -> Html.(h1 [ txt s ])
+    | `Header (Two, s) -> Html.(h2 [ txt s ])
+    | `Header (Three, s) -> Html.(h3 [ txt s ])
+    | `Header (Four, s) -> Html.(h4 [ txt s ])
+    | `Header (Five, s) -> Html.(h5 [ txt s ])
+    | `Header (Six, s) -> Html.(h6 [ txt s ])
+    | `Toc Std -> Html.(div [ txt "__TOC__" ])
+    | `Toc Short -> Html.(div [ txt "__SHORT_TOC__" ])
+    | `Toc No -> Html.(div [ txt "__NOTOC__" ])
+    | `Indent (lvl, t) ->
+        let s = Fmt.str "text-indent: %d%%;" (lvl * 5) in
+        Html.(p ~a:[ a_style s ] @@ text_to_html conf t)
+    | `Pre s -> Html.(pre [ txt s ])
+    | `Node (None, k, l) -> node_list_to_html conf k l
+    | `Node (Some _, _, _) ->
+        (* Top level lists never contain text. *)
+        assert false
+    | `Newline -> Html.br ()
+    | `Rule -> Html.hr ()
+    | #text_desc as t -> Html.(p @@ text_desc_to_html conf t)
+end
 
 let first_cnt = 1
 let tab lev s = String.make (2 * lev) ' ' ^ s
@@ -893,23 +953,24 @@ and select_list_lines conf prompt list = function
       else (List.rev list, s :: sl)
   | [] -> (List.rev list, [])
 
-let html_of_tlsw conf s =
-  let lines, _ = lines_list_of_string s in
-  let sections_nums =
-    match sections_nums_of_tlsw_lines lines with [ _ ] -> [] | l -> l
-  in
-  hotl conf (Some lines) first_cnt None sections_nums [] ("" :: lines)
+let html_of_tlsw _conf _s = assert false
+  (* let lines, _ = lines_list_of_string s in *)
+  (* let sections_nums = *)
+  (*   match sections_nums_of_tlsw_lines lines with [ _ ] -> [] | l -> l *)
+  (* in *)
+  (* hotl conf (Some lines) first_cnt None sections_nums [] ("" :: lines) *)
 
 let html_of_tlsw2 conf base s =
   Logs.debug (fun k -> k "%a" Fmt.text s);
   let on_err ~loc e =
     Logs.debug (fun k -> k "Syntax error: %s@ %a" e Loc.pp_with_source loc)
   in
-  let ctx = Process.make conf base ~cancel_links:false ~always_show_links:false in
+  let cancel_links = Util.p_getenv conf.env "cgl" = Some "on" in
+  let ctx = Process.make conf base ~cancel_links ~always_show_links:false in
   let l =
     Tlsw.Parser.parse ~recover:true ~on_err s
     |> Seq.map (Process.process_block ctx)
-    |> Seq.map Tlsw.Ast.to_html
+    |> Seq.map (Printer.to_html conf)
   in
   Fmt.str "%a" Fmt.(seq Html.(pp_elt ~encode:Fun.id ~indent:true ())) l
 

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -3,6 +3,10 @@
 open Def
 open Config
 open Util
+module Tlsw = Geneweb_tlsw
+module Loc = Geneweb_loc
+module Html = Tyxml.Html
+module Driver = Geneweb_db.Driver
 
 (* TLSW: Text Language Stolen to Wikipedia
    = title level 1 =
@@ -37,6 +41,194 @@ open Util
    __SHORT_TOC__ : short summary (unnumbered)
    __NOTOC__ : no (automatic) numbered summary *)
 
+let encode s = (Mutil.encode s :> string)
+let command conf = (Util.commd conf :> string)
+let ( // ) = Filename.concat
+
+let parse_notes_aliases conf =
+  let fname =
+    match List.assoc "notes_alias_file" conf.base_env with
+    | f -> f
+    | exception Not_found -> !GWPARAM.bpath conf.bname // "notes.alias"
+  in
+  match Secure.open_in fname with
+  | exception Sys_error _ -> []
+  | ic ->
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | exception End_of_file -> acc
+        | line ->
+            let acc =
+              match String.index line ' ' with
+              | exception Not_found -> acc
+              | i ->
+                  let x = String.sub line 0 i in
+                  let y =
+                    String.sub line (i + 1) (String.length line - i - 1)
+                  in
+                  (x, y) :: acc
+            in
+            loop acc
+      in
+      loop []
+
+module Process : sig
+  type t
+
+  val make : Config.config -> Driver.base -> cancel_links:bool -> always_show_links:bool -> t
+  val process_block : t -> Tlsw.Ast.block -> Tlsw.Ast.block
+end = struct
+  module Ast = Tlsw.Ast
+  module MS = Map.Make (String)
+
+  type t = {
+    conf : Config.config;
+    base : Driver.base;
+    cancel_links : bool;
+    always_show_links : bool;
+    notes_aliases : string MS.t;
+  }
+
+  let fix_path path = String.map (fun c -> if c = ':' then '/' else c) path
+
+  let make conf base ~cancel_links ~always_show_links =
+    let notes_aliases =
+      parse_notes_aliases conf |> List.to_seq
+      |> Seq.filter_map (fun (x, path) ->
+          if Tlsw.Parser.is_valid_path path then
+            let path = fix_path path in
+            if Sys.file_exists path then Some (x, path)
+            else None
+          else
+            None
+      )
+      |> MS.of_seq
+    in
+    { conf; base; cancel_links; always_show_links; notes_aliases }
+
+  let process_person ctx fn sn oc text =
+    let name = match text with Some t -> t | None -> Fmt.str "%s %s" fn sn in
+    let fn = Name.lower fn in
+    let sn = Name.lower sn in
+    let oc = Option.value ~default:0 oc in
+    let tag = Ast.Person { fn; sn; oc = Some oc } in
+    if ctx.always_show_links then `Link (tag, Some name)
+    else if Util.person_exists ctx.conf ctx.base (fn, sn, oc) then
+      if ctx.cancel_links then `Span (Ast.Plain, name)
+      else `Link (tag, Some name)
+    else
+      let name =
+        if ctx.conf.hide_names then Util.private_txt ctx.conf "" else name
+      in
+      `Span (Ast.Error, name)
+
+  let process_note ctx ~path ?anchor ~wizard text =
+    let text = Option.value ~default:path text in
+    if ctx.cancel_links then `Span (Ast.Plain, text)
+    else
+      if wizard then
+        let path = fix_path path in
+        `Link (Ast.Note { path; anchor; wizard }, Some text)
+      else
+        let path =
+          match MS.find path ctx.notes_aliases with
+          | exception Not_found -> fix_path path
+          | f -> f
+        in
+        `Link (Ast.Note { path; anchor; wizard }, Some text)
+
+  let process_image _ctx ~path ?width text =
+    if Tlsw.Parser.is_valid_path path then
+      let path = fix_path path in
+      `Link (Ast.Image { path; width }, text)
+    else
+      let text = Option.value ~default:path text in
+      `Span (Ast.Highlight, text)
+
+  let process_link ctx (tag, text) =
+    match tag with
+    | Tlsw.Ast.Person { fn; sn; oc } -> process_person ctx fn sn oc text
+    | Note { path; anchor; wizard } ->
+        process_note ctx ~path ?anchor ~wizard text
+    | Image { path; width } -> process_image ctx ~path ?width text
+
+  let process_span_desc ctx desc =
+    match desc with `Link l -> process_link ctx l | `Span _ -> desc
+
+  let process_span ctx Ast.{ desc; loc } =
+    let desc = process_span_desc ctx desc in
+    Ast.{ desc; loc }
+
+  let process_text_desc ctx (`Text l) =
+    let l = List.map (process_span ctx) l in
+    `Text l
+
+  let process_text ctx Ast.{ desc; loc } =
+    let desc = process_text_desc ctx desc in
+    Ast.{ desc; loc }
+
+  let process_node_list ctx (`Node (t, k, l)) =
+    let t = Option.map (process_text ctx) t in
+    `Node (t, k, l)
+
+  let process_block ctx (Ast.{ desc; loc } : Ast.block) =
+    let desc =
+      match desc with
+      | `Node _ as x -> process_node_list ctx x
+      | `Text _ as x -> process_text_desc ctx x
+      | _ -> desc
+    in
+    Ast.{ desc; loc }
+end
+
+let pp_person_link conf ppf (fn, sn, oc) =
+  let fn = encode fn in
+  let sn = encode sn in
+  Fmt.pf ppf "%sp=%s;n=%s%a" (command conf) fn sn Fmt.(option ~none:nop int) oc
+
+let pp_note_link conf ppf (path, anchor, wizard) =
+  let path = encode path in
+  if wizard then Fmt.pf ppf "%sm=WIZNOTES&f=%s" (command conf) path
+  else
+    match anchor with
+    | Some a ->
+        let a = encode a in
+        Fmt.pf ppf "%sm=WIZNOTES&f=%s#%s" (command conf) path a
+    | None -> Fmt.pf ppf "%sm=WIZNOTES&f=%s" (command conf) path
+
+let pp_image_link conf ppf path =
+  let path = encode path in
+  Fmt.pf ppf "%sm=IM&s=%s" (command conf) path
+
+let _link_to_html conf (tag, text) =
+  let a ~cls ?text uri =
+    let s = Option.value ~default:uri text in
+    Html.(a ~a:[ a_href uri; a_class [ cls ] ] [ txt s ])
+  in
+  let img ~cls ?width ?alt src =
+    let alt = Option.value ~default:"" alt in
+    let attrs =
+      match width with
+      | Some w ->
+          let s = Fmt.str "max-width: %s" w in
+          [ Html.a_style s ]
+      | None -> []
+    in
+    let attrs = Html.a_class [ cls ] :: attrs in
+    Html.(img ~a:attrs ~src ~alt ())
+  in
+  match tag with
+  | Tlsw.Ast.Person { fn; sn; oc } ->
+      let lk = Fmt.str "%a" (pp_person_link conf) (fn, sn, oc) in
+      a ~cls:"person-link" ?text lk
+  | Note { path; anchor; wizard } ->
+      let lk = Fmt.str "%a" (pp_note_link conf) (path, anchor, wizard) in
+      a ~cls:"note-link" ?text lk
+  | Image { path; width; _ } ->
+      let src = Fmt.str "%a" (pp_image_link conf) path in
+      img ~cls:"image-link" ?width ?alt:text src
+
 let first_cnt = 1
 let tab lev s = String.make (2 * lev) ' ' ^ s
 
@@ -69,34 +261,6 @@ let make_edit_button conf ?(mode = "") fnotes ?(cnt = None) () =
     {|<a href="%s" class="align-self-center ml-3 mb-1"
   title="%s">(%s)</a>|}
     href title (transl conf "modify")
-
-let notes_aliases conf =
-  let fname =
-    match List.assoc_opt "notes_alias_file" conf.base_env with
-    | Some f -> f
-    | None -> Filename.concat (Util.bpath conf.bname) "notes.alias"
-  in
-  match try Some (Secure.open_in fname) with Sys_error _ -> None with
-  | Some ic ->
-      let rec loop list =
-        match try Some (input_line ic) with End_of_file -> None with
-        | Some s ->
-            let list =
-              (* S: is it replacable by `String.split_on_char ' '` s? *)
-              try
-                let i = String.index s ' ' in
-                ( String.sub s 0 i,
-                  String.sub s (i + 1) (String.length s - i - 1) )
-                :: list
-              with Not_found -> list
-            in
-            loop list
-        | None ->
-            close_in ic;
-            list
-      in
-      loop []
-  | None -> []
 
 let map_notes aliases f = try List.assoc f aliases with Not_found -> f
 let fname_of_path (dirs, file) = List.fold_right Filename.concat dirs file
@@ -307,7 +471,7 @@ let syntax_links conf wi s =
       | NotesLinks.WLpage (j, fpath1, fname1, anchor, text) ->
           let text = bold_italic_syntax text in
           let fpath, fname =
-            let aliases = notes_aliases conf in
+            let aliases = parse_notes_aliases conf in
             let fname = map_notes aliases fname1 in
             match NotesLinks.check_file_name fname with
             | Some fpath -> (fpath, fname)
@@ -735,6 +899,19 @@ let html_of_tlsw conf s =
     match sections_nums_of_tlsw_lines lines with [ _ ] -> [] | l -> l
   in
   hotl conf (Some lines) first_cnt None sections_nums [] ("" :: lines)
+
+let html_of_tlsw2 conf base s =
+  Logs.debug (fun k -> k "%a" Fmt.text s);
+  let on_err ~loc e =
+    Logs.debug (fun k -> k "Syntax error: %s@ %a" e Loc.pp_with_source loc)
+  in
+  let ctx = Process.make conf base ~cancel_links:false ~always_show_links:false in
+  let l =
+    Tlsw.Parser.parse ~recover:true ~on_err s
+    |> Seq.map (Process.process_block ctx)
+    |> Seq.map Tlsw.Ast.to_html
+  in
+  Fmt.str "%a" Fmt.(seq Html.(pp_elt ~encode:Fun.id ~indent:true ())) l
 
 let html_with_summary_of_tlsw conf wi edit_opt s =
   let lines, no_toc = lines_list_of_string s in

--- a/lib/wiki.mli
+++ b/lib/wiki.mli
@@ -56,6 +56,8 @@ val make_edit_button :
 val html_of_tlsw : config -> string -> string list
 (** Parses a whole TLSW text to a list of strings *)
 
+val html_of_tlsw2 : config -> Geneweb_db.Driver.base -> string -> string
+
 val html_with_summary_of_tlsw :
   config -> wiki_info -> (bool * string * string) option -> string -> string
 (** HTML displaying a table of content for a TLSW file *)
@@ -109,7 +111,7 @@ val print_mod_ok :
 
 (*S: shouldn't the following functions be defined elsewhere? *)
 
-val notes_aliases : config -> (string * string) list
+val parse_notes_aliases : config -> (string * string) list
 (** Reads the notes alias file (conf.base_env.notes_alias_file or
     base_path/notes.alias). File format is "KEY value\n...", returns the list of
     (KEY,value) *)

--- a/test/dune
+++ b/test/dune
@@ -30,7 +30,8 @@
  (libraries qcheck qcheck-alcotest geneweb_compat geneweb_search))
 
 (executable
- (name wiki_check)
+ (package geneweb)
+ (public_name wiki_check)
  (modules wiki_check)
  (libraries
   geneweb_compat

--- a/test/dune
+++ b/test/dune
@@ -28,3 +28,17 @@
 (test
  (name heap_test)
  (libraries qcheck qcheck-alcotest geneweb_compat geneweb_search))
+
+(executable
+ (name wiki_check)
+ (modules wiki_check)
+ (libraries
+  geneweb_compat
+  geneweb_util
+  geneweb_db
+  geneweb_tlsw
+  cmdliner
+  tyxml
+  fmt
+  logs
+  progress))

--- a/test/tlsw/dune
+++ b/test/tlsw/dune
@@ -1,0 +1,16 @@
+(executable
+ (name parse)
+ (libraries geneweb_tlsw geneweb_compat pp_loc tyxml))
+
+(rule
+ (deps
+  (:input ./input.txt))
+ (action
+  (with-stdout-to
+   output.html
+   (run ./parse.exe %{input}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff expected.html output.html)))

--- a/test/tlsw/expected.html
+++ b/test/tlsw/expected.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head><title>input.txt</title></head>
+ <body><h1> Title 1 </h1><h2> Title 2 </h2><h3> Title 3 </h3>
+  <h4> Title 4 </h4><h5> Title 5 </h5><h6> Title 6 </h6><br/><h2> Rule </h2>
+  <hr/><hr/><br/><h2> Tables of contents </h2><div>__TOC__</div>
+  <div>__SHORT_TOC__</div><div>__NOTOC__</div><br/>
+  <h2> Normal paragraph </h2>
+  <p>
+   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+   sagittis
+   ipsum augue, vitae suscipit nisi tincidunt at. Aliquam erat volutpat.
+   Integer
+   consectetur est sapien, vel imperdiet massa fermentum et. Nunc sagittis
+   tempor
+   erat, eget eleifend metus malesuada quis. Etiam ullamcorper mi sit amet
+   libero
+   tempus hendrerit.
+  </p><br/><h2> Formatted paragraph </h2>
+  <p>Lorem <i>ipsum</i> dolor sit amet, 
+   <span style="text-decoration: underline">consectetur</span>
+    adipiscing elit. Suspendisse sagittis
+   ipsum augue, vitae suscipit nisi tincidunt at. Aliquam 
+   <span style="text-decoration: line-through">erat</span>
+    volutpat. Integer
+   consectetur <b><i>est</i></b> sapien, vel imperdiet massa 
+   <mark>fermentum</mark> et. Nunc sagittis tempor
+                         erat, eget eleifend metus 
+   <b>malesuada</b>
+    quis. Etiam ullamcorper mi sit amet libero
+   tempus hendrerit.
+  </p><br/><h2> Pre paragraph </h2>
+  <pre>
+   Lorem ''ipsum'' dolor sit amet, __consectetur__ adipiscing elit.
+   Suspendisse sagittis
+    ipsum augue, vitae suscipit nisi tincidunt at. Aliquam ~~erat~~ volutpat.
+   Integer
+    consectetur '''''est''''' sapien, vel imperdiet massa {fermentum} et.
+   Nunc sagittis tempor
+    erat, eget eleifend metus '''malesuada''' quis. Etiam ullamcorper mi sit
+   amet libero
+    tempus hendrerit.
+  </pre><h2> Not pre paragraph </h2>
+  <p> Lorem <i>ipsum</i> dolor sit amet, 
+   <span style="text-decoration: underline">consectetur</span>
+    adipiscing elit. Suspendisse sagittis
+    ipsum augue, vitae suscipit nisi tincidunt at. Aliquam 
+   <span style="text-decoration: line-through">erat</span>
+    volutpat. Integer
+    consectetur <b><i>est</i></b> sapien, vel imperdiet massa 
+   <mark>fermentum</mark> et. Nunc sagittis tempor
+                          erat, eget eleifend metus 
+   <b>malesuada</b>
+    quis. Etiam ullamcorper mi sit amet libero
+    tempus hendrerit.
+  </p><br/><h2> Not pre paragraph </h2><br/>
+  <p> Lorem <i>ipsum</i> dolor sit amet, 
+   <span style="text-decoration: underline">consectetur</span>
+    adipiscing elit. Suspendisse sagittis
+   ipsum augue, vitae suscipit nisi tincidunt at. Aliquam 
+   <span style="text-decoration: line-through">erat</span>
+    volutpat. Integer
+   consectetur <b><i>est</i></b> sapien, vel imperdiet massa 
+   <mark>fermentum</mark> et. Nunc sagittis tempor
+                         erat, eget eleifend metus 
+   <b>malesuada</b>
+    quis. Etiam ullamcorper mi sit amet libero
+   tempus hendrerit.
+  </p><br/><h2> Indentation </h2>
+  <p style="text-indent: 5%;">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+   sagittis
+  </p>
+  <p style="text-indent: 10%;">
+    ipsum augue, vitae suscipit nisi tincidunt at. Aliquam erat volutpat.
+   Integer
+  </p>
+  <p style="text-indent: 5%;">
+    consectetur est sapien, vel imperdiet massa fermentum et. Nunc sagittis
+   tempor
+  </p>
+  <p style="text-indent: 15%;">
+    erat, eget eleifend metus malesuada quis. Etiam ullamcorper mi sit amet
+   libero
+   tempus hendrerit.
+  </p><br/><h2> Person links </h2>
+  <p><span style="color: blue">(jean/martin/) </span>
+                                                     <span
+                                                      style="color: blue">
+                                                      (jean/martin/10) 
+                                                     </span>
+   
+   <span style="color: blue">(jean/martin/10) dolor sit amet</span>
+  </p><br/><h2> Note links </h2>
+  <p><span style="color: red">(file.txt)</span>
+                                               <span style="color: red">
+                                                (dir1:dir2:file.txt)
+                                               </span>
+   
+   <span style="color: red">(file.txt)dolor sit amet</span>
+                                                           <span
+                                                            style="color: red">
+                                                            (dir1:dir2:file.txt)
+                                                           </span>
+   
+   <span style="color: red">(dir1:dir2:file.txt)dolor sit amet</span>
+  </p><br/><h2> Wizard note links </h2>
+  <p><span style="color: green">(file.txt)</span>
+                                                 <span style="color: green">
+                                                  (dir1:dir2:file.txt)
+                                                 </span>
+   
+   <span style="color: green">(file.txt)dolor sit amet</span>
+                                                             <span
+                                                              style="color: green"
+                                                              >
+                                                              (dir1:dir2:file.txt)
+                                                             </span>
+   
+   <span style="color: green">(dir1:dir2:file.txt)dolor sit amet</span>
+  </p><br/><h2> Image links </h2>
+  <p><span style="color: yellow">(file.jpg)</span>
+                                                  <span style="color: yellow">
+                                                   (dir1:dir2:file.jpg)
+                                                  </span>
+   
+   <span style="color: yellow">(file.jpg)dolor sit amet</span>
+                                                              <span
+                                                               style="color: yellow"
+                                                               >
+                                                               (dir1:dir2:file.jpg)dolor
+                                                               sit amet
+                                                              </span>
+  </p><br/><h2> Simple lists </h2>
+  <ul><li> First element</li><li> Second element</li><li> Third element</li>
+  </ul><br/>
+  <ol><li> First element</li><li> Second element</li><li> Third element</li>
+  </ol><br/><h2> Nested lists </h2>
+  <ul><li> First level<ul><li> Second level</li></ul></li>
+   <li> First level
+    <ul><li> Second level<ul><li> Third level</li></ul></li></ul>
+   </li>
+  </ul><br/>
+  <ol><li> First level<ol><li> Second level</li></ol></li>
+   <li> First level
+    <ol><li> Second level<ol><li> Third level</li></ol></li></ol>
+   </li>
+  </ol><br/><h2> Nested ordered and unordered lists </h2>
+  <ul>
+   <li> First unordered level
+    <ul>
+     <li> Second unordered level
+      <ol><li> First ordered level</li>
+       <li> First ordered level<ol><li> Second ordered level</li></ol></li>
+       <li> First ordered level
+           </li>
+      </ol>
+     </li>
+    </ul>
+   </li>
+  </ul>
+ </body>
+</html>

--- a/test/tlsw/input.txt
+++ b/test/tlsw/input.txt
@@ -1,0 +1,114 @@
+= Title 1 =
+== Title 2 ==
+=== Title 3 ===
+==== Title 4 ====
+===== Title 5 =====
+====== Title 6 ======
+
+== Rule ==
+----
+--------
+
+== Tables of contents ==
+__TOC__
+__SHORT_TOC__
+__NOTOC__
+
+== Normal paragraph ==
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse sagittis
+ipsum augue, vitae suscipit nisi tincidunt at. Aliquam erat volutpat. Integer
+consectetur est sapien, vel imperdiet massa fermentum et. Nunc sagittis tempor
+erat, eget eleifend metus malesuada quis. Etiam ullamcorper mi sit amet libero
+tempus hendrerit.
+
+== Formatted paragraph ==
+Lorem ''ipsum'' dolor sit amet, __consectetur__ adipiscing elit. Suspendisse sagittis
+ipsum augue, vitae suscipit nisi tincidunt at. Aliquam ~~erat~~ volutpat. Integer
+consectetur '''''est''''' sapien, vel imperdiet massa {fermentum} et. Nunc sagittis tempor
+erat, eget eleifend metus '''malesuada''' quis. Etiam ullamcorper mi sit amet libero
+tempus hendrerit.
+
+== Pre paragraph ==
+
+ Lorem ''ipsum'' dolor sit amet, __consectetur__ adipiscing elit. Suspendisse sagittis
+ ipsum augue, vitae suscipit nisi tincidunt at. Aliquam ~~erat~~ volutpat. Integer
+ consectetur '''''est''''' sapien, vel imperdiet massa {fermentum} et. Nunc sagittis tempor
+ erat, eget eleifend metus '''malesuada''' quis. Etiam ullamcorper mi sit amet libero
+ tempus hendrerit.
+
+== Not pre paragraph ==
+ Lorem ''ipsum'' dolor sit amet, __consectetur__ adipiscing elit. Suspendisse sagittis
+ ipsum augue, vitae suscipit nisi tincidunt at. Aliquam ~~erat~~ volutpat. Integer
+ consectetur '''''est''''' sapien, vel imperdiet massa {fermentum} et. Nunc sagittis tempor
+ erat, eget eleifend metus '''malesuada''' quis. Etiam ullamcorper mi sit amet libero
+ tempus hendrerit.
+
+== Not pre paragraph ==
+
+ Lorem ''ipsum'' dolor sit amet, __consectetur__ adipiscing elit. Suspendisse sagittis
+ipsum augue, vitae suscipit nisi tincidunt at. Aliquam ~~erat~~ volutpat. Integer
+consectetur '''''est''''' sapien, vel imperdiet massa {fermentum} et. Nunc sagittis tempor
+erat, eget eleifend metus '''malesuada''' quis. Etiam ullamcorper mi sit amet libero
+tempus hendrerit.
+
+== Indentation ==
+: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse sagittis
+:: ipsum augue, vitae suscipit nisi tincidunt at. Aliquam erat volutpat. Integer
+: consectetur est sapien, vel imperdiet massa fermentum et. Nunc sagittis tempor
+::: erat, eget eleifend metus malesuada quis. Etiam ullamcorper mi sit amet libero
+tempus hendrerit.
+
+== Person links ==
+[[jean/martin]]
+[[jean/martin/10]]
+[[jean/martin/10/dolor sit amet]]
+
+== Note links ==
+[[[file.txt]]]
+[[[dir1:dir2:file.txt]]]
+[[[file.txt/dolor sit amet]]]
+[[[dir1:dir2:file.txt]]]
+[[[dir1:dir2:file.txt/dolor sit amet]]]
+
+== Wizard note links ==
+[[w:file.txt]]
+[[w:dir1:dir2:file.txt]]
+[[w:file.txt/dolor sit amet]]
+[[w:dir1:dir2:file.txt]]
+[[w:dir1:dir2:file.txt/dolor sit amet]]
+
+== Image links ==
+[[image:file.jpg]]
+[[image:dir1:dir2:file.jpg]]
+[[image:file.jpg/dolor sit amet]]
+[[image:dir1:dir2:file.jpg/dolor sit amet/120px]]
+
+== Simple lists ==
+* First element
+* Second element
+* Third element
+
+# First element
+# Second element
+# Third element
+
+== Nested lists ==
+* First level
+** Second level
+* First level
+** Second level
+*** Third level
+
+# First level
+## Second level
+# First level
+## Second level
+### Third level
+
+== Nested ordered and unordered lists ==
+* First unordered level
+** Second unordered level
+# First ordered level
+# First ordered level
+## Second ordered level
+# First ordered level

--- a/test/tlsw/parse.ml
+++ b/test/tlsw/parse.ml
@@ -9,7 +9,7 @@ let on_err ~loc err =
   exit 1
 
 let tlsw_to_html name s =
-  let l = Parser.parse ~on_err s |> List.map Ast.to_html in
+  let l = Parser.parse ~on_err ~recover:true s |> List.map Ast.to_html in
   Html.(
     html
       (head (title (txt name)) [])

--- a/test/tlsw/parse.ml
+++ b/test/tlsw/parse.ml
@@ -9,7 +9,7 @@ let on_err ~loc err =
   exit 1
 
 let tlsw_to_html name s =
-  let l = Parser.parse ~on_err ~recover:true s |> List.map Ast.to_html in
+  let l = Parser.parse ~on_err ~recover:true s |> Seq.map Ast.to_html |> List.of_seq in
   Html.(
     html
       (head (title (txt name)) [])

--- a/test/tlsw/parse.ml
+++ b/test/tlsw/parse.ml
@@ -1,0 +1,23 @@
+module Html = Tyxml.Html
+module Ast = Geneweb_tlsw.Ast
+module Parser = Geneweb_tlsw.Parser
+module Loc = Geneweb_loc
+module Compat = Geneweb_compat
+
+let on_err ~loc err =
+  Fmt.pr "Syntax error: %s@ %a@." err Loc.pp_with_source loc;
+  exit 1
+
+let tlsw_to_html name s =
+  let l = Parser.parse ~on_err s |> List.map Ast.to_html in
+  Html.(
+    html
+      (head (title (txt name)) [])
+      (body l))
+    [@ocamlformat "disable"]
+
+let () =
+  let name = Sys.argv.(1) in
+  let s = Compat.In_channel.with_open_text name Compat.In_channel.input_all in
+  let html = tlsw_to_html name s in
+  Format.printf "%a@." Html.(pp ~indent:true ()) html

--- a/test/wiki_check.ml
+++ b/test/wiki_check.ml
@@ -51,7 +51,9 @@ let process_base ~mode ~in_memory bname =
         Logs.app (fun k -> k "Press enter to continue...@.");
         ignore (read_line () : string)
   in
-  let parse p s = ignore (Parser.parse ~on_err:(on_err p) s : Ast.t list) in
+  let parse p s =
+    ignore (Parser.parse ~recover:false ~on_err:(on_err p) s : Ast.t list)
+  in
   match mode with
   | Batch ->
       with_bar ~total @@ fun f ->
@@ -69,7 +71,7 @@ let process_gw fl =
           (Fmt.styled (`Fg `Red) pp_header)
           () err Loc.pp_with_source loc)
   in
-  ignore (Parser.parse ~on_err s : Ast.t list)
+  ignore (Parser.parse ~recover:true ~on_err s : Ast.t list)
 
 let run ~bd ~mode ~in_memory bases gws =
   Secure.set_base_dir bd;

--- a/test/wiki_check.ml
+++ b/test/wiki_check.ml
@@ -1,0 +1,124 @@
+module Html = Tyxml.Html
+module Ast = Geneweb_tlsw.Ast
+module Parser = Geneweb_tlsw.Parser
+module Loc = Geneweb_loc
+module Driver = Geneweb_db.Driver
+module Collection = Geneweb_db.Collection
+module Compat = Geneweb_compat
+
+let ( // ) = Filename.concat
+let pp_header ppf () = Fmt.pf ppf "Syntax error:"
+
+type mode = Incremental | Batch
+
+let with_timer f =
+  let start = Unix.gettimeofday () in
+  let r = f () in
+  let stop = Unix.gettimeofday () in
+  (r, stop -. start)
+
+let with_bar ~total =
+  let bar ~total =
+    Progress.Line.(
+      list [ spinner (); bar total; count_to total; percentage_of total ])
+  in
+  Progress.with_reporter (bar ~total)
+
+let iter_notes base ipers f =
+  Collection.iteri
+    (fun _i iper ->
+      let p = Driver.poi base iper in
+      let s = Driver.get_notes p |> Driver.sou base in
+      f p s)
+    ipers
+
+let process_base ~mode ~in_memory bname =
+  if in_memory then Driver.load_database (Secure.base_dir () // bname);
+  Driver.with_database (Secure.base_dir () // bname) @@ fun base ->
+  let ipers = Driver.ipers base in
+  let total = Driver.nb_of_persons base in
+  let on_err p ~loc err =
+    let fn = Driver.get_first_name p |> Driver.sou base in
+    let sn = Driver.get_surname p |> Driver.sou base in
+    let occ = Driver.get_occ p in
+    Logs.err (fun k ->
+        k "%a in notes of (%s, %s, %d): %s@ %a@."
+          (Fmt.styled (`Fg `Red) pp_header)
+          () fn sn occ err Loc.pp_with_source loc);
+    match mode with
+    | Batch -> ()
+    | Incremental ->
+        Logs.app (fun k -> k "Press enter to continue...@.");
+        ignore (read_line () : string)
+  in
+  let parse p s = ignore (Parser.parse ~on_err:(on_err p) s : Ast.t list) in
+  match mode with
+  | Batch ->
+      with_bar ~total @@ fun f ->
+      iter_notes base ipers @@ fun p s ->
+      parse p s;
+      f 1
+  | Incremental -> iter_notes base ipers @@ parse
+
+let process_gw fl =
+  Compat.In_channel.with_open_text fl @@ fun ic ->
+  let s = Compat.In_channel.input_all ic in
+  let on_err ~loc err =
+    Logs.err (fun k ->
+        k "%a: %s@ %a@."
+          (Fmt.styled (`Fg `Red) pp_header)
+          () err Loc.pp_with_source loc)
+  in
+  ignore (Parser.parse ~on_err s : Ast.t list)
+
+let run ~bd ~mode ~in_memory bases gws =
+  Secure.set_base_dir bd;
+  let (), duration =
+    with_timer @@ fun () ->
+    List.iter (fun bname -> process_base ~mode ~in_memory bname) bases;
+    List.iter (fun fl -> process_gw fl) gws
+  in
+  Logs.app (fun k -> k "Total time: %6.2fs" duration)
+
+module Cmd = struct
+  open Cmdliner
+  open Cmdliner.Term.Syntax
+
+  let mode = Arg.enum [ ("incremental", Incremental); ("batch", Batch) ]
+
+  let bd =
+    let doc = "Base directory" in
+    Arg.(value & opt string "." & info [ "bd" ] ~docv:"PATH" ~doc)
+
+  let bases =
+    let doc = "Base name" in
+    Arg.(value & opt_all string [] & info [ "b"; "base" ] ~docv:"BASE" ~doc)
+
+  let gws =
+    let doc = "Geneweb file" in
+    Arg.(value & opt_all string [] & info [ "g"; "gw" ] ~docv:"FILE" ~doc)
+
+  let in_memory =
+    let doc = "Load data in memory" in
+    Arg.(value & flag & info [ "in-memory" ] ~doc)
+
+  let mode =
+    let doc = "Mode" in
+    Arg.(value & opt mode Batch & info [ "m"; "mode" ] ~docv:"MODE" ~doc)
+
+  let t =
+    let doc = "Check wiki syntax of databases" in
+    Cmd.v (Cmd.info "Wiki_check" ~doc)
+    @@ let+ bd = bd
+       and+ mode = mode
+       and+ in_memory = in_memory
+       and+ bases = bases
+       and+ gws = gws in
+       run ~bd ~mode ~in_memory bases gws
+end
+
+let () =
+  Fmt.set_style_renderer Format.err_formatter `Ansi_tty;
+  let pp_header _ _ = () in
+  Logs.set_reporter (Progress.logs_reporter ~pp_header ());
+  exit @@ Cmdliner.Cmd.eval Cmd.t

--- a/test/wiki_check.ml
+++ b/test/wiki_check.ml
@@ -52,7 +52,7 @@ let process_base ~mode ~in_memory bname =
         ignore (read_line () : string)
   in
   let parse p s =
-    ignore (Parser.parse ~recover:false ~on_err:(on_err p) s : Ast.t list)
+    ignore (Parser.parse ~recover:false ~on_err:(on_err p) s : Ast.block list)
   in
   match mode with
   | Batch ->

--- a/test/wiki_check.ml
+++ b/test/wiki_check.ml
@@ -52,7 +52,7 @@ let process_base ~mode ~in_memory bname =
         ignore (read_line () : string)
   in
   let parse p s =
-    ignore (Parser.parse ~recover:false ~on_err:(on_err p) s : Ast.block list)
+    ignore (Parser.parse ~recover:false ~on_err:(on_err p) s : Ast.block Seq.t)
   in
   match mode with
   | Batch ->
@@ -71,7 +71,7 @@ let process_gw fl =
           (Fmt.styled (`Fg `Red) pp_header)
           () err Loc.pp_with_source loc)
   in
-  ignore (Parser.parse ~recover:true ~on_err s : Ast.t list)
+  ignore (Parser.parse ~recover:true ~on_err s : Ast.block Seq.t)
 
 let run ~bd ~mode ~in_memory bases gws =
   Secure.set_base_dir bd;


### PR DESCRIPTION
This PR adds a completely new parser for the `Text Language Stolen to Wikipedia` language.

TODO:
- [ ] Add a recovery mode.
- [x] Add the new image syntax.
- [ ] Support `gw` format in the syntax checker.
- [x] ~~Add a BNF description of the Wiki syntax.~~
- [ ] Improve documentation.
- [x] Add tests.