### PR TITLE
ci: fix opam cache key formatting and re-enable cache invalidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,16 +76,17 @@ jobs:
           command: start-timer
 
       - name: Cache Opam dependencies
-        id: cache-opam
         uses: actions/cache@v5
         with:
-          path: ${{ runner.os == 'Windows' && 'C:\.opam' || '~/.opam' }}
-          key: ${{ runner.os }}-opam-${{ matrix.ocaml-compiler }}-cache
+          path: ${{ runner.os == 'Windows' && 'C:\\.opam' || '~/.opam' }}
+          key: ${{ runner.os }}-opam-${{ matrix.ocaml-compiler }}-${{ hashFiles('**/*.opam') }}
+          restore-keys: ${{ runner.os }}-opam-${{ matrix.ocaml-compiler }}-
 
       - name: Setup Ocaml with v3
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
 
       - name: Install Perl dependencies (Windows @v3)
         if: runner.os == 'Windows'
@@ -118,7 +119,7 @@ jobs:
       - name: Build Geneweb
         id: build
         shell: bash
-        run: opam exec -- make distrib
+        run: opam exec -- make distrib distrib-rpc
 
       - name: Run tests
         id: tests


### PR DESCRIPTION
The opam cache key was previously simplified and ended up without hash-based invalidation due to macOS-26 hashFiles issues. Those issues have since been resolved, so restore the use of `hashFiles('**/*.opam')` in the key and add a matching `restore-keys` line to ensure we can fallback to broader keys.

Also enable `dune-cache` which should speed up rebuilds once dune's incremental cache is active.

This still uses the single `~/.opam` / `C:\.opam` cache strategy, bearing in mind that an opam.lock-based cache key could also be introduced later to improve determinism.