### PR TITLE
Bump dune language version to 3.6

### DIFF
--- a/bin/connex/connex.ml
+++ b/bin/connex/connex.ml
@@ -29,10 +29,6 @@ let rec merge_families ifaml1f ifaml2f =
   | ifaml1, [] -> ifaml1
   | [], ifaml2 -> ifaml2
 
-let rec filter f = function
-  | x :: l -> if f x then x :: filter f l else filter f l
-  | [] -> []
-
 let connected_families base ifam cpl =
   let rec loop ifaml ipl_scanned = function
     | ip :: ipl ->

--- a/bin/fixbase/gwfixbase.ml
+++ b/bin/fixbase/gwfixbase.ml
@@ -3,7 +3,6 @@ module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
 module Collection = Geneweb_db.Collection
 
-let i = ref 0
 let nb_ind_init = ref 0
 
 let dump_persons bname ofile =

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -39,9 +39,9 @@ type descend = int Def.gen_descend
 (** Family's descendants entry in the base *)
 
 type ('person, 'string) gen_min_person = {
-  mutable m_first_name : 'string;
-  mutable m_surname : 'string;
-  mutable m_occ : int;
+  m_first_name : 'string;
+  m_surname : 'string;
+  m_occ : int;
   mutable m_rparents : ('person, 'string) gen_relation list;
   mutable m_related : int list;
   mutable m_pevents : ('person, 'string) gen_pers_event list;
@@ -92,10 +92,10 @@ type file_info = {
 type gen = {
   (* Table that associates unique string to its position inside
      [g_base]'s unique string array *)
-  mutable g_strings : (string, int) Hashtbl.t;
+  g_strings : (string, int) Hashtbl.t;
   (* Table that associates person's names hash with the index of
      person's entry inside the [g_base].*)
-  mutable g_names : (int, int) Hashtbl.t;
+  g_names : (int, int) Hashtbl.t;
   (* Counter of persons inside [g_base] *)
   mutable g_pcnt : int;
   (* Counter of families inside [g_base] *)

--- a/bin/gwd/robot.ml
+++ b/bin/gwd/robot.ml
@@ -96,10 +96,6 @@ let purge_who tm xcl sec =
   in
   List.iter (fun k -> xcl.who <- W.remove k xcl.who) to_remove
 
-let input_excl ic =
-  let b = really_input_string ic (String.length magic_robot) in
-  if b <> magic_robot then raise Not_found else (input_value ic : excl)
-
 let output_excl oc xcl =
   output_string oc magic_robot;
   output_value oc (xcl : excl)

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -415,7 +415,7 @@ type gen = {
   fam_done : (Driver.ifam, bool) Collection.Marker.t;
   mutable notes_pl_p : Driver.person list;
   mutable ext_files : (string * string list ref) list;
-  mutable notes_alias : (string * string) list;
+  notes_alias : (string * string) list;
   mutable pevents_pl_p : Driver.person list;
 }
 

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -8,8 +8,6 @@ let bin_dir = ref ""
 let base_dir = ref ""
 let lang_param = ref ""
 let only_file = ref ""
-let bname = ref ""
-let commnd = ref ""
 
 let printer_conf =
   {
@@ -34,10 +32,6 @@ let encode s = (Mutil.encode s :> string)
 let rec list_remove_assoc x = function
   | (x1, y1) :: l -> if x = x1 then l else (x1, y1) :: list_remove_assoc x l
   | [] -> []
-
-let rec list_assoc_all x = function
-  | [] -> []
-  | (a, b) :: l -> if a = x then b :: list_assoc_all x l else list_assoc_all x l
 
 type config = {
   lang : string;
@@ -310,20 +304,6 @@ let parse_upto lim =
   in
   loop 0
 
-let parse_upto_void lim =
-  let rec loop len (strm__ : _ Stream.t) =
-    match Stream.peek strm__ with
-    | Some c when c = lim ->
-        Stream.junk strm__;
-        ()
-    | Some c -> (
-        Stream.junk strm__;
-        try loop (Buff.store len c) strm__
-        with Stream.Failure -> raise (Stream.Error ""))
-    | _ -> raise Stream.Failure
-  in
-  loop 0
-
 let is_directory x =
   try (Unix.lstat x).Unix.st_kind = Unix.S_DIR
   with Unix.Unix_error (_, _, _) -> false
@@ -453,13 +433,6 @@ let nth_field s n =
     else loop (nth + 1) (j + 1)
   in
   loop 0 0
-
-let translate_phrase lexicon s n =
-  let n = match n with Some n -> n | None -> 0 in
-  try
-    let s = Hashtbl.find lexicon s in
-    nth_field s n
-  with Not_found -> "[" ^ nth_field s n ^ "]"
 
 let file_contents fname =
   try
@@ -1662,17 +1635,6 @@ let raw_file conf s =
     else "text/html"
   in
   print_typed_file conf typ fname
-
-let has_gwb_directories dh =
-  try
-    let rec loop () =
-      let e = Unix.readdir dh in
-      if Filename.check_suffix e ".gwb" then true else loop ()
-    in
-    loop ()
-  with End_of_file ->
-    Unix.closedir dh;
-    false
 
 let setup_comm_ok conf = function
   | "gwsetup" -> setup_gen conf

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -44,28 +44,7 @@ let notes_links s =
   in
   loop [] [] 1 0
 
-let read_file_contents fname =
-  match try Some (Secure.open_in fname) with Sys_error _ -> None with
-  | Some ic -> (
-      let len = ref 0 in
-      try
-        let rec loop () =
-          len := Buff.store !len (input_char ic);
-          loop ()
-        in
-        loop ()
-      with End_of_file ->
-        close_in ic;
-        Buff.get !len)
-  | None -> ""
-
 type cache_linked_pages_t = (Def.NLDB.key, int) Hashtbl.t
-
-let read_cache_linked_pages conf : cache_linked_pages_t =
-  let ic = open_in_bin conf in
-  let ht : cache_linked_pages_t = input_value ic in
-  close_in ic;
-  ht
 
 let save_cache_linked_pages bdir cache_linked_pages =
   let oc = open_out_bin (Filename.concat bdir Notes.cache_linked_pages_name) in

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.9)
+(lang dune 3.6)
 
 (name geneweb)
 

--- a/geneweb-rpc.opam
+++ b/geneweb-rpc.opam
@@ -9,7 +9,7 @@ homepage: "https://geneweb.org"
 doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.6"}
   "ocaml" {>= "4.10"}
   "geneweb" {= version}
   "qcheck" {with-test}

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -11,7 +11,7 @@ homepage: "https://geneweb.org"
 doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.6"}
   "ocaml" {>= "4.10"}
   "alcotest" {with-test}
   "benchmark"

--- a/plugins/forum/forum.ml
+++ b/plugins/forum/forum.ml
@@ -51,14 +51,11 @@ module MF : MF = struct
   }
 
   type filename = string
-  type pos = { mutable p_ord : bool; mutable p_ext : int; mutable p_pos : int }
+  type pos = { mutable p_ext : int; mutable p_pos : int }
 
   let filename_of_string x = x
-
-  let last_pos ic =
-    { p_ord = true; p_ext = 0; p_pos = in_channel_length ic.ic_chan }
-
-  let not_a_pos = { p_ord = false; p_ext = 0; p_pos = -1 }
+  let last_pos ic = { p_ext = 0; p_pos = in_channel_length ic.ic_chan }
+  let not_a_pos = { p_ext = 0; p_pos = -1 }
   let prev_pos pos = { pos with p_pos = pos.p_pos - 1 }
   let next_pos pos = { pos with p_pos = pos.p_pos + 1 }
 
@@ -70,11 +67,9 @@ module MF : MF = struct
   let pos_of_string s =
     try
       let pos = int_of_string s in
-      if pos < 0 then not_a_pos else { p_ord = true; p_ext = 0; p_pos = pos }
+      if pos < 0 then not_a_pos else { p_ext = 0; p_pos = pos }
     with Failure _ -> (
-      try
-        Scanf.sscanf s "%d-%d" (fun a b ->
-            { p_ord = a = 0; p_ext = a; p_pos = b })
+      try Scanf.sscanf s "%d-%d" (fun a b -> { p_ext = a; p_pos = b })
       with Scanf.Scan_failure _ -> not_a_pos)
 
   let extend fname f =
@@ -142,7 +137,7 @@ module MF : MF = struct
 
   let rpos_in ic =
     let pos = in_channel_length ic.ic_chan - pos_in ic.ic_chan in
-    { p_ord = ic.ic_ext = 0; p_ext = ic.ic_ext; p_pos = pos }
+    { p_ext = ic.ic_ext; p_pos = pos }
 
   let rec rseek_in ic pos =
     if ic.ic_ext = pos.p_ext then
@@ -150,7 +145,6 @@ module MF : MF = struct
       if pos.p_pos > len then
         if pos.p_ext >= 1 then (
           let ext = ic.ic_ext - 1 in
-          pos.p_ord <- ext = 0;
           pos.p_ext <- ext;
           pos.p_pos <- pos.p_pos - len;
           rseek_in ic pos)

--- a/test/search_test.ml
+++ b/test/search_test.ml
@@ -8,6 +8,7 @@ module Iterator = Geneweb_search.Iterator
 module Seq = Geneweb_compat.Seq
 
 (* Compute the Levenshtein distance of [s1] and [s2]. *)
+(* Unused --
 let distance s1 s2 =
   let l1 = String.length s1 in
   let l2 = String.length s2 in
@@ -25,7 +26,7 @@ let distance s1 s2 =
     done;
     Array.blit dp 0 prev 0 (l2 + 1)
   done;
-  prev.(l2)
+  prev.(l2) *)
 
 module Trie_tests = struct
   let test_cardinal _trie _a () =
@@ -117,16 +118,12 @@ module Flatset_tests = struct
   module C = Flatset.Comparator
 
   module Naive = struct
-    type t = int array
-
     let of_seq s =
       let arr = Array.of_seq s in
       Array.fast_sort Int.compare arr;
       arr
 
-    let to_seq = Array.to_seq
     let mem = Array.mem
-    let cardinal = List.length
     let empty = [||]
 
     let union a1 a2 =


### PR DESCRIPTION
The current version for the Dune language is 2.9. Several useful features have been added in Dune 3 and we cannot use them 
without changing the Dune language version.

This PR increases it to 3.6. 

Notice that changing this version modifies compilation flags and the OCaml compiler found 
a lot of dead codes with the new flags.