### PR TITLE
gwsetup (Windows): detach child process stdin to prevent cmd.exe blocking

### DIFF
--- a/lib/wserver/wserver.ml
+++ b/lib/wserver/wserver.ml
@@ -241,8 +241,13 @@ let accept_connection_windows socket =
         [| "WSERVER=" ^ string_of_sockaddr addr |]
     in
     let args = Sys.argv in
-    Unix.create_process_env Sys.argv.(0) args env Unix.stdin Unix.stdout
-      Unix.stderr
+    let null_in = Unix.openfile "NUL" [ Unix.O_RDONLY ] 0 in
+    let pid =
+      Unix.create_process_env Sys.argv.(0) args env null_in Unix.stdout
+        Unix.stderr
+    in
+    Unix.close null_in;
+    pid
   in
   let _ = Unix.waitpid [] pid in
   Compat.In_channel.with_open_bin !sock_in close_in;


### PR DESCRIPTION
On Windows, the gwsetup HTTP handler respawns itself using `Unix.create_process_env` and currently inherits the console stdin.

When request handlers invoke Sys.command, this launches `cmd.exe /c <command>` which also inherits the console stdin. With modern Windows console behavior, `cmd.exe` may block waiting for console input, causing gwsetup to hang until an `Enter` keypress is received.

The child process does not require stdin because HTTP requests are read from the socket (sock_in) and the intro() path is skipped when WSERVER is set.

Fix by redirecting stdin to the Windows NUL device when spawning the child process. This prevents `cmd.exe` from attaching to the console and eliminates the blocking behavior.

Changes:
- Open "NUL" as read-only and pass it as stdin to Unix.create_process_env
- Close the temporary descriptor after spawning

This change is Windows-specific and limited to `accept_connection_windows`. All `Sys.command` calls benefit automatically.