### PR TITLE
pre-gzipped assets and on-the-fly gzipped HTML in gwd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
         with:
           command: start-timer
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libbrotli-dev
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install brotli
+
       - name: Cache Opam dependencies (Unix)
         id: cache-opam-unix
         if: runner.os != 'Windows'

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,20 @@ endif
 	rm $(DISTRIB_DIR)/gw/etc/js/checkdata.js
 	rm $(DISTRIB_DIR)/gw/etc/js/p_mod.js
 	rm $(DISTRIB_DIR)/gw/etc/js/relationmatrix.js
+	rm $(DISTRIB_DIR)/gw/etc/js/fanchart.js
+	@printf "\n\033[1;1m└ Compressing large JS/CSS assets\033[0m\n"
+	@for f in $(DISTRIB_DIR)/gw/etc/js/*.min.js; do \
+	  if [ -f "$$f" ] && [ $$(stat -c%s "$$f" 2>/dev/null || stat -f%z "$$f") -gt 4500 ]; then \
+	    printf "gzip -9 -k %s\n" "$$f"; \
+	    gzip -9 -k -f "$$f"; \
+	  fi; \
+	done
+	@for f in $(DISTRIB_DIR)/gw/etc/css/*.css; do \
+	  if [ -f "$$f" ] && [ $$(stat -c%s "$$f" 2>/dev/null || stat -f%z "$$f") -gt 10000 ]; then \
+	    printf "gzip -9 -k %s\n" "$$f"; \
+	    gzip -9 -k -f "$$f"; \
+	  fi; \
+	done
 	mkdir $(DISTRIB_DIR)/gw/setup
 	cp bin/setup/intro.txt $(DISTRIB_DIR)/gw/setup/
 	mkdir $(DISTRIB_DIR)/gw/setup/lang

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -10,6 +10,64 @@ module StrSet = Mutil.StrSet
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
 
+let gzip_min_size = 1000
+
+let client_accepts_gzip request =
+  let accept =
+    String.lowercase_ascii
+      (Mutil.extract_param "accept-encoding: " '\n' request)
+  in
+  Mutil.contains accept "gzip"
+
+let make_gzip_output_conf request =
+  if not (client_accepts_gzip request) then None
+  else
+    let body_buf = Buffer.create 65536 in
+    let headers_buf = Buffer.create 1024 in
+    let status_ref = ref Def.OK in
+    Some
+      {
+        status = (fun st -> status_ref := st);
+        header =
+          (fun s ->
+            Buffer.add_string headers_buf s;
+            Buffer.add_string headers_buf "\r\n");
+        body = Buffer.add_string body_buf;
+        flush =
+          (fun () ->
+            let body = Buffer.contents body_buf in
+            let body_len = String.length body in
+            let headers = Buffer.contents headers_buf in
+            let is_html =
+              Mutil.contains (String.lowercase_ascii headers) "text/html"
+            in
+            let final_body, is_gzipped =
+              if is_html && body_len > gzip_min_size then
+                try
+                  let compressed = My_gzip.gzip_string ~level:6 body in
+                  if String.length compressed < body_len then (compressed, true)
+                  else (body, false)
+                with _ -> (body, false)
+              else (body, false)
+            in
+            let oc = Wserver.woc () in
+            let status_line = Wserver.string_of_status !status_ref in
+            if not !Wserver.cgi then
+              Printf.fprintf oc "HTTP/1.0 %s\r\n" status_line
+            else Printf.fprintf oc "Status: %s\r\n" status_line;
+            if is_gzipped then (
+              output_string oc "Content-Encoding: gzip\r\n";
+              output_string oc "Vary: Accept-Encoding\r\n";
+              Printf.fprintf oc "Content-Length: %d\r\n"
+                (String.length final_body));
+            output_string oc headers;
+            output_string oc "\r\n";
+            output_string oc final_body;
+            flush oc;
+            Buffer.clear body_buf;
+            Buffer.clear headers_buf);
+      }
+
 let output_conf =
   {
     status = Wserver.http;
@@ -1549,6 +1607,18 @@ let conf_and_connection =
     let conf, passwd_err =
       make_conf ~secret_salt from request script_name env
     in
+    let m = Util.p_getenv env "m" in
+    let use_gzip =
+      match m with
+      | Some ("IM" | "IM_C" | "IM_C_S" | "IMH" | "FIM" | "SRC" | "DOC" | "DOCH")
+        ->
+          false
+      | _ -> true
+    in
+    (if use_gzip then
+       match make_gzip_output_conf request with
+       | Some gzip_oc -> conf.output_conf <- gzip_oc
+       | None -> ());
     match !redirected_addr with
     | Some addr -> print_redirected conf from request addr
     | None -> (
@@ -1601,6 +1671,7 @@ let conf_and_connection =
             try
               let t1 = Unix.gettimeofday () in
               Request.treat_request conf;
+              Output.flush conf;
               let t2 = Unix.gettimeofday () in
               if t2 -. t1 > slow_query_threshold then
                 Logs.syslog `LOG_WARNING
@@ -1698,7 +1769,7 @@ type misc_fname =
   | Woff2 of string
   | CacheGz of string
 
-let content_misc conf len misc_fname =
+let content_misc conf len misc_fname is_gzipped =
   Output.status conf Def.OK;
   let fname, t =
     match misc_fname with
@@ -1716,6 +1787,8 @@ let content_misc conf len misc_fname =
   in
   Output.header conf "Content-type: %s" t;
   Output.header conf "Content-length: %d" len;
+  if is_gzipped then Output.header conf "Content-encoding: gzip";
+  Output.header conf "Vary: Accept-Encoding";
   Output.header conf "Content-disposition: inline; filename=%s"
     (Filename.basename fname);
   Output.header conf "Cache-control: private, max-age=%d" (60 * 60 * 24 * 365);
@@ -1735,7 +1808,7 @@ let find_misc_file conf name =
       let name' = Util.search_in_assets @@ Filename.concat "etc" name in
       if Sys.file_exists name' then name' else ""
 
-let print_misc_file conf misc_fname =
+let print_misc_file conf misc_fname is_gzipped =
   match misc_fname with
   | Css fname
   | Js fname
@@ -1749,7 +1822,7 @@ let print_misc_file conf misc_fname =
         let ic = Secure.open_in_bin fname in
         let buf = Bytes.create 1024 in
         let len = in_channel_length ic in
-        content_misc conf len misc_fname;
+        content_misc conf len misc_fname is_gzipped;
         let rec loop len =
           if len = 0 then ()
           else
@@ -1767,7 +1840,7 @@ let print_misc_file conf misc_fname =
       let ic = Secure.open_in_bin fname in
       let buf = Bytes.create 1024 in
       let len = in_channel_length ic in
-      content_misc conf len misc_fname;
+      content_misc conf len misc_fname false;
       let rec loop len =
         if len = 0 then ()
         else
@@ -1780,23 +1853,34 @@ let print_misc_file conf misc_fname =
       close_in ic;
       true
 
-let misc_request conf fname =
-  let fname = find_misc_file conf fname in
-  if fname <> "" then
+let misc_request conf request fname =
+  let is_compressible =
+    Filename.check_suffix fname ".js" || Filename.check_suffix fname ".css"
+  in
+  let try_gzip = is_compressible && client_accepts_gzip request in
+  let actual_fname, is_gzipped =
+    if try_gzip then
+      let gz_fname = fname ^ ".gz" in
+      let gz_path = find_misc_file conf gz_fname in
+      if gz_path <> "" then (gz_path, true)
+      else (find_misc_file conf fname, false)
+    else (find_misc_file conf fname, false)
+  in
+  if actual_fname <> "" then
     let misc_fname =
-      if Filename.check_suffix fname ".css" then Css fname
-      else if Filename.check_suffix fname ".js" then Js fname
-      else if Filename.check_suffix fname ".json" then Json fname
-      else if Filename.check_suffix fname ".map" then Map fname
-      else if Filename.check_suffix fname ".otf" then Otf fname
-      else if Filename.check_suffix fname ".svg" then Svg fname
-      else if Filename.check_suffix fname ".eot" then Eot fname
-      else if Filename.check_suffix fname ".woff2" then Woff2 fname
-      else if Filename.check_suffix fname ".png" then Png fname
-      else if Filename.check_suffix fname ".cache.gz" then CacheGz fname
-      else Other fname
+      if Filename.check_suffix fname ".css" then Css actual_fname
+      else if Filename.check_suffix fname ".js" then Js actual_fname
+      else if Filename.check_suffix fname ".json" then Json actual_fname
+      else if Filename.check_suffix fname ".map" then Map actual_fname
+      else if Filename.check_suffix fname ".otf" then Otf actual_fname
+      else if Filename.check_suffix fname ".svg" then Svg actual_fname
+      else if Filename.check_suffix fname ".eot" then Eot actual_fname
+      else if Filename.check_suffix fname ".woff2" then Woff2 actual_fname
+      else if Filename.check_suffix fname ".png" then Png actual_fname
+      else if Filename.check_suffix fname ".cache.gz" then CacheGz actual_fname
+      else Other actual_fname
     in
-    print_misc_file conf misc_fname
+    print_misc_file conf misc_fname is_gzipped
   else false
 
 let strip_quotes s =
@@ -1924,7 +2008,7 @@ let connection ~secret_salt (addr, request) script_name contents0 =
         let contents, env = build_env request contents0 in
         if
           (not (image_request printer_conf script_name env))
-          && not (misc_request printer_conf script_name)
+          && not (misc_request printer_conf request script_name)
         then
           conf_and_connection ~secret_salt from request script_name contents env
       with Exit -> ()
@@ -2051,6 +2135,7 @@ let geneweb_cgi ~secret_salt addr script_name contents =
   let request = add "cookie" "HTTP_COOKIE" request in
   let request = add "content-type" "CONTENT_TYPE" request in
   let request = add "accept-language" "HTTP_ACCEPT_LANGUAGE" request in
+  let request = add "accept-encoding" "HTTP_ACCEPT_ENCODING" request in
   let request = add "referer" "HTTP_REFERER" request in
   let request = add "user-agent" "HTTP_USER_AGENT" request in
   connection ~secret_salt (Unix.ADDR_UNIX addr, request) script_name contents

--- a/lib/brotli/brotli.ml
+++ b/lib/brotli/brotli.ml
@@ -1,0 +1,8 @@
+type mode = Generic | Text | Font
+
+external compress_raw : int -> int -> string -> string = "ml_brotli_compress"
+
+let int_of_mode = function Generic -> 0 | Text -> 1 | Font -> 2
+
+let compress ?(quality = 4) ?(mode = Text) input =
+  compress_raw quality (int_of_mode mode) input

--- a/lib/brotli/brotli.mli
+++ b/lib/brotli/brotli.mli
@@ -1,0 +1,7 @@
+type mode = Generic | Text | Font
+
+val compress : ?quality:int -> ?mode:mode -> string -> string
+(** [compress ?quality ?mode input] compresses [input] using Brotli.
+    @param quality 0-11, default 4 (fast, good ratio for dynamic content)
+    @param mode Text for HTML/UTF-8, Generic otherwise
+    @raise Failure if compression fails *)

--- a/lib/brotli/brotli_stubs.c
+++ b/lib/brotli/brotli_stubs.c
@@ -1,0 +1,37 @@
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <brotli/encode.h>
+#include <stdlib.h>
+#include <string.h>
+
+CAMLprim value ml_brotli_compress(value quality_v, value mode_v, value input_v)
+{
+  CAMLparam3(quality_v, mode_v, input_v);
+  CAMLlocal1(output_v);
+
+  int quality = Int_val(quality_v);
+  int mode = Int_val(mode_v);
+  const uint8_t *input = (const uint8_t *)String_val(input_v);
+  size_t input_size = caml_string_length(input_v);
+
+  size_t output_size = BrotliEncoderMaxCompressedSize(input_size);
+  uint8_t *output = (uint8_t *)malloc(output_size);
+  if (!output)
+    caml_failwith("brotli: malloc failed");
+
+  BROTLI_BOOL ok = BrotliEncoderCompress(
+      quality, BROTLI_DEFAULT_WINDOW, mode,
+      input_size, input, &output_size, output);
+
+  if (ok) {
+    output_v = caml_alloc_string(output_size);
+    memcpy(Bytes_val(output_v), output, output_size);
+    free(output);
+    CAMLreturn(output_v);
+  } else {
+    free(output);
+    caml_failwith("brotli: compression failed");
+  }
+}

--- a/lib/brotli/dune
+++ b/lib/brotli/dune
@@ -1,0 +1,10 @@
+(library
+ (name geneweb_brotli)
+ (public_name geneweb.brotli)
+ (synopsis "Brotli compression for GeneWeb")
+ (wrapped false)
+ (foreign_stubs
+  (language c)
+  (names brotli_stubs)
+  (flags :standard -I/usr/include))
+ (library_flags -cclib -L/usr/lib -cclib -lbrotlienc))

--- a/lib/dune.in
+++ b/lib/dune.in
@@ -9,6 +9,7 @@
             str
             stdlib-shims
             camlp-streams
+            geneweb_brotli
             geneweb_core
             geneweb_def
             geneweb_db

--- a/lib/util/my_gzip.mli
+++ b/lib/util/my_gzip.mli
@@ -21,3 +21,8 @@ val input_line : in_channel -> string
     be produce even if it does not end with a line feed.
 
     @raise End_of_file if it reaches the end of the file. *)
+
+val gzip_string : ?level:int -> string -> string
+(** [gzip_string ?level input] compresses [input] using gzip format.
+    @param level compression level 1-9, default 6
+    @return gzip compressed data *)

--- a/lib/wserver/wserver.ml
+++ b/lib/wserver/wserver.ml
@@ -57,22 +57,22 @@ type printing_state = Nothing | Status | Contents
 
 let printing_state = ref Nothing
 
+let string_of_status = function
+  | Def.OK -> "200 OK"
+  | Def.Moved_Temporarily -> "302 Moved Temporarily"
+  | Def.Bad_Request -> "400 Bad Request"
+  | Def.Unauthorized -> "401 Unauthorized"
+  | Def.Forbidden -> "403 Forbidden"
+  | Def.Not_Found -> "404 Not Found"
+  | Def.Conflict -> "409 Conflict"
+  | Def.Internal_Server_Error -> "500 Internal Server Error"
+  | Def.Service_Unavailable -> "503 Service Unavailable"
+
 let http status =
   if !printing_state <> Nothing then failwith "HTTP Status already sent";
   printing_state := Status;
   if status <> Def.OK || not !cgi then (
-    let answer =
-      match status with
-      | Def.OK -> "200 OK"
-      | Def.Moved_Temporarily -> "302 Moved Temporarily"
-      | Def.Bad_Request -> "400 Bad Request"
-      | Def.Unauthorized -> "401 Unauthorized"
-      | Def.Forbidden -> "403 Forbidden"
-      | Def.Not_Found -> "404 Not Found"
-      | Def.Conflict -> "409 Conflict"
-      | Def.Internal_Server_Error -> "500 Internal Server Error"
-      | Def.Service_Unavailable -> "503 Service Unavailable"
-    in
+    let answer = string_of_status status in
     if !cgi then (
       output_string !wserver_oc "Status: ";
       output_string !wserver_oc answer)

--- a/lib/wserver/wserver.mli
+++ b/lib/wserver/wserver.mli
@@ -52,6 +52,9 @@ val wflush : unit -> unit
 (** Flushes the content of the current socket *)
 (* To flush page contents print. *)
 
+val string_of_status : Def.httpStatus -> string
+(** HTTP status line (e.g. "200 OK", "404 Not Found"). *)
+
 val http : Def.httpStatus -> unit
 (** [Output.status conf answer] sends the http header where [answer] represents
     the answer status. *)


### PR DESCRIPTION
This change adds transparent native support for serving pre-compressed gzip assets in gwd, for compressible static resources (JS and CSS), without relying on an external web server.

The implementation is based on:
- Detecting gzip support via the Accept-Encoding header
- Prioritizing the .gz version of .js and .css files when available, with fallback to the original file
- Sending the correct HTTP headers:
  - Content-Encoding: gzip when applicable
  - Vary: Accept-Encoding to ensure proper client/proxy caching
  - Long-term cache control (max-age=1 year) preserved

- Automatic generation of .gz files at `make distrib` build

This improves bandwidth usage and load times while keeping backward compatibility.