### PR TITLE
fix(cousins): restore implex counting and add per-request caching

### DIFF
--- a/hd/etc/ancmenu.txt
+++ b/hd/etc/ancmenu.txt
@@ -130,94 +130,19 @@ function missing_events_options () {
       <div class="d-flex flex-column">
         <div class="d-flex flex-column was-validated">
           <label class="sr-only" for="v">[*specify::generation/generations]0[:]</label>
-          <select class="custom-select " id="v" name="v" required title="[up to] 2^n-2 / [only] 2^(n-1)">
+          <select class="custom-select" id="v" name="v" required
+            title="[up to] 2^n-2 / [only] 2^(n-1)">
             <option value="" label=" "></option>
-            %foreach;ancestor_level;
-              %if;(level>0)
-                %empty_sorted_list;
-                %(%anc_paths;%foreach;path_at_level quasi identique !%)
-                %foreach;ancestor;
-                  %apply;add_in_sorted_list(ancestor.birth_date.year)
-                  %apply;add_in_sorted_list(ancestor.death_date.year)
-                %end;
--               %let;b_max_implex_lev;%if;(b.max_implex_lev!="")%b.max_implex_lev;%else;20%end;%in;
-                %let;levelp;%expr(level+1)%in;
-                %let;number_of_ancestors_max;%expr(2^levelp-2)%in;
-                %let;number_of_ancestors_max_at_level;%expr(2^level)%in;
-                %let;dd;%expr(levelp/10)%in;
-                %let;dd_at_level;%expr(level/10)%in;
-                %let;anc_paths_c;%if;(level<b_max_implex_lev)%anc_paths_cnt.v;%else;%number_of_ancestors.v;%end;%in;
-                %let;anc_paths_c_r;%if;(level<b_max_implex_lev)%anc_paths_cnt_raw.v;%else;%number_of_ancestors.v;%end;%in;
-                %let;anc_paths_c_l;%if;(level<b_max_implex_lev)%anc_paths_at_level_cnt.v;%else;%number_of_ancestors_at_level.v;%end;%in;
-                %let;anc_paths_c_l_r;%if;(level<b_max_implex_lev)%anc_paths_at_level_cnt_raw.v;%else;%number_of_ancestors_at_level.v;%end;%in;
-                %let;extra_paths;%expr(anc_paths_c_r-anc_paths_c)%in;
-                %let;extra_paths_at_level;%if;(level<b_max_implex_lev)%expr(anc_paths_c_l_r-anc_paths_c_l)%else;0%end;%in;
-                %let;percent;%expr(100*anc_paths_c|number_of_ancestors_max)%in;
-                %let;percent_paths;%expr(100*anc_paths_c_r|number_of_ancestors_max)%in;
-                %let;percent_plus;%expr(100*(anc_paths_c-anc_paths_c_l)|number_of_ancestors_max)%in;
-                %let;percent_at_level;%expr(100*anc_paths_c_l|number_of_ancestors_max_at_level)%in;
-                %let;percent_paths_at_level;%expr(100*anc_paths_c_l_r|number_of_ancestors_max_at_level)%in;
-                %let;blue;rgba(210,230,255,.5)%in;%let;lred;rgba(255,210,180,.5)%in;%let;whit;rgba(255,255,255,0)%in;
-                <option value="%level;" title="" class="d-flex px-2"
-                    data-lex='%apply;ancname(level)'
-                    data-noa='%anc_paths_c;'
-                    data-noa_l='%anc_paths_c_l;'
-                    %if;(extra_paths!=0)data-path='+%extra_paths;'%end;%sp;
-                    %if;(extra_paths_at_level!=0)data-path_l='+%extra_paths_at_level;'%end;%sp;
-                    data-sty=' style="background:linear-gradient(90deg,
-                      rgba(155,200,255,.5) %percent_plus;%%,%nn;%(lightblue%)
-                      %blue; %percent_plus;%%,%nn;
-                      %blue; %percent;%%,%nn;
-                      %lred; %percent;%%,%nn;
-                      %lred; %percent_paths;%%,%nn;
-                      %whit; %percent_paths;%%"'
-                    data-sty_l=' style="background: linear-gradient(90deg,
-                      rgba(180,200,220,.5) %percent_at_level;%%,%nn;%(lightgrey%)
-                      %lred; %percent_at_level;%%,%nn;
-                      %lred; %percent_paths_at_level;%%,%nn;
-                      %whit; %percent_paths_at_level;%%"'
-                    %( carefull after level 61, number_of_ancestors_max > ocaml max_int;! %)
-                    data-pp='%nn;
-                      %if;(level<61)/%nn;
-                        %if;(level<14)%number_of_ancestors_max;%else;%expr(number_of_ancestors_max|(10^(3*dd)))%end; %nn;
-                        %if;(dd>9)>10³⁰%elseif;(dd=9)Y%nn;
-                        %elseif;(dd=8)Y%elseif;(dd=7)Z%elseif;(dd=6)E%elseif;(dd=5)P%nn;
-                        %elseif;(dd=4)T%elseif;(dd=3)G%elseif;(dd=2)M%elseif;(dd=1 and level>13)k%else;%end;
-                        %if;(percent!=0) (%percent;
-                          %if;(percent_paths!=percent)-%percent_paths;%end; %%)
-                        %else; (%expr(percent*10)
-                          %if;(percent_paths!=percent)-%expr(percent_paths*10)%end; ‰)
-                        %end;
-                      %end;'
-                    data-pp_l='%nn;
-                      %if;(level<61)/%nn;
-                        %if;(level<17)%number_of_ancestors_max_at_level;
-                        %else;%expr(number_of_ancestors_max_at_level|(10^(3*dd_at_level)))%end; %nn;
-                        %if;(level>100)>10³⁰%elseif;(level>90)Y%nn;
-                        %elseif;(level>80)Y%elseif;(level>70)Z%elseif;(level>60)E%elseif;(level>50)P%nn;
-                        %elseif;(level>39)T%elseif;(level>29)G%elseif;(level>18)M%elseif;(level>16)k%else;%end;
-                        %if;(percent_at_level!=0) (%percent_at_level;
-                          %if;(percent_paths_at_level!=percent_at_level)-%percent_paths_at_level;%end; %%)%end;
-                      %end;'
-                    data-per='%foreach;sorted_list_item;
-                                %if;(prev_item.1 = "")%item.1;%end;
-                                %if;(next_item.1 = "")-%item.1;%end;
-                              %end;'
-                    >%nn;
-                  %sp;%apply;thegen%with;%apply;nth([nth (generation)], level)%end;%if;(level<10) %(todo fix margin%) %end;%nn;
-                </option>
-              %end;
-            %end;
           </select>
           <div class="invalid-feedback ml-1">
             <i class="fas fa-triangle-exclamation mr-1"></i>[*specify::generation/generations]0
           </div>
         </div>
         <div class="d-flex justify-content-end mt-2">
-          <div class="order-2 align-self-center ml-4">
-            <button type="submit" class="btn btn-outline-primary">Ok</button>
+          <div class="order-2 align-self-center mx-4">
+            <button type="submit" class="btn btn-outline-primary">OK</button>
           </div>
-          <div class="order-1">
+          <div class="order-1 mr-5">
             <div class="custom-control custom-checkbox">
               <input type="checkbox" class="custom-control-input" id="only" name="only">
               <label class="custom-control-label" for="only">[*only the generation selected]<span class="text-primary ml-1">✱</span></label>
@@ -595,23 +520,123 @@ function missing_events_options () {
 </div>
 %include;js
 %query_time;
-%let;redlight2;rgb(255,136,46)%in;
 <script>
+const ancStats = %anc_stats_json;;
+const maxAncLevel = %max_anc_level;;
+const ANC_COLORS = {
+  prev: 'rgba(155,200,255,.5)',
+  uniq: 'rgba(210,230,255,.5)',
+  path: 'rgba(255,210,180,.5)',
+  empty: 'rgba(255,255,255,0)',
+  level: 'rgba(180,200,220,.5)'
+};
+
+function gradientCumul(gc) {
+  if (!gc) return '';
+  const { prev, unique, paths } = gc;
+  return ' style="background:linear-gradient(90deg,'
+    + `${ANC_COLORS.prev} ${prev}%,`
+    + `${ANC_COLORS.uniq} ${prev}%,`
+    + `${ANC_COLORS.uniq} ${unique}%,`
+    + `${ANC_COLORS.path} ${unique}%,`
+    + `${ANC_COLORS.path} ${paths}%,`
+    + `${ANC_COLORS.empty} ${paths}%)"`;
+}
+
+function gradientLevel(gl) {
+  if (!gl) return '';
+  const { unique, paths } = gl;
+  return ' style="background:linear-gradient(90deg,'
+    + `${ANC_COLORS.level} ${unique}%,`
+    + `${ANC_COLORS.path} ${unique}%,`
+    + `${ANC_COLORS.path} ${paths}%,`
+    + `${ANC_COLORS.empty} ${paths}%)"`;
+}
+// Inject options from JSON
+ancStats.data.forEach(function(d) {
+  var $opt = $('<option>', { value: d.v, text: d.t });
+  $opt.data('noa', d.noa);
+  $opt.data('noa_l', d.noa_l);
+  $opt.data('path', d.path);
+  $opt.data('path_l', d.path_l);
+  $opt.data('per', d.per);
+  $opt.data('gc', d.gc);
+  $opt.data('gl', d.gl);
+  $opt.data('pp', d.pp);
+  $opt.data('pp_l', d.pp_l);
+  if (d.v > maxAncLevel) {
+    $opt.prop('disabled', true);
+    $opt.addClass('text-muted');
+  }
+  $('#v').append($opt);
+});
+
 $(document).ready(function() {
   $("#v").select2({
-    templateResult: function(el) { return '<div' + (($('#only').is(':checked')) ? ($(el.element).data('sty_l') || '') : ($(el.element).data('sty') || '')) + '" class="d-flex justify-content-around text-right ' + ($(el.element).prop('class') || '') + '"><span class="onlycheck pl-2 text-right" title="' + ($(el.element).data('lex') || '') + '">' + (($('#only').is(':checked')) ? "[only]" : "[up to]") + el.text + '</span><span class="ml-2 text-nowrap">' + ($(el.element).data('per') || '') + '</span>' + (($('#only').is(':checked')) ? ('') : ('<div class="col-3 ml-auto text-right">+' + ($(el.element).data('noa_l') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path_l') || '') + '</span></div>')) + '<span class="col-3 text-right" title="'+ (($('#only').is(':checked')) ? (($(el.element).data('noa_l') || '') + ($(el.element).data('path_l') || '') + ($(el.element).data('pp_l') || '')) : (($(el.element).data('noa') || '') + ($(el.element).data('path') || '') + ($(el.element).data('pp') || ''))) + '">' + (($('#only').is(':checked')) ? (($(el.element).data('noa_l') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path_l') || '')) : (($(el.element).data('noa') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path') || ''))) + '</span></span></div>'; },
-    templateSelection: function(el) { return '<span class="onlycheck">' + (($('#only').is(':checked')) ? "[only]" : "[up to]") + '</span><span>' + el.text + '</span><span class="ml-auto noa"> ' + (($('#only').is(':checked')) ? ('(' + ($(el.element).data('noa_l') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path_l') || '') + '</span>)') : ('(' + ($(el.element).data('noa') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path') || '') + '</span>)')) + '</span><span class=" d-none noa_l"> ' + (($('#only').is(':checked')) ? ('(' + ($(el.element).data('noa') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path') || '') + '</span>)') : ('(' + ($(el.element).data('noa_l') || '') + '<span class="ancmenu-implex">' + ($(el.element).data('path_l') || '') + '</span>)')) + '</span>'; },
+    templateResult: function(el) {
+      var $el = $(el.element);
+      var isOnly = $('#only').is(':checked');
+      var sty = isOnly
+        ? gradientLevel($el.data('gl'))
+        : gradientCumul($el.data('gc'));
+      var lex = el.text || '';
+      var per = $el.data('per') || '';
+      var noa_l = $el.data('noa_l') || '';
+      var path_l = $el.data('path_l') || '';
+      var noa = $el.data('noa') || '';
+      var path = $el.data('path') || '';
+      var pp = $el.data(isOnly ? 'pp_l' : 'pp') || '';
+      var titleNum = isOnly ? (noa_l + path_l) : (noa + path);
+      var title = titleNum + pp;
+      var prefix = isOnly ? '[only] ' : '[up to] ';
+      var cls = el.disabled ? 'text-muted' : '';
+      var colDate = 'width:' + (isOnly ? '12' : '8') + 'rem';
+
+      return '<div' + sty + ' class="d-flex justify-content-center ' + cls
+        + '" title="' + title + '">'
+        + '<span class="text-right" style="width:14rem">' + prefix + lex + '</span>'
+        + '<span class="text-center" style="' + colDate + '">' + per + '</span>'
+        + '<span class="text-right" style="width:10rem">+' + noa_l
+        + '<span class="ancmenu-implex">' + path_l + '</span></span>'
+        + (isOnly ? '' : '<span class="text-right" style="width:12rem">' + noa
+          + '<span class="ancmenu-implex">' + path + '</span></span>')
+        + '</div>';
+    },
+    templateSelection: function(el) {
+      var isOnly = $('#only').is(':checked');
+      var noa = $(el.element).data(isOnly ? 'noa_l' : 'noa') || '';
+      var path = $(el.element).data(isOnly ? 'path_l' : 'path') || '';
+      var noa2 = $(el.element).data(isOnly ? 'noa' : 'noa_l') || '';
+      var path2 = $(el.element).data(isOnly ? 'path' : 'path_l') || '';
+      var noaHtml = noa
+        ? ' (' + noa + '<span class="ancmenu-implex">' + path + '</span>)'
+        : '';
+      var noa2Html = noa2
+        ? ' (' + noa2 + '<span class="ancmenu-implex">' + path2 + '</span>)'
+        : '';
+      return '<span class="onlycheck">'
+        + (isOnly ? '[only]' : '[up to]') + '</span>'
+        + '<span>' + el.text + '</span>'
+        + '<span class="ml-auto noa">' + noaHtml + '</span>'
+        + '<span class="d-none noa_l">' + noa2Html + '</span>';
+    },
     escapeMarkup: function(markup) { return markup; },
     width: "resolve",
     allowClear: false,
-    placeholder: "… [specify::generation/generations]0 (max %max_anc_level;)",
+    placeholder: "… [specify::generation/generations]0 (max " + maxAncLevel + ")",
     theme: "classic"
   }).maximizeSelect2Height();
-});
+
   $("body").on('change', '#only', function() {
-   ($('#only').is(':checked')) ? ($('.onlycheck').text("[only]"), $('.noa').addClass("d-none"), $('.noa_l').removeClass("d-none"))
-                               : ($('.onlycheck').text("[up to]"), $('.noa').removeClass("d-none"), $('.noa_l').addClass("d-none"))
+    ($('#only').is(':checked'))
+      ? ($('.onlycheck').text('[only]'),
+         $('.noa').addClass('d-none'),
+         $('.noa_l').removeClass('d-none'))
+      : ($('.onlycheck').text('[up to]'),
+         $('.noa').removeClass('d-none'),
+         $('.noa_l').addClass('d-none'));
   });
+});
 </script>
 <script>
 (function () {

--- a/hd/etc/ancsosa.txt
+++ b/hd/etc/ancsosa.txt
@@ -1337,76 +1337,83 @@ TODO: obtenir les secondes valeurs valeurs jj/mm/aaaa pour les cas « ou | » 
 
 %if;(e.t = "P")
   %include;perso_short
-%elseif;(e.t = "N" and e.only = "on")
-  %( short display; only the selected generation %)
-  %reset_count;
-  %foreach;ancestor_at_level;
-    %if;(e.v>=0 and level=e.v)
-      <ul>%nl;
-        %foreach;ancestor;
-          <li>%sp;
-            %if;(ancestor.interval != "")%ancestor.interval;
-            %else;
-              %if;(ancestor.same = "")%incr_count;%end;
-              %ancestor.anc_sosa;%sp;
-              %if;(ancestor.same != "")=&gt;%else;-%end;%sp;
-              %apply;link%with;%ancestor.access;%and;
-                %if;(ancestor.same != "")%ancestor.same;
-                %else;%ancestor;%end;
-                %and;%ancestor.index;
-              %end;
-              %if;(ancestor.same = "")%ancestor.title;%ancestor.dates;
-              %else;
-                %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)
-              %end;
-            %end;
-          </li>%nl;
-        %end;
-      </ul>
-    %end;
-  %end;
-  <p>[*total][:] %count; [person/persons]n</p>
 
-%elseif;(e.t = "N")
-  %( short display %)
-  %let;nb_gen;%apply;min(e.v, max_anc_level)%in;
-  <p>%apply;togena(nb_gen).</p>
-  %reset_count;
-    %foreach;ancestor_level(nb_gen)
-      %apply;lazy_print%with;
-        %nl;%if;(level!=0)<b>[*generation/generations]0 %level;</b>%nl;%end;
-        <ul>%nl;
-      %end;
-      %foreach;ancestor;
-        %lazy_force;
-        %if;(ancestor.same = "")%if;(level!=0)%incr_count;%end;%end;
-        <li class="%if;ancestor.has_parents;goway%else;noway%end;">%nn;
-          %if;(e.sosab = 16)%ancestor.anc_sosa.hexa;
-          %elseif;(e.sosab = 8)%ancestor.anc_sosa.octal;
-          %else;%ancestor.anc_sosa;
-          %end;%sp;
-          %if;(ancestor.same != "")=&gt;%else;-%end;%sp;
-          %apply;link%with;%ancestor.access;%and;
-             %if;(ancestor.same != "")%nn;
-               %if;(e.sosab = 16)%ancestor.same.hexa;
-               %elseif;(e.sosab = 8)%ancestor.same.octal;
-               %else;%ancestor.same;
-               %end;
-             %else;%ancestor;
-             %end;%and;%ancestor.index;
+%( short display %)
+%elseif;(e.t="N")
+  %let;v0;%if;(e.v0!="" and e.v0>0)%e.v0;%else;0%end;%in;
+  %if;(e.only="on" or v0=e.v)
+    %reset_count;
+    %foreach;ancestor_at_level;
+      %if;(e.v>=0 and level=e.v)
+        <ul class="mb-2">%nl;
+          %foreach;ancestor;
+            %if;(ancestor.first_name!="?" and ancestor.surname!="?")
+              <li>%sp;
+                %if;(ancestor.interval!="")%ancestor.interval;
+                %else;
+                  %if;(ancestor.same="")%incr_count;%end;
+                  %ancestor.anc_sosa;%sp;
+                  %if;(ancestor.same!="")=&gt;%else;-%end;%sp;
+                  %apply;link%with;%ancestor.access;%and;
+                    %if;(ancestor.same!="")%ancestor.same;
+                    %else;%ancestor;%end;
+                    %and;%ancestor.index;
+                  %end;
+                  %if;(ancestor.same="")%ancestor.title;%ancestor.dates;
+                  %else;
+                    %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)
+                  %end;
+                %end;
+              </li>%nl;
+            %end;
           %end;
-          %if;(ancestor.same != "")
-            %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)<br>
-          %end;
-          %if;(ancestor.same = "")%ancestor.title;%ancestor.dates;%end;
-        </li>%nl;
-      %end;
-      %if;lazy_printed;
         </ul>
       %end;
     %end;
-  <p>[*total][:] 1+%count; [ancestor/ancestors]n</p>
-  %elseif;(e.t = "M" and e.evt = "on")
+  %else;
+    %let;nb_gen;%apply;min(e.v, max_anc_level)%in;
+    %reset_count;
+    %foreach;ancestor_level(nb_gen)
+      %if;(level>=v0)
+        %apply;lazy_print%with;
+          %nl;%if;(level!=0)<div%if;not cancel_links; class="ml-2"%end;><b>[*generation/generations]0 %level;</b></div>%nl;%end;
+          <ul class="mb-2">%nl;
+        %end;
+        %foreach;ancestor;
+          %lazy_force;
+          %if;(ancestor.first_name!="?" and ancestor.surname!="?")
+            %if;(level!=0 and ancestor.same="")%incr_count;%end;
+            <li class="%if;ancestor.has_parents;goway%else;noway%end;">%nn;
+              %if;(e.sosab=16)%ancestor.anc_sosa.hexa;
+              %elseif;(e.sosab=8)%ancestor.anc_sosa.octal;
+              %else;%ancestor.anc_sosa;
+              %end;%sp;
+              %if;(ancestor.same!="")=&gt;%else;-%end;%sp;
+              %apply;link%with;%ancestor.access;%and;
+                 %if;(ancestor.same!="")%nn;
+                   %if;(e.sosab=16)%ancestor.same.hexa;
+                   %elseif;(e.sosab=8)%ancestor.same.octal;
+                   %else;%ancestor.same;
+                   %end;
+                 %else;%ancestor;
+                 %end;%and;%ancestor.index;
+              %end;
+              %if;(ancestor.same!="")
+                %sp;(<a href="#i%ancestor.index;" title="[implex/implexes]0, [see above]">↑</a>)<br>
+              %end;
+              %if;(ancestor.same="")%ancestor.title;%ancestor.dates;%end;
+            </li>%nl;
+          %end;
+        %end;
+        %if;lazy_printed;
+          </ul>
+        %end;
+      %end;
+    %end;
+  %end;
+  <div class="ml-2">[*total][:] [him/her]s + %count; [ancestor/ancestors]n.</div>
+
+%elseif;(e.t="M" and e.evt="on")
     %include;miss_evt
 
 %elseif;(e.t = "M" and e.al = "on")

--- a/lib/ancStatsDisplay.ml
+++ b/lib/ancStatsDisplay.ml
@@ -1,0 +1,294 @@
+(* ancStatsDisplay.ml - Ancestor statistics JSON for Select2 ancmenu display *)
+
+module Percent : sig
+  type t
+
+  val of_int : int -> t
+  val to_int : t -> int
+end = struct
+  type t = int
+
+  let of_int x = max 0 (min 100 x)
+  let to_int x = x
+end
+
+type gradient_cumul = {
+  gc_prev : Percent.t;
+  gc_unique : Percent.t;
+  gc_paths : Percent.t;
+}
+
+type gradient_level = { gl_unique : Percent.t; gl_paths : Percent.t }
+
+let make_gradient_cumul ~prev ~unique ~paths =
+  let p = Percent.of_int prev in
+  let u = Percent.of_int (max prev unique) in
+  let s = Percent.of_int (max (max prev unique) paths) in
+  { gc_prev = p; gc_unique = u; gc_paths = s }
+
+let make_gradient_level ~unique ~paths =
+  let u = Percent.of_int unique in
+  let s = Percent.of_int (max unique paths) in
+  { gl_unique = u; gl_paths = s }
+
+(* Theoretical maximum ancestors at generation n:
+   - cumulated: 2^(n+1) - 2 (all ancestors from gen 1 to n)
+   - at level:  2^n (ancestors at exactly gen n) *)
+let max_ancestors_cumul gen = if gen >= 61 then 0 else (1 lsl (gen + 1)) - 2
+let max_ancestors_level gen = if gen >= 61 then 0 else 1 lsl gen
+let percent num denom = if denom <= 0 then 0 else min 100 (100 * num / denom)
+
+(* SI notation for large theoretical counts: k, M, G, T, P, E, Z, Y *)
+let format_si n gen =
+  if gen < 14 then string_of_int n
+  else
+    let decade = (gen + 1) / 10 in
+    let rec pow10 acc k = if k <= 0 then acc else pow10 (acc * 10) (k - 1) in
+    let divisor = pow10 1 (3 * decade) in
+    let suffix =
+      match decade with
+      | 1 -> "k"
+      | 2 -> "M"
+      | 3 -> "G"
+      | 4 -> "T"
+      | 5 -> "P"
+      | 6 -> "E"
+      | 7 -> "Z"
+      | _ -> "Y"
+    in
+    Printf.sprintf "%d %s" (n / divisor) suffix
+
+(* Percentage tooltip: "/theoretical (pct%)" or "/theoretical (pct_u-pct_p%)" *)
+let format_pct_tooltip theo pct_unique pct_paths gen =
+  if gen >= 61 || theo = 0 then ""
+  else
+    let theo_str = format_si theo gen in
+    if pct_unique = pct_paths then
+      if pct_unique = 0 then
+        Printf.sprintf "/%s (%d ‰)" theo_str (pct_unique * 10)
+      else Printf.sprintf "/%s (%d %%)" theo_str pct_unique
+    else if pct_unique = 0 then
+      Printf.sprintf "/%s (%d-%d ‰)" theo_str (pct_unique * 10) (pct_paths * 10)
+    else Printf.sprintf "/%s (%d-%d %%)" theo_str pct_unique pct_paths
+
+let escape_json s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (fun c ->
+      match c with
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c -> Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+
+let generation_label conf gen =
+  let nth = Util.transl_nth conf "nth (generation)" gen in
+  let s = Printf.sprintf (Util.ftransl conf "the %s generation") nth in
+  escape_json (" " ^ s)
+
+(* Extract birth/death year from person *)
+let get_years base parent_ip =
+  let p = Geneweb_db.Driver.poi base parent_ip in
+  let year_of_cdate cd =
+    match Date.od_of_cdate cd with
+    | Some (Def.Dgreg (dg, _)) -> Some dg.Def.year
+    | _ -> None
+  in
+  let birth = year_of_cdate (Geneweb_db.Driver.get_birth p) in
+  let baptism = year_of_cdate (Geneweb_db.Driver.get_baptism p) in
+  let death =
+    match Geneweb_db.Driver.get_death p with
+    | Def.Death (_, cd) -> year_of_cdate cd
+    | _ -> None
+  in
+  let burial =
+    match Geneweb_db.Driver.get_burial p with
+    | Def.Buried cd | Def.Cremated cd -> year_of_cdate cd
+    | Def.UnknownBurial -> None
+  in
+  let pick a b = match a with Some _ -> a | None -> b in
+  let early = pick birth baptism in
+  let late = pick death burial in
+  (early, late)
+
+(* JSON schema:
+   data[] = {
+     v  : generation number
+     tt : label
+     noa: unique cumulative ancestors
+     path: implex
+     per: year range
+     gc : { prev; unique; paths }  (* cumulative percentages *)
+     gl : { unique; paths }        (* level percentages *)
+     pp : tooltip cumul
+     pp_l : tooltip level }*)
+
+(* Main JSON computation for ancestor menu *)
+let compute_json conf base p =
+  let root_ip = Geneweb_db.Driver.get_iper p in
+  let buf = Buffer.create 16384 in
+  let data_buf = Buffer.create 16384 in
+
+  let seen_ever = Hashtbl.create 4096 in
+  let total_paths = ref 0 in
+  let prev_unique_cumul = ref 0 in
+
+  let curr_gen = Hashtbl.create 4096 in
+  let next_gen = Hashtbl.create 4096 in
+  Hashtbl.add curr_gen root_ip 1;
+
+  let gen = ref 0 in
+  let max_gen = ref 0 in
+  let first = ref true in
+
+  while Hashtbl.length curr_gen > 0 do
+    incr gen;
+    Hashtbl.clear next_gen;
+
+    let seen_this_gen = Hashtbl.create 128 in
+    let new_anc = ref 0 in
+    let paths_this_gen = ref 0 in
+    let min_year = ref max_int in
+    let max_year = ref min_int in
+
+    Hashtbl.iter
+      (fun child_ip path_count ->
+        let child = Geneweb_db.Driver.poi base child_ip in
+        match Geneweb_db.Driver.get_parents child with
+        | None -> ()
+        | Some ifam ->
+            let fam = Geneweb_db.Driver.foi base ifam in
+            let parents =
+              [
+                Geneweb_db.Driver.get_father fam;
+                Geneweb_db.Driver.get_mother fam;
+              ]
+            in
+            List.iter
+              (fun parent_ip ->
+                paths_this_gen := !paths_this_gen + path_count;
+
+                if not (Hashtbl.mem seen_this_gen parent_ip) then begin
+                  Hashtbl.add seen_this_gen parent_ip ();
+                  let birth, death = get_years base parent_ip in
+                  let upd = function
+                    | Some y ->
+                        if y < !min_year then min_year := y;
+                        if y > !max_year then max_year := y
+                    | None -> ()
+                  in
+                  upd birth;
+                  upd death
+                end;
+
+                if not (Hashtbl.mem seen_ever parent_ip) then begin
+                  incr new_anc;
+                  Hashtbl.add seen_ever parent_ip ()
+                end;
+
+                let prev =
+                  try Hashtbl.find next_gen parent_ip with Not_found -> 0
+                in
+                Hashtbl.replace next_gen parent_ip (prev + path_count))
+              parents)
+      curr_gen;
+
+    let unique_this_gen = Hashtbl.length seen_this_gen in
+
+    if unique_this_gen > 0 then begin
+      max_gen := !gen;
+      total_paths := !total_paths + !paths_this_gen;
+
+      let unique_cumul = Hashtbl.length seen_ever in
+      let paths_cumul = !total_paths in
+
+      let implex_cumul = paths_cumul - unique_cumul in
+      let implex_local =
+        !paths_this_gen - unique_this_gen + (unique_this_gen - !new_anc)
+      in
+
+      let theo_c = max_ancestors_cumul !gen in
+      let theo_l = max_ancestors_level !gen in
+
+      let pct_prev = percent !prev_unique_cumul theo_c in
+      let pct_uc = percent unique_cumul theo_c in
+      let pct_pc = percent paths_cumul theo_c in
+      let pct_ul = percent !new_anc theo_l in
+      let pct_pl = percent !paths_this_gen theo_l in
+
+      let gc =
+        make_gradient_cumul ~prev:pct_prev ~unique:pct_uc ~paths:pct_pc
+      in
+      let gl = make_gradient_level ~unique:pct_ul ~paths:pct_pl in
+
+      let label = generation_label conf !gen in
+      let period =
+        if !min_year = max_int then "-"
+        else Printf.sprintf "%d-%d" !min_year !max_year
+      in
+
+      if not !first then Buffer.add_char data_buf ',';
+      first := false;
+
+      Buffer.add_string data_buf "{\"v\":";
+      Buffer.add_string data_buf (string_of_int !gen);
+      Buffer.add_string data_buf ",\"t\":\"";
+      Buffer.add_string data_buf label;
+      Buffer.add_string data_buf "\",\"noa\":\"";
+      Buffer.add_string data_buf (string_of_int unique_cumul);
+      Buffer.add_string data_buf "\",\"noa_l\":\"";
+      Buffer.add_string data_buf (string_of_int !new_anc);
+      Buffer.add_string data_buf "\",\"path\":\"";
+      if implex_cumul > 0 then (
+        Buffer.add_char data_buf '+';
+        Buffer.add_string data_buf (string_of_int implex_cumul));
+      Buffer.add_string data_buf "\",\"path_l\":\"";
+      if implex_local > 0 then (
+        Buffer.add_char data_buf '+';
+        Buffer.add_string data_buf (string_of_int implex_local));
+      Buffer.add_string data_buf "\",\"per\":\"";
+      Buffer.add_string data_buf period;
+      Buffer.add_string data_buf "\"";
+
+      (* gc *)
+      Buffer.add_string data_buf ",\"gc\":{\"prev\":";
+      Buffer.add_string data_buf (string_of_int (Percent.to_int gc.gc_prev));
+      Buffer.add_string data_buf ",\"unique\":";
+      Buffer.add_string data_buf (string_of_int (Percent.to_int gc.gc_unique));
+      Buffer.add_string data_buf ",\"paths\":";
+      Buffer.add_string data_buf (string_of_int (Percent.to_int gc.gc_paths));
+      Buffer.add_string data_buf "}";
+
+      (* gl *)
+      Buffer.add_string data_buf ",\"gl\":{\"unique\":";
+      Buffer.add_string data_buf (string_of_int (Percent.to_int gl.gl_unique));
+      Buffer.add_string data_buf ",\"paths\":";
+      Buffer.add_string data_buf (string_of_int (Percent.to_int gl.gl_paths));
+      Buffer.add_string data_buf "}";
+
+      (* tooltips *)
+      Buffer.add_string data_buf ",\"pp\":\"";
+      Buffer.add_string data_buf
+        (escape_json (format_pct_tooltip theo_c pct_uc pct_pc !gen));
+      Buffer.add_string data_buf "\",\"pp_l\":\"";
+      Buffer.add_string data_buf
+        (escape_json (format_pct_tooltip theo_l pct_ul pct_pl !gen));
+      Buffer.add_string data_buf "\"}";
+
+      prev_unique_cumul := unique_cumul
+    end;
+
+    Hashtbl.reset curr_gen;
+    Hashtbl.iter (fun k v -> Hashtbl.add curr_gen k v) next_gen
+  done;
+
+  Buffer.add_string buf "{\"max\":";
+  Buffer.add_string buf (string_of_int !max_gen);
+  Buffer.add_string buf ",\"data\":[";
+  Buffer.add_buffer buf data_buf;
+  Buffer.add_string buf "]}";
+  Buffer.contents buf

--- a/lib/cousins.ml
+++ b/lib/cousins.ml
@@ -526,23 +526,17 @@ let init_desc_cnt conf base p =
   done;
   desc_cnt
 
-let anc_cnt_aux conf base lev at_to p =
-  let cous = Hashtbl.create 10000 in
-  let asc_cnt = init_asc_cnt conf base p in
+let anc_cnt_aux ?asc_cnt conf base lev at_to p =
+  let asc_cnt =
+    match asc_cnt with Some a -> a | None -> init_asc_cnt conf base p
+  in
   if at_to then if lev < Array.length asc_cnt then Some asc_cnt.(lev) else None
   else
-    let rec loop i =
-      if i > lev || i >= Array.length asc_cnt - 1 then
-        Some (Hashtbl.fold (fun _k v acc -> v :: acc) cous [])
-      else (
-        (* several cousins records with same ip, different faml! *)
-        List.iter
-          (fun (ip, faml, ianc, lvl) ->
-            Hashtbl.replace cous ip (ip, faml, ianc, lvl))
-          asc_cnt.(i);
-        loop (i + 1))
+    let rec loop acc i =
+      if i > lev || i >= Array.length asc_cnt then Some acc
+      else loop (List.rev_append asc_cnt.(i) acc) (i + 1)
     in
-    loop 1
+    loop [] 1
 
 let desc_cnt_aux conf base lev at_to p =
   let cous = Hashtbl.create 10000 in

--- a/lib/cousins.mli
+++ b/lib/cousins.mli
@@ -123,6 +123,7 @@ val cousins_fold :
     levels). *)
 
 val anc_cnt_aux :
+  ?asc_cnt:one_cousin list array ->
   config ->
   Geneweb_db.Driver.base ->
   int ->
@@ -130,7 +131,10 @@ val anc_cnt_aux :
   Geneweb_db.Driver.person ->
   one_cousin list option
 (** Returns ancestors at level (if bool=true) or up to level (if bool=false).
-    Level 1 = parents, level 2 = grandparents, etc. *)
+    Level 1 = parents, level 2 = grandparents, etc.
+    @param asc_cnt
+      Pre-computed ancestor array from {!init_asc_cnt} for caching across
+      multiple calls on the same person. If omitted, computed internally. *)
 
 val desc_cnt_aux :
   config ->
@@ -141,3 +145,12 @@ val desc_cnt_aux :
   one_cousin list option
 (** Returns descendants at level (if bool=true) or up to level (if bool=false).
     Level 1 = children, level 2 = grandchildren, etc. *)
+
+val init_asc_cnt :
+  config ->
+  Geneweb_db.Driver.base ->
+  Geneweb_db.Driver.person ->
+  one_cousin list array
+(** Builds array of ancestors by level. Index 0 = person, 1 = parents, etc. Each
+    entry contains all ancestor paths to that level (including duplicates for
+    implex detection). *)

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -2101,6 +2101,8 @@ and eval_compound_var conf base env ((a, _) as ep) loc = function
       eval_anc_paths_cnt conf base env ep Paths_cnt true loc sl
   | "anc_paths_at_level" :: sl ->
       eval_anc_paths_cnt conf base env ep Paths true loc sl
+  | [ "anc_stats_json" ] ->
+      VVstring (AncStatsDisplay.compute_json conf base (fst ep))
   | "desc_paths_cnt_raw" :: sl ->
       eval_desc_paths_cnt conf base env ep Paths_cnt_raw false loc sl
   | "desc_paths_cnt" :: sl ->

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -31,6 +31,16 @@ let get_cousins_sparse =
         cache := Some (Driver.get_iper p, sparse);
         sparse
 
+let get_asc_cnt =
+  let cache = ref None in
+  fun conf base p ->
+    match !cache with
+    | Some (cached_ip, arr) when cached_ip = Driver.get_iper p -> arr
+    | _ ->
+        let arr = Cousins.init_asc_cnt conf base p in
+        cache := Some (Driver.get_iper p, arr);
+        arr
+
 let max_im_wid = 240
 let round_2_dec x = floor ((x *. 100.0) +. 0.5) /. 100.0
 
@@ -2472,14 +2482,15 @@ and eval_anc_paths_cnt conf base env (p, _) path_mode at_to ?(l1_l2 = (0, 0))
   | sl -> (
       match get_env "level" env with
       | Vint lev -> (
+          let asc_cnt = get_asc_cnt conf base p in
           match path_mode with
           | Paths_cnt_raw -> (
-              let list1 = Cousins.anc_cnt_aux conf base lev at_to p in
+              let list1 = Cousins.anc_cnt_aux ~asc_cnt conf base lev at_to p in
               match list1 with
               | Some list1 -> VVstring (eval_int conf (List.length list1) sl)
               | None -> raise Not_found)
           | Paths_cnt -> (
-              let list1 = Cousins.anc_cnt_aux conf base lev at_to p in
+              let list1 = Cousins.anc_cnt_aux ~asc_cnt conf base lev at_to p in
               match list1 with
               | Some list1 ->
                   VVstring
@@ -2488,7 +2499,7 @@ and eval_anc_paths_cnt conf base env (p, _) path_mode at_to ?(l1_l2 = (0, 0))
                        sl)
               | None -> raise Not_found)
           | Paths -> (
-              let l = Cousins.anc_cnt_aux conf base lev at_to p in
+              let l = Cousins.anc_cnt_aux ~asc_cnt conf base lev at_to p in
               match l with
               | Some l -> (
                   match get_env "cousins" env with


### PR DESCRIPTION
Fix two regressions introduced in commits 4e92bd0 and 0457f29:

1. Lost implex values in ancmenu.txt (commit 4e92bd0): Hashtbl.replace deduplicated ancestors before return, causing anc_paths_cnt_raw and anc_paths_cnt to return identical values. The implex count (extra_paths = raw - cnt) became zero. Fix: Remove Hashtbl entirely, return raw list with duplicates. Deduplication is already handled by cousins_fold for Paths_cnt.

2. Performance regression 1.6s -> 30s+ (commit 0457f29): Removal of asc_cnt_t global ref caused init_asc_cnt to recompute the full ancestor tree on every call. ancmenu.txt iterates 20+ levels with 3 calls per level = 60+ recomputations per request. Fix: Add optional ?asc_cnt parameter and get_asc_cnt cache helper in perso.ml following existing get_cousins_sparse pattern.

Changes:
- anc_cnt_aux: remove Hashtbl, use List.rev_append for path aggregation
- anc_cnt_aux: add ?asc_cnt optional parameter for external caching
- perso.ml: add get_asc_cnt with per-person memoization
- cousins.mli: expose init_asc_cnt for cache initialization