### PR TITLE
Bump Ancient version to 0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Install ancient dependency
         if: env.USE_NNP == 'true'
-        run: opam pin ancient -y https://github.com/OCamlPro/ocaml-ancient.git
+        run: opam install ancient.0.10.0
 
       - name: Configure
         run: opam exec -- ocaml ./configure.ml --sosa-zarith ${{ env.USE_NNP == 'true' && '--gwd-caching' || '' }}

--- a/configure.ml
+++ b/configure.ml
@@ -8,11 +8,6 @@ let rm = ref ""
 let ext = ref ""
 let os_type = ref ""
 let installed pkg = 0 = Sys.command ("ocamlfind query -qo -qe " ^ pkg)
-
-let nnp_compiler =
-  if not Sys.win32 then 1 = Sys.command "$(ocamlc -config-var naked_pointers)"
-  else false
-
 let errmsg = "usage: " ^ Sys.argv.(0) ^ " [options]"
 let api = ref false
 let syslog = ref false
@@ -54,20 +49,11 @@ let () =
   let ancient_lib, ancient_file =
     let no_cache = ("", "gw_ancient.dum.ml") in
     if !caching then
-      if nnp_compiler then
-        if installed "ancient" then ("ancient", "gw_ancient.wrapped.ml")
-        else (
-          Format.eprintf
-            "Warning: ocaml-ancient not installed. Cannot enable database \
-             caching.@.";
-          no_cache)
+      if installed "ancient" then ("ancient", "gw_ancient.wrapped.ml")
       else (
         Format.eprintf
-          "Warning: the OCaml compiler was not installed with the \
-           no-naked-pointers@ option. The gwd caching feature requires this \
-           option because GeneWeb@ uses the Marshal module on values from the \
-           database, which is not compatible@ with Ancient when naked pointers \
-           could be present.@.";
+          "Warning: `ocaml-ancient` not installed. Require version 0.10.0 or \
+           later. Cannot enable database caching.@.";
         no_cache)
     else no_cache
   in

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN opam init --disable-sandboxing --auto-setup --bare
 
 # Copy opam file for dependency resolution then install dependencies
 COPY --chown=opam:opam *.opam ./
-RUN eval "$(opam env)" && opam install . --deps-only --with-test && opam install ancient.0.10.0
+RUN eval "$(opam env)" && opam update && opam install . --deps-only --with-test && opam install ancient.0.10.0
 
 # Clone repository and build Geneweb
 WORKDIR /home/opam/geneweb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN opam init --disable-sandboxing --auto-setup --bare
 
 # Copy opam file for dependency resolution then install dependencies
 COPY --chown=opam:opam *.opam ./
-RUN eval "$(opam env)" && opam install . --deps-only --with-test && opam pin add ancient "https://github.com/OCamlPro/ocaml-ancient.git#ea8df144ee96c660b2401c832a10f30f8c69994a"
+RUN eval "$(opam env)" && opam install . --deps-only --with-test && opam install ancient.0.10.0
 
 # Clone repository and build Geneweb
 WORKDIR /home/opam/geneweb

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 #                                                      STAGE 1: Build Geneweb
 ###############################################################################
 
-FROM ocaml/opam:debian-ocaml-4.14-nnp AS builder
+FROM ocaml/opam:debian-ocaml-4.14-nnp@sha256:ddd652d354faad46a4d44ef58fc5a2e3d75dce855065e1f2de7ab50ac36992d0 AS builder
 
 ENV OPAMYES=yes
 ENV OPAMJOBS=2
@@ -16,6 +16,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     m4 libgmp-dev libpcre3-dev libipc-system-simple-perl xdot zlib1g-dev pkg-config \
     && ln -sf /usr/bin/opam-2.3 /usr/bin/opam
 
+# Update local opam repository
+USER opam
+WORKDIR /home/opam/opam-repository
+RUN git fetch origin master && git checkout 2ca36230be22748ea153057760524e23defe5fc7 && opam update
+
 # Initialize OPAM
 USER opam
 WORKDIR /home/opam
@@ -23,7 +28,7 @@ RUN opam init --disable-sandboxing --auto-setup --bare
 
 # Copy opam file for dependency resolution then install dependencies
 COPY --chown=opam:opam *.opam ./
-RUN eval "$(opam env)" && opam update && opam install . --deps-only --with-test && opam install ancient.0.10.0
+RUN eval "$(opam env)" && opam install . --deps-only --with-test && opam install ancient.0.10.0
 
 # Clone repository and build Geneweb
 WORKDIR /home/opam/geneweb

--- a/dune-project
+++ b/dune-project
@@ -50,7 +50,7 @@
   )
   (depopts
     ocaml-option-nnp
-    ancient
+    (ancient (>= 0.10.0))
     zarith
   )
 )

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750134718,
-        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "lastModified": 1750741721,
+        "narHash": "sha256-Z0djmTa1YmnGMfE9jEe05oO4zggjDmxOGKwt844bUhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748872490,
-        "narHash": "sha256-/6O+UEU5lVhSTTzoYWpLxv+T8Tv85xmYk1GQVxrPW68=",
+        "lastModified": 1750845426,
+        "narHash": "sha256-BOd+VWufslKioTW3YiGI2Bub+uMKP/F40MhwzY2/yQU=",
         "owner": "OCamlPro",
         "repo": "ocaml-ancient",
-        "rev": "2d5a5c6658b1bdd0339ac73df32130b9a71bf500",
+        "rev": "828399fe8fd005a704df60894f7e7259314d4e6b",
         "type": "github"
       },
       "original": {

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -41,7 +41,11 @@ depends: [
   "ocamlformat" {with-dev-setup & = "0.27.0"}
   "odoc" {with-doc}
 ]
-depopts: ["ocaml-option-nnp" "ancient" "zarith"]
+depopts: [
+  "ocaml-option-nnp"
+  "ancient" {>= "0.10.0"}
+  "zarith"
+]
 dev-repo: "git+https://github.com/geneweb/geneweb.git"
 build-env: DUNE_PROFILE = "release"
 


### PR DESCRIPTION
A new version of Ancient have been released! This PR bumps the minimal
version of Ancient to 0.10.0.

There is no need to check the presence of `nnp` option or the operating
system in `configure.ml` as Ancient cannot be installed on Windows or
OCaml 4 without the nnp option.