### PR TITLE
Optimize `Sosa.branches` for Zarith

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ Makefile.config
 Makefile.local
 
 # Generated from dune.in files
-benchmark/dune
 bin/cache_files/dune
 bin/connex/dune
 bin/consang/dune

--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -1,4 +1,12 @@
-open Geneweb
+module Driver = Geneweb_db.Driver
+module Sosa = Geneweb_sosa
+module Place = Geneweb.Place
+module Util = Geneweb.Util
+module Config = Geneweb.Config
+module UpdateData = Geneweb.UpdateData
+module Perso = Geneweb.Perso
+module BirthDeath = Geneweb.BirthDeath
+module Check = Geneweb.Check
 
 let style = ref Benchmark.Auto
 
@@ -145,7 +153,7 @@ let bench () =
              };
            ]
       :: bench_w_base
-           ~load:[ Geneweb_db.load_persons_array ]
+           ~load:[ Geneweb_db.Driver.load_persons_array ]
            "Util.authorized_age"
            (fun base conf ->
              Geneweb_db.Collection.iter
@@ -168,7 +176,8 @@ let bench () =
            (fun base _conf ->
              Geneweb_db.Collection.fold
                (fun acc p ->
-                 Perso.first_possible_duplication base (Geneweb_db.get_iper p)
+                 Perso.first_possible_duplication base
+                   (Geneweb_db.Driver.get_iper p)
                    ([], [])
                  :: acc)
                []
@@ -178,7 +187,7 @@ let bench () =
            (fun base get ->
              (Sys.opaque_identity BirthDeath.select_person) conf base get true
              |> Sys.opaque_identity ignore)
-           [ (fun p -> Date.od_of_cdate (Geneweb_db.get_birth p)) ]
+           [ (fun p -> Date.od_of_cdate (Geneweb_db.Driver.get_birth p)) ]
       :: suite
   | _ -> suite
 

--- a/benchmark/dune
+++ b/benchmark/dune
@@ -1,0 +1,8 @@
+(executable
+  (name bench)
+  (libraries unix geneweb geneweb.sosa benchmark))
+
+(rule
+  (action (run ./bench.exe) )
+  (alias runbench)
+)

--- a/benchmark/dune.in
+++ b/benchmark/dune.in
@@ -1,9 +1,0 @@
-(executable
-  (name bench)
-  (preprocess (action (run %{bin:cppo} %%%CPPO_D%%% -V OCAML:%{ocaml_version} %{input-file})))
-  (libraries unix geneweb benchmark))
-
-(rule
-  (action (run ./bench.exe) )
-  (alias runbench)
-)

--- a/lib/sosa/geneweb_sosa.zarith.ml
+++ b/lib/sosa/geneweb_sosa.zarith.ml
@@ -52,8 +52,5 @@ let of_string = Z.of_string
 let gen x = Z.log2 x + 1
 
 let branches x =
-  let rec aux acc d =
-    if Z.equal Z.zero d then acc
-    else aux (Z.to_int (Z.logand d one) :: acc) (Z.shift_right d 1)
-  in
-  List.tl (aux [] x)
+  let n = Z.numbits x in
+  List.init (n - 1) (fun i -> if Z.testbit x (n - i - 2) then 1 else 0)


### PR DESCRIPTION
The `branches` function implements the standard algorithm in OCaml to
retrieve the binary representation of a Zarith number. However,
`Z.testbit` is more appropriate since Zarith already uses binary
representation internally.

Running `make bench` shows an improvement of approximately 28%.

This PR is rebased on #2392 