### PR TITLE
strip anchor fragment from note filename in gwu export

### DIFF
--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -447,6 +447,11 @@ let add_linked_files gen from s some_linked_files =
             String.sub b 0 k
           with Not_found -> b
         in
+        let fname =
+          match String.index_opt fname '#' with
+          | Some k -> String.sub fname 0 k
+          | None -> fname
+        in
         let fname = map_notes gen.notes_alias fname in
         let f = from () in
         let new_linked_files =

--- a/test/wiki_test.ml
+++ b/test/wiki_test.ml
@@ -23,6 +23,11 @@ let expect_failure name speed f =
 let l =
   [
     ([ WLpage (13, ([], "aaa"), "aaa", "", "bbb") ], "[[[aaa/bbb]]]");
+    ([ WLpage (17, ([], "aaa"), "aaa", "b_2", "ccc") ], "[[[aaa#b_2/ccc]]]");
+    ( [
+        WLpage (31, ([ "Sources" ], "Index"), "Sources:Index", "a_2", "sources");
+      ],
+      "[[[Sources:Index#a_2/sources]]]" );
     ( [ WLperson (11, ("ccc", "ddd", 0), Some "ccc ddd", None, None) ],
       "[[ccc/ddd]]" );
     ( [ WLperson (17, ("ccc", "ddd", 0), Some "Texte", None, None) ],


### PR DESCRIPTION
`add_linked_files` parsed [[[page#anchor/text]]] but kept the 
#anchor in the filename, causing check_file_name to reject it.
The note was then missing from the .gw export.

Closes #140.