### PR TITLE
fix `-add_lexicon` file lookup in CGI mode

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -326,7 +326,13 @@ let load_lexicon =
               in
               rev_iter
                 (fun fname ->
-                  let fname = Util.search_in_assets fname in
+                  let fname =
+                    let f = Util.search_in_assets fname in
+                    if Sys.file_exists f then f
+                    else
+                      let bf = Filename.concat (Secure.base_dir ()) fname in
+                      if Sys.file_exists bf then bf else f
+                  in
                   if Sys.file_exists fname then
                     Mutil.input_lexicon lang ht (fun () -> Secure.open_in fname)
                   else Logs.warn (fun k -> k "File %s unavailable\n" fname))


### PR DESCRIPTION
`search_in_assets` only searches `Secure.assets()` directories (typically “gw” and “.”), not the base directory. In server mode the CWD usually coincides with `bases/` so relative paths like “lang/extra.txt” resolve. In CGI mode the CWD is the web server directory and the file is not found.

Add a local fallback to `Secure.base_dir()` in `load_lexicon` only, without altering the general asset search path.

Fixes #544.