### PR TITLE
fix missing \n in notes.

### DIFF
--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1446,7 +1446,7 @@ let get_note_or_source conf base
         | _ -> lines
       else lines
     in
-    Notes.source_note_with_env conf base env (String.concat " " lines)
+    Notes.source_note_with_env conf base env (String.concat "\n" lines)
     |> safe_val
   else null_val
 


### PR DESCRIPTION
within a <pre> html block, this was destroying the line breaks