### PR TITLE
allow death reason without date

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -3096,7 +3096,8 @@ let rec negative_date_ancestors persons ascends unions families couples i =
         | None -> p.birth
       end ;
       death = match p.death with
-        | Death (dr, cd2) -> Death (dr, neg_year_cdate cd2)
+        | Death (dr, cd2) when cd2 <> Date.cdate_None ->
+            Death (dr, neg_year_cdate cd2)
         | _ -> p.death
     }
   in

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -1387,7 +1387,7 @@ let update_pevents_with_person p =
           in
           Some evt
     | Death (_, cd) ->
-        let date = Date.cdate_of_od (Some (Date.date_of_cdate cd)) in
+        let date = cd in
         let evt =
           {
             epers_name = Epers_Death;

--- a/bin/gwdiff/gwdiff.ml
+++ b/bin/gwdiff/gwdiff.ml
@@ -270,10 +270,7 @@ let compatible_death p1 p2 =
     p1.death = p2.death
     ||
     match (p1.death, p2.death) with
-    | Death (_, cdate1), Death (_, cdate2) ->
-        let date1 = Date.date_of_cdate cdate1 in
-        let date2 = Date.date_of_cdate cdate2 in
-        compatible_dates date1 date2
+    | Death (_, cdate1), Death (_, cdate2) -> compatible_cdates cdate1 cdate2
     | NotDead, _
     | DeadYoung, Death (_, _)
     | DeadDontKnowWhen, (Death (_, _) | DeadYoung | DeadDontKnowWhen)

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -381,7 +381,7 @@ let print_infos opts base is_child csrc cbp p =
   if opts.source = None then
     print_if_no_empty opts base "#ps" (Driver.get_baptism_src p);
   (match Driver.get_death p with
-  | Death (dr, d) ->
+  | Death (dr, d) -> (
       Printf.ksprintf (oc opts) " ";
       (match dr with
       | Killed -> Printf.ksprintf (oc opts) "k"
@@ -389,7 +389,9 @@ let print_infos opts base is_child csrc cbp p =
       | Executed -> Printf.ksprintf (oc opts) "e"
       | Disappeared -> Printf.ksprintf (oc opts) "s"
       | _ -> ());
-      print_date opts (Date.date_of_cdate d)
+      match Date.od_of_cdate d with
+      | Some d -> print_date opts d
+      | None -> Printf.ksprintf (oc opts) "0")
   | DeadYoung -> Printf.ksprintf (oc opts) " mj"
   | DeadDontKnowWhen -> Printf.ksprintf (oc opts) " 0"
   | DontKnowIfDead -> (

--- a/lib/db/gutil.ml
+++ b/lib/db/gutil.ml
@@ -271,12 +271,20 @@ let sort_person_list_aux sort base =
               Driver.get_death p2 )
           with
           | Some d1, _, Some d2, _ -> Date.compare_date d1 d2
-          | Some d1, _, _, Death (_, d2) ->
-              Date.compare_date d1 (Date.date_of_cdate d2)
-          | _, Death (_, d1), Some d2, _ ->
-              Date.compare_date (Date.date_of_cdate d1) d2
-          | _, Death (_, d1), _, Death (_, d2) ->
-              Date.compare_date (Date.date_of_cdate d1) (Date.date_of_cdate d2)
+          | Some d1, _, _, Death (_, d2) -> (
+              match Date.od_of_cdate d2 with
+              | Some d2 -> Date.compare_date d1 d2
+              | None -> 1)
+          | _, Death (_, d1), Some d2, _ -> (
+              match Date.od_of_cdate d1 with
+              | Some d1 -> Date.compare_date d1 d2
+              | None -> -1)
+          | _, Death (_, d1), _, Death (_, d2) -> (
+              match (Date.od_of_cdate d1, Date.od_of_cdate d2) with
+              | Some d1, Some d2 -> Date.compare_date d1 d2
+              | Some _, None -> 1
+              | None, Some _ -> -1
+              | None, None -> 0)
           | Some _, _, _, _ -> 1
           | _, Death (_, _), _, _ -> 1
           | _, _, Some _, _ -> -1

--- a/lib/mergeIndDisplay.ml
+++ b/lib/mergeIndDisplay.ml
@@ -215,7 +215,7 @@ let print_differences conf base branches p1 p2 =
       let is = 2 in
       match Driver.get_death p with
       | NotDead -> transl_nth conf "alive" is |> Adef.safe
-      | Death (dr, cd) ->
+      | Death (dr, cd) -> (
           let s =
             match dr with
             | Killed -> transl_nth conf "killed (in action)" is
@@ -224,8 +224,9 @@ let print_differences conf base branches p1 p2 =
             | Disappeared -> transl_nth conf "disappeared" is
             | Unspecified -> transl_nth conf "died" is
           in
-          s ^<^ " "
-          ^<^ DateDisplay.string_of_ondate conf (Date.date_of_cdate cd)
+          match Date.od_of_cdate cd with
+          | Some d -> s ^<^ " " ^<^ DateDisplay.string_of_ondate conf d
+          | None -> s |> Adef.safe)
       | DeadYoung -> transl_nth conf "died young" is |> Adef.safe
       | DeadDontKnowWhen -> transl_nth conf "died" is |> Adef.safe
       | DontKnowIfDead | OfCourseDead -> Adef.safe "");

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -391,12 +391,14 @@ let get_death_text conf p p_auth =
   let on_death_date =
     match (p_auth, Driver.get_death p) with
     | true, Death (_, d) -> (
-        let d = Date.date_of_cdate d in
-        match List.assoc_opt "long_date" conf.base_env with
-        | Some "yes" ->
-            DateDisplay.string_of_ondate ~link:false conf d
-            ^>^ DateDisplay.get_wday conf d
-        | Some _ | None -> DateDisplay.string_of_ondate ~link:false conf d)
+        match Date.od_of_cdate d with
+        | None -> "" |> Adef.safe
+        | Some d -> (
+            match List.assoc_opt "long_date" conf.base_env with
+            | Some "yes" ->
+                DateDisplay.string_of_ondate ~link:false conf d
+                ^>^ DateDisplay.get_wday conf d
+            | Some _ | None -> DateDisplay.string_of_ondate ~link:false conf d))
     | _ -> "" |> Adef.safe
   in
   died ^^^ " " ^<^ on_death_date
@@ -3199,8 +3201,10 @@ and eval_person_field_var conf base env ((p, p_auth) as ep) (loc : Loc.t) =
       if p_auth then eval_place_field conf pl sl else null_val
   | "death_date" :: sl -> (
       match Driver.get_death p with
-      | Death (_, cd) when p_auth ->
-          eval_date_field_var conf (Date.date_of_cdate cd) sl
+      | Death (_, cd) when p_auth -> (
+          match Date.od_of_cdate cd with
+          | Some d -> eval_date_field_var conf d sl
+          | None -> null_val)
       | Death _ | NotDead | DeadYoung | DeadDontKnowWhen | DontKnowIfDead
       | OfCourseDead ->
           null_val)
@@ -3807,7 +3811,7 @@ and eval_bool_person_field conf base env (p, p_auth) = function
   | "has_date" -> GWPARAM.p_auth conf base p
   | "has_death_date" -> (
       match Driver.get_death p with
-      | Death (_, _) -> p_auth
+      | Death (_, cd) -> p_auth && cd <> Date.cdate_None
       | NotDead | DeadYoung | DeadDontKnowWhen | DontKnowIfDead | OfCourseDead
         ->
           false)
@@ -4414,10 +4418,10 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
           raise Not_found)
   | "slash_death_date" -> (
       match (p_auth, Driver.get_death p) with
-      | true, Death (_, d) ->
-          Date.date_of_cdate d
-          |> DateDisplay.string_slash_of_date conf
-          |> safe_val
+      | true, Death (_, d) -> (
+          match Date.od_of_cdate d with
+          | Some d -> DateDisplay.string_slash_of_date conf d |> safe_val
+          | None -> null_val)
       | _ -> null_val)
   | "slash_approx_death_date" -> (
       match (p_auth, fst (Util.get_approx_death_date_place conf base p)) with

--- a/lib/title.ml
+++ b/lib/title.ml
@@ -77,10 +77,14 @@ let compare_title_dates conf base (x1, t1) (x2, t2) =
     ->
       Date.compare_date d1 d2
   | (_, _, _, Death (_, d1)), (_, Some d2, _, _)
-    when Date.compare_date (Date.date_of_cdate d1) d2 <= 0 ->
+    when match Date.od_of_cdate d1 with
+         | Some d1 -> Date.compare_date d1 d2 <= 0
+         | None -> false ->
       -1
   | (_, Some (Dgreg (_, _) as d1), _, _), (_, _, _, Death (_, d2))
-    when Date.compare_date d1 (Date.date_of_cdate d2) > 0 ->
+    when match Date.od_of_cdate d2 with
+         | Some d2 -> Date.compare_date d1 d2 > 0
+         | None -> false ->
       1
   | _ -> (
       match

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -387,7 +387,9 @@ let reconstitute_death conf birth baptism death_place burial burial_place =
   | _s -> (
       match d with
       | Some d -> Death (dr, Date.cdate_of_date d)
-      | None -> DeadDontKnowWhen)
+      | None ->
+          if dr <> Unspecified then Death (dr, Date.cdate_None)
+          else DeadDontKnowWhen)
 
 let reconstitute_burial conf burial_place =
   let d = Update.reconstitute_date conf "burial" in
@@ -456,6 +458,8 @@ let reconstitute_from_pevents pevents ext bi bp de bu =
                     | ( DeadYoung | DeadDontKnowWhen | OfCourseDead
                       | DontKnowIfDead ) as death ->
                         death
+                    | Death (dr, _) when dr <> Unspecified ->
+                        Death (dr, Date.cdate_None)
                     | Death _ | NotDead -> DeadDontKnowWhen)
               in
               let de =


### PR DESCRIPTION
In reconstitute_death, store Death(dr, cdate_None) when a death reason is selected without a date instead of discarding it as DeadDontKnowWhen.

In reconstitute_from_pevents, preserve Death(dr, cdate_None) in the Epers_Death/None branch instead of overwriting it.

Secure all call sites that assumed Death(_, cd) always carries a valid cdate by using od_of_cdate instead of date_of_cdate: perso.ml (get_death_text, slash_death_date, death_date, has_death_date), gutil.ml, title.ml, db1link.ml, gwdiff.ml, gwuLib.ml, mergeIndDisplay.ml, ged2gwb.ml.

Fixes #465.