### PR TITLE
Fix documentation of the option `-o` in `gwu`

### DIFF
--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -99,7 +99,7 @@ let speclist c =
         (fun s ->
           let oc = open_out s in
           c := { !c with oc = (s, output_string oc, fun () -> close_out oc) }),
-      "<GED> output file name (default: stdout)." );
+      "<FILE> output file name (default: stdout)." );
     ( "-parentship",
       Arg.Unit (fun () -> c := { !c with parentship = true }),
       " select individuals involved in parentship computation between pairs of \


### PR DESCRIPTION
The documentation of the option `-o` is misleading because `gwu` outputs gw format, not GEDCOM format. As this option is shared between `ged2gw` and `gwu`, I wrote a generic documentation.