### PR TITLE
Remove `My_unix.listen_noeintr`

### DIFF
--- a/lib/util/my_unix.ml
+++ b/lib/util/my_unix.ml
@@ -5,7 +5,3 @@ let rec waitpid_noeintr flags pid =
 let rec accept_noeintr ?cloexec fd =
   try Unix.accept ?cloexec fd
   with Unix.Unix_error (Unix.EINTR, _, _) -> accept_noeintr ?cloexec fd
-
-let rec listen_noeintr fd n =
-  try Unix.listen fd n
-  with Unix.Unix_error (Unix.EINTR, _, _) -> listen_noeintr fd n

--- a/lib/util/my_unix.mli
+++ b/lib/util/my_unix.mli
@@ -10,7 +10,3 @@ val accept_noeintr :
   ?cloexec:bool -> Unix.file_descr -> Unix.file_descr * Unix.sockaddr
 (** Equivalent to [Unix.accept], but this variant restart upon interruption by
     signals. *)
-
-val listen_noeintr : Unix.file_descr -> int -> unit
-(** Equivalent to [Unix.listen], but this variant restart upon interruption by
-    signals. *)

--- a/lib/wserver/wserver.ml
+++ b/lib/wserver/wserver.ml
@@ -351,7 +351,7 @@ let start ?addr ~port ?(timeout = 0) ~max_pending_requests ~n_workers callback =
         Unix.setsockopt socket Unix.IPV6_ONLY false;
       Unix.setsockopt socket Unix.SO_REUSEADDR true;
       Unix.bind socket (Unix.ADDR_INET (addr, port));
-      My_unix.listen_noeintr socket max_pending_requests;
+      Unix.listen socket max_pending_requests;
       let tm = Unix.localtime (Unix.time ()) in
       Format.eprintf "Ready %4d-%02d-%02d %02d:%02d port %d...@."
         (1900 + tm.Unix.tm_year) (succ tm.Unix.tm_mon) tm.Unix.tm_mday


### PR DESCRIPTION
`Unix.listen` is not a blocking system call and cannot raise `EINTR` error. This wrapper is useless.