### PR TITLE
test/run_gw_test.sh typo error in PR #2463

### DIFF
--- a/test/run_gw_test.sh
+++ b/test/run_gw_test.sh
@@ -218,7 +218,7 @@ crl () {
         echo "'text in pre tags not properly formatted, issue 2221, ${urlprfix}w=$PWD&$cmd"
         RC=$(($RC+1))
       elif test "$cmd" = 'p=marie&n=dupond&oc=0' && \
-           ! grep $GREPOPT "Galichet.*un.commentaire.entre.crochets" /tmp/tmp.txt; then
+           grep $GREPOPT "Galichet.*un.commentaire.entre.crochets" /tmp/tmp.txt; then
         echo "'Failure parsing notes with brackets, issue 2218, ${urlprfix}w=$PWD&$cmd"
         RC=$(($RC+1))
       fi


### PR DESCRIPTION
test/run_gw_test.sh typo error in PR #2463
The typo error was in cid
c5e18d18f "test/run_gw_test.sh Add test comment in brackets"