### PR TITLE
fix(gwd): set stdout to binary mode in CGI on Windows

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2640,6 +2640,7 @@ let main () =
   Util.is_welcome := false;
   if cgi then (
     Wserver.cgi := true;
+    set_binary_mode_out stdout true;
     let query =
       if Sys.getenv_opt "REQUEST_METHOD" = Some "POST" then (
         let len =


### PR DESCRIPTION
On Windows, stdout defaults to text mode which converts \n to \r\n. This corrupts binary output (images, PDFs) served via CGI.

The fix mirrors the existing set_binary_mode_in for stdin. HTML output is unaffected as \n is just whitespace.

Co-authored-by: pit47623 (original diagnosis and fix, 2020)

Fixes #103