### PR TITLE
fix Sosa.div overflow on 32-bit systems

### DIFF
--- a/lib/sosa/geneweb_sosa.array.ml
+++ b/lib/sosa/geneweb_sosa.array.ml
@@ -146,8 +146,8 @@ let mul x n =
     loop zero x n
 
 let div x n =
-  if n > max_mul_base then invalid_arg "Sosa.div"
-  else
+  if n <= 0 then invalid_arg "Sosa.div"
+  else if n <= max_mul_base then
     let l =
       let rec loop i l r =
         if i < 0 then l
@@ -159,6 +159,11 @@ let div x n =
       loop (Array.length x - 1) [] 0
     in
     Array.of_list (normalize l)
+  else if Array.length x <= 2 then of_int (to_int x / n)
+  else
+    let nv = of_int n in
+    let rec loop q x = if gt nv x then q else loop (inc q 1) (sub x nv) in
+    loop zero x
 
 let modl x n =
   of_int


### PR DESCRIPTION
On 32-bit OCaml, max_int is 2^30-1 (1,073,741,823). The division algorithm uses: (r mod n) * base where base = 2^24.

This multiplication overflows when n > 63 because:
  (n-1) * 16,777,216 > max_int

This causes "Invalid_argument: Sosa.div" in templates like cousmenu.txt which perform divisions by year spans (e.g. 2020-1920 = 100 > 63) or by powers of 2 for DNA percentage calculations (2^6 = 64 > 63).

The fix handles large divisors (n > max_mul_base) by:
- Using native int division when dividend fits in 2 array cells
- Falling back to iterative subtraction for larger dividends

This restores compatibility with 32-bit builds (CGI deployments) while maintaining performance for common cases (n <= 63).