### PR TITLE
Fix wrong type used in `Search.lookup` procedure

### DIFF
--- a/rpc/lib/service.ml
+++ b/rpc/lib/service.ml
@@ -76,8 +76,8 @@ module Analyze = Geneweb_search.Analyze
 module Search = struct
   let lookup ~fuel idx =
     decl "lookup"
-      Desc.Syntax.(tup3 string string int @-> ret (list string))
-      (fun (name, s, size) ->
+      Desc.Syntax.(string @-> string @-> int @-> ret (list string))
+      (fun name s size ->
         match List.assoc name idx with
         | exception Not_found ->
             (* TODO: Methods could fail and emit errors. We can implement

--- a/rpc/server/route.ml
+++ b/rpc/server/route.ml
@@ -10,7 +10,7 @@ type t = string * Service.t
 let path n srv = (n, srv)
 
 let not_implemented id =
-  Response.(error ~id @@ Error.server_error ~code:10 "not implemented")
+  Response.(error ~id @@ Error.server_error ~code:(-32097) "not implemented")
 
 let route l =
   let map = MS.of_seq (List.to_seq l) in
@@ -28,11 +28,11 @@ let route l =
               match%lwt Service.Desc.eval desc f params with
               | Ok r -> Lwt.return @@ Response.ok ~id r
               | Error e ->
-                  (* TODO: choose an error code *)
                   Lwt.return
                   @@ Response.(
                        error ~id
-                       @@ Error.server_error ~code:10 "%a" Service.pp_error e))
+                       @@ Error.server_error ~code:(-32098) "%a"
+                            Service.pp_error e))
         in
         match params with
         | Some (`List l) -> call l

--- a/rpc/test/rpc.html
+++ b/rpc/test/rpc.html
@@ -57,7 +57,7 @@
 
       async function search_callback() {
         const input = document.getElementById("input-search");
-        const msg = await client2.lookup(["dict", input.value, 15]);
+        const msg = await client2.lookup("dict", input.value, 15);
         const output = document.getElementById("output-search");
         console.log(msg);
         output.innerHTML = "";


### PR DESCRIPTION
The type `(string * int * int) @-> string list` takes a single argument, which is a bit counterintuitive. The type `string @-> int @-> int @-> string list` is simpler.

This commit also fixes an issues with server error. JSON-RPC standard expects specific error code for internal server code. Our JSON-RPC implementation checks that we respect the standard, but we emit such internal errors with wrong code.

Notice the change in `rpc.html`. You should probably update your code to invoke `lookup` the same way.