### PR TITLE
remove duplicate -f flag in gwsetup gwc command

### DIFF
--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -949,7 +949,7 @@ let gwc_or_ged2gwb out_name_of_in_name conf =
   else print_file conf "create.htm"
 
 let gwc_check conf =
-  let conf = { conf with env = ("nofail", "on") :: ("f", "on") :: conf.env } in
+  let conf = { conf with env = ("nofail", "on") :: conf.env } in
   gwc_or_ged2gwb out_name_of_gw conf
 
 let ged2gwb_check conf =


### PR DESCRIPTION
The `gwc_check` function was hardcoding `("f", "on")` in conf.env, causing duplicate -f parameters when the user checked the “Delete database if already existing” checkbox: `gwc -nofail -f /path/file.gw -o base -f > comm.log`

Removed hardcoded -f injection, allowing user checkbox to control the -f flag properly. Kept -nofail for backward compatibility with web interface error handling.

Fix #1845.