### PR TITLE
Fix individual and family deletions

### DIFF
--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -1016,7 +1016,7 @@ let effective_chg_order base ip u ifam n =
 
 let effective_del conf base ip fam =
   let ifam = Driver.get_ifam fam in
-  Driver.delete_family base ifam;
+  Driver.delete_family_rec base ifam;
   let changed =
     let gen_p =
       let p =

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -945,7 +945,7 @@ let effective_del_no_commit base op =
   Update.update_related_pointers base op.key_index
     (rparents_of op.rparents @ pwitnesses_of op.pevents)
     [];
-  Driver.delete_person base op.key_index
+  Driver.delete_person_rec base op.key_index
 
 let effective_del_commit conf base op =
   Notes.update_notes_links_db base (Def.NLDB.PgInd op.key_index) "";


### PR DESCRIPTION
The PR #2241 merged the legacy and the current GeneWeb Database library. There exists two versions of `delete_person` and `delete_family`. A low level version `Driver.delete_person` and `Driver.delete_family` delete the record without updating related persons and a recursive version `Driver.delete_person_rec` and `Driver.delete_family_rec` that recursively delete data.

Before #2241, `delete_person_rec` and `delete_family_rec` shadowed `delete_person` and `delete_family`. It is not the case anymore but I didn't update correctly `updateFamOk` and `updateIndOk`.

This PR must restore the previous behavior.