### PR TITLE
add HTTPS protocol detection for server-generated URLs

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -405,7 +405,7 @@ let print_renamed conf new_n =
       in
       loop 0
     in
-    "http://" ^ Util.get_server_string conf ^ new_req
+    Util.get_protocol conf ^ "://" ^ Util.get_server_string conf ^ new_req
   in
   let env =
     Templ.Env.(
@@ -432,7 +432,7 @@ let log_redirect from request req =
 
 let print_redirected conf from request new_addr =
   let req = Util.get_request_string conf in
-  let link = "http://" ^ new_addr ^ req in
+  let link = Util.get_protocol conf ^ "://" ^ new_addr ^ req in
   let env = Templ.Env.(add "link" (Templ.Vstring (Mutil.encode link)) empty) in
   log_redirect from request req;
   try Templ.output_simple conf env "redirect"

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1499,6 +1499,19 @@ let get_request_string conf =
     let query_string = try Sys.getenv "QUERY_STRING" with Not_found -> "" in
     script_name ^ "?" ^ query_string
 
+let get_protocol conf =
+  let forwarded_proto =
+    Mutil.extract_param "x-forwarded-proto: " '\r' conf.request
+  in
+  if String.lowercase_ascii forwarded_proto = "https" then "https"
+  else
+    let host = get_server_string conf in
+    if
+      String.length host > 4
+      && String.sub host (String.length host - 4) 4 = ":443"
+    then "https"
+    else "http"
+
 let message_to_wizard conf =
   if conf.wizard || conf.just_friend_wizard then (
     let print_file fname =

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -571,6 +571,10 @@ val get_request_string : config -> string
 (** Returns request string. Request string has format {i scriptname?querystring}
     where scriptname is a path to the script in URI. *)
 
+val get_protocol : config -> string
+(** Returns "https" if request came through HTTPS proxy (via X-Forwarded-Proto
+    header) or if server port is 443, otherwise "http". *)
+
 val create_topological_sort :
   config ->
   Geneweb_db.Driver.base ->

--- a/plugins/no_index/plugin_no_index.ml
+++ b/plugins/no_index/plugin_no_index.ml
@@ -121,7 +121,9 @@ let no_index conf base =
   let opt2 = Util.p_getenv conf.env "opt" = Some "no_index_pwd" in
   if opt1 || opt2 then (
     let link = url_no_index conf base opt2 in
-    Output.print_sstring conf {|<a href="http://|};
+    Output.print_sstring conf {|<a href="|};
+    Output.print_sstring conf (Util.get_protocol conf);
+    Output.print_sstring conf "://";
     Output.print_string conf link;
     Output.print_sstring conf {|">|};
     Output.print_string conf link;


### PR DESCRIPTION
Detect original client protocol via X-Forwarded-Proto header (standard reverse proxy header) or :443 port suffix. Fixes hardcoded `http://` in:
- plugin_no_index opt=no_index URL generation
- print_renamed database redirect links
- print_redirected server redirect links

The JS-based permalink copy (`copylink.js`) already handles this correctly via window.location.origin.

Fixes #1015.