### PR TITLE
Restore distribution-relative default for base directory

### DIFF
--- a/bin/gwd/cmd.ml
+++ b/bin/gwd/cmd.ml
@@ -190,7 +190,7 @@ let base_dir =
   let absent = Dirs.name default_base_dir in
   C.Arg.(
     value
-    & opt dirpath (Dirs.path default_base_dir)
+    & opt dirpath (Secure.base_dir ())
     & info [ "bd"; "base-dir" ] ~absent ~docs:dirs_section ~doc)
 
 let socket_dir =

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2149,13 +2149,14 @@ let geneweb_server ~predictable_mode () =
   commit: %s
   gwd: %s
   working_dir: %s
+  base_dir: %s
   gw_prefix: %s
   etc_prefix: %s
   images_prefix: %s
   images_dir: %s
   secure asset: %a|}
                   Version.src Version.branch Version.commit_id Sys.argv.(0)
-                  (Sys.getcwd ()) (Option.get !gw_prefix)
+                  (Sys.getcwd ()) (Secure.base_dir ()) (Option.get !gw_prefix)
                   (Option.get !etc_prefix)
                   (Option.get !images_prefix)
                   !images_dir

--- a/lib/util/filesystem.ml
+++ b/lib/util/filesystem.ml
@@ -39,11 +39,12 @@ let ( // ) = Filename.concat
 
 let iter_path_entries f path =
   let rec loop path =
-    match (Filename.dirname path, Filename.basename path) with
-    | ("." | "/"), _ -> f path
-    | path, base ->
-        loop path;
-        f (path // base)
+    let dir = Filename.dirname path in
+    if dir = path then f path
+    else begin
+      loop dir;
+      f (dir // Filename.basename path)
+    end
   in
   loop path
 

--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -14,7 +14,22 @@ let default_base_dir =
   let t = Dirs.make () in
   Dirs.(data_home t // "geneweb" // "bases")
 
-let bd_r = ref (Dirs.path default_base_dir)
+let bd_r =
+  let ( / ) = Filename.concat in
+  let candidates =
+    [
+      "bases";
+      Filename.parent_dir_name / "bases";
+      Filename.dirname Sys.executable_name / Filename.parent_dir_name / "bases";
+    ]
+  in
+  let rec first_existing = function
+    | [] -> Dirs.path default_base_dir
+    | d :: rest ->
+        if Sys.file_exists d && Sys.is_directory d then d
+        else first_existing rest
+  in
+  ref (first_existing candidates)
 
 (* [decompose: string -> string list] decompose a path into a list of
    directory and a basename. "a/b/c" -> [ "a" ; "b"; "c" ] *)


### PR DESCRIPTION
Regression introduced by the XDG / dune-sites integration: `default_base_dir` is a typed `Geneweb_dirs.one` var pointing to `~/.local/share/geneweb/bases`, which breaks some CGI and local daemon deployments that ship a `bases/` directory next to the executable and previously worked without passing `--bd`.

Resolve bd_r at module-load time by probing, in order:
  - ./bases
  - ../bases
  - <exe_dir>/../bases
  - XDG data_home/geneweb/bases (fallback)

`default_base_dir` (the typed var) is left untouched so `--help` still shows the XDG symbolic path as the system-wide default. `cmd.ml` uses `Secure.base_dir ()` as the cmdliner default value to pick up the resolved path.
