### PR TITLE
Allow definition of variables in simple templates (hg)

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -299,11 +299,11 @@ let print_renamed conf new_n =
   let env =
     Templ.Env.(
       empty
-      |> add "old" (Mutil.encode conf.bname)
-      |> add "new" (Mutil.encode new_n)
-      |> add "link" (Mutil.encode link))
+      |> add "old" (Templ.Vstring (Mutil.encode conf.bname))
+      |> add "new" (Templ.Vstring (Mutil.encode new_n))
+      |> add "link" (Templ.Vstring (Mutil.encode link)))
   in
-  try Templ.output_builtin conf env "renamed"
+  try Templ.output_simple conf env "renamed"
   with _ ->
     let title _ = Output.printf conf "%s -&gt; %s" conf.bname new_n in
     Hutil.header conf title;
@@ -323,9 +323,9 @@ let log_redirect from request req =
 let print_redirected conf from request new_addr =
   let req = Util.get_request_string conf in
   let link = "http://" ^ new_addr ^ req in
-  let env = Templ.Env.(add "link" (Mutil.encode link) empty) in
+  let env = Templ.Env.(add "link" (Templ.Vstring (Mutil.encode link)) empty) in
   log_redirect from request req;
-  try Templ.output_builtin conf env "redirect"
+  try Templ.output_simple conf env "redirect"
   with _ ->
     let title _ = Output.print_sstring conf "Address changed" in
     Hutil.header conf title;
@@ -2199,7 +2199,7 @@ let set_predictable_mode () =
   Logs.warn (fun k ->
       k
         "Predictable mode must not be enabled in production. It disables \
-         security enhancements.");
+         security enhancements and caching.");
   predictable_mode := true
 
 let main () =

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -475,7 +475,7 @@ let treat_request =
   in
   let handle_no_bfile conf l =
     if conf.bname = "" then
-      try Templ.output_builtin conf Templ.Env.empty "index"
+      try Templ.output_simple conf Templ.Env.empty "index"
       with _ -> propose_base conf
     else print_page conf l
   in

--- a/bin/gwd/robot.ml
+++ b/bin/gwd/robot.ml
@@ -34,10 +34,10 @@ let robot_error conf cnt sec =
   let env =
     Templ.Env.(
       empty
-      |> add "cnt" (Adef.encoded @@ string_of_int cnt)
-      |> add "sec" (Adef.encoded @@ string_of_int sec))
+      |> add "cnt" (Templ.Vstring (Adef.encoded @@ string_of_int cnt))
+      |> add "sec" (Templ.Vstring (Adef.encoded @@ string_of_int sec)))
   in
-  (try Templ.output_builtin conf env "robot"
+  (try Templ.output_simple conf env "robot"
    with _ ->
      let title _ = Output.print_sstring conf "Access refused" in
      Output.print_sstring conf "<head><title>";

--- a/lib/dagDisplay.ml
+++ b/lib/dagDisplay.ml
@@ -809,7 +809,7 @@ let print_slices_menu conf hts =
   in
   let title _ = header 0 in
   Hutil.header conf title;
-  if cgl then () else Templ.output_builtin conf Templ.Env.empty "buttons_rel";
+  if cgl then () else Templ.output_simple conf Templ.Env.empty "buttons_rel";
   Output.print_sstring conf {|<form method="get" action="|};
   Output.print_sstring conf conf.command;
   Output.print_sstring conf {|"><p>|};
@@ -849,7 +849,7 @@ let print_dag_page conf page_title hts next_txt =
   Hutil.header conf title;
   (* title goes into <title> ... </title> *)
   (* page <h1> title is handled by buttons_rel!! *)
-  if cgl then () else Templ.output_builtin conf Templ.Env.empty "buttons_rel";
+  if cgl then () else Templ.output_simple conf Templ.Env.empty "buttons_rel";
   print_html_table conf hts;
   if (next_txt : Adef.escaped_string :> string) <> "" then
     if cgl then Output.print_sstring conf {|">&gt;&gt;</p>|}

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -72,7 +72,7 @@ let header_without_http_nor_home conf title =
   Output.print_sstring conf str1;
   title true;
   Output.print_sstring conf str2;
-  Templ.output_builtin conf Templ.Env.empty "css";
+  Templ.output_simple conf Templ.Env.empty "css";
   Output.print_sstring conf "</head>\n";
   let s =
     try " dir=\"" ^ Hashtbl.find conf.lexicon "!dir" ^ "\""
@@ -80,7 +80,7 @@ let header_without_http_nor_home conf title =
   in
   let s = s ^ Util.body_prop conf in
   Output.printf conf "<body%s>\n" s;
-  Templ.output_builtin conf Templ.Env.empty "hed";
+  Templ.output_simple conf Templ.Env.empty "hed";
   Util.message_to_wizard conf
 
 let is_fluid conf =
@@ -141,9 +141,9 @@ let rheader conf title = header_with_title ~error:true conf title
 
 let trailer conf =
   let conf = { conf with is_printed_by_template = false } in
-  Templ.output_builtin conf Templ.Env.empty "trl";
-  Templ.output_builtin conf Templ.Env.empty "copyr";
-  Templ.output_builtin conf Templ.Env.empty "js";
+  Templ.output_simple conf Templ.Env.empty "trl";
+  Templ.output_simple conf Templ.Env.empty "copyr";
+  Templ.output_simple conf Templ.Env.empty "js";
   let query_time = Unix.gettimeofday () -. conf.query_start in
   Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
     !GWPARAM.errors_other !GWPARAM.set_vars;

--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -513,7 +513,7 @@ let print conf base =
   else
     match List.assoc "TYPE" nenv with
     | "album" | "gallery" ->
-        Templ.output_builtin conf Templ.Env.empty "notes_gallery"
+        Templ.output_simple conf Templ.Env.empty "notes_gallery"
     | (exception Not_found) | _ -> (
         let title = try List.assoc "TITLE" nenv with Not_found -> "" in
         let title = Util.safe_html title in
@@ -546,7 +546,7 @@ let print_mod conf base =
   else
     match List.assoc "TYPE" nenv with
     | ("gallery" | "album") as typ ->
-        Templ.output_builtin conf Templ.Env.empty ("notes_upd_" ^ typ)
+        Templ.output_simple conf Templ.Env.empty ("notes_upd_" ^ typ)
     | (exception Not_found) | _ ->
         let title _ =
           Output.printf conf "%s - %s%s"

--- a/lib/relationDisplay.ml
+++ b/lib/relationDisplay.ml
@@ -143,7 +143,7 @@ let print_shortest_path conf base p1 p2 =
         | Some "on" -> ()
         | _ ->
             let conf = { conf with is_printed_by_template = false } in
-            Templ.output_builtin conf Templ.Env.empty "buttons_rel");
+            Templ.output_simple conf Templ.Env.empty "buttons_rel");
         if excl_faml = [] then (
           ([ s1; s2 ] : Adef.safe_string list :> string list)
           |> cftransl conf "no known relationship link between %s and %s"
@@ -860,7 +860,7 @@ let print_main_relationship conf base long p1 p2 rel =
   | Some "on" -> ()
   | _ ->
       let conf = { conf with is_printed_by_template = false } in
-      Templ.output_builtin conf Templ.Env.empty "buttons_rel");
+      Templ.output_simple conf Templ.Env.empty "buttons_rel");
   (match (Util.p_getenv conf.env "sp", Util.p_getenv conf.env "spouse") with
   | Some ("off" | "0"), _ | _, Some "off" ->
       conf.senv <- conf.senv @ [ ("sp", Mutil.encode "0") ]

--- a/lib/relationLink.ml
+++ b/lib/relationLink.ml
@@ -632,7 +632,7 @@ let print_relation_ok conf base info =
   | Some "on" -> ()
   | _ ->
       let conf = { conf with is_printed_by_template = false } in
-      Templ.output_builtin conf Templ.Env.empty "buttons_rel");
+      Templ.output_simple conf Templ.Env.empty "buttons_rel");
   Output.print_sstring conf {|<p style="clear:both">|};
   print_relation_path conf base info;
   Hutil.trailer conf

--- a/lib/srcfileDisplay.ml
+++ b/lib/srcfileDisplay.ml
@@ -378,7 +378,7 @@ let rec copy_from_stream conf base strm mode =
           | '%' -> Output.print_sstring conf "%"
           | '[' | ']' -> Output.printf conf "%c" c
           | 'h' -> hidden_env conf
-          | 'j' -> Templ.output_builtin conf Templ.Env.empty "hed"
+          | 'j' -> Templ.output_simple conf Templ.Env.empty "hed"
           | 'P' ->
               let _ = Stream.next strm in
               ()

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -45,11 +45,8 @@ let resolve_include conf loc fl =
 
 let parse conf fl =
   let fl = Util.etc_file_name conf fl in
-  try Parser.parse ~on_exn ~resolve_include:(resolve_include conf) (`File fl)
-  with e ->
-    let bt = Printexc.get_raw_backtrace () in
-    Logs.debug (fun k -> k "%a" pp_exception (e, bt));
-    Printexc.raise_with_backtrace e bt
+  Parser.parse ~cached:!Logs.debug_flag ~on_exn
+    ~resolve_include:(resolve_include conf) (`File fl)
 
 let sort_apply_parameters loc f_expr xl vl =
   let named_vl, unnamed_vl =
@@ -1423,8 +1420,8 @@ and print_var print_ast_list conf ifun env ep loc sl =
           try
             let fl = Util.etc_file_name conf templ in
             let astl =
-              Parser.parse ~on_exn ~resolve_include:(resolve_include conf)
-                (`File fl)
+              Parser.parse ~cached:!Logs.debug_flag ~on_exn
+                ~resolve_include:(resolve_include conf) (`File fl)
             in
             print_ast_list env ep astl
           with _ ->
@@ -1493,19 +1490,30 @@ and print_variable conf sl =
       | _ -> raise Not_found
     with Not_found -> Output.printf conf " %%%s?" (String.concat "." sl))
 
-let output conf ifun env ep fl = eval conf ifun env ep @@ parse conf fl
+let output conf ifun env ep fl =
+  try eval conf ifun env ep @@ parse conf fl
+  with e ->
+    let bt = Printexc.get_raw_backtrace () in
+    Logs.debug (fun k -> k "%a" pp_exception (e, bt))
 
-let output_builtin conf env fl =
+type simple_env = Vstring of Adef.encoded_string | Vother of unit vother
+
+let output_simple conf env fl =
+  let get_vother = function Vother x -> Some x | _ -> None in
+  let set_vother x = Vother x in
   let ifun =
     {
       eval_var =
         (fun env _ _ -> function
-          | [ s ] -> VVstring ((Env.find s env : Adef.encoded_string) :> string)
+          | [ s ] -> (
+              match Env.find s env with
+              | Vstring s -> VVstring (s :> string)
+              | _ -> raise Not_found)
           | _ -> raise Not_found);
       eval_transl = (fun _ -> eval_transl conf);
       eval_predefined_apply = (fun _ -> raise Not_found);
-      get_vother = (fun _ -> None);
-      set_vother = (fun _ -> Adef.encoded "");
+      get_vother;
+      set_vother;
       print_foreach = (fun _ -> raise Not_found);
     }
   in

--- a/lib/templ.mli
+++ b/lib/templ.mli
@@ -48,7 +48,8 @@ val output :
 (** [output conf ifun env v fl] outputs on the client socket the template [fl]
     using the functions [ifun] and the environment [env]. *)
 
-val output_builtin :
-  Config.config -> Adef.encoded_string Env.t -> string -> unit
-(** [output_builtin conf env fl] outputs on the client socket the template [fl]
+type simple_env = Vstring of Adef.encoded_string | Vother of unit vother
+
+val output_simple : Config.config -> simple_env Env.t -> string -> unit
+(** [output_simple conf env fl] outputs on the client socket the template [fl]
     using only builtin evaluator and the environment [env]. *)

--- a/lib/templ/parser.mli
+++ b/lib/templ/parser.mli
@@ -1,12 +1,13 @@
-val parse_source : Loc.source -> Ast.t list
-(** [parse_source src] parses [src] without expanding included templates. *)
-
 val parse :
+  ?cached:bool ->
   on_exn:(exn -> Printexc.raw_backtrace -> unit) ->
   resolve_include:(Loc.t -> string -> string) ->
   Loc.source ->
   Ast.t list
-(** [parse ~on_exn ~find src] parses [src] and expands included templates.
-    The [resolve_include] function resolves paths for included files.
-    The [on_exn] callback handles exceptions raised during included template
-    parsing, providing both the exception and its backtrace. *)
+(** [parse ?cached ~on_exn ~find src] parses [src] and expands included
+    templates.
+    - [cached] option enables caching of the parsing process.
+      The default is [true].
+    - [resolve_include] function resolves paths for included files.
+    - [on_exn] callback handles exceptions raised during included template
+      parsing, providing both the exception and its backtrace. *)

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -892,8 +892,10 @@ let print_mod_view_page conf can_edit mode fname title env s =
     Util.hidden_input conf "digest" (Mutil.digest s |> Mutil.encode);
   Output.print_sstring conf
     {|<div class="d-flex flex-column"><div class="pt-1">|};
-  let env = Templ.Env.(add "name" (Adef.encoded "notes") empty) in
-  Templ.output_builtin conf env "toolbar";
+  let env =
+    Templ.Env.(add "name" (Templ.Vstring (Adef.encoded "notes")) empty)
+  in
+  Templ.output_simple conf env "toolbar";
   Output.print_sstring conf {|</div><div class="row editor-container">|};
   Output.print_sstring conf
     {|<div class="d-flex flex-column col-9"><textarea name="notes" id="notes_comments"
@@ -909,8 +911,7 @@ let print_mod_view_page conf can_edit mode fname title env s =
       (Utf8.capitalize_fst (transl_nth conf "validate/delete" 0));
     Output.print_sstring conf "</button>");
   Output.print_sstring conf "</div><div class=\"col mx-2 p-2\"";
-  let env = Templ.Env.(add "name" (Adef.encoded "notes") empty) in
-  Templ.output_builtin conf env "toolbar";
+  Templ.output_simple conf env "toolbar";
   Output.print_sstring conf "</div></div>";
   Output.print_sstring conf "</div></form>";
   Hutil.trailer conf


### PR DESCRIPTION
The PR #2232 introduces regressions in the template engine. The issue comes from unbound variables in the evaluator function of the template engine. The environment management in this engine is a complete mess. Basically, we have (at least) three environments:
1. A builtin environment defined in the display modules (like `perso.ml` for instance). This environment is split into two parts: variables and functions and functions can be arbitrary OCaml code.
2. An environment for the template variables.
3. An environment for the template functions.

The environment for template variables is embedded into the builtin one using `set_vother` and `get_vother` functions and these function MUST be defined in each display modules...

In particular `Templ.output_builtin` didn't define them (it was dummy implementation) because it expected environments that can only store strings, which is not sufficient to implement them.

Changes:
1. The most important changes is to change the implementation of `Templ.output_builtin` and the type of its environment. It is a hotfix because better approaches are really extensive.
2. Improve sightly errors of the evaluator. We must catch exceptions throwing in the evaluator and print them, as some recursive calls destroy most of the backtrace and we cannot localize the origin of the error without this information.
3. Add a `cached` flag in the pipeline to disable caching for debugging purpose. Currently, I use the flag `Logs.debug_flag` to determine if we are in debugging mode. We should refactor this later after integrating Logs library and sources.