### PR TITLE
fix GEDCOM B.C./BCE date import/export

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -685,7 +685,12 @@ EXTEND
       | "-"; i = INT ->
         (try (- int_of_string i) with  Failure _ -> raise Stream.Failure)
       | i = INT; ID "BCE" ->
-        (try (- int_of_string i) with  Failure _ -> raise Stream.Failure) ] ]
+        (try (- int_of_string i) with  Failure _ -> raise Stream.Failure)
+      | i = INT; ID "B"; "."; ID "C"; "." ->
+        (try (- int_of_string i) with  Failure _ -> raise Stream.Failure)
+      | i = INT; ID "B"; "."; ID "C" ->
+        (try (- int_of_string i) with  Failure _ -> raise Stream.Failure)
+      ] ]
   ;
 END
 [@@@ocaml.warning "+27"]

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -290,6 +290,13 @@ let ged_calendar opts = function
   | Dfrench -> Printf.ksprintf (oc opts) "@#DFRENCH R@ "
   | Dhebrew -> Printf.ksprintf (oc opts) "@#DHEBREW@ "
 
+let ged_bce opts =
+  match opts.Gwexport.charset with Gwexport.Utf8 -> "BCE" | _ -> "B.C."
+
+let ged_year opts y =
+  if y >= 0 then Printf.ksprintf (oc opts) "%d" y
+  else Printf.ksprintf (oc opts) "%d %s" (-y) (ged_bce opts)
+
 let ged_date_dmy opts dt cal =
   (match dt.prec with
   | Sure -> ()
@@ -302,8 +309,7 @@ let ged_date_dmy opts dt cal =
   ged_calendar opts cal;
   if dt.day <> 0 then Printf.ksprintf (oc opts) "%02d " dt.day;
   if dt.month <> 0 then Printf.ksprintf (oc opts) "%s " (ged_month cal dt.month);
-  if dt.year >= 0 then Printf.ksprintf (oc opts) "%d" dt.year
-  else Printf.ksprintf (oc opts) "%d BCE" (-dt.year);
+  ged_year opts dt.year;
   match dt.prec with
   | OrYear dmy2 ->
       Printf.ksprintf (oc opts) " AND ";
@@ -311,14 +317,14 @@ let ged_date_dmy opts dt cal =
       if dmy2.day2 <> 0 then Printf.ksprintf (oc opts) "%02d " dmy2.day2;
       if dmy2.month2 <> 0 then
         Printf.ksprintf (oc opts) "%s " (ged_month cal dmy2.month2);
-      Printf.ksprintf (oc opts) "%d" dmy2.year2
+      ged_year opts dmy2.year2
   | YearInt dmy2 ->
       Printf.ksprintf (oc opts) " AND ";
       ged_calendar opts cal;
       if dmy2.day2 <> 0 then Printf.ksprintf (oc opts) "%02d " dmy2.day2;
       if dmy2.month2 <> 0 then
         Printf.ksprintf (oc opts) "%s " (ged_month cal dmy2.month2);
-      Printf.ksprintf (oc opts) "%d" dmy2.year2
+      ged_year opts dmy2.year2
   | _ -> ()
 
 let ged_date opts = function


### PR DESCRIPTION
Export: use B.C. (GEDCOM 5.5) or BCE (5.5.1) depending on charset. Handle negative years in OrYear/YearInt secondary dates. Extract ged_bce/ged_year helpers in gwb2gedLib.ml.

Import: recognize B.C. syntax (GEDCOM 5.5) in addition to existing BCE and minus sign in ged2gwb parser.

Fixes #1791