### PR TITLE
Use a single output for logs

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -548,12 +548,11 @@ let treat_request =
                   else SrcfileDisplay.incr_request_counter conf
                 with
                 | Some (welcome_cnt, request_cnt, start_date) ->
-                    Logs.log (fun oc ->
-                        let thousand oc x =
-                          output_string oc @@ Mutil.string_of_int_sep "," x
-                        in
-                        Printf.fprintf oc
-                          "  #accesses %a (#welcome %a) since %s\n" thousand
+                    let thousand ppf x =
+                      Fmt.string ppf (Mutil.string_of_int_sep "," x)
+                    in
+                    Logs.info (fun k ->
+                        k "#accesses %a (#welcome %a) since %s" thousand
                           (welcome_cnt + request_cnt)
                           thousand welcome_cnt start_date)
                 | None -> ());

--- a/lib/logs/logs.mli
+++ b/lib/logs/logs.mli
@@ -7,11 +7,11 @@ val verbosity_level : int ref
 val debug_flag : bool ref
 (** If set to [true], prints backtrace when printing log. *)
 
-val oc : out_channel option ref
-(** The output channel in which log is written. *)
+type output = Stdout | Stderr | Channel of out_channel
 
-val log : (out_channel -> unit) -> unit
-(** Prints on [oc] *)
+val set_output_channel : output -> unit
+(** Set the output channel for logs. The default is [Stderr]. If the previous
+    output was a file, it is properly closed. *)
 
 type level =
   [ `LOG_EMERG  (** A panic condition. Print if [!verbosity_level >= 0]. *)


### PR DESCRIPTION
The `Logs` module contented two printer functions:
1. `Logs.log` that prints on a output channel `Logs.oc`. By default this channel is not set and the printer does nothing at all.
2. `Logs.syslog` that prints on stderr.

This commit simplifies things by:
- Removing `Logs.log`.
- `Logs.oc` is now hidden and can be set with `Logs.set_output_channel`. By default, all the functions of `Logs` print on the error output.
- The cli option `-log` can change the output channel to print all the logs into a file.
- New log entries are appended to the end of the log file.