### PR TITLE
Do not capture closed input channel in `Database.with_database`

### DIFF
--- a/lib/db/database.ml
+++ b/lib/db/database.ml
@@ -1217,10 +1217,6 @@ let with_database ?(read_only = false) bname k =
     I.load version ~inx:(bname // "strings.inx")
       [ snd patches.h_string; snd pending.h_string ]
   in
-  if read_only then
-    for i = 0 to strings.len - 1 do
-      I.insert inv_idx (strings.get i) i
-    done;
   let insert_string s =
     try I.find inv_idx s
     with Not_found ->

--- a/lib/db/dune
+++ b/lib/db/dune
@@ -5,6 +5,7 @@
    unix
    re
    fmt
+   geneweb.logs
    geneweb.def
    geneweb.ancient
    geneweb.util))


### PR DESCRIPTION
We do not execute again `Database.with_database` if the database is loaded in main memory. In particular, all the channels open in this function are closed after executing `Driver.load_database`. Alas, we capture a closed channel in `index_of_string`. This commit fixes this bug.

The inversed index for strings is now loaded in main memory when we use Ancient.