### PR TITLE
fix: handle stored year<=0 in Hebrew/French/Islamic dates

### DIFF
--- a/lib/util/calendar.ml
+++ b/lib/util/calendar.ml
@@ -3,6 +3,13 @@ let to_calendar_date kind { Def.day; month; year; delta; _ } =
   let month = max 1 month in
   match Calendars.make kind ~day ~month ~year ~delta with
   | Ok d -> d
+  | Error _ when year <= 0 -> (
+      match Calendars.make kind ~day ~month ~year:1 ~delta with
+      | Ok d -> d
+      | Error err ->
+          failwith
+            (Printf.sprintf "Invalid date: %s"
+               (Calendars.Unsafe.to_string err.value)))
   | Error err ->
       failwith
         (Printf.sprintf "Invalid date: %s"


### PR DESCRIPTION
Existing databases may contain year 0 (e.g. Adam/Eve in Hebrew calendar). After Calendars rejects year<=0 (https://github.com/geneweb/calendars/pull/9), to_calendar_date would crash on these records. Retry with year=1 when make fails on non-positive year for calendars that have no year zero.