### PR TITLE
gwsetup: gwu/gwb2ged rework -a, -d, -ad, -aws and -parentship

### DIFF
--- a/bin/gwexport/gwexport.mli
+++ b/bin/gwexport/gwexport.mli
@@ -20,10 +20,12 @@ type gwexport_opts = {
       (* If asc, ascdesc and desc are not set & parenting = true, then
          select individuals involved in parentship between pair of keys
          (/!\ assumes the input are pairs of keys) *)
-  picture_path : bool; (* Unused by this module *)
+  picture_path : bool; (* Used in gwb2gedLib module *)
   source : string option; (* Unused by this module *)
   surnames : string list; (* Used to select persons by their surname *)
-  verbose : bool; (* Unused by this module *)
+  verbose : bool; (* Used in gwus module *)
+  test : bool;
+      (* Used in gwu to print detailed etst data (use it only on small results) *)
 }
 
 val default_opts : gwexport_opts

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -67,31 +67,33 @@ let () =
         Driver.load_unions_array base;
         Driver.load_descends_array base;
         ());
-      if opts.Gwexport.verbose then (
-        let iper_filter, ifam_filter = select in
-        let nb_persons =
-          Geneweb_db.Collection.fold (fun count i ->
-            if iper_filter i then 
-              (Printf.eprintf "P: %s\n"
-                (Geneweb_db.Gutil.designation base (Driver.poi base i));
-              count + 1)
-            else count
-          ) 0 (Driver.ipers base)
-        in
-        let nb_families =
-          Geneweb_db.Collection.fold (fun count i ->
-            if ifam_filter i then (
-              let father = Driver.get_father (Driver.foi base i) in
-              let mother = Driver.get_mother (Driver.foi base i) in
-              Printf.eprintf "F: %s & %s\n" 
-                (Geneweb_db.Gutil.designation base (Driver.poi base father))
-                (Geneweb_db.Gutil.designation base (Driver.poi base mother));
-              count + 1 )
-            else count
-          ) 0 (Driver.ifams base)
-        in
-        Printf.eprintf "Exporting %d persons and %d families\n" 
-          nb_persons nb_families);
+      (if opts.Gwexport.test then
+         let iper_filter, ifam_filter = select in
+         let nb_persons =
+           Geneweb_db.Collection.fold
+             (fun count i ->
+               if iper_filter i then (
+                 Printf.eprintf "P: %s\n"
+                   (Geneweb_db.Gutil.designation base (Driver.poi base i));
+                 count + 1)
+               else count)
+             0 (Driver.ipers base)
+         in
+         let nb_families =
+           Geneweb_db.Collection.fold
+             (fun count i ->
+               if ifam_filter i then (
+                 let father = Driver.get_father (Driver.foi base i) in
+                 let mother = Driver.get_mother (Driver.foi base i) in
+                 Printf.eprintf "F: %s & %s\n"
+                   (Geneweb_db.Gutil.designation base (Driver.poi base father))
+                   (Geneweb_db.Gutil.designation base (Driver.poi base mother));
+                 count + 1)
+               else count)
+             0 (Driver.ifams base)
+         in
+         Printf.eprintf "Exporting %d persons and %d families\n" nb_persons
+           nb_families);
       let _ofile, oc, close = opts.Gwexport.oc in
       if not !GwuLib.raw_output then oc "encoding: utf-8\n";
       if !GwuLib.old_gw then oc "\n" else oc "gwplus\n\n";

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -67,6 +67,31 @@ let () =
         Driver.load_unions_array base;
         Driver.load_descends_array base;
         ());
+      if opts.Gwexport.verbose then (
+        let iper_filter, ifam_filter = select in
+        let nb_persons =
+          Geneweb_db.Collection.fold (fun count i ->
+            if iper_filter i then 
+              (Printf.eprintf "P: %s\n"
+                (Geneweb_db.Gutil.designation base (Driver.poi base i));
+              count + 1)
+            else count
+          ) 0 (Driver.ipers base)
+        in
+        let nb_families =
+          Geneweb_db.Collection.fold (fun count i ->
+            if ifam_filter i then (
+              let father = Driver.get_father (Driver.foi base i) in
+              let mother = Driver.get_mother (Driver.foi base i) in
+              Printf.eprintf "F: %s & %s\n" 
+                (Geneweb_db.Gutil.designation base (Driver.poi base father))
+                (Geneweb_db.Gutil.designation base (Driver.poi base mother));
+              count + 1 )
+            else count
+          ) 0 (Driver.ifams base)
+        in
+        Printf.eprintf "Exporting %d persons and %d families\n" 
+          nb_persons nb_families);
       let _ofile, oc, close = opts.Gwexport.oc in
       if not !GwuLib.raw_output then oc "encoding: utf-8\n";
       if !GwuLib.old_gw then oc "\n" else oc "gwplus\n\n";

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -856,7 +856,6 @@ let infer_rc conf rc =
 let exec_f conf comm =
   let s = comm ^ " > " ^ "comm.log" in
   Printf.eprintf "$ cd \"%s\"\n" (Sys.getcwd ());
-  flush stderr;
   Printf.eprintf "$ %s\n" s;
   flush stderr;
   let rc = Sys.command s in
@@ -1041,6 +1040,7 @@ let connex ok_file conf =
     else (
       Printf.eprintf "%s (%s) %s (%s)\n" "Unknown Os_type" Sys.os_type
         "or wrong uname response" uname;
+      flush stderr;
       2)
   in
   flush stderr;
@@ -1252,7 +1252,6 @@ let cleanup_1 conf =
   in
   let in_base_dir = in_base ^ ".gwb" in
   Printf.eprintf "$ cd \"%s\"\n" (Sys.getcwd ());
-  flush stderr;
   let c = Filename.concat !bin_dir "gwu" ^ " " ^ in_base ^ " -o tmp.gw" in
   Printf.eprintf "$ %s\n" c;
   flush stderr;
@@ -1294,11 +1293,13 @@ let rec check_new_names conf l1 l2 =
   | (k, v) :: l, x :: m ->
       if k <> x then (
         Printf.eprintf "Mismatch: k (%s) <> x (%s)\n" k x;
+        flush stderr;
         print_file conf "err_outd.htm";
         raise Exit)
       else if not (Mutil.good_name v) then (
         let conf = { conf with env = ("o", v) :: conf.env } in
         Printf.eprintf "Bad name: (%s)\n" v;
+        flush stderr;
         print_file conf "err_name.htm";
         raise Exit)
       else check_new_names conf l m
@@ -1306,6 +1307,7 @@ let rec check_new_names conf l1 l2 =
   | _ ->
       Printf.eprintf "Bad exit (l1:%d, l2:%d)\n" (List.length l1)
         (List.length l2);
+      flush stderr;
       print_file conf "err_outd.htm";
       raise Exit
 
@@ -1329,10 +1331,12 @@ let rename conf =
     |> List.rev
   in
   List.iter (fun (k, v) -> Printf.eprintf "k=%s, v=%s\n" k v) rename_list;
+  flush stderr;
   let rename_cnt_files k v =
     (* we assume that etc/bname/cache has been renamed *)
     let dir = !GWPARAM.cnt_d k in
     Printf.eprintf "Rename cnt files in %s\n" dir;
+    flush stderr;
     let files = Sys.readdir dir in
     Array.iter
       (fun filename ->
@@ -1363,13 +1367,9 @@ let rename conf =
           flush stderr;
           try
             if GWPARAM.is_reorg_base k then begin
-              Printf.eprintf "Is reorg\n";
-              flush stderr;
               Sys.rename (k ^ ".gwb") (v ^ ".gwb")
             end
             else begin
-              Printf.eprintf "Is not reorg\n";
-              flush stderr;
               if Sys.file_exists (k ^ ".gwb") then
                 Sys.rename (k ^ ".gwb") (v ^ ".gwb");
               if Sys.file_exists (k ^ ".gwf") then
@@ -1954,6 +1954,7 @@ let intro () =
   Arg.parse speclist anonfun usage;
   if !bin_dir = "" then bin_dir := !setup_dir;
   Printf.eprintf "Start gwsetup\n";
+  flush stderr;
   default_lang := default_setup_lang;
   let gwd_lang, setup_lang =
     if !daemon then


### PR DESCRIPTION
* streamline -a, -d, -ad
* implement -aws to include siblings of persons listed
* implement -parentship: list persons on shortest path, including parents for sibling links
   -aws in this context includes all siblings of end of path persons
* Add -t option to print out results. Lists persons and families being exported
  To be used only for limited size results!

