### PR TITLE
m=N: multi-surname branch/alphabetic display

### DIFF
--- a/lib/some.mli
+++ b/lib/some.mli
@@ -70,3 +70,16 @@ val print_several_possible_surnames :
   Geneweb_db.Driver.base ->
   'a * (string * Geneweb_db.Driver.person list) list ->
   unit
+
+val get_extra_surnames : Config.config -> string list
+(** Collect v1=, v2=, ... surname values from URL env. *)
+
+val collect_surname_suggestions :
+  Config.config ->
+  Geneweb_db.Driver.base ->
+  Geneweb_db.Driver.iper list ->
+  string list ->
+  string list
+(** [collect_surname_suggestions conf base iperl known] returns surnames found
+    in aliases and boundary children, excluding those already in [known]. Sorted
+    alphabetically. *)


### PR DESCRIPTION
Allow combining related surname variants in a single branch or alphabetic view via URL parameters `v1=`, `v2=`, etc. alongside the existing `v=` primary surname. Backward compatible: `v=` alone works as before.

Branch view: tree traversal follows into children carrying any accepted name (primary or extra). Surname display is suppressed only for primary names; extra individuals always show their surname, making variant carriers visually distinct in the tree.

Branch structure uses primary ipers only for select_ancestors, avoiding duplicate branches. select_ancestors now checks parent surname membership against all accepted names (primary + extras), preventing spurious branch heads at variant boundaries.

Alphabetic view: extra individuals are grouped with their surname appended to the first-name key, ensuring visual distinction. Both views share a navigation bar with datalist-based autocomplete for adding variants and badge controls for removing them, with proper v(i) renumbering on removal.

New helpers: get_extra_surnames, extra_surname_url_params, url_excluding, url_removing_extra, print_variant_controls, print_nav_variant_bar, collect_surname_suggestions.

Replaces print_display_mode_navigation, print_branch_to_alphabetic and print_alphabetic_to_branch with unified print_nav_variant_bar.

Closes #274.