### PR TITLE
fix(ged2gwb): resolve SOUR references to TITL/TEXT content

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -1059,7 +1059,26 @@ let treat_notes gen rl =
 let treat_source gen r =
   if String.length r.rval > 0 && r.rval.[0] = '@' then
     match find_sources_record gen r.rval with
-      Some v -> strip_spaces v.rcont, v.rsons
+      Some v ->
+        let src =
+          let titl =
+            match find_field "TITL" v.rsons with
+              Some l -> rebuild_text l
+            | None -> ""
+          in
+          let text =
+            match find_field "TEXT" v.rsons with
+              Some l -> rebuild_text l
+            | None -> ""
+          in
+          let rcont = strip_spaces v.rcont in
+          if titl <> "" && text <> "" then "{" ^ titl ^ "} " ^ text
+          else if titl <> "" then titl
+          else if text <> "" then text
+          else if rcont <> "" then rcont
+          else r.rval
+        in
+        src, v.rsons
     | None ->
         print_location r.rpos;
         Printf.fprintf !log_oc "Source %s not found\n" r.rval;


### PR DESCRIPTION
When importing GEDCOM files with source references like:
```
  2 SOUR @S1@
```
pointing to:
```
  0 @S1@ SOUR
  1 TITL acte1
  1 TEXT reconnu le 18/04/1697.
```
The source field now displays “{acte1} reconnu le 18/04/1697.” instead of the raw reference “@S1@”.

Format: {TITL} TEXT, or just TITL/TEXT if only one is present. Falls back to raw reference if no content found.

Closes #157, #284, #1296.