### PR TITLE
resolve Windows file corruption in copy_file

### DIFF
--- a/lib/util/filesystem.ml
+++ b/lib/util/filesystem.ml
@@ -103,14 +103,15 @@ let walk_folder ?(recursive = false) f path acc =
   in
   traverse [ path ] acc
 
-let copy_file ?(perm = 0o640) src dst =
+let copy_file ?(perm = 0o640) ?(overwrite = true) src dst =
   let sz = 8192 in
   let buf = Bytes.create sz in
+  let flags =
+    if overwrite then [ Open_wronly; Open_creat; Open_trunc; Open_binary ]
+    else [ Open_wronly; Open_creat; Open_excl; Open_binary ]
+  in
   Compat.In_channel.with_open_bin src @@ fun ic ->
-  Compat.Out_channel.with_open_gen
-    [ Open_wronly; Open_append; Open_trunc ]
-    perm dst
-  @@ fun oc ->
+  Compat.Out_channel.with_open_gen flags perm dst @@ fun oc ->
   let rec loop () =
     match Compat.In_channel.input ic buf 0 sz with
     | 0 -> ()

--- a/lib/util/filesystem.mli
+++ b/lib/util/filesystem.mli
@@ -53,11 +53,13 @@ val walk_folder : ?recursive:bool -> (entry -> 'a -> 'a) -> string -> 'a -> 'a
     If [recursive] is [true], subdirectories are explored recursively. The
     default is [false]. *)
 
-val copy_file : ?perm:int -> string -> string -> unit
-(** [copy_file ?perm src dst] copies the file [src] into the destination [dst].
-    The file [dst] is created, if it does not exist.
+val copy_file : ?perm:int -> ?overwrite:bool -> string -> string -> unit
+(** [copy_file ?perm ?overwrite src dst] copies the file [src] into the
+    destination [dst]. The file [dst] is created with permissions [perm]. The
+    default permission value is [0o640].
 
-    If the file [dst] does not exist, it is created with permissions [perm]. The
-    default is [0o644]. If the file [dst] exists, it is erased.
+    If [overwrite] is [true] (default), existing destination files are
+    overwritten. If [overwrite] is [false], the function fails if the
+    destination already exists.
 
     This function can be used to copy binary files. *)


### PR DESCRIPTION
- Add Open_binary flag to prevent text mode conversion on Windows
- Remove problematic Open_append flag
- Set documentation to 0o640 default permission for web server compatibility
- Add overwrite parameter for better control over destination file handling.

Fixes #2265