### PR TITLE
Use `dune-site` to install GeneWeb assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ endif
 	cp $(BUILD_DISTRIB_DIR)update_nldb/update_nldb.exe $(DISTRIB_DIR)/gw/update_nldb$(EXT)
 	@printf "\n\033[1;1m└ Copy templates in $(DISTRIB_DIR)/gw/\033[0m\n"
 	cp -R hd/* $(DISTRIB_DIR)/gw/
+	rm $(DISTRIB_DIR)/gw/dune
 	rm $(DISTRIB_DIR)/gw/etc/js/checkdata.js
 	rm $(DISTRIB_DIR)/gw/etc/js/p_mod.js
 	rm $(DISTRIB_DIR)/gw/etc/js/relationmatrix.js

--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -252,7 +252,9 @@ let speclist =
   [
     ( "-bd",
       Arg.String Secure.set_base_dir,
-      "<DIR> Specify where the 'bases' directory is installed (default '.')" );
+      Fmt.str
+        "<DIR> Specify where the 'bases' directory is installed (default %S)"
+        Secure.default_base_dir );
     ("", Arg.Unit (fun () -> ()), "");
     ("-fn", Arg.Set fnames, " first names");
     ("-fna", Arg.Set fname_aliases, " first name aliases (only with -checkdata)");
@@ -281,7 +283,7 @@ let speclist =
     ("", Arg.Unit (fun () -> ()), "");
     ("-prog", Arg.Set prog, " show progress bar");
   ]
-  |> List.filter (fun (opt, _, _) -> opt <> "") (* retire les séparateurs *)
+  |> List.filter (fun (opt, _, _) -> opt <> "") (* retire les sÃ©parateurs *)
   |> Arg.align
 
 let anonfun i = bname := i
@@ -323,17 +325,17 @@ let () =
   let fields = if !all || !pub_names then `Pub_names :: fields else fields in
   let fields = if !all || !aliases then `Aliases :: fields else fields in
 
-  (* Gestion spéciale fn/sn : d'abord checkdata puis datalist merged si besoin *)
+  (* Gestion spÃ©ciale fn/sn : d'abord checkdata puis datalist merged si besoin *)
   let should_merge = !merge_aliases || !all in
 
   if !all || !fnames then (
     if gen_cd then (
-      (* Génère toujours le cache fnames checkdata *)
+      (* GÃ©nÃ¨re toujours le cache fnames checkdata *)
       total :=
         !total
         +. gen_checkdata_only bname "fnames"
              (collect_checkdata_names base `Fnames);
-      (* Si -all, génère aussi fnames_alias checkdata *)
+      (* Si -all, gÃ©nÃ¨re aussi fnames_alias checkdata *)
       if !all then
         total :=
           !total
@@ -354,12 +356,12 @@ let () =
 
   if !all || !snames then (
     if gen_cd then (
-      (* Génère toujours le cache snames checkdata *)
+      (* GÃ©nÃ¨re toujours le cache snames checkdata *)
       total :=
         !total
         +. gen_checkdata_only bname "snames"
              (collect_checkdata_names base `Snames);
-      (* Si -all, génère aussi snames_alias checkdata *)
+      (* Si -all, gÃ©nÃ¨re aussi snames_alias checkdata *)
       if !all then
         total :=
           !total
@@ -378,7 +380,7 @@ let () =
           +. gen_datalist_only bname "snames"
                (collect_checkdata_names base `Snames));
 
-  (* Caches alias séparés pour checkdata uniquement *)
+  (* Caches alias sÃ©parÃ©s pour checkdata uniquement *)
   if !fname_aliases then
     total :=
       !total

--- a/bin/cache_files/dune
+++ b/bin/cache_files/dune
@@ -1,6 +1,5 @@
-(executables
+(executable
  (package geneweb)
- (names cache_files)
- (public_names geneweb.cache_files)
- (modules cache_files)
+ (name cache_files)
+ (public_name cache_files)
  (libraries decompress.gz unix str geneweb))

--- a/bin/connex/dune
+++ b/bin/connex/dune
@@ -1,6 +1,5 @@
-(executables
+(executable
  (package geneweb)
- (names connex)
- (public_names geneweb.connex)
- (modules connex)
+ (name connex)
+ (public_name connex)
  (libraries unix str geneweb))

--- a/bin/consang/dune
+++ b/bin/consang/dune
@@ -1,6 +1,6 @@
 (executable
  (package geneweb)
  (name consang)
- (public_name geneweb.consang)
+ (public_name consang)
  (modules consang)
  (libraries unix geneweb logs logs.fmt logs-syslog))

--- a/bin/fixbase/dune
+++ b/bin/fixbase/dune
@@ -1,6 +1,5 @@
 (executable
  (package geneweb)
  (name gwfixbase)
- (public_name geneweb.gwfixbase)
- (modules gwfixbase)
+ (public_name gwfixbase)
  (libraries unix str geneweb))

--- a/bin/ged2gwb/dune
+++ b/bin/ged2gwb/dune
@@ -1,8 +1,7 @@
 (executable
  (package geneweb)
  (name ged2gwb)
- (public_name geneweb.ged2gwb)
- (modules ged2gwb)
+ (public_name ged2gwb)
  (preprocess
   (action
    (run

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3155,8 +3155,9 @@ let out_file = ref "a"
 let speclist =
   [ ( "-bd",
       Arg.String Secure.set_base_dir,
+      Fmt.str
       "<DIR> Specify where the “bases” directory with databases is installed \
-       (default if empty is “.”)." )
+       (default if empty is %S)." Secure.default_base_dir )
   ; ( "-o", Arg.Set_string out_file,
       "<file> Output database (default: <input file name>.gwb, a.gwb if not \
        available). Alphanumerics and -" )

--- a/bin/gwb2ged/dune
+++ b/bin/gwb2ged/dune
@@ -8,6 +8,6 @@
 (executable
  (package geneweb)
  (name gwb2ged)
- (public_name geneweb.gwb2ged)
+ (public_name gwb2ged)
  (modules gwb2ged)
  (libraries geneweb gwb2ged_lib gwu_lib str unix))

--- a/bin/gwc/dune
+++ b/bin/gwc/dune
@@ -1,6 +1,5 @@
 (executable
  (package geneweb)
  (name gwc)
- (public_name geneweb.gwc)
- (modules gwc gwcomp db1link)
+ (public_name gwc)
  (libraries unix geneweb))

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -125,8 +125,10 @@ let speclist =
   [
     ( "-bd",
       Arg.String Secure.set_base_dir,
-      "<DIR> Specify where the “bases” directory with databases is installed \
-       (default if empty is “.”)." );
+      Fmt.str
+        "<DIR> Specify where the “bases” directory with databases is installed \
+         (default if empty is %S)."
+        Secure.default_base_dir );
     ( "-bnotes",
       Arg.Set_string bnotes,
       " [drop|erase|first|merge] Behavior for base notes of the next file. \

--- a/bin/gwd/dune
+++ b/bin/gwd/dune
@@ -18,7 +18,7 @@
 (executable
  (package geneweb)
  (name gwd)
- (public_name geneweb.gwd)
+ (public_name gwd)
  (flags -linkall)
  (libraries
   dynlink

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -8,6 +8,7 @@ open Gwd_lib
 module StrSet = Mutil.StrSet
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
+module Sites = Geneweb_sites.Sites
 
 type log = Stdout | Stderr | File of string | Syslog
 
@@ -102,6 +103,43 @@ let output_conf =
     flush = Wserver.wflush;
   }
 
+let ( // ) = Filename.concat
+
+let default_gw_prefix =
+  match Sites.hd with
+  | s :: _ -> s
+  | _ ->
+      (* This case occurs if gwd hasn't been installed with dune. *)
+      Filename.current_dir_name // "gw"
+
+let gw_prefix = ref None
+let set_gw_prefix s = gw_prefix := Some s
+let default_images_prefix = default_gw_prefix // "images"
+let images_prefix = ref None
+let set_images_prefix s = images_prefix := Some s
+let default_etc_prefix = default_gw_prefix // "etc"
+let etc_prefix = ref None
+let set_etc_prefix s = etc_prefix := Some s
+
+let parse_prefixes () =
+  let p =
+    match (!gw_prefix, !images_prefix) with
+    | Some s, None -> s // "images"
+    | _, Some s -> s
+    | None, None -> default_images_prefix
+  in
+  images_prefix := Some p;
+  let p =
+    match (!gw_prefix, !etc_prefix) with
+    | Some s, None -> s // "etc"
+    | _, Some s -> s
+    | None, None -> default_etc_prefix
+  in
+  etc_prefix := Some p;
+  let p = Option.value ~default:default_gw_prefix !gw_prefix in
+  gw_prefix := Some p;
+  Secure.add_assets p
+
 let printer_conf = { Config.empty with output_conf }
 let auth_file = ref ""
 let cache_langs = ref []
@@ -113,9 +151,6 @@ let default_lang = ref "fr"
 let friend_passwd = ref ""
 let green_color = "#2f6400"
 let images_dir = ref ""
-let gw_prefix = ref ""
-let images_prefix = ref ""
-let etc_prefix = ref ""
 let lexicon_list = ref [ Filename.concat "lang" "lexicon.txt" ]
 let login_timeout = ref 1800
 let default_n_workers = 20
@@ -1330,13 +1365,9 @@ let make_conf ~secret_salt from_addr request script_name env =
   if threshold_test <> "" then
     RelationLink.threshold := int_of_string threshold_test;
   GWPARAM.test_reorg base_file;
-  let gw_prefix_computed =
-    if !gw_prefix <> "" then !gw_prefix
-    else String.concat Filename.dir_sep [ "gw" ]
-  in
   let base_env =
     if base_file = "" then []
-    else Util.read_base_env base_file gw_prefix_computed !debug
+    else Util.read_base_env base_file (Option.get !gw_prefix) !debug
   in
   let default_lang =
     try
@@ -1509,19 +1540,9 @@ let make_conf ~secret_salt from_addr request script_name env =
       today_wd = tm.Unix.tm_wday;
       time = (tm.Unix.tm_hour, tm.Unix.tm_min, tm.Unix.tm_sec);
       ctime = utm;
-      gw_prefix = gw_prefix_computed;
-      images_prefix =
-        (match (!gw_prefix, !images_prefix) with
-        | gw_p, im_p when gw_p <> "" && im_p = "" ->
-            String.concat Filename.dir_sep [ gw_p; "images" ]
-        | _, im_p when im_p <> "" -> im_p
-        | _, _ -> Filename.concat "gw" "images");
-      etc_prefix =
-        (match (!gw_prefix, !etc_prefix) with
-        | gw_p, etc_p when gw_p <> "" && etc_p = "" ->
-            String.concat Filename.dir_sep [ gw_p; "etc" ]
-        | _, etc_p when etc_p <> "" -> etc_p
-        | _, _ -> Filename.concat "gw" "etc");
+      gw_prefix = Option.get !gw_prefix;
+      images_prefix = Option.get !images_prefix;
+      etc_prefix = Option.get !etc_prefix;
       cgi;
       output_conf;
       forced_plugins = !forced_plugins;
@@ -2127,7 +2148,9 @@ let geneweb_server ~predictable_mode () =
   images_dir: %s
   secure asset: %a|}
                   Version.src Version.branch Version.commit_id Sys.argv.(0)
-                  (Sys.getcwd ()) !gw_prefix !etc_prefix !images_prefix
+                  (Sys.getcwd ()) (Option.get !gw_prefix)
+                  (Option.get !etc_prefix)
+                  (Option.get !images_prefix)
                   !images_dir
                   Fmt.(box @@ brackets @@ list ~sep:comma string)
                   (Secure.assets ())))
@@ -2342,16 +2365,17 @@ let parse_cmd () =
   let speclist =
     [
       ( "-hd",
-        Arg.String
-          (fun x ->
-            gw_prefix := x;
-            Secure.add_assets x),
-        "<DIR> Specify where the “etc”, “images” and “lang” directories are \
-         installed (default if empty is “gw”)." );
+        Arg.String set_gw_prefix,
+        Fmt.str
+          "<DIR> Specify where the “etc”, “images” and “lang” directories are \
+           installed (default if empty is %S)."
+          default_gw_prefix );
       ( "-bd",
         Arg.String Secure.set_base_dir,
-        "<DIR> Specify where the “bases” directory with databases is installed \
-         (default if empty is “bases”)." );
+        Fmt.str
+          "<DIR> Specify where the “bases” directory with databases is \
+           installed (default if empty is %S)."
+          Secure.default_base_dir );
       ( "-wd",
         Arg.String make_sock_dir,
         "<DIR> Directory for socket communication (Windows) and access count."
@@ -2369,12 +2393,12 @@ let parse_cmd () =
       ( "-etc_prefix",
         Arg.String
           (fun x ->
-            etc_prefix := x;
+            set_etc_prefix x;
             Secure.add_assets x),
         "<DIR> Specify where the “etc” directory is installed (default if \
          empty is [-hd value]/etc)." );
       ( "-images_prefix",
-        Arg.String (fun x -> images_prefix := x),
+        Arg.String set_images_prefix,
         "<DIR> Specify where the “images” directory is installed (default if \
          empty is [-hd value]/images)." );
       ( "-images_dir",
@@ -2578,7 +2602,7 @@ let main () =
        let d = Filename.dirname f in
        if Filename.is_relative d then Filename.concat (Sys.getcwd ()) d else d
      in
-     images_prefix := "file://" ^ slashify abs_dir);
+     images_prefix := Some ("file://" ^ slashify abs_dir));
   GWPARAM.cnt_dir := !GWPARAM.cnt_d "";
   let dist_etc_d = Filename.concat (Filename.dirname Sys.argv.(0)) "etc" in
   if !Mutil.particles_file = "" then
@@ -2647,6 +2671,7 @@ let () =
     exit 1);
   Logs.set_level ~all:true (Some Logs.Info);
   parse_cmd ();
+  parse_prefixes ();
   with_log !log_file @@ fun reporter ->
   Fmt_tty.setup_std_outputs ~style_renderer:`Ansi_tty ();
   Logs.set_reporter reporter;

--- a/bin/gwdiff/dune
+++ b/bin/gwdiff/dune
@@ -1,6 +1,5 @@
-(executables
+(executable
  (package geneweb)
- (names gwdiff)
- (public_names geneweb.gwdiff)
- (modules gwdiff)
+ (name gwdiff)
+ (public_name gwdiff)
  (libraries unix str geneweb))

--- a/bin/gwgc/dune
+++ b/bin/gwgc/dune
@@ -1,6 +1,6 @@
 (executable
  (package geneweb)
  (name gwgc)
- (public_name geneweb.gwgc)
+ (public_name gwgc)
  (modules gwgc)
  (libraries unix str geneweb))

--- a/bin/gwu/dune
+++ b/bin/gwu/dune
@@ -8,6 +8,6 @@
 (executable
  (package geneweb)
  (name gwu)
- (public_name geneweb.gwu)
+ (public_name gwu)
  (modules gwu)
  (libraries geneweb gwexport_lib gwu_lib str unix))

--- a/bin/robot/dune
+++ b/bin/robot/dune
@@ -1,6 +1,6 @@
 (executable
  (package geneweb)
  (name robot)
- (public_name geneweb.robot)
+ (public_name gwrobot)
  (modules robot)
  (libraries unix geneweb))

--- a/bin/setup/dune
+++ b/bin/setup/dune
@@ -1,6 +1,5 @@
 (executable
  (package geneweb)
  (name setup)
- (public_name geneweb.setup)
- (libraries unix str wserver geneweb)
- (modules setup))
+ (public_name gwsetup)
+ (libraries unix str wserver geneweb))

--- a/bin/update_nldb/dune
+++ b/bin/update_nldb/dune
@@ -1,6 +1,6 @@
-(executables
+(executable
  (package geneweb)
- (names update_nldb)
- (public_names geneweb.update_nldb)
+ (name update_nldb)
+ (public_name update_nldb)
  (modules update_nldb)
  (libraries unix str geneweb))

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -12,8 +12,10 @@ let speclist =
   [
     ( "-bd",
       Arg.String Secure.set_base_dir,
-      "<DIR> Specify where the bases directory with databases is installed \
-       (default if empty is .)." );
+      Fmt.str
+        "<DIR> Specify where the bases directory with databases is installed \
+         (default if empty is %S)."
+        Secure.default_base_dir );
     ("-debug", Arg.Set debug, " Debug mode.");
   ]
 

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,8 @@
 (lang dune 3.6)
+(using dune_site 0.1)
+(generate_opam_files true)
 
 (name geneweb)
-(generate_opam_files true)
 (license GPL-2.0-only)
 (authors "Daniel de Rauglaudre")
 (maintainers "Elie Canonici-Merle <elie.canonicimerle@geneanet.org>")
@@ -12,8 +13,10 @@
 (package
   (name geneweb)
   (synopsis "Genealogy library and software")
-  (description "GeneWeb is an open source genealogy software written in OCaml. It comes with a Web interface and can be used off-line or as a Web service.")
+  (description "GeneWeb is an open source genealogy software written in OCaml. \
+    It comes with a Web interface and can be used off-line or as a Web service.")
   (tags (genealogy))
+  (sites (share hd))
   (depends
     (ocaml (>= 4.10))
     (alcotest :with-test)

--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
     digestif
     pp_loc
     dune-site
+    xdg
     (utop :with-dev-setup)
     (ocamlformat (and :with-dev-setup (= "0.28.1")))
   )

--- a/dune-project
+++ b/dune-project
@@ -41,6 +41,7 @@
     yojson
     digestif
     pp_loc
+    dune-site
     (utop :with-dev-setup)
     (ocamlformat (and :with-dev-setup (= "0.28.1")))
   )

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
               pcre2
               benchmark
               calendars
+              dune-site
               camlp5
               camlp-streams
               decompress

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
               benchmark
               calendars
               dune-site
+              xdg
               camlp5
               camlp-streams
               decompress

--- a/geneweb-rpc.opam
+++ b/geneweb-rpc.opam
@@ -48,7 +48,7 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
   ["cmdliner" "install" "tool-support"
               "--update-opam-install=%{_:name}%.install"
-              "_build/install/default/bin/geneweb-rpc.server" {os-family != "windows"}
-              "_build/install/default/bin/geneweb-rpc.server.exe" {os-family = "windows"}
+              "_build/install/default/bin/gwd-rpc" {os-family != "windows"}
+              "_build/install/default/bin/gwd-rpc.exe" {os-family = "windows"}
               "_build/cmdliner-install"]
 ]

--- a/geneweb-rpc.opam.template
+++ b/geneweb-rpc.opam.template
@@ -15,7 +15,7 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
   ["cmdliner" "install" "tool-support"
               "--update-opam-install=%{_:name}%.install"
-              "_build/install/default/bin/geneweb-rpc.server" {os-family != "windows"}
-              "_build/install/default/bin/geneweb-rpc.server.exe" {os-family = "windows"}
+              "_build/install/default/bin/gwd-rpc" {os-family != "windows"}
+              "_build/install/default/bin/gwd-rpc.exe" {os-family = "windows"}
               "_build/cmdliner-install"]
 ]

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -39,6 +39,7 @@ depends: [
   "digestif"
   "pp_loc"
   "dune-site"
+  "xdg"
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "odoc" {with-doc}

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -38,6 +38,7 @@ depends: [
   "yojson"
   "digestif"
   "pp_loc"
+  "dune-site"
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "odoc" {with-doc}

--- a/hd/dune
+++ b/hd/dune
@@ -1,0 +1,9 @@
+(install
+ (package geneweb)
+ (section
+  (site
+   (geneweb hd)))
+ (files
+  (glob_files_rec etc/*)
+  (glob_files_rec images/*)
+  (glob_files_rec lang/*)))

--- a/lib/dune
+++ b/lib/dune
@@ -24,6 +24,7 @@
   geneweb_util
   geneweb_templ
   geneweb_logs
+  geneweb_sites
   yojson
   markup
   re

--- a/lib/sites/dune
+++ b/lib/sites/dune
@@ -1,0 +1,9 @@
+(generate_sites_module
+ (module geneweb_sites)
+ (sites geneweb))
+
+(library
+ (package geneweb)
+ (name geneweb_sites)
+ (modules geneweb_sites)
+ (libraries dune-site))

--- a/lib/util/dune
+++ b/lib/util/dune
@@ -15,4 +15,5 @@
   uucp
   uunf
   uutf
-  digestif))
+  digestif
+  xdg))

--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -7,7 +7,13 @@
 
 let ok_r = ref []
 let assets_r = ref [ "gw" ]
-let bd_r = ref (Filename.concat Filename.current_dir_name "bases")
+let ( // ) = Filename.concat
+
+let default_base_dir =
+  let t = Xdg.create ~env:Sys.getenv_opt () in
+  Xdg.data_dir t // "geneweb" // "bases"
+
+let bd_r = ref default_base_dir
 
 (* [decompose: string -> string list] decompose a path into a list of
    directory and a basename. "a/b/c" -> [ "a" ; "b"; "c" ] *)

--- a/lib/util/secure.mli
+++ b/lib/util/secure.mli
@@ -3,6 +3,9 @@
 val assets : unit -> string list
 (** Returns list of allowed to acces assets *)
 
+val default_base_dir : string
+(** Default value for the base directory. *)
+
 val base_dir : unit -> string
 (** Returns directory where databases are installed to which acces is allowed *)
 

--- a/rpc/server/dune
+++ b/rpc/server/dune
@@ -1,7 +1,7 @@
 (executable
  (package geneweb-rpc)
  (name server)
- (public_name geneweb-rpc.server)
+ (public_name gwd-rpc)
  (libraries
   geneweb_rpc
   lwt

--- a/rpc/test/dune
+++ b/rpc/test/dune
@@ -1,7 +1,5 @@
 (executable
- (package geneweb-rpc)
  (name rpc_test)
- (public_name rpc_test)
  (modules rpc_test)
  (libraries fmt yojson geneweb_rpc httpun httpun-lwt-unix httpun-ws))
 


### PR DESCRIPTION
This PR adds support for opam installation. We use `dune-site`
to install the directory `hd` and the absolute path of
this directory is written in the binaries.

You can run gwd as follows:
```console
dune exec -- bin/gwd/gwd.exe -debug
```
By default, `gwd` looks for bases in `$HOME/.local/geneweb/bases/`.

You can install GeneWeb with opam as follows:
```console
opam install ./geneweb.opam
```
and run gwd:
```console
gwd -debug
```

The usual installation still works:
```console
make distrib
cd distribution
./gwd.sh
```
and looks for bases in `./distribution/bases`.