### PR TITLE
Do not link dune-site with GeneWeb library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ uninstall: ## Uninstall geneweb using dune
 	dune build @install
 	dune uninstall
 
-distrib: info build-geneweb ## Build the project and copy what is necessary for distribution
+distrib: info ## Build the project and copy what is necessary for distribution
+	dune build --release @bin/all @lib/all
 	@printf "Done.\n"
 	@rm -rf $(DISTRIB_DIR)
 	@printf "\n\033[1;1mCreating distribution directory\033[0m\n"

--- a/bin/gwd/dune
+++ b/bin/gwd/dune
@@ -8,12 +8,16 @@
    %{target}
    (run ocaml %{maker} %{project_root}/plugins))))
 
+(generate_sites_module
+ (module geneweb_sites)
+ (sites geneweb))
+
 (library
  (name gwd_lib)
  (public_name geneweb.gwd_lib)
  (wrapped true)
- (libraries geneweb wserver)
- (modules gwdPlugin request))
+ (libraries geneweb wserver dune-site)
+ (modules gwdPlugin request geneweb_sites))
 
 (executable
  (package geneweb)

--- a/lib/dune
+++ b/lib/dune
@@ -24,7 +24,6 @@
   geneweb_util
   geneweb_templ
   geneweb_logs
-  geneweb_sites
   yojson
   markup
   re

--- a/lib/sites/dune
+++ b/lib/sites/dune
@@ -1,9 +1,0 @@
-(generate_sites_module
- (module geneweb_sites)
- (sites geneweb))
-
-(library
- (package geneweb)
- (name geneweb_sites)
- (modules geneweb_sites)
- (libraries dune-site))


### PR DESCRIPTION
As A2 noticed it in #2472, using `dune-site` to distrib static files increased binary sizes. `dune` introduces the `-linkall` flag of `ocamlc` when it compiles a binary that depends on `dune-site`. There is a mention of this fact in the documentation and the motivation of this behavior in the following issue:
https://github.com/ocaml/dune/issues/12749

We should get rid of `dune-site`... I thought that it was a good feature of `dune` but it seems that `dune-site` is no longer maintained and the feature was dedicated to plugin installation. We should write our own implementation of `dune-site`.

This PR is a pis aller. It ensures that `gwd` is the only binary that depends on `dune-site`, so `gwd` is still huge (about 25 Mio on my computer).

I also modified `distrib` target of the Makefile. `make build-geneweb` builds GeneWeb for developers but we want to turn optimizations on for users.