### PR TITLE
add Epers_Adoption as primary personal event

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -1334,6 +1334,7 @@ let find_pevent_name_from_tag gen tag tagv =
   | "CREM" -> Epers_Cremation
   | "accomplishment" -> Epers_Accomplishment
   | "acquisition" -> Epers_Acquisition
+  | "ADOP" -> Epers_Adoption
   | "award" | "distinction" -> Epers_Distinction
   | "BAPL" | "lds baptism" -> Epers_BaptismLDS
   | "BARM" -> Epers_BarMitzvah
@@ -1380,10 +1381,10 @@ let find_pevent_name_from_tag gen tag tagv =
   | _ -> Epers_Name (add_string gen (strip_spaces tagv))
 
 let primary_pevents =
-  ["BAPM"; "CHR"; "BAPL"; "BARM"; "BASM"; "BIRT"; "BLES"; "BURI"; "CENS";
-   "CONF"; "CONL"; "CREM"; "DEAT"; "DECO"; "EDUC"; "EMIG"; "ENDL"; "FCOM";
-   "GRAD"; "IMMI"; "NATU"; "OCCU"; "ORDN"; "PROP"; "RETI"; "RESI"; "SLGS";
-   "SLGC"; "WILL"]
+  ["BAPM"; "CHR"; "ADOP"; "BAPL"; "BARM"; "BASM"; "BIRT"; "BLES"; "BURI";
+   "CENS"; "CONF"; "CONL"; "CREM"; "DEAT"; "DECO"; "EDUC"; "EMIG"; "ENDL";
+   "FCOM"; "GRAD"; "IMMI"; "NATU"; "OCCU"; "ORDN"; "PROP"; "RETI"; "RESI";
+   "SLGS"; "SLGC"; "WILL"]
 
 let treat_indi_pevent gen ip r =
   let prim_events =

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -363,6 +363,7 @@ let ged_tag_pevent base evt =
   | Epers_Accomplishment -> "Accomplishment"
   | Epers_Acquisition -> "Acquisition"
   | Epers_Adhesion -> "Membership"
+  | Epers_Adoption -> "ADOP"
   | Epers_BaptismLDS -> "BAPL"
   | Epers_BarMitzvah -> "BARM"
   | Epers_BatMitzvah -> "BASM"
@@ -409,10 +410,10 @@ let ged_tag_pevent base evt =
 
 let is_primary_pevents = function
   | Epers_Birth | Epers_Baptism | Epers_Death | Epers_Burial | Epers_Cremation
-  | Epers_BaptismLDS | Epers_BarMitzvah | Epers_BatMitzvah | Epers_Benediction
-  | Epers_Confirmation | Epers_ConfirmationLDS | Epers_Dotation
-  | Epers_Education | Epers_Emigration | Epers_FirstCommunion | Epers_Graduate
-  | Epers_Immigration | Epers_Naturalisation | Epers_Occupation
+  | Epers_Adoption | Epers_BaptismLDS | Epers_BarMitzvah | Epers_BatMitzvah
+  | Epers_Benediction | Epers_Confirmation | Epers_ConfirmationLDS
+  | Epers_Dotation | Epers_Education | Epers_Emigration | Epers_FirstCommunion
+  | Epers_Graduate | Epers_Immigration | Epers_Naturalisation | Epers_Occupation
   | Epers_Ordination | Epers_Property | Epers_Recensement | Epers_Residence
   | Epers_Retired | Epers_ScellentChildLDS | Epers_ScellentSpouseLDS
   | Epers_Will ->

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -1000,7 +1000,7 @@ let insert_family gen co fath_sex moth_sex witl fevtl fo deo =
     If event is [Epers_Name] stores event name as a string in the base. *)
 let pevent_name_unique_string gen = function
   | ( Epers_Birth | Epers_Baptism | Epers_Death | Epers_Burial | Epers_Cremation
-    | Epers_Accomplishment | Epers_Acquisition | Epers_Adhesion
+    | Epers_Accomplishment | Epers_Acquisition | Epers_Adhesion | Epers_Adoption
     | Epers_BaptismLDS | Epers_BarMitzvah | Epers_BatMitzvah | Epers_Benediction
     | Epers_ChangeName | Epers_Circumcision | Epers_Confirmation
     | Epers_ConfirmationLDS | Epers_Decoration | Epers_DemobilisationMilitaire

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -692,6 +692,7 @@ let get_pevent_name str l =
   | "#acco" :: l' -> (Epers_Accomplishment, l')
   | "#acqu" :: l' -> (Epers_Acquisition, l')
   | "#adhe" :: l' -> (Epers_Adhesion, l')
+  | "#adop" :: l' -> (Epers_Adoption, l')
   | "#awar" :: l' -> (Epers_Decoration, l')
   | "#bapl" :: l' -> (Epers_BaptismLDS, l')
   | "#barm" :: l' -> (Epers_BarMitzvah, l')

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -576,6 +576,7 @@ let print_pevent opts base gen e =
   | Epers_Accomplishment -> Printf.ksprintf (oc opts) "#acco"
   | Epers_Acquisition -> Printf.ksprintf (oc opts) "#acqu"
   | Epers_Adhesion -> Printf.ksprintf (oc opts) "#adhe"
+  | Epers_Adoption -> Printf.ksprintf (oc opts) "#adop"
   | Epers_BaptismLDS -> Printf.ksprintf (oc opts) "#bapl"
   | Epers_BarMitzvah -> Printf.ksprintf (oc opts) "#barm"
   | Epers_BatMitzvah -> Printf.ksprintf (oc opts) "#basm"

--- a/hd/etc/templm/upd_datalist.txt
+++ b/hd/etc/templm/upd_datalist.txt
@@ -44,6 +44,7 @@
     <option id="#acco" value="[*accomplishment]">[*accomplishment]</option>
     <option id="#acqu" value="[*acquisition]">[*acquisition]</option>
     <option id="#adhe" value="[*adhesion]">[*adhesion]</option>
+    <option id="#adop" value="[*adoption]">[*adoption]</option>
     <option id="#bapl" value="[*baptismLDS]">[*baptismLDS]</option>
     <option id="#barm" value="[*bar mitzvah]">[*bar mitzvah]</option>
     <option id="#basm" value="[*bat mitzvah]">[*bat mitzvah]</option>

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -273,6 +273,7 @@
     <option value="#acco" data-sort="1"%if;(event.e_name="#acco") selected%end;>[*accomplishment]</option>
     <option value="#acqu" data-sort="1"%if;(event.e_name="#acqu") selected%end;>[*acquisition]</option>
     <option value="#adhe" data-sort="1"%if;(event.e_name="#adhe") selected%end;>[*adhesion]</option>
+    <option value="#adop" data-sort="1"%if;(event.e_name="#adop") selected%end;>[*adoption]</option>
     <option value="#barm" data-sort="1"%if;(event.e_name="#barm") selected%end;>[*bar mitzvah]</option>
     <option value="#basm" data-sort="1"%if;(event.e_name="#basm") selected%end;>[*bat mitzvah]</option>
     <option value="#bles" data-sort="1"%if;(event.e_name="#bles") selected%end;>[*benediction]</option>

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -1969,6 +1969,39 @@ ru: участие
 sv: medlemskap
 tr: üyelik
 
+    adoption
+af: aanneming
+bg: осиновяване
+br: adtadiñ
+ca: adopció
+co: aduzzione
+cs: adopce
+da: adoption
+de: Adoption
+en: adoption
+eo: adopto
+es: adopción
+et: lapsendamine
+fi: adoptio
+fr: adoption
+he: אימוץ
+is: ættleiðing
+it: adozione
+lt: įvaikinimas
+lv: adopcija
+nl: adoptie
+no: adopsjon
+oc: adopcion
+pl: adopcja
+pt: adopção
+pt-br: adoção
+ro: adopție
+ru: усыновление
+sk: adopcia
+sl: posvojitev
+sv: adoption
+tr: evlat edinme
+
     adoptive father/adoptive mother/adoptive parents
 af: aangenome vader/angenome moeder/aangenome ouers
 bg: осиновител/осиновителка/осиновители

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -24,6 +24,7 @@ let string_of_epers_name base epers_name =
   | Epers_Accomplishment -> "accomplishment"
   | Epers_Acquisition -> "acquisition"
   | Epers_Adhesion -> "adhesion"
+  | Epers_Adoption -> "adoption"
   | Epers_BaptismLDS -> "baptism (LDS)"
   | Epers_BarMitzvah -> "bar mitzvah"
   | Epers_BatMitzvah -> "bat mitzvah"

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -128,6 +128,7 @@ type 'string gen_pers_event_name =
   | Epers_Accomplishment
   | Epers_Acquisition
   | Epers_Adhesion
+  | Epers_Adoption
   | Epers_BaptismLDS
   | Epers_BarMitzvah
   | Epers_BatMitzvah

--- a/lib/hasher.ml
+++ b/lib/hasher.ml
@@ -219,6 +219,7 @@ module Make (H : Digestif.S) = struct
     | Epers_Accomplishment -> string "Epers_Accomplishment"
     | Epers_Acquisition -> string "Epers_Acquisition"
     | Epers_Adhesion -> string "Epers_Adhesion"
+    | Epers_Adoption -> string "Epers_Adoption"
     | Epers_BaptismLDS -> string "Epers_BaptismLDS"
     | Epers_BarMitzvah -> string "Epers_BarMitzvah"
     | Epers_BatMitzvah -> string "Epers_BatMitzvah"

--- a/lib/historyDiffDisplay.ml
+++ b/lib/historyDiffDisplay.ml
@@ -290,6 +290,7 @@ let string_of_epers_name conf epers_name =
   | Epers_Acquisition ->
       Adef.safe @@ Utf8.capitalize_fst (transl conf "acquisition")
   | Epers_Adhesion -> Adef.safe @@ Utf8.capitalize_fst (transl conf "adhesion")
+  | Epers_Adoption -> Adef.safe @@ Utf8.capitalize_fst (transl conf "adoption")
   | Epers_BaptismLDS ->
       Adef.safe @@ Utf8.capitalize_fst (transl conf "baptismLDS")
   | Epers_BarMitzvah ->

--- a/lib/show/def_show.mli
+++ b/lib/show/def_show.mli
@@ -194,6 +194,7 @@ type 'string gen_pers_event_name = 'string Def.gen_pers_event_name =
   | Epers_Accomplishment
   | Epers_Acquisition
   | Epers_Adhesion
+  | Epers_Adoption
   | Epers_BaptismLDS
   | Epers_BarMitzvah
   | Epers_BatMitzvah

--- a/lib/updateInd.ml
+++ b/lib/updateInd.ml
@@ -364,6 +364,7 @@ and eval_event_var e = function
           | Epers_Accomplishment -> str_val "#acco"
           | Epers_Acquisition -> str_val "#acqu"
           | Epers_Adhesion -> str_val "#adhe"
+          | Epers_Adoption -> str_val "#adop"
           | Epers_BaptismLDS -> str_val "#bapl"
           | Epers_BarMitzvah -> str_val "#barm"
           | Epers_BatMitzvah -> str_val "#basm"

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -137,6 +137,7 @@ let rec reconstitute_pevents conf ext cnt =
         | "#acco" -> Epers_Accomplishment
         | "#acqu" -> Epers_Acquisition
         | "#adhe" -> Epers_Adhesion
+        | "#adop" -> Epers_Adoption
         | "#awar" -> Epers_Decoration
         | "#bapl" -> Epers_BaptismLDS
         | "#barm" -> Epers_BarMitzvah

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1237,6 +1237,7 @@ let string_of_pevent_name conf base epers_name =
   | Epers_Accomplishment -> Adef.safe @@ transl conf "accomplishment"
   | Epers_Acquisition -> Adef.safe @@ transl conf "acquisition"
   | Epers_Adhesion -> Adef.safe @@ transl conf "adhesion"
+  | Epers_Adoption -> Adef.safe @@ transl conf "adoption"
   | Epers_BaptismLDS -> Adef.safe @@ transl conf "baptismLDS"
   | Epers_BarMitzvah -> Adef.safe @@ transl conf "bar mitzvah"
   | Epers_BatMitzvah -> Adef.safe @@ transl conf "bat mitzvah"

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -33,15 +33,15 @@ let map_pers_event ?(fd = identity) fp fs e =
     match e.epers_name with
     | ( Epers_Birth | Epers_Baptism | Epers_Death | Epers_Burial
       | Epers_Cremation | Epers_Accomplishment | Epers_Acquisition
-      | Epers_Adhesion | Epers_BaptismLDS | Epers_BarMitzvah | Epers_BatMitzvah
-      | Epers_Benediction | Epers_ChangeName | Epers_Circumcision
-      | Epers_Confirmation | Epers_ConfirmationLDS | Epers_Decoration
-      | Epers_DemobilisationMilitaire | Epers_Diploma | Epers_Distinction
-      | Epers_Dotation | Epers_DotationLDS | Epers_Education | Epers_Election
-      | Epers_Emigration | Epers_Excommunication | Epers_FamilyLinkLDS
-      | Epers_FirstCommunion | Epers_Funeral | Epers_Graduate
-      | Epers_Hospitalisation | Epers_Illness | Epers_Immigration
-      | Epers_ListePassenger | Epers_MilitaryDistinction
+      | Epers_Adhesion | Epers_Adoption | Epers_BaptismLDS | Epers_BarMitzvah
+      | Epers_BatMitzvah | Epers_Benediction | Epers_ChangeName
+      | Epers_Circumcision | Epers_Confirmation | Epers_ConfirmationLDS
+      | Epers_Decoration | Epers_DemobilisationMilitaire | Epers_Diploma
+      | Epers_Distinction | Epers_Dotation | Epers_DotationLDS | Epers_Education
+      | Epers_Election | Epers_Emigration | Epers_Excommunication
+      | Epers_FamilyLinkLDS | Epers_FirstCommunion | Epers_Funeral
+      | Epers_Graduate | Epers_Hospitalisation | Epers_Illness
+      | Epers_Immigration | Epers_ListePassenger | Epers_MilitaryDistinction
       | Epers_MilitaryPromotion | Epers_MilitaryService
       | Epers_MobilisationMilitaire | Epers_Naturalisation | Epers_Occupation
       | Epers_Ordination | Epers_Property | Epers_Recensement | Epers_Residence

--- a/plugins/gwxjg/gwxjg_ezgw.ml
+++ b/plugins/gwxjg/gwxjg_ezgw.ml
@@ -230,6 +230,7 @@ module Event = struct
     | Pevent Epers_Accomplishment -> "EPERS_ACCOMPLISHMENT"
     | Pevent Epers_Acquisition -> "EPERS_ACQUISITION"
     | Pevent Epers_Adhesion -> "EPERS_ADHESION"
+    | Pevent Epers_Adoption -> "EPERS_ADOPTION"
     | Pevent Epers_BaptismLDS -> "EPERS_BAPTISMLDS"
     | Pevent Epers_BarMitzvah -> "EPERS_BARMITZVAH"
     | Pevent Epers_BatMitzvah -> "EPERS_BATMITZVAH"


### PR DESCRIPTION
Integrate adoption as a standard personal event with GEDCOM tag "ADOP" following the same pattern as other primary events (birth, baptism, etc.).

Changes:
- Add Epers_Adoption variant to gen_pers_event_name type
- Map GEDCOM "ADOP" tag to Epers_Adoption in import/export
- Add "#adop" tag for .gw format
- Include in primary_pevents list for proper GEDCOM compliance
- Update all pattern matchings across codebase

This enables proper handling of adoption events in genealogical data while maintaining backward compatibility with existing databases.

Nearly a copy of PR #2411 for Gnt branch. Thank you for that @canonici.