### PR TITLE
Fix build section in `geneweb.opam` file

### DIFF
--- a/geneweb.opam
+++ b/geneweb.opam
@@ -50,6 +50,6 @@ dev-repo: "git+https://github.com/geneweb/geneweb.git"
 build-env: DUNE_PROFILE = "release"
 
 build: [
-  [ "ocaml" "./configure.ml" "--release" ]
-  [ make "build" ]
+  [ "ocaml" "./configure.ml" ]
+  [ make "build-geneweb" ]
 ]

--- a/geneweb.opam.template
+++ b/geneweb.opam.template
@@ -1,6 +1,6 @@
 build-env: DUNE_PROFILE = "release"
 
 build: [
-  [ "ocaml" "./configure.ml" "--release" ]
-  [ make "build" ]
+  [ "ocaml" "./configure.ml" ]
+  [ make "build-geneweb" ]
 ]


### PR DESCRIPTION
The `--release` option have been removed in `configure.ml`. If you want to compile GeneWeb with release flag, you must type:
```console
DUNE_PROFILE=release make distrib
```
or
```console
DUNE_PROFILE=dev make build
```