### PR TITLE
Do not change effective user ID and group ID in `Wserver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ documentation at https://geneweb.tuxfamily.org/.
 Quite similar to the MacOS solution, without the security check.
 ```xxx.command``` files have an equivalent ```xxx.sh``` variant.
 
+### Security considerations
+
+On UNIX-like operating systems, special privileges are often required to open
+a port below `1024`. If you have no other choice but to use such a port, we
+recommend the following approaches:
+- On `Linux`, use capabilites as follows:
+```console
+sudo setcap 'cap_net_bind_service=+ep' gwd
+./gwd -p 80
+```
+- On `macOS`, use `launchd` to redirect the port on 80.
+
 ## Resources
 
 * Documentation: https://geneweb.tuxfamily.org/wiki/GeneWeb

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2483,7 +2483,22 @@ let main () =
     geneweb_cgi ~secret_salt addr (Filename.basename script) query)
   else geneweb_server ~predictable_mode:!predictable_mode ()
 
+let has_root_privileges () =
+  assert Sys.unix;
+  let root = 0 in
+  Unix.getuid () = root
+  || Unix.getgid () = root
+  || Unix.geteuid () = root
+  || Unix.getegid () = root
+
 let () =
+  if Sys.unix && has_root_privileges () then (
+    Logs.err (fun k ->
+        k
+          "The gwd server should never be run with root privileges. If you \
+           need elevated privileges, for example to open a port below 1024, \
+           see the security section of the documentation.");
+    exit 1);
   try main () with
   | Unix.Unix_error (Unix.EADDRINUSE, "bind", _) ->
       Printf.eprintf "\nError: ";
@@ -2499,8 +2514,8 @@ let () =
   | Unix.Unix_error (Unix.EACCES, "bind", _) when Sys.unix ->
       Printf.eprintf
         "Error: invalid access to the port %d: users port number less than \
-         1024 are reserved to the system. Solution: do it as root or choose \
-         another port number greater than 1024."
+         1024 are reserved to the system. Please, read the security section\n\
+         of the documentation."
         !selected_port;
       flush stderr
   | Register_plugin_failure (p, `dynlink_error e) ->

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -503,28 +503,14 @@ let treat_request =
       if
         conf.wizard || conf.friend
         || List.assoc_opt "visitor_access" conf.base_env <> Some "no"
-      then
+      then (
         if
           List.assoc_opt "wizards_cant_write" conf.base_env = Some "yes"
           && this_request_updates_database conf
         then
           Hutil.incorrect_request conf
             ~comment:"Wizard actions not allowed on this base"
-        else (
-          (if Sys.unix then
-             match bfile with
-             | None -> ()
-             | Some bfile ->
-                 let stat = Unix.stat bfile in
-                 let fuid = stat.Unix.st_uid in
-                 let fgid = stat.Unix.st_gid in
-                 let pgid = Unix.getgid () in
-                 let puid = Unix.getuid () in
-                 (* FIXME possible issue with effective uid/gid! *)
-                 (* see setuid, setgid man pages *)
-                 if puid <> fuid then Unix.setuid fuid;
-                 if pgid <> fgid then Unix.setgid fgid);
-
+        else
           let plugins =
             match List.assoc_opt "plugins" conf.Config.base_env with
             | None -> []


### PR DESCRIPTION
The effect of the below code is to change the effective user and group ID of the workers to match the user and group of the database file:
```ocaml
if Sys.unix then
 match bfile with
 | None -> ()
 | Some bfile ->
     let stat = Unix.stat bfile in
     let fuid = stat.Unix.st_uid in
     let fgid = stat.Unix.st_gid in
     let pgid = Unix.getgid () in
     let puid = Unix.getuid () in
     (* FIXME possible issue with effective uid/gid! *)
     (* see setuid, setgid man pages *)
     if puid <> fuid then Unix.setuid fuid;
     if pgid <> fgid then Unix.setgid fgid
```
In previous versions of GeneWeb, command-line options were used to specify the user and group, instead of relying on the database file's permissions. These options were removed around 2000.

I believe the intent of this code was to implement a form of privilege dropping. On Unix systems, you often need special privileges to perform certain tasks, as listening on ports below 1024. A common pattern is to start a server with root privileges, bind your socket to a privileged port, and then drop those privileges to a less-privileged user before handling client requests.

The current implementation is flawed for several reasons. This approach is no longer recommended. `gwd` should not be run with effective root ID:
- I remove this code and prevent users from running `gwd` with too much privileges.
- I add documentation explaining how to open privileged port on Linux without root.