### PR TITLE
always track connections independently from `-robot_xcl` option

### DIFF
--- a/etc/a.gwf
+++ b/etc/a.gwf
@@ -436,6 +436,9 @@ cache_cousins_ttl=1
 # Disable the forum (all the request on the forum are “incorect request”.
 #disable_forum=yes
 
+# Hide number of connected users/friends/wizards in footer (copyr template).
+#hide_connections=yes
+
 # Manitou is a wizard who can:
 # - delete any forum message
 # - edit any wizard’s notes

--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -131,7 +131,7 @@
           </div>
         %end;
         <!-- Connections info -->
-        %if;(connections.total!="")
+        %if;(connections.total!="" and b.hide_connections!="yes")
           <div class="d-flex flex-column justify-items-center align-items-center small ml-1 ml-md-3">
             %if;(connections.friends!="" and connections.friends>0)<span>%connections.friends;
               %if;(connections.friends=1) [wizard/wizards/friend/friends/exterior]2


### PR DESCRIPTION
The -robot_xcl option controls robot exclusion thresholds, but connection counting was only enabled when this option was set. These are unrelated features: displaying user/friend/wizard counts should not require configuring robot exclusion.

Now connections are always tracked. When `-robot_xcl` is not set, max_int thresholds are used so no exclusion occurs.

Add `hide_connections=yes bvar` to disable display in copyr template.

Fixes #819.