### PR TITLE
direct UTF-8 to ANSEL conversion, prevent CONC line split from breaking ANSEL

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -247,7 +247,7 @@ let ascii_of_macintosh s =
 
 let utf8_of_string s =
   match !charset with
-  | Ansel -> Mutil.utf_8_of_iso_8859_1 (Ansel.to_iso_8859_1 s)
+  | Ansel -> Ansel.to_utf_8 s
   | Ascii -> Mutil.utf_8_of_iso_8859_1 s
   | Msdos -> Mutil.utf_8_of_iso_8859_1 (ascii_of_msdos s)
   | MacIntosh -> Mutil.utf_8_of_iso_8859_1 (ascii_of_macintosh s)

--- a/bin/gwb2ged/gwb2ged.ml
+++ b/bin/gwb2ged/gwb2ged.ml
@@ -15,9 +15,15 @@ let anonfun s =
     bname := Some s)
   else raise (Arg.Bad "Cannot treat several databases")
 
+let ansel_warning =
+  "Warning: ANSEL charset was administratively withdrawn in 2013. UTF-8 is \
+   recommended for new GEDCOM files."
+
 let () =
   let opts = ref Gwexport.default_opts in
   Arg.parse (speclist opts) anonfun Gwexport.errmsg;
+  if !opts.Gwexport.charset = Gwexport.Ansel then
+    Printf.eprintf "%s\n%!" ansel_warning;
   match !bname with
   | None -> raise @@ Arg.Bad "Expect a database"
   | Some bname ->

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -87,7 +87,7 @@ let ged_month cal m =
 
 let encode opts s =
   match opts.Gwexport.charset with
-  | Gwexport.Ansel -> Ansel.of_iso_8859_1 @@ Mutil.iso_8859_1_of_utf_8 s
+  | Gwexport.Ansel -> Ansel.of_utf_8 s
   | Gwexport.Ascii | Gwexport.Ansi -> Mutil.iso_8859_1_of_utf_8 s
   | Gwexport.Utf8 -> s
 

--- a/bin/setup/lang/gwb2ged.htm
+++ b/bin/setup/lang/gwb2ged.htm
@@ -55,23 +55,23 @@ ll be the name of the database ended by the suffix
 <table class="setup">
 <tr><td>-charset</td></tr>
 <tr align="left"><td>
-<input type="radio" name="charset" value="ASCII" id="ASCII"/>   
-<label for="ASCII">[Encode the characters in ASCII.]
-</label></td>
-</tr>
-<tr align="left"><td>
 <input type="radio" name="charset" value="UTF-8" id="UTF-8" checked>   
 <label for="UTF-8">[Encode the characters in UTF-8.]
 </label></td>
 </tr>
 <tr align="left"><td>
-<input type="radio" name="charset" value="ANSEL" id="ANSEL"/>   
-<label for="ANSEL">[Encode the characters in ANSEL.]
+<input type="radio" name="charset" value="ANSI" id="ANSI"/>&nbsp;&nbsp;&nbsp;
+<label for="ANSI">[Encode the characters in ANSI (ISO 8859-1).]
 </label></td>
 </tr>
 <tr align="left"><td>
-<input type="radio" name="charset" value="ANSI" id="ANSI"/>&nbsp;&nbsp;&nbsp;
-<label for="ANSI">[Encode the characters in ANSI (ISO 8859-1).]
+<input type="radio" name="charset" value="ANSEL" id="ANSEL"/>   
+<label for="ANSEL">[Encode the characters in ANSEL (withdrawn 2013, not recommended).]
+</label></td>
+</tr>
+<tr align="left"><td>
+<input type="radio" name="charset" value="ASCII" id="ASCII"/>   
+<label for="ASCII">[Encode the characters in ASCII.]
 </label></td>
 </tr>
 </table></dl>

--- a/lib/ansel.ml
+++ b/lib/ansel.ml
@@ -4,6 +4,477 @@
 let iso_8859_1_unknown = '\129'
 let ansel_unknown = 129
 
+let of_utf_8 s =
+  let buf = Buffer.create (String.length s * 2) in
+  let len = String.length s in
+  let rec loop i =
+    if i >= len then Buffer.contents buf
+    else
+      let c = Char.code s.[i] in
+      let uchar, next =
+        if c < 0x80 then (c, i + 1)
+        else if c < 0xC0 then (0xFFFD, i + 1)
+        else if c < 0xE0 && i + 1 < len then
+          let c1 = Char.code s.[i + 1] in
+          (((c land 0x1F) lsl 6) lor (c1 land 0x3F), i + 2)
+        else if c < 0xF0 && i + 2 < len then
+          let c1 = Char.code s.[i + 1] in
+          let c2 = Char.code s.[i + 2] in
+          ( ((c land 0x0F) lsl 12) lor ((c1 land 0x3F) lsl 6) lor (c2 land 0x3F),
+            i + 3 )
+        else (0xFFFD, i + 1)
+      in
+      (match uchar with
+      | u when u < 0x80 -> Buffer.add_char buf (Char.chr u)
+      | 0x00A1 -> Buffer.add_char buf '\xC6'
+      | 0x00A3 -> Buffer.add_char buf '\xB9'
+      | 0x00A9 -> Buffer.add_char buf '\xC3'
+      | 0x00AE -> Buffer.add_char buf '\xAA'
+      | 0x00B1 -> Buffer.add_char buf '\xAB'
+      | 0x00B7 -> Buffer.add_char buf '\xA8'
+      | 0x00BF -> Buffer.add_char buf '\xC5'
+      | 0x00C6 -> Buffer.add_char buf '\xA5'
+      | 0x00D0 -> Buffer.add_char buf '\xA3'
+      | 0x00D8 -> Buffer.add_char buf '\xA2'
+      | 0x00DE -> Buffer.add_char buf '\xA4'
+      | 0x00DF -> Buffer.add_char buf '\xCF'
+      | 0x00E6 -> Buffer.add_char buf '\xB5'
+      | 0x00F0 -> Buffer.add_char buf '\xBA'
+      | 0x00F8 -> Buffer.add_char buf '\xB2'
+      | 0x00FE -> Buffer.add_char buf '\xB4'
+      | 0x0131 -> Buffer.add_char buf '\xB8'
+      | 0x0141 -> Buffer.add_char buf '\xA1'
+      | 0x0142 -> Buffer.add_char buf '\xB1'
+      | 0x0110 -> Buffer.add_char buf '\xA3'
+      | 0x0111 -> Buffer.add_char buf '\xB3'
+      | 0x02BB -> Buffer.add_char buf '\xB0'
+      | 0x02BC -> Buffer.add_char buf '\xAE'
+      | 0x0152 -> Buffer.add_char buf '\xA6'
+      | 0x0153 -> Buffer.add_char buf '\xB6'
+      | 0x00C0 -> Buffer.add_string buf "\xE1\x41"
+      | 0x00C1 -> Buffer.add_string buf "\xE2\x41"
+      | 0x00C2 -> Buffer.add_string buf "\xE3\x41"
+      | 0x00C3 -> Buffer.add_string buf "\xE4\x41"
+      | 0x00C4 -> Buffer.add_string buf "\xE8\x41"
+      | 0x00C5 -> Buffer.add_string buf "\xEA\x41"
+      | 0x00C7 -> Buffer.add_string buf "\xF0\x43"
+      | 0x00C8 -> Buffer.add_string buf "\xE1\x45"
+      | 0x00C9 -> Buffer.add_string buf "\xE2\x45"
+      | 0x00CA -> Buffer.add_string buf "\xE3\x45"
+      | 0x00CB -> Buffer.add_string buf "\xE8\x45"
+      | 0x00CC -> Buffer.add_string buf "\xE1\x49"
+      | 0x00CD -> Buffer.add_string buf "\xE2\x49"
+      | 0x00CE -> Buffer.add_string buf "\xE3\x49"
+      | 0x00CF -> Buffer.add_string buf "\xE8\x49"
+      | 0x00D1 -> Buffer.add_string buf "\xE4\x4E"
+      | 0x00D2 -> Buffer.add_string buf "\xE1\x4F"
+      | 0x00D3 -> Buffer.add_string buf "\xE2\x4F"
+      | 0x00D4 -> Buffer.add_string buf "\xE3\x4F"
+      | 0x00D5 -> Buffer.add_string buf "\xE4\x4F"
+      | 0x00D6 -> Buffer.add_string buf "\xE8\x4F"
+      | 0x00D9 -> Buffer.add_string buf "\xE1\x55"
+      | 0x00DA -> Buffer.add_string buf "\xE2\x55"
+      | 0x00DB -> Buffer.add_string buf "\xE3\x55"
+      | 0x00DC -> Buffer.add_string buf "\xE8\x55"
+      | 0x00DD -> Buffer.add_string buf "\xE2\x59"
+      | 0x00E0 -> Buffer.add_string buf "\xE1\x61"
+      | 0x00E1 -> Buffer.add_string buf "\xE2\x61"
+      | 0x00E2 -> Buffer.add_string buf "\xE3\x61"
+      | 0x00E3 -> Buffer.add_string buf "\xE4\x61"
+      | 0x00E4 -> Buffer.add_string buf "\xE8\x61"
+      | 0x00E5 -> Buffer.add_string buf "\xEA\x61"
+      | 0x00E7 -> Buffer.add_string buf "\xF0\x63"
+      | 0x00E8 -> Buffer.add_string buf "\xE1\x65"
+      | 0x00E9 -> Buffer.add_string buf "\xE2\x65"
+      | 0x00EA -> Buffer.add_string buf "\xE3\x65"
+      | 0x00EB -> Buffer.add_string buf "\xE8\x65"
+      | 0x00EC -> Buffer.add_string buf "\xE1\x69"
+      | 0x00ED -> Buffer.add_string buf "\xE2\x69"
+      | 0x00EE -> Buffer.add_string buf "\xE3\x69"
+      | 0x00EF -> Buffer.add_string buf "\xE8\x69"
+      | 0x00F1 -> Buffer.add_string buf "\xE4\x6E"
+      | 0x00F2 -> Buffer.add_string buf "\xE1\x6F"
+      | 0x00F3 -> Buffer.add_string buf "\xE2\x6F"
+      | 0x00F4 -> Buffer.add_string buf "\xE3\x6F"
+      | 0x00F5 -> Buffer.add_string buf "\xE4\x6F"
+      | 0x00F6 -> Buffer.add_string buf "\xE8\x6F"
+      | 0x00F9 -> Buffer.add_string buf "\xE1\x75"
+      | 0x00FA -> Buffer.add_string buf "\xE2\x75"
+      | 0x00FB -> Buffer.add_string buf "\xE3\x75"
+      | 0x00FC -> Buffer.add_string buf "\xE8\x75"
+      | 0x00FD -> Buffer.add_string buf "\xE2\x79"
+      | 0x00FF -> Buffer.add_string buf "\xE8\x79"
+      | 0x0100 -> Buffer.add_string buf "\xE5\x41"
+      | 0x0101 -> Buffer.add_string buf "\xE5\x61"
+      | 0x0102 -> Buffer.add_string buf "\xE6\x41"
+      | 0x0103 -> Buffer.add_string buf "\xE6\x61"
+      | 0x0104 -> Buffer.add_string buf "\xF1\x41"
+      | 0x0105 -> Buffer.add_string buf "\xF1\x61"
+      | 0x0106 -> Buffer.add_string buf "\xE2\x43"
+      | 0x0107 -> Buffer.add_string buf "\xE2\x63"
+      | 0x0108 -> Buffer.add_string buf "\xE3\x43"
+      | 0x0109 -> Buffer.add_string buf "\xE3\x63"
+      | 0x010A -> Buffer.add_string buf "\xE7\x43"
+      | 0x010B -> Buffer.add_string buf "\xE7\x63"
+      | 0x010C -> Buffer.add_string buf "\xE9\x43"
+      | 0x010D -> Buffer.add_string buf "\xE9\x63"
+      | 0x010E -> Buffer.add_string buf "\xE9\x44"
+      | 0x010F -> Buffer.add_string buf "\xE9\x64"
+      | 0x0112 -> Buffer.add_string buf "\xE5\x45"
+      | 0x0113 -> Buffer.add_string buf "\xE5\x65"
+      | 0x0116 -> Buffer.add_string buf "\xE7\x45"
+      | 0x0117 -> Buffer.add_string buf "\xE7\x65"
+      | 0x0118 -> Buffer.add_string buf "\xF1\x45"
+      | 0x0119 -> Buffer.add_string buf "\xF1\x65"
+      | 0x011A -> Buffer.add_string buf "\xE9\x45"
+      | 0x011B -> Buffer.add_string buf "\xE9\x65"
+      | 0x011C -> Buffer.add_string buf "\xE3\x47"
+      | 0x011D -> Buffer.add_string buf "\xE3\x67"
+      | 0x011E -> Buffer.add_string buf "\xE6\x47"
+      | 0x011F -> Buffer.add_string buf "\xE6\x67"
+      | 0x0120 -> Buffer.add_string buf "\xE7\x47"
+      | 0x0121 -> Buffer.add_string buf "\xE7\x67"
+      | 0x0122 -> Buffer.add_string buf "\xF0\x47"
+      | 0x0123 -> Buffer.add_string buf "\xF0\x67"
+      | 0x0124 -> Buffer.add_string buf "\xE3\x48"
+      | 0x0125 -> Buffer.add_string buf "\xE3\x68"
+      | 0x0128 -> Buffer.add_string buf "\xE4\x49"
+      | 0x0129 -> Buffer.add_string buf "\xE4\x69"
+      | 0x012A -> Buffer.add_string buf "\xE5\x49"
+      | 0x012B -> Buffer.add_string buf "\xE5\x69"
+      | 0x012C -> Buffer.add_string buf "\xE6\x49"
+      | 0x012D -> Buffer.add_string buf "\xE6\x69"
+      | 0x012E -> Buffer.add_string buf "\xF1\x49"
+      | 0x012F -> Buffer.add_string buf "\xF1\x69"
+      | 0x0134 -> Buffer.add_string buf "\xE3\x4A"
+      | 0x0135 -> Buffer.add_string buf "\xE3\x6A"
+      | 0x0136 -> Buffer.add_string buf "\xF0\x4B"
+      | 0x0137 -> Buffer.add_string buf "\xF0\x6B"
+      | 0x0139 -> Buffer.add_string buf "\xE2\x4C"
+      | 0x013A -> Buffer.add_string buf "\xE2\x6C"
+      | 0x013B -> Buffer.add_string buf "\xF0\x4C"
+      | 0x013C -> Buffer.add_string buf "\xF0\x6C"
+      | 0x013D -> Buffer.add_string buf "\xE9\x4C"
+      | 0x013E -> Buffer.add_string buf "\xE9\x6C"
+      | 0x0143 -> Buffer.add_string buf "\xE2\x4E"
+      | 0x0144 -> Buffer.add_string buf "\xE2\x6E"
+      | 0x0145 -> Buffer.add_string buf "\xF0\x4E"
+      | 0x0146 -> Buffer.add_string buf "\xF0\x6E"
+      | 0x0147 -> Buffer.add_string buf "\xE9\x4E"
+      | 0x0148 -> Buffer.add_string buf "\xE9\x6E"
+      | 0x014C -> Buffer.add_string buf "\xE5\x4F"
+      | 0x014D -> Buffer.add_string buf "\xE5\x6F"
+      | 0x014E -> Buffer.add_string buf "\xE6\x4F"
+      | 0x014F -> Buffer.add_string buf "\xE6\x6F"
+      | 0x0150 -> Buffer.add_string buf "\xEE\x4F"
+      | 0x0151 -> Buffer.add_string buf "\xEE\x6F"
+      | 0x0154 -> Buffer.add_string buf "\xE2\x52"
+      | 0x0155 -> Buffer.add_string buf "\xE2\x72"
+      | 0x0156 -> Buffer.add_string buf "\xF0\x52"
+      | 0x0157 -> Buffer.add_string buf "\xF0\x72"
+      | 0x0158 -> Buffer.add_string buf "\xE9\x52"
+      | 0x0159 -> Buffer.add_string buf "\xE9\x72"
+      | 0x015A -> Buffer.add_string buf "\xE2\x53"
+      | 0x015B -> Buffer.add_string buf "\xE2\x73"
+      | 0x015C -> Buffer.add_string buf "\xE3\x53"
+      | 0x015D -> Buffer.add_string buf "\xE3\x73"
+      | 0x015E -> Buffer.add_string buf "\xF0\x53"
+      | 0x015F -> Buffer.add_string buf "\xF0\x73"
+      | 0x0160 -> Buffer.add_string buf "\xE9\x53"
+      | 0x0161 -> Buffer.add_string buf "\xE9\x73"
+      | 0x0162 -> Buffer.add_string buf "\xF0\x54"
+      | 0x0163 -> Buffer.add_string buf "\xF0\x74"
+      | 0x0164 -> Buffer.add_string buf "\xE9\x54"
+      | 0x0165 -> Buffer.add_string buf "\xE9\x74"
+      | 0x0168 -> Buffer.add_string buf "\xE4\x55"
+      | 0x0169 -> Buffer.add_string buf "\xE4\x75"
+      | 0x016A -> Buffer.add_string buf "\xE5\x55"
+      | 0x016B -> Buffer.add_string buf "\xE5\x75"
+      | 0x016C -> Buffer.add_string buf "\xE6\x55"
+      | 0x016D -> Buffer.add_string buf "\xE6\x75"
+      | 0x016E -> Buffer.add_string buf "\xEA\x55"
+      | 0x016F -> Buffer.add_string buf "\xEA\x75"
+      | 0x0170 -> Buffer.add_string buf "\xEE\x55"
+      | 0x0171 -> Buffer.add_string buf "\xEE\x75"
+      | 0x0172 -> Buffer.add_string buf "\xF1\x55"
+      | 0x0173 -> Buffer.add_string buf "\xF1\x75"
+      | 0x0174 -> Buffer.add_string buf "\xE3\x57"
+      | 0x0175 -> Buffer.add_string buf "\xE3\x77"
+      | 0x0176 -> Buffer.add_string buf "\xE3\x59"
+      | 0x0177 -> Buffer.add_string buf "\xE3\x79"
+      | 0x0178 -> Buffer.add_string buf "\xE8\x59"
+      | 0x0179 -> Buffer.add_string buf "\xE2\x5A"
+      | 0x017A -> Buffer.add_string buf "\xE2\x7A"
+      | 0x017B -> Buffer.add_string buf "\xE7\x5A"
+      | 0x017C -> Buffer.add_string buf "\xE7\x7A"
+      | 0x017D -> Buffer.add_string buf "\xE9\x5A"
+      | 0x017E -> Buffer.add_string buf "\xE9\x7A"
+      | 0x0218 -> Buffer.add_string buf "\xF0\x53"
+      | 0x0219 -> Buffer.add_string buf "\xF0\x73"
+      | 0x021A -> Buffer.add_string buf "\xF0\x54"
+      | 0x021B -> Buffer.add_string buf "\xF0\x74"
+      | _ -> Buffer.add_char buf (Char.chr ansel_unknown));
+      loop next
+  in
+  loop 0
+
+let to_utf_8 s =
+  let buf = Buffer.create (String.length s * 2) in
+  let len = String.length s in
+  let rec loop i =
+    if i >= len then Buffer.contents buf
+    else
+      let c = Char.code s.[i] in
+      if c < 0x80 then (
+        Buffer.add_char buf s.[i];
+        loop (i + 1))
+      else if c >= 0xE0 && c <= 0xF9 && i + 1 < len then
+        let base = Char.code s.[i + 1] in
+        let utf8 =
+          match c with
+          | 0xE1 -> (
+              match base with
+              | 0x41 -> "\xC3\x80"
+              | 0x45 -> "\xC3\x88"
+              | 0x49 -> "\xC3\x8C"
+              | 0x4F -> "\xC3\x92"
+              | 0x55 -> "\xC3\x99"
+              | 0x61 -> "\xC3\xA0"
+              | 0x65 -> "\xC3\xA8"
+              | 0x69 -> "\xC3\xAC"
+              | 0x6F -> "\xC3\xB2"
+              | 0x75 -> "\xC3\xB9"
+              | _ -> "")
+          | 0xE2 -> (
+              match base with
+              | 0x41 -> "\xC3\x81"
+              | 0x43 -> "\xC4\x86"
+              | 0x45 -> "\xC3\x89"
+              | 0x49 -> "\xC3\x8D"
+              | 0x4C -> "\xC4\xB9"
+              | 0x4E -> "\xC5\x83"
+              | 0x4F -> "\xC3\x93"
+              | 0x52 -> "\xC5\x94"
+              | 0x53 -> "\xC5\x9A"
+              | 0x55 -> "\xC3\x9A"
+              | 0x59 -> "\xC3\x9D"
+              | 0x5A -> "\xC5\xB9"
+              | 0x61 -> "\xC3\xA1"
+              | 0x63 -> "\xC4\x87"
+              | 0x65 -> "\xC3\xA9"
+              | 0x69 -> "\xC3\xAD"
+              | 0x6C -> "\xC4\xBA"
+              | 0x6E -> "\xC5\x84"
+              | 0x6F -> "\xC3\xB3"
+              | 0x72 -> "\xC5\x95"
+              | 0x73 -> "\xC5\x9B"
+              | 0x75 -> "\xC3\xBA"
+              | 0x79 -> "\xC3\xBD"
+              | 0x7A -> "\xC5\xBA"
+              | _ -> "")
+          | 0xE3 -> (
+              match base with
+              | 0x41 -> "\xC3\x82"
+              | 0x43 -> "\xC4\x88"
+              | 0x45 -> "\xC3\x8A"
+              | 0x47 -> "\xC4\x9C"
+              | 0x48 -> "\xC4\xA4"
+              | 0x49 -> "\xC3\x8E"
+              | 0x4A -> "\xC4\xB4"
+              | 0x4F -> "\xC3\x94"
+              | 0x53 -> "\xC5\x9C"
+              | 0x55 -> "\xC3\x9B"
+              | 0x57 -> "\xC5\xB4"
+              | 0x59 -> "\xC5\xB6"
+              | 0x61 -> "\xC3\xA2"
+              | 0x63 -> "\xC4\x89"
+              | 0x65 -> "\xC3\xAA"
+              | 0x67 -> "\xC4\x9D"
+              | 0x68 -> "\xC4\xA5"
+              | 0x69 -> "\xC3\xAE"
+              | 0x6A -> "\xC4\xB5"
+              | 0x6F -> "\xC3\xB4"
+              | 0x73 -> "\xC5\x9D"
+              | 0x75 -> "\xC3\xBB"
+              | 0x77 -> "\xC5\xB5"
+              | 0x79 -> "\xC5\xB7"
+              | _ -> "")
+          | 0xE4 -> (
+              match base with
+              | 0x41 -> "\xC3\x83"
+              | 0x49 -> "\xC4\xA8"
+              | 0x4E -> "\xC3\x91"
+              | 0x4F -> "\xC3\x95"
+              | 0x55 -> "\xC5\xA8"
+              | 0x61 -> "\xC3\xA3"
+              | 0x69 -> "\xC4\xA9"
+              | 0x6E -> "\xC3\xB1"
+              | 0x6F -> "\xC3\xB5"
+              | 0x75 -> "\xC5\xA9"
+              | _ -> "")
+          | 0xE5 -> (
+              match base with
+              | 0x41 -> "\xC4\x80"
+              | 0x45 -> "\xC4\x92"
+              | 0x49 -> "\xC4\xAA"
+              | 0x4F -> "\xC5\x8C"
+              | 0x55 -> "\xC5\xAA"
+              | 0x61 -> "\xC4\x81"
+              | 0x65 -> "\xC4\x93"
+              | 0x69 -> "\xC4\xAB"
+              | 0x6F -> "\xC5\x8D"
+              | 0x75 -> "\xC5\xAB"
+              | _ -> "")
+          | 0xE6 -> (
+              match base with
+              | 0x41 -> "\xC4\x82"
+              | 0x47 -> "\xC4\x9E"
+              | 0x49 -> "\xC4\xAC"
+              | 0x4F -> "\xC5\x8E"
+              | 0x55 -> "\xC5\xAC"
+              | 0x61 -> "\xC4\x83"
+              | 0x67 -> "\xC4\x9F"
+              | 0x69 -> "\xC4\xAD"
+              | 0x6F -> "\xC5\x8F"
+              | 0x75 -> "\xC5\xAD"
+              | _ -> "")
+          | 0xE7 -> (
+              match base with
+              | 0x43 -> "\xC4\x8A"
+              | 0x45 -> "\xC4\x96"
+              | 0x47 -> "\xC4\xA0"
+              | 0x5A -> "\xC5\xBB"
+              | 0x63 -> "\xC4\x8B"
+              | 0x65 -> "\xC4\x97"
+              | 0x67 -> "\xC4\xA1"
+              | 0x7A -> "\xC5\xBC"
+              | _ -> "")
+          | 0xE8 -> (
+              match base with
+              | 0x41 -> "\xC3\x84"
+              | 0x45 -> "\xC3\x8B"
+              | 0x49 -> "\xC3\x8F"
+              | 0x4F -> "\xC3\x96"
+              | 0x55 -> "\xC3\x9C"
+              | 0x59 -> "\xC5\xB8"
+              | 0x61 -> "\xC3\xA4"
+              | 0x65 -> "\xC3\xAB"
+              | 0x69 -> "\xC3\xAF"
+              | 0x6F -> "\xC3\xB6"
+              | 0x75 -> "\xC3\xBC"
+              | 0x79 -> "\xC3\xBF"
+              | _ -> "")
+          | 0xE9 -> (
+              match base with
+              | 0x43 -> "\xC4\x8C"
+              | 0x44 -> "\xC4\x8E"
+              | 0x45 -> "\xC4\x9A"
+              | 0x4C -> "\xC4\xBD"
+              | 0x4E -> "\xC5\x87"
+              | 0x52 -> "\xC5\x98"
+              | 0x53 -> "\xC5\xA0"
+              | 0x54 -> "\xC5\xA4"
+              | 0x5A -> "\xC5\xBD"
+              | 0x63 -> "\xC4\x8D"
+              | 0x64 -> "\xC4\x8F"
+              | 0x65 -> "\xC4\x9B"
+              | 0x6C -> "\xC4\xBE"
+              | 0x6E -> "\xC5\x88"
+              | 0x72 -> "\xC5\x99"
+              | 0x73 -> "\xC5\xA1"
+              | 0x74 -> "\xC5\xA5"
+              | 0x7A -> "\xC5\xBE"
+              | _ -> "")
+          | 0xEA -> (
+              match base with
+              | 0x41 -> "\xC3\x85"
+              | 0x55 -> "\xC5\xAE"
+              | 0x61 -> "\xC3\xA5"
+              | 0x75 -> "\xC5\xAF"
+              | _ -> "")
+          | 0xEE -> (
+              match base with
+              | 0x4F -> "\xC5\x90"
+              | 0x55 -> "\xC5\xB0"
+              | 0x6F -> "\xC5\x91"
+              | 0x75 -> "\xC5\xB1"
+              | _ -> "")
+          | 0xF0 -> (
+              match base with
+              | 0x43 -> "\xC3\x87"
+              | 0x47 -> "\xC4\xA2"
+              | 0x4B -> "\xC4\xB6"
+              | 0x4C -> "\xC4\xBB"
+              | 0x4E -> "\xC5\x85"
+              | 0x52 -> "\xC5\x96"
+              | 0x53 -> "\xC5\x9E"
+              | 0x54 -> "\xC5\xA2"
+              | 0x63 -> "\xC3\xA7"
+              | 0x67 -> "\xC4\xA3"
+              | 0x6B -> "\xC4\xB7"
+              | 0x6C -> "\xC4\xBC"
+              | 0x6E -> "\xC5\x86"
+              | 0x72 -> "\xC5\x97"
+              | 0x73 -> "\xC5\x9F"
+              | 0x74 -> "\xC5\xA3"
+              | _ -> "")
+          | 0xF1 -> (
+              match base with
+              | 0x41 -> "\xC4\x84"
+              | 0x45 -> "\xC4\x98"
+              | 0x49 -> "\xC4\xAE"
+              | 0x55 -> "\xC5\xB2"
+              | 0x61 -> "\xC4\x85"
+              | 0x65 -> "\xC4\x99"
+              | 0x69 -> "\xC4\xAF"
+              | 0x75 -> "\xC5\xB3"
+              | _ -> "")
+          | _ -> ""
+        in
+        if utf8 = "" then (
+          Buffer.add_char buf s.[i];
+          loop (i + 1))
+        else (
+          Buffer.add_string buf utf8;
+          loop (i + 2))
+      else
+        let utf8 =
+          match c with
+          | 0xA1 -> "\xC5\x81"
+          | 0xA2 -> "\xC3\x98"
+          | 0xA3 -> "\xC3\x90"
+          | 0xA4 -> "\xC3\x9E"
+          | 0xA5 -> "\xC3\x86"
+          | 0xA6 -> "\xC5\x92"
+          | 0xA8 -> "\xC2\xB7"
+          | 0xAA -> "\xC2\xAE"
+          | 0xAB -> "\xC2\xB1"
+          | 0xAE -> "\xCA\xBC"
+          | 0xB0 -> "\xCA\xBB"
+          | 0xB1 -> "\xC5\x82"
+          | 0xB2 -> "\xC3\xB8"
+          | 0xB3 -> "\xC4\x91"
+          | 0xB4 -> "\xC3\xBE"
+          | 0xB5 -> "\xC3\xA6"
+          | 0xB6 -> "\xC5\x93"
+          | 0xB8 -> "\xC4\xB1"
+          | 0xB9 -> "\xC2\xA3"
+          | 0xBA -> "\xC3\xB0"
+          | 0xC3 -> "\xC2\xA9"
+          | 0xC5 -> "\xC2\xBF"
+          | 0xC6 -> "\xC2\xA1"
+          | 0xCF -> "\xC3\x9F"
+          | _ -> ""
+        in
+        if utf8 = "" then (
+          Buffer.add_char buf s.[i];
+          loop (i + 1))
+        else (
+          Buffer.add_string buf utf8;
+          loop (i + 1))
+  in
+  loop 0
+
 let no_accent = function
   | '\224' .. '\229' -> 'a'
   | '\162' | '\231' -> 'c'

--- a/lib/ansel.mli
+++ b/lib/ansel.mli
@@ -1,6 +1,17 @@
 val of_iso_8859_1 : string -> string
-(** Convert ISO-8859-1 encoded string to ANSEL encoding used inside gedcom files
-*)
+(** Convert ISO-8859-1 encoded string to ANSEL encoding used inside gedcom
+    files. Limited to Latin-1 characters only. *)
 
 val to_iso_8859_1 : string -> string
-(** Convert ANSEL used inside gedcom files to ISO-8859-1 encoding *)
+(** Convert ANSEL used inside gedcom files to ISO-8859-1 encoding. Limited to
+    Latin-1 characters only. *)
+
+val of_utf_8 : string -> string
+(** Convert UTF-8 encoded string to ANSEL encoding per GEDCOM 5.5.1. Supports
+    Latin-1, Latin Extended-A (U+0000-U+017F), ligatures Œ/œ, symbols (© ® ± £ ·
+    ¿ ¡), and special characters (ı ʼ ʻ). Note: ANSEL was withdrawn as a
+    standard in 2013; UTF-8 recommended. *)
+
+val to_utf_8 : string -> string
+(** Convert ANSEL encoding to UTF-8 per GEDCOM 5.5.1 Appendix C. Handles
+    combining diacritics (0xE0-0xF9) and direct codes. *)


### PR DESCRIPTION
https://www.tamurajones.net/ANSELUnicodeConversion.xhtml 

Note that this website recommand to avoid saving GEDCOM in Ansel. Should we remove that support?