### PR TITLE
Add server-to-client notification system

### DIFF
--- a/bin/gwd/request.mli
+++ b/bin/gwd/request.mli
@@ -50,7 +50,6 @@ val treat_request : Config.config -> unit
 (**/**)
 
 (* Used by v7 plugin *)
-val incorrect_request : ?comment:string -> Config.config -> unit
 val only_special_env : (string * _) list -> bool
 
 (**/**)

--- a/hd/etc/css/css.css
+++ b/hd/etc/css/css.css
@@ -1,3 +1,22 @@
+/* Notifications */
+.notif-ctr {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1080;
+  max-width: 330px;
+}
+
+code {
+  font-size: 1rem;
+}
+
+.toast-body {
+  background-color: white;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
 /* Élargissement raisonnable du container pour les hautes résolutions */
 @media (min-width: 1600px) {
   body .container {

--- a/hd/etc/index.txt
+++ b/hd/etc/index.txt
@@ -75,5 +75,8 @@
   </div>
 </div>
 </div>
+%if;(e.notif!="")<script>
+%include;js_notif
+</script>%end;
 </body>
 </html>

--- a/hd/etc/js.txt
+++ b/hd/etc/js.txt
@@ -1,4 +1,4 @@
-<!-- $Id: js.txt v7.1 10/01/2025 04:15:45 $ -->
+<!-- $Id: js.txt v7.1 17/01/2026 10:39:33 $ -->
 %if;(evar.templ="")
   %if;(bvar.use_cdn="yes")
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"
@@ -743,7 +743,9 @@ function safeInitialize(fn) {
     console.error('Initialization error:', error);
   }
 }
-
+%if;(e.notif!="")
+%include;js_notif
+%end;
 %( Initialize on DOM Content Loaded %)
 document.addEventListener('DOMContentLoaded', () => {
 %if;is_welcome;

--- a/hd/etc/js_notif.txt
+++ b/hd/etc/js_notif.txt
@@ -1,0 +1,33 @@
+<!-- Notification inline script for index/js.txt -->
+var notifLabels={
+  danger:'[*NOTIF error/warning/success/info]0',
+  warning:'[*NOTIF error/warning/success/info]1',
+  success:'[*NOTIF error/warning/success/info]2',
+  info:'[*NOTIF error/warning/success/info]3'
+};
+var notifIcons={
+  danger:'fa-circle-xmark',
+  warning:'fa-triangle-exclamation',
+  success:'fa-circle-check',
+  info:'fa-circle-info'
+};
+(function(){
+  var txt=document.createElement('textarea');
+  txt.innerHTML='%e.notif;';
+  try{var items=JSON.parse(txt.value);}catch(e){return;}
+  if(!items||!items.length)return;
+  var c=document.createElement('div');
+  c.className='notif-ctr';
+  document.body.appendChild(c);
+  items.forEach(function(x){
+    var ti=x.title||notifLabels[x.level],
+        ic=notifIcons[x.level]||'fa-circle-info',
+        h='<div class="toast show border-'+x.level+'" role="alert">'+
+          '<div class="toast-header bg-'+x.level+' text-white">'+
+          '<i class="fa '+ic+' mr-2"></i><strong class="mr-auto">'+ti+'</strong>'+
+          '<button type="button" class="close text-white ml-2 mb-1" onclick="this.closest(\'.toast\').remove()">'+
+          '<span>&times;</span></button></div>'+
+          '<div class="toast-body">'+x.message+'</div></div>';
+    c.insertAdjacentHTML('beforeend',h);
+  });
+})();

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -14273,14 +14273,97 @@ en: Database <b>%s</b> does not exist.
 fr: La base de données <b>%s</b> n’existe pas.
 
     NOTIF_TT incorrect request
-de: Ungültige Anfrage
-en: Incorrect request
-fr: Requête incorrecte
+->: incorrect request
 
     NOTIF incorrect request %s
-de: <b>%s</b> ist hier nicht verfügbar.
-en: <b>%s</b> is not available here.
-fr: <b>%s</b> n'est pas disponible ici.
+de: <b>m=%s</b> existiert nicht.
+en: <b>m=%s</b> does not exist.
+fr: <b>m=%s</b> n'existe pas.
+
+    NOTIF incorrect em value
+de: Ungültiger <b>em=</b> Wert.
+en: Invalid <b>em=</b> value.
+fr: Valeur <b>em=</b> incorrecte.
+
+    NOTIF_TT incorrect em value
+de: Ungültiger Parameter
+en: Invalid parameter
+fr: Paramètre invalide
+
+    NOTIF incorrect em value
+de: Ungültiger <b>em=</b> Wert.
+en: Invalid <b>em=</b> value.
+fr: Valeur <b>em=</b> incorrecte.
+
+    NOTIF_TT incorrect person env
+de: Konfigurationsfehler
+en: Configuration error
+fr: Erreur de configuration
+
+    NOTIF incorrect person env
+de: Ungültige Person-Konfiguration (em=, ei=, ep=, en=, eoc=).
+en: Invalid person configuration (em=, ei=, ep=, en=, eoc=).
+fr: Configuration de personne incorrecte (em=, ei=, ep=, en=, eoc=).
+
+    NOTIF_TT wizards cant write
+de: Zugriff verweigert
+en: Access denied
+fr: Accès refusé
+
+    NOTIF wizards cant write
+de: Schreibaktionen sind für diese Datenbank nicht erlaubt.
+en: Write actions are not allowed on this database.
+fr: Les actions d'écriture ne sont pas autorisées sur cette base.
+
+    NOTIF_TT missing doc param
+de: Fehlender Parameter
+en: Missing parameter
+fr: Paramètre manquant
+
+    NOTIF missing doc param
+de: Fehlender <b>s=</b> Parameter für m=DOC.
+en: Missing <b>s=</b> parameter for m=DOC.
+fr: Paramètre <b>s=</b> manquant pour m=DOC.
+
+    NOTIF_TT missing p and n for relation
+de: Fehlender Parameters
+en: Missing parameters
+fr: Paramètres manquant
+
+    NOTIF missing p and n for relation
+de: Fehlende Parameter <b>p=</b> und <b>n=</b> für m=R.
+en: Missing <b>p=</b> and <b>n=</b> parameters for m=R.
+fr: Paramètres <b>p=</b> et <b>n=</b> manquants pour m=R.
+
+    NOTIF_TT missing v param
+de: Fehlender Parameter
+en: Missing parameter
+fr: Paramètre manquant
+
+    NOTIF missing v param
+de: Fehlender <b>v=</b> Parameter für m=H/SRC/TP.
+en: Missing <b>v=</b> parameter for m=H/SRC/TP.
+fr: Paramètre <b>v=</b> manquant pour m=H/SRC/TP.
+
+    NOTIF_TT incorrect fallback for relation
+de: Beziehungsfehler
+en: Relation error
+fr: Erreur de relation
+
+    NOTIF incorrect fallback for relation
+de: Personen für Beziehungsberechnung nicht gefunden.
+en: Persons for relation computation not found.
+fr: Personnes pour le calcul de relation introuvables.
+
+    NOTIF_TT missing fn and sn for search
+de: Fehlender Parameters
+en: Missing parameters
+fr: Paramètres manquant
+
+    NOTIF missing fn and sn for search
+de: Fehlende Parameter <b>fn=</b> und <b>sn=</b> für die Suche.
+en: Missing <b>fn=</b> and <b>sn=</b> parameters for search.
+fr: Paramètres <b>fn=</b> et <b>sn=</b> manquants pour la recherche.
 
     NOTIF_TT incompatible notes_links
 de: Inkompatibles verknüpfte Notizen Format

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -14257,6 +14257,41 @@ de: Notiz ohne Titel
 en: note without title
 fr: note sans titre
 
+    NOTIF error/warning/success/info
+de: Fehler/Warnung/Erfolg/Information
+en: error/warning/success/information
+fr: erreur/attention/succès/information
+
+    NOTIF_TT unknown base
+de: Datenbank nicht gefunden!
+en: Database not found!
+fr: Base introuvable !
+
+    NOTIF unknown base %s
+de: Die Datenbank <b>%s</b> existiert nicht.
+en: Database <b>%s</b> does not exist.
+fr: La base de données <b>%s</b> n’existe pas.
+
+    NOTIF_TT incorrect request
+de: Ungültige Anfrage
+en: Incorrect request
+fr: Requête incorrecte
+
+    NOTIF incorrect request %s
+de: <b>%s</b> ist hier nicht verfügbar.
+en: <b>%s</b> is not available here.
+fr: <b>%s</b> n'est pas disponible ici.
+
+    NOTIF_TT incompatible notes_links
+de: Inkompatibles verknüpfte Notizen Format
+en: Incompatible linked notes format
+fr: Format des notes liées incompatible
+
+    NOTIF incompatible notes_links
+de: Führen Sie das Tool <code><b>update_nldb</b></code> aus<br>oder <b>löschen</b> Sie die Datei <b>notes_links</b>.
+en: Run <code><b>update_nldb</b></code> tool or <b>delete notes_links</b> file.
+fr: Relancez l’outil <code><b>update_nldb</b></code><br> ou <b>supprimez</b> le fichier <b>notes_links</b>.
+
     nth
 af: n-de/1ste/2de/3de/4de/5de/6de/7de/8ste/9de/10de/11de/12de/13de/14de/15de/16de/17de/18de/19de/20ste/21ste/22ste/23ste/24ste/25ste/26ste/27ste/28ste/29ste/30de/31ste/32ste/33ste/34ste/35ste/36ste/37ste/38ste/39ste/40ste/41ste/42ste/43ste/44ste/45ste/46ste/47ste/48ste/49ste/50ste/51ste/52ste/53ste/54ste/55ste/56ste/57ste/58ste/59ste/60ste/61ste/62ste/63ste/64ste/65ste/66ste/67ste/68ste/69ste/70ste/71ste/72ste/73ste/74ste/75ste/76ste/77ste/78ste/79ste/80ste/81ste/82ste/83ste/84ste/85ste/86ste/87ste/88ste/89ste/90ste/91ste/92ste/93ste/94ste/95ste/96ste/97ste/98ste/99ste
 bg: n-ти/първи/втори/трети/четвърти/пети/шести/седми/осми/девети/десети/единадесети/дванадесети/тринадесети/четиринадесети/петнадесети/шестнадесети/седемнадесети/осемнадесети/деветнадесети/двадесети/21-и/22-и/23-и/24-и/25-и/26-и/27-и/28-и/29-и/30-и/31-и/32-и/33-и/34-и/35-и/36-и/37-и/38-и/39-и/40-и/41-и/42-и/43-и/44-и/45-и/46-и/47-и/48-и/49-и/50-и/51-и/52-и/53-и/54-и/55-и/56-и/57-и/58-и/59-и/60-и/61-и/62-и/63-и/64-и/65-и/66-и/67-и/68-и/69-и/70-и/71-и/72-и/73-и/74-и/75-и/76-и/77-и/78-и/79-и/80-и/81-и/82-и/83-и/84-и/85-и/86-и/87-и/88-и/89-и/90-и/91-и/92-и/93-и/94-и/95-и/96-и/97-и/98-и/99-и

--- a/lib/db/driver.mli
+++ b/lib/db/driver.mli
@@ -655,6 +655,9 @@ val ifam_marker : ifam Collection.t -> 'a -> (ifam, 'a) Collection.Marker.t
 (** [ifam_marker c v] create marker over collection of family's ids and
     initialise it for every element with [v] *)
 
+val check_nldb_format : base -> [ `Ok | `BadFormat | `NoFile ]
+(** Check notes_links file format without reading content. *)
+
 val read_nldb : base -> (iper, ifam) Def.NLDB.t
 (** TODOOCP : doc *)
 

--- a/lib/notif.ml
+++ b/lib/notif.ml
@@ -1,0 +1,56 @@
+type level = Info | Success | Warning | Err
+type mode = Auto | Dismissible
+type t = { level : level; title : string; message : string; mode : mode }
+
+let queue : t list ref = ref []
+let clear () = queue := []
+
+let add ?(mode = Auto) ?(title = "") level message =
+  let mode = match level with Err -> Dismissible | _ -> mode in
+  queue := { level; title; message; mode } :: !queue
+
+let info ?(mode = Auto) ?(title = "") msg = add ~mode ~title Info msg
+let success ?(mode = Auto) ?(title = "") msg = add ~mode ~title Success msg
+let warning ?(mode = Auto) ?(title = "") msg = add ~mode ~title Warning msg
+let error ?(title = "") msg = add ~title Err msg
+let has_pending () = !queue <> []
+
+let level_to_class = function
+  | Info -> "info"
+  | Success -> "success"
+  | Warning -> "warning"
+  | Err -> "danger"
+
+let mode_to_autohide = function Auto -> true | Dismissible -> false
+
+let inject_pending conf =
+  if not (has_pending ()) then conf
+  else
+    let existing =
+      match List.assoc_opt "notif" conf.Config.env with
+      | Some v -> (
+          try
+            match Yojson.Basic.from_string (v :> string) with
+            | `List l -> l
+            | _ -> []
+          with _ -> [])
+      | None -> []
+    in
+    let new_items =
+      List.map
+        (fun n ->
+          `Assoc
+            [
+              ("level", `String (level_to_class n.level));
+              ("title", `String n.title);
+              ("message", `String n.message);
+              ("autohide", `Bool (mode_to_autohide n.mode));
+            ])
+        (List.rev !queue)
+    in
+    clear ();
+    let json = Yojson.Basic.to_string (`List (existing @ new_items)) in
+    {
+      conf with
+      env = ("notif", Adef.encoded json) :: List.remove_assoc "notif" conf.env;
+    }

--- a/lib/notif.mli
+++ b/lib/notif.mli
@@ -1,0 +1,35 @@
+(** Server-to-client notification system using Bootstrap toasts. *)
+
+type level =
+  | Info
+  | Success
+  | Warning
+  | Err  (** Notification severity level. Affects toast styling. *)
+
+type mode =
+  | Auto
+  | Dismissible
+      (** Auto: toast disappears after 6s. Dismissible: requires user click. *)
+
+val clear : unit -> unit
+(** Clear all pending notifications. *)
+
+val info : ?mode:mode -> ?title:string -> string -> unit
+(** Queue info notification (blue). Default mode: Auto. *)
+
+val success : ?mode:mode -> ?title:string -> string -> unit
+(** Queue success notification (green). Default mode: Auto. *)
+
+val warning : ?mode:mode -> ?title:string -> string -> unit
+(** Queue warning notification (yellow). Default mode: Auto. *)
+
+val error : ?title:string -> string -> unit
+(** Queue error notification (red). Always Dismissible. If title is empty,
+    default label from lexicon is used. *)
+
+val has_pending : unit -> bool
+(** Check if notifications are pending. *)
+
+val inject_pending : Config.config -> Config.config
+(** Inject pending notifications into conf.env as notif. Merges with any
+    existing notifications. Clears queue. Returns conf unchanged if empty. *)

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -927,7 +927,7 @@ and print_foreach_env_binding (conf : Config.config) print_ast set_vother env ep
       match env_vars with
       | [] -> acc
       | (k, v) :: env_vars ->
-          if List.mem_assoc k acc then loop acc env_vars
+          if k = "notif" || List.mem_assoc k acc then loop acc env_vars
           else loop ((k, v) :: acc) env_vars
     in
     loop [] (conf.env @ conf.henv @ conf.senv)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -3625,7 +3625,8 @@ let url_set_aux conf url evar_l str_l =
   let url_env =
     List.fold_left
       (fun acc (k, v) ->
-        if List.mem k evar_l then acc else (k, Adef.as_string v) :: acc)
+        if List.mem k evar_l || k = "notif" then acc
+        else (k, Adef.as_string v) :: acc)
       url_env conf_map
     |> List.rev
   in


### PR DESCRIPTION
* add server-to-client notification system via Bootstrap toasts

Implement notification infrastructure for displaying server messages
(errors, warnings, info, success) to users.

Architecture:
- lib/notif.ml: Queue-based notification system with level/mode/title
- Notif.inject_pending injects JSON into conf.env for template access
- etc/js_notif.txt: Inline script included in js.txt and index.txt
- etc/css.css: Fixed positioning for toast container (.notif-ctr)

Features:
- Four severity levels: Info, Success, Warning, Error
- Two modes: Auto (6 s timeout) or Dismissible (errors always dismissible)
- Separate title/message translations (NOTIF_TT/NOTIF prefixes in lexicon)

Use cases implemented:
- Incompatible notes_links format: graceful degradation instead of crash
- Unknown database: redirect to index with error notification
- Invalid m= endpoint: redirect to welcome with error notification

Technical changes:
- Driver.NLDB.read returns [] on bad format instead of raising exception
- Driver.check_nldb_format added for early format detection in w_base
- notif key excluded from `url_set_aux` and `env_binding` to avoid URL pollution


<img width="467" height="170" alt="image" src="https://github.com/user-attachments/assets/c67beb05-7afc-465f-8313-3c982c98f64f" />

