### PR TITLE
Better client to test RPC server

### DIFF
--- a/rpc/lib/service.ml
+++ b/rpc/lib/service.ml
@@ -76,8 +76,8 @@ module Analyze = Geneweb_search.Analyze
 module Search = struct
   let lookup ~fuel idx =
     decl "lookup"
-      Desc.Syntax.(tup3 string string int @-> ret (list string))
-      (fun (name, s, size) ->
+      Desc.Syntax.(string @-> string @-> int @-> ret (list string))
+      (fun name s size ->
         match List.assoc name idx with
         | exception Not_found ->
             (* TODO: Methods could fail and emit errors. We can implement

--- a/rpc/server/route.ml
+++ b/rpc/server/route.ml
@@ -10,7 +10,7 @@ type t = string * Service.t
 let path n srv = (n, srv)
 
 let not_implemented id =
-  Response.(error ~id @@ Error.server_error ~code:10 "not implemented")
+  Response.(error ~id @@ Error.server_error ~code:(-32097) "not implemented")
 
 let route l =
   let map = MS.of_seq (List.to_seq l) in
@@ -28,11 +28,11 @@ let route l =
               match%lwt Service.Desc.eval desc f params with
               | Ok r -> Lwt.return @@ Response.ok ~id r
               | Error e ->
-                  (* TODO: choose an error code *)
                   Lwt.return
                   @@ Response.(
                        error ~id
-                       @@ Error.server_error ~code:10 "%a" Service.pp_error e))
+                       @@ Error.server_error ~code:(-32098) "%a"
+                            Service.pp_error e))
         in
         match params with
         | Some (`List l) -> call l

--- a/rpc/test/rpc.html
+++ b/rpc/test/rpc.html
@@ -57,7 +57,7 @@
 
       async function search_callback() {
         const input = document.getElementById("input-search");
-        const msg = await client2.lookup(["dict", input.value, 15]);
+        const msg = await client2.lookup("dict", input.value, 15);
         const output = document.getElementById("output-search");
         console.log(msg);
         output.innerHTML = "";

--- a/rpc/test/rpc_test.ml
+++ b/rpc/test/rpc_test.ml
@@ -3,8 +3,61 @@ module U = Yojson.Safe.Util
 module Json_rpc = Geneweb_rpc.Json_rpc
 open Lwt.Infix
 
-let default_interface = "localhost"
-let default_port = 8080
+exception Syntax_error
+exception Eof
+
+type input = { content : string; mutable offset : int }
+
+let make_input content = { content; offset = 0 }
+
+let next_char ({ content; offset } as input) =
+  if offset >= String.length content then raise Eof
+  else
+    let r = content.[offset] in
+    input.offset <- input.offset + 1;
+    r
+
+let char_to_int c = Char.code c - 48
+
+let rec next_token input =
+  let rec tokenize_int x =
+    match next_char input with
+    | '0' .. '9' as c -> tokenize_int ((10 * x) + char_to_int c)
+    | ' ' | (exception Eof) -> `Int x
+    | _ -> raise Syntax_error
+  in
+  let rec tokenize_quoted_string buf =
+    match next_char input with
+    | '"' -> `String (Buffer.contents buf)
+    | _ as c ->
+        Buffer.add_char buf c;
+        tokenize_quoted_string buf
+    | exception Eof -> raise Syntax_error
+  in
+  let rec tokenize_unquoted_string buf =
+    match next_char input with
+    | ' ' | (exception Eof) -> `String (Buffer.contents buf)
+    | _ as c ->
+        Buffer.add_char buf c;
+        tokenize_unquoted_string buf
+  in
+  match next_char input with
+  | '0' .. '9' as c -> tokenize_int (char_to_int c)
+  | '"' -> tokenize_quoted_string (Buffer.create 17)
+  | ' ' -> next_token input
+  | _ as c ->
+      let buf = Buffer.create 17 in
+      Buffer.add_char buf c;
+      tokenize_unquoted_string buf
+
+let parse_input s =
+  let input = make_input s in
+  let rec loop tokens =
+    match next_token input with
+    | exception Eof -> List.rev tokens
+    | tk -> loop (tk :: tokens)
+  in
+  loop []
 
 let rpc_handler content =
   try
@@ -16,19 +69,39 @@ let rpc_handler content =
     Fmt.pr "The server sent an invalid JSON message:@ %s@ Parser error:@ %s@."
       content s
 
+(* FIXME: hackish synchronisation for logs. This may fail
+   if the server answer to quickly. *)
+let condition : unit Lwt_condition.t = Lwt_condition.create ()
+
+let wait_answer ~timeout () =
+  Lwt.pick [ Lwt_unix.sleep timeout; Lwt_condition.wait condition ]
+
 let rec loop wsd i () =
+  let open Lwt.Syntax in
   let write wsd content =
     let len = String.length content in
     Httpun_ws.Wsd.schedule wsd ~kind:`Text ~off:0 ~len
     @@ Bigstringaf.of_string content ~off:0 ~len
   in
-  let request = Json_rpc.Request.make (`Int i) "ping" in
-  let content = Json_rpc.Request.to_json request |> Y.(to_string ~std:true) in
-  write wsd content;
-  Lwt_unix.sleep 1.0 >>= loop wsd (i + 1)
+  let* () = if i > 0 then wait_answer ~timeout:5.0 () else Lwt.return_unit in
+  let* () = Lwt_io.write Lwt_io.stdout "rpc> " in
+  let* s = Lwt_io.read_line Lwt_io.stdin in
+  match parse_input s with
+  | `String meth :: args ->
+      let params = `List args in
+      let request = Json_rpc.Request.make ~params (`Int i) meth in
+      let content =
+        Json_rpc.Request.to_json request |> Y.(to_string ~std:true)
+      in
+      write wsd content;
+      loop wsd (i + 1) ()
+  | (exception Syntax_error) | _ ->
+      Fmt.pr "Syntax error@.";
+      loop wsd i ()
 
 let ws_handler _u wsd =
   let on_read ~kind:_ content ~off:_ ~len:_ =
+    Lwt_condition.signal condition ();
     rpc_handler @@ Bigstringaf.to_string content
   in
   let frame ~opcode ~is_fin:_ ~len:_ payload =
@@ -46,15 +119,25 @@ let error_handler = function
   | `Invalid_response_body_length _ -> Fmt.pr "Invalid response body length@."
   | `Exn exn -> Fmt.pr "Uncaught exception:@ %s@." (Printexc.to_string exn)
 
+let default_interface = "localhost"
+let default_port = 8080
+let default_service = "search"
+
 let () =
   let interface = ref default_interface in
   let port = ref default_port in
-  let usage = "rpc_test.exe -i INTERFACE -p PORT" in
+  let service = ref default_service in
+  let usage = "rpc_test.exe -i INTERFACE -p PORT -s SERVICE" in
 
   Arg.parse
     [
-      ("-i", Set_string interface, "Interface (localhost by default)");
-      ("-p", Set_int port, "Port (8080 by default)");
+      ( "-i",
+        Set_string interface,
+        Fmt.str "Interface (%s by default)" default_interface );
+      ("-p", Set_int port, Fmt.str "Port (%d by default)" default_port);
+      ( "-s",
+        Set_string service,
+        Fmt.str "Choose the service (%s by default)" default_service );
     ]
     (fun (_ : string) -> ())
     usage;
@@ -73,7 +156,8 @@ let () =
           [ ("host", String.concat ":" [ !interface; string_of_int !port ]) ])
     in
     let upgrade_request =
-      Httpun_ws.Handshake.create_request ~nonce ~headers "/pingpong"
+      Httpun_ws.Handshake.create_request ~nonce ~headers
+        (Fmt.str "/%s" !service)
     in
     let p, u = Lwt.wait () in
     let request_body =


### PR DESCRIPTION
The rpc_test.exe binary is helpful to understand the rpc error and so
on. You can start it as follows:
```console
dune exec -- rpc/test/rpc_test.exe -s search
```
You got a prompt and you can call a remote procedure as follows:
```output
rpc> lookup dict "foo bar" 30
```

Notice that the parser is very naive and supports only integer, quoted
string and unquoted string without spaces.

This PR is rebased on #2537 