### PR TITLE
Fix port cli option of the RPC server

### DIFF
--- a/rpc/server/cmd.ml
+++ b/rpc/server/cmd.ml
@@ -89,7 +89,8 @@ let parse_connection_opt interface port max_connection idle_timeout crt key =
   let port =
     match (port, crt) with
     | None, Some _ -> default_tls_port
-    | _ -> default_port
+    | None, None -> default_port
+    | Some p, _ -> p
   in
   match (crt, key) with
   | Some crt, Some key ->


### PR DESCRIPTION
The cli parser ignored silently the option.