### PR TITLE
fix(gwb2ged): export all first name aliases as GEDCOM NAME lines

### DIFF
--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -276,7 +276,16 @@ let ged_name opts base per =
   List.iter
     (fun s ->
       Printf.ksprintf (oc opts) "1 NAME %s\n" (encode opts (Driver.sou base s)))
-    (Driver.get_aliases per)
+    (Driver.get_aliases per);
+  let sn =
+    encode opts (Mutil.nominative (Driver.sou base (Driver.get_surname per)))
+  in
+  List.iter
+    (fun n ->
+      Printf.ksprintf (oc opts) "1 NAME %s /%s/\n"
+        (encode opts (Driver.sou base n))
+        sn)
+    (Driver.get_first_names_aliases per)
 
 let ged_sex opts per =
   match Driver.get_sex per with


### PR DESCRIPTION
Only the first element of first_names_aliases was partially used (embedded in the primary 1 NAME line by ged_1st_name). All remaining aliases were silently discarded during GEDCOM export, causing data loss on gwb→ged→gwb round-trips.

Export every first_names_alias as an additional "1 NAME fn_alias /sn/" line, following GEDCOM 5.5.1 multiple NAME convention.

Fixes #849