### PR TITLE
add %J (comparable to %I) macro for gwsetup allowing macros

### DIFF
--- a/bin/setup/lang/macros.htm
+++ b/bin/setup/lang/macros.htm
@@ -6,7 +6,8 @@ gwsetup macros
 
 <body>
 <!--
-insert at the bottom of setup/welcome.thm
+insert at the bottom of setup/welcome.thm 
+or type http://localhost:2316/gwsetup?lang=fr;v=macros.htm;i=10  
 -->
 
 <h2>Macros gwsetup</h2>
@@ -21,7 +22,7 @@ assigns the current IP address to evar.anon and the content of the only.txt file
 <p>
 
 <table border="1" width="100%%">
-<tr><td>  Macro </td><td>Result</td><td width="40%%">Explanation</td></tr>
+<tr><td width="15%%">  Macro </td><td>Result</td><td width="40%%">Explanation</td></tr>
 <tr><td>  &#37;/ </td><td> %/ </td><td> if Sys.unix / else \ </td></tr>
 <tr><td>  &#37;&#37; </td><td> %% </td><td> &#37; </td></tr>
 
@@ -31,10 +32,9 @@ assigns the current IP address to evar.anon and the content of the only.txt file
 <tr><td>  &#37;c </td><td> %c </td><td> print setup dir </td></tr>
 <tr><td>  &#37;d </td><td> %d </td><td> print conf.comm </td></tr>
 <tr><td>  &#37;e </td><td> %e </td><td> print env variables </td></tr>
-<tr><td>  &#37;ffile.ext; </td><td> %fsetup.txt;
-  </td><td> Read file file.ext (setup.txt) </td></tr>
+<tr><td>  &#37;ffile.ext; </td><td> %fsetup.txt; </td><td> Read file file.ext (setup.txt) </td></tr>
 <tr><td>  &#37;g{..} </td><td> %g{test} </td><td> print comm.log or content of {..} if does not exist </td></tr>
-<tr><td>  &#37;h </td><td> %h </td><td> print env variables </td></tr>
+<tr><td>  &#37;h </td><td> %h </td><td> print &#60;input type=hidden name=var value=val> for each env variables </td></tr>
 <tr><td>  &#37;i </td><td> %i </td><td> print evar.i </td></tr>
 <tr><td>  &#37;j </td><td> %j </td><td> print file selector </td></tr>
 <tr><td>  &#37;k{&lt;li&gt;%a&lt;/li&gt;|no var} </td><td> %k{<li>%a</li>|no var} </td><td> print env variables (appear as &#37;a) </td></tr>
@@ -70,8 +70,20 @@ assigns the current IP address to evar.anon and the content of the only.txt file
 
 <tr><td>  &#37;Ivar;value;{true part|false part} </td>
   <td> %Itest;essai;{test=essai|test!=essai} </td><td> if var=value print true part otherwise false part (not fully tested) </td></tr>
-<tr><td>  &#37;Iz;;{|:&#37;z} </td>
-  <td> %Iz;;{|:%z} </td><td> another test with a macro as parameter) </td></tr>
+<tr><td>  &#37;Ivar;value;{true part|false part} </td>
+  <td> %Itest;test;{test=test|test!=test} </td><td> if var=value print true part otherwise false part (not fully tested) </td></tr>
+<tr><td>  &#37;Iz;;{true|false: %%z} </td>
+  <td> %Iz;;{true|false: %z} </td><td> another test with I) </td></tr>
+<tr><td>  &#37;Iz;z;{true|false: %%z} </td>
+  <td> %Iz;z;{true|false: %z} </td><td> another test with I) </td></tr>
+<tr><td>  &#37;Iz;%z;{true|false: %%z} </td>
+  <td> %Iz;%z;{true|false: %z} </td><td> another test with I) </td></tr>
+<tr><td>  &#37;J%%z;2316;{2316|pas 2316} </td>
+  <td> %J%z;2316;{2316|pas 2316} </td><td> another test with J and a macro as value) </td></tr>
+<tr><td>  &#37;J%%z;2315;{2315|pas 2315} </td>
+  <td> %J%z;2315;{2315|pas 2315} </td><td> another test with J and a macro as value) </td></tr>
+<tr><td>  &#37;Jfr;%%l;{fr|pas fr} </td>
+  <td> %Jfr;%l;{fr|pas fr} </td><td> another test with J and a macro as value) </td></tr>
 
 </table>
 

--- a/bin/setup/lang/welcome.htm
+++ b/bin/setup/lang/welcome.htm
@@ -85,3 +85,4 @@
   <a href="lv">Latviesu</a>
   <a href="sv">Svenska</a>
 </div>
+

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -598,10 +598,30 @@ let rec copy_from_stream conf print strm =
                   print_specific_file conf print outfile strm
               | 'I' ->
                   (* %Ivar;value;{var = value part|false part} *)
-                  (* var is a evar from url of a bvar from basename.gwf or setup.gwf *)
+                  (* var is a evar from url or a bvar from basename.gwf or setup.gwf *)
                   let k1 = get_variable strm in
                   let k2 = get_variable strm in
                   print_if_else conf print (s_getenv conf.env k1 = k2) strm
+              | 'J' ->
+                  (* %Jvar;value;{var = value part|false part} *)
+                  (* var and value may contain %m macros *)
+                  let k1 = parse_upto ';' strm in
+                  let s1 = ref "" in
+                  let _ =
+                    copy_from_stream conf
+                      (fun k -> s1 := !s1 ^ k)
+                      (Stream.of_string k1)
+                  in
+                  let k1 = !s1 in
+                  let k2 = parse_upto ';' strm in
+                  let s2 = ref "" in
+                  let _ =
+                    copy_from_stream conf
+                      (fun k -> s2 := !s2 ^ k)
+                      (Stream.of_string k2)
+                  in
+                  let k2 = !s2 in
+                  print_if_else conf print (k1 = k2) strm
               | 'K' ->
                   (* print the name of -o filename, prepend bname or -o1 filename *)
                   let outfile1 = strip_spaces (s_getenv conf.env "o") in


### PR DESCRIPTION
test arguments may contain macros:
examples
%J%z;2316;{port is 2316|port is not 2316}
%J%l;fr;{lang is fr|lang is not fr}