### PR TITLE
add `MARIAGE=` backlink tag for family sources in wiki notes

### DIFF
--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -35,9 +35,11 @@ let notes_links s =
             if List.mem lfname list_nt then list_nt else lfname :: list_nt
           in
           loop list_nt list_ind pos j
-      | NotesLinks.WLperson (j, key, _name, text) ->
+      | NotesLinks.WLperson (j, key, _name, text, fam_marker) ->
           let list_ind =
-            let link = { NLDB.lnTxt = text; lnPos = pos } in
+            let link =
+              { NLDB.lnTxt = text; lnPos = pos; lnFamMarker = fam_marker }
+            in
             (key, link) :: list_ind
           in
           loop list_nt list_ind (pos + 1) j

--- a/hd/etc/modules/sources.txt
+++ b/hd/etc/modules/sources.txt
@@ -9,6 +9,7 @@
     <li>%apply;capitalize(linked_page.BIBLIO)</li>
   </ul>
 %end;
+
 %reset_count;
 %if;has_sources;%incr_count;%end;
 %foreach;event;
@@ -17,8 +18,21 @@
 %if;(count>0)
   <h2 class="mt-2">%if;(count=1)[*source/sources]0%else;[*source/sources]1%end;</h2>
   <ul class="pl-4 pY-0">
+  %let;marr;[marriage/marriages]0%in;
   %foreach;source;
-    <li>%apply;capitalize(source_type)[:] %source;.</li>
+    <li>%apply;capitalize(source_type)[:]
+      %if;(marr in source_type and has_linked_page_family.MARIAGE)
+        %linked_page_family.MARIAGE; ;%sp;
+      %end;%source;.
+    </li>
+  %end;
+  %if;(has_linked_page_family.MARIAGE)
+    %reset_count
+    %foreach;family;%incr_count;
+      %if;not has_marriage_source;
+        <li>[*marriage/marriages]0 %count;[:] %linked_page_family.MARIAGE;.</li>
+      %end;
+    %end;
   %end;
   %if;(op_m=2)
     %reset_count;

--- a/lib/db/driver.ml
+++ b/lib/db/driver.ml
@@ -278,7 +278,7 @@ let make bname particles arrays k =
 let bfname base fname = Filename.concat base.data.bdir fname
 
 module NLDB = struct
-  let magic = "GWNL0010"
+  let magic = "GWNL0011"
 
   let read base =
     let fname = bfname base "notes_links" in

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -461,7 +461,7 @@ module NLDB = struct
     | PgWizard of string
 
   type key = string * string * int
-  type ind = { lnTxt : string option; lnPos : int }
+  type ind = { lnTxt : string option; lnPos : int; lnFamMarker : int option }
   type ('a, 'b) t = (('a, 'b) page * (string list * (key * ind) list)) list
 
   let equal_key (fn1, sn1, oc1) (fn2, sn2, oc2) =

--- a/lib/notes.mli
+++ b/lib/notes.mli
@@ -125,3 +125,12 @@ val update_cache_linked_pages :
 
 val json_extract_img : Config.config -> string -> string * string
 val safe_gallery : Config.config -> Geneweb_db.Driver.base -> string -> string
+
+val get_linked_page_family :
+  Config.config ->
+  Geneweb_db.Driver.base ->
+  Geneweb_db.Driver.ifam ->
+  string ->
+  Adef.safe_string
+(** [get_linked_page_family conf base ifam tag] returns backlink HTML for family
+    [ifam] and header tag [tag] (e.g. "MARIAGE"). *)

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -26,7 +26,7 @@ let check_file_name s =
 
 type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
-  | WLperson of int * key * string option * string option
+  | WLperson of int * key * string option * string option * int option
   | WLwizard of int * string * string
   | WLnone of int * string
 
@@ -144,7 +144,19 @@ let misc_notes_link s i =
             in
             let fn = Name.lower fn in
             let sn = Name.lower sn in
-            WLperson (j, (fn, sn, oc), name, text)
+            let j, fam_marker =
+              if j < slen && s.[j] = '#' then
+                let rec parse_int acc k =
+                  if k < slen && s.[k] >= '0' && s.[k] <= '9' then
+                    parse_int
+                      ((acc * 10) + Char.code s.[k] - Char.code '0')
+                      (k + 1)
+                  else (k, if acc > 0 then Some acc else None)
+                in
+                parse_int 0 (j + 1)
+              else (j, None)
+            in
+            WLperson (j, (fn, sn, oc), name, text, fam_marker)
           with Not_found -> wlnone j
       else wlnone j
   else wlnone (i + 1)

--- a/lib/notesLinks.mli
+++ b/lib/notesLinks.mli
@@ -1,6 +1,6 @@
 type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
-  | WLperson of int * Def.NLDB.key * string option * string option
+  | WLperson of int * Def.NLDB.key * string option * string option * int option
   | WLwizard of int * string * string
   | WLnone of int * string
 

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3005,6 +3005,14 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) (loc : Loc.t) =
             VVbool r
         | _ -> raise Not_found
       else VVbool false
+  | [ "has_linked_page_family"; s ] -> (
+      match get_env "fam" env with
+      | Vfam (ifam, _, _, m_auth) ->
+          if m_auth then
+            let v = Notes.get_linked_page_family conf base ifam s in
+            VVbool ((v :> string) <> "")
+          else VVbool false
+      | _ -> VVbool false)
   (* TODO exclude TYPE gallery and album ?? *)
   (* TODO fold link_to_ind and Notes.link_to_ind !! *)
   | [ "has_linked_pages" ] ->
@@ -3081,6 +3089,11 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) (loc : Loc.t) =
           List.fold_left (linked_page_text conf base p s key) (Adef.safe "") db
           |> safe_val
       | _ -> raise Not_found)
+  | [ "linked_page_family"; s ] -> (
+      match get_env "fam" env with
+      | Vfam (ifam, _, _, _) ->
+          VVstring (Notes.get_linked_page_family conf base ifam s :> string)
+      | _ -> VVstring "")
   | "marriage_date" :: sl -> (
       match get_env "fam" env with
       | Vfam (_, fam, _, true) -> (

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2820,10 +2820,10 @@ let rec in_text case_sens s m =
     else if m.[i] = '[' && i + 1 < String.length m && m.[i + 1] = '[' then
       match NotesLinks.misc_notes_link m i with
       | NotesLinks.WLpage (j, _, _, _, text)
-      | NotesLinks.WLperson (j, _, Some text, _)
+      | NotesLinks.WLperson (j, _, Some text, _, _)
       | NotesLinks.WLwizard (j, _, text) ->
           if in_text case_sens s text then true else loop false j
-      | NotesLinks.WLperson (j, (fn, sn, _), None, _) ->
+      | NotesLinks.WLperson (j, (fn, sn, _), None, _, _) ->
           if in_text case_sens s (fn ^ " " ^ sn) then true else loop false j
       | NotesLinks.WLnone (j, _) -> loop false j
     else

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -323,7 +323,7 @@ let syntax_links conf wi s =
           in
           Buffer.add_string buff t;
           loop quot_lev pos j
-      | NotesLinks.WLperson (j, (fn, sn, oc), name, _) ->
+      | NotesLinks.WLperson (j, (fn, sn, oc), name, _, _) ->
           let name =
             if wi.wi_person_exists (fn, sn, oc) || conf.friend || conf.wizard
             then Option.value ~default:"??" name
@@ -459,7 +459,7 @@ let remove_links s =
       let len, i =
         match NotesLinks.misc_notes_link s i with
         | NotesLinks.WLpage (j, _, _, _, text) -> (Buff.mstore len text, j)
-        | NotesLinks.WLperson (j, (fn, sn, _), name, text) ->
+        | NotesLinks.WLperson (j, (fn, sn, _), name, text, _) ->
             let text =
               match text with
               | None | Some "" -> Option.value ~default:(fn ^ " " ^ sn) name

--- a/test/search_test.ml
+++ b/test/search_test.ml
@@ -1,9 +1,6 @@
 module A = Alcotest
 module Compat = Geneweb_compat
-module Index = Geneweb_search.Index.Default
 module Trie = Geneweb_search.Trie.Default
-module Word = Geneweb_search.Word.Default
-module Analyze = Geneweb_search.Analyze
 module Iterator = Geneweb_search.Iterator
 module Seq = Geneweb_compat.Seq
 
@@ -210,9 +207,9 @@ module Flatset_tests = struct
     let b = Seq.equal Int.equal seq1 seq2 in
     if not b then
       Fmt.pr "it1 = %a@. it2 = %a@."
-        Fmt.(seq ~sep:comma int)
+        (Fmt.seq ~sep:Fmt.comma Fmt.int)
         seq1
-        Fmt.(seq ~sep:comma int)
+        (Fmt.seq ~sep:Fmt.comma Fmt.int)
         seq2;
     b
 
@@ -232,7 +229,7 @@ module Flatset_tests = struct
 
   let test_random_iterator_union =
     QCheck.Test.make ~count:1000 ~name:"random iterator union"
-      QCheck.(make Gen.(list_size (int_range 1 100) nonempty_array))
+      QCheck.(make (Gen.list_size (Gen.int_range 1 100) nonempty_array))
     @@ fun l ->
     let it1 =
       let l1 = List.map (fun a -> Array.to_seq a |> Naive.of_seq) l in
@@ -260,7 +257,7 @@ module Flatset_tests = struct
 
   let test_random_iterator_join =
     QCheck.Test.make ~count:1000 ~name:"random iterator join"
-      QCheck.(make Gen.(list_size (int_range 1 3) nonempty_array))
+      QCheck.(make (Gen.list_size (Gen.int_range 1 3) nonempty_array))
     @@ fun l ->
     let it1 =
       let l1 = List.map (fun a -> Array.to_seq a |> Naive.of_seq) l in

--- a/test/wiki_test.ml
+++ b/test/wiki_test.ml
@@ -1,6 +1,4 @@
-open Alcotest
-open Geneweb
-open NotesLinks
+open Geneweb.NotesLinks
 
 let f s =
   let len = String.length s in
@@ -8,8 +6,8 @@ let f s =
     if i = len then List.rev acc
     else
       match misc_notes_link s i with
-      | (WLpage (j, _, _, _, _) | WLperson (j, _, _, _) | WLwizard (j, _, _)) as
-        x ->
+      | (WLpage (j, _, _, _, _) | WLperson (j, _, _, _, _) | WLwizard (j, _, _))
+        as x ->
           loop (x :: acc) j
       | WLnone (j, _text) as wn -> loop (wn :: acc) j
   in
@@ -19,19 +17,26 @@ let expect_failure name speed f =
   Alcotest.test_case name speed (fun () ->
       try
         f ();
-        Alcotest.fail "Expected this test to fail, but it passed"
+        Alcotest.fail "Expected failure"
       with _ -> ())
 
 let l =
   [
     ([ WLpage (13, ([], "aaa"), "aaa", "", "bbb") ], "[[[aaa/bbb]]]");
-    ([ WLperson (11, ("ccc", "ddd", 0), Some "ccc ddd", None) ], "[[ccc/ddd]]");
-    ( [ WLperson (17, ("ccc", "ddd", 0), Some "Texte", None) ],
+    ( [ WLperson (11, ("ccc", "ddd", 0), Some "ccc ddd", None, None) ],
+      "[[ccc/ddd]]" );
+    ( [ WLperson (17, ("ccc", "ddd", 0), Some "Texte", None, None) ],
       "[[ccc/ddd/Texte]]" );
-    ( [ WLperson (21, ("ccc", "ddd", 1), Some "Ccc Ddd", None) ],
+    ( [ WLperson (21, ("ccc", "ddd", 1), Some "Ccc Ddd", None, None) ],
       "[[ccc/ddd/1/Ccc Ddd]]" );
-    ( [ WLperson (25, ("ccc", "ddd", 0), Some "Texte", Some "Texte 2") ],
+    ( [ WLperson (25, ("ccc", "ddd", 0), Some "Texte", Some "Texte 2", None) ],
       "[[ccc/ddd/Texte;Texte 2]]" );
+    ( [ WLperson (13, ("ccc", "ddd", 0), Some "ccc ddd", None, Some 1) ],
+      "[[ccc/ddd]]#1" );
+    ( [ WLperson (14, ("ccc", "ddd", 0), Some "ccc ddd", None, Some 42) ],
+      "[[ccc/ddd]]#42" );
+    ( [ WLperson (17, ("ccc", "ddd", 0), Some "ccc ddd", Some "txt", Some 5) ],
+      "[[ccc/ddd;txt]]#5" );
     ([ WLnone (6, "[[[]]]") ], "[[[]]]");
     ([ WLnone (4, "[[]]") ], "[[]]");
     ([ WLnone (3, "[[w") ], "[[w");
@@ -39,9 +44,9 @@ let l =
       "[[[d_azincourt/d&#039;Azincourt]]]" );
     ( [
         WLnone (1, "[");
-        WLperson (12, ("aaa", "bbb", 0), Some "aaa bbb", None);
+        WLperson (12, ("aaa", "bbb", 0), Some "aaa bbb", None, None);
         WLnone (14, ", ");
-        WLperson (33, ("ccc", "ddd", 0), Some "Ccc Ddd", None);
+        WLperson (33, ("ccc", "ddd", 0), Some "Ccc Ddd", None, None);
         WLnone (58, ", http://site.com/eee#fff");
       ],
       "[[[aaa/bbb]], [[ccc/ddd/Ccc Ddd]], http://site.com/eee#fff" );
@@ -55,40 +60,33 @@ let l =
 
 let pp_token ppf tk =
   match tk with
-  | WLpage (pos, p, fname, anchor, text) ->
-      Fmt.pf ppf "WLpage (%d, %a, %s, %s, %s)" pos
-        Fmt.(
-          parens @@ pair ~sep:comma (brackets @@ list ~sep:semi string) string)
-        p fname anchor text
-  | WLperson (pos, (fn, sn, oc), name, text) ->
-      Fmt.pf ppf "WLperson (%d, (%s, %s, %d), %a, %a)" pos fn sn oc
-        Fmt.(option string)
+  | WLpage (pos, (p, fname), full, anchor, text) ->
+      Fmt.pf ppf "WLpage (%d, ([%s], %s), %s, %s, %s)" pos
+        (String.concat "; " p) fname full anchor text
+  | WLperson (pos, (fn, sn, oc), name, text, fam_marker) ->
+      Fmt.pf ppf "WLperson (%d, (%s, %s, %d), %a, %a, %a)" pos fn sn oc
+        Fmt.(option ~none:(any "None") string)
         name
-        Fmt.(option string)
+        Fmt.(option ~none:(any "None") string)
         text
+        Fmt.(option ~none:(any "None") int)
+        fam_marker
   | WLwizard (pos, wiz, name) -> Fmt.pf ppf "WLwizard (%d, %s, %s)" pos wiz name
   | WLnone (pos, s) -> Fmt.pf ppf "WLnone (%d, %s)" pos s
 
-let testable_wiki = testable pp_token ( = )
+let eq_token = ( = )
+let token_t = Alcotest.testable pp_token eq_token
 
-let test expected s () =
-  (check (list testable_wiki)) "" expected (f s);
-  ()
+let tests s (expected, input) () =
+  Alcotest.(check (list token_t)) s expected (f input)
 
-let bold_italic_syntax _ =
-  let test a r = (check string) a r (Wiki.bold_italic_syntax a) in
-  test "" "";
-  test "abc ''def'' ghi" "abc <i>def</i> ghi";
-  test "abc '''def''' ghi" "abc <b>def</b> ghi";
-  test "abc '''''def''''' ghi" "abc <b><i>def</i></b> ghi"
+let test_cases =
+  List.mapi
+    (fun i (exp, inp) ->
+      Alcotest.test_case
+        (Printf.sprintf "case %d: %s" i inp)
+        `Quick
+        (tests inp (exp, inp)))
+    l
 
-let v =
-  [
-    ( "misc-notes-link",
-      (* todo List.map here or in test? *)
-      List.map
-        (fun (expected, s) -> test_case "Wiki links" `Quick (test expected s))
-        l );
-    ( "bold-italic-syntax",
-      [ test_case "Wiki.bold_italic_syntax" `Quick bold_italic_syntax ] );
-  ]
+let v = [ ("wiki", test_cases) ]


### PR DESCRIPTION
Extend the existing individual backlink system (OCCU, HEAD, BIBLIO, BNOTE, DEATH) to support marriage/family sources through a new MARIAGE= header tag in wiki notes.

Syntax: [[person/name;annotation]]#N

The #N suffix groups persons belonging to the same family/marriage. When both spouses of a family are tagged with the same #N marker, the MARIAGE= value is displayed in their family sources section.

Optional annotations after “;” are collected and displayed as suffix:
- Both annotated: “TAG (him/her)”
- One annotated: “TAG (annotation)”
- None: “TAG”

Unlike individual tags where * in annotation is replaced by tag value, family annotations are always displayed literally as supplementary info.

Implementation:
- Def.NLDB.ind: add `lnFamMarker` field (int option)
- NotesLinks: parse “#N” suffix after “]]” in wiki links
- Notes: new `linked_page_text_family` and `get_linked_page_family`
- Perso: template variables `linked_page_family.X`, `has_linked_page_family.X`
- Driver: bump NLDB magic number to `GWNL0011` (requires update_nldb rebuild)

Template usage:
  %if;(has_linked_page_family.MARIAGE)%linked_page_family.MARIAGE;%end;

Example note:
```
  TITLE=…
  MARIAGE=AD75 TD Paris 4e M 1923-1932

  [[Jean/Dupont;him]]#1 [[Louise/Martin;her]#1

  [[pierre/durand/3/Durand]]#2 &01/12/1932 [[marie/bernard/0/Berdard]]#2
```
Displays “AD75 TD Paris 4e M 1923-1932 (him/her)” for the source of mariage of Jean and Louise.