### PR TITLE
connex: fix empty URLs for unknown persons, modernize output

### DIFF
--- a/bin/setup/lang/connex.htm
+++ b/bin/setup/lang/connex.htm
@@ -2,29 +2,23 @@
 <html lang="%l">
 <head>
   <!-- Copyright (c) 1998-2006 INRIA - GeneWeb -->
-  <!-- $Id: connex.htm,v 7.00 2018-04-09 05:35:06 hg Exp $ -->
   <meta charset="utf-8">
   <meta name="robots" content="none">
   <link rel="shortcut icon" href="images/favicon_gwsetup.png">
-
-  <title>[Connex]
-</title>
+  <title>[Connex]</title>
 %fsetup.css;
 </head>
 
 <body %Vbody_prop;>
-<div style="background:url('images/gwlogo.png') no-repeat left top; text-align:center; height:95px; line-height:95px; color:#2f6400;">
-<h1 style="margin:0;">
-[Listing connected components]
-</h1>
+<div style="background:url('images/gwlogo.png') no-repeat left top;
+ text-align:center; height:95px; line-height:95px; color:#2f6400;">
+<h1 style="margin:0;">[Listing connected components]</h1>
 </div>
 <ul>
 <li>
 <form method="get" action="connex">
 <input type="hidden" name="opt" value="check">
 <input type="hidden" name="lang" value="%l">
-<input type="hidden" name="server" value="%m">
-<input type="hidden" name="gwd_p" value="%P">
 [Select your database by clicking on the associated button][:]
 <p>
 <table class="setup">
@@ -35,7 +29,7 @@
 </tr>|
 <tr align="left"><td>- [there is no database at present]
 </tr></td>}
-</table></dl>
+</table>
 <p>
 <li>
 [Select the options you want][:]
@@ -43,105 +37,115 @@
 <table class="setup">
 <tr align="left">
 <td><input type="checkbox" name="a" id="a" value="on">
-<label for="a" style="font-family: monospace">-a&nbsp;&nbsp;</label>[All connex components.]
+<label for="a" style="font-family: monospace">-a&nbsp;&nbsp;</label>
+[All connex components.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
 <td><input type="checkbox" name="s" id="s" value="on">
-<label for="s" style="font-family: monospace">-s&nbsp;&nbsp;</label>[Produce connected components statistics.]
+<label for="s" style="font-family: monospace">-s&nbsp;&nbsp;</label>
+[Produce connected components statistics.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
 <td>
-<label for="d_1" style="font-family: monospace">-d&nbsp;&nbsp;
-<input type="input" name="d" size="2" maxlength="2" style="padding-left:4px">
-</label>&nbsp;&nbsp;[Details for this length.]
+<label for="d" style="font-family: monospace">-d&nbsp;&nbsp;
+<input type="input" name="d" id="d" size="2" maxlength="2"
+ style="padding-left:4px">
+</label>&nbsp;&nbsp;[Show detail for components of this size.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
 <td>
 <label for="i" style="font-family: monospace">-i&nbsp;&nbsp;
-<input type="input" name="i" size="20" maxlength="50" style="padding-left:4px"></label>&nbsp;&nbsp;[Ignore this file.]
+<input type="input" name="i" id="i" size="20" maxlength="50"
+ style="padding-left:4px"></label>&nbsp;&nbsp;[Ignore this origin file.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
 <td><input type="checkbox" name="bf" id="bf" value="on">
-<label for="bf" style="font-family: monospace">-bf&nbsp;&nbsp;</label>[By origin file.]
+<label for="bf" style="font-family: monospace">-bf&nbsp;&nbsp;</label>
+[Group by origin file.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 [<span style="color:#FF0000;">WARNING</span>: The following three options result in irreversible deletions. Having a backup archive is recommended.]
 %(
-<span style="color:#FF0000;">WARNING</span>: The following three options result 
+WARNING: The following three options result
 in irreversible deletions. Having a backup archive is recommended.
 %)
 <p>
 <table class="setup">
 <tr align="left">
 <td>
-<label for="del_1" style="font-family: monospace">-del
-<input type="input" name="del" size="5" maxlength="2" style="padding-left:4px"></label>&nbsp;&nbsp;[Ask for deleting branches whose size <= that value.]
+<label for="del" style="font-family: monospace">-del
+<input type="input" name="del" id="del" size="5" maxlength="2"
+ style="padding-left:4px"></label>&nbsp;&nbsp;
+[Prompt for deleting branches of size <= this value.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
 <td>
-<label for="cnt_1" style="font-family: monospace">-cnt
-<input type="input" name="cnt" size="5" maxlength="2" style="padding-left:4px"></label>&nbsp;&nbsp;[Specifiy the number of branches to be deleted.]
+<label for="cnt" style="font-family: monospace">-cnt
+<input type="input" name="cnt" id="cnt" size="5" maxlength="4"
+ style="padding-left:4px"></label>&nbsp;&nbsp;
+[Delete up to n branches of size <= -del value.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <table class="setup">
 <tr align="left">
 <td><input type="checkbox" name="exact" id="exact" value="on">
-<label for="exact" style="font-family: monospace">-exact&nbsp;&nbsp;</label>[Restrict deleting branches whose size = -del.]
+<label for="exact" style="font-family: monospace">-exact</label>&nbsp;&nbsp;
+[With -del, match size exactly instead of <=.]
 </td>
 </tr>
-</table></dl>
+</table>
+<p>
+<li>
+[Output][:]
 <p>
 <table class="setup">
 <tr align="left">
-<td>
-<input type="radio" name="o" id="o" value="choice">
-<label for="ot" style="font-family: monospace">-o &nbsp;
-<input type="input" name="ot" size="20" maxlength="50" style="padding-left:4px"></label>&nbsp;&nbsp;[Output results to this file.]
+<td><input type="radio" name="o" value="" checked>
+[No redirection (results on terminal only).]
 </td>
 </tr>
-<p>
 <tr align="left">
-<td><input type="radio" name="o" id="o" value="/notes_d/connex.txt">
-<label for="o" style="font-family: monospace">&nbsp;&nbsp;</label>
+<td><input type="radio" name="o" value="/notes_d/connex.txt">
 [Output results in basename/notes_d/connex.txt (-o must stay empty and notes_d must exist).]
 </td>
 </tr>
-<p>
 <tr align="left">
-<td><input type="radio" name="o" id="o" value="" checked/>
-<label for="o" style="font-family: monospace">&nbsp;&nbsp;</label>[No redirection of results.]
+<td><input type="radio" name="o" value="choice">
+<input type="input" name="ot" size="30" maxlength="80"
+ style="padding-left:4px">&nbsp;&nbsp;
+[Output results to this file.]
 </td>
 </tr>
-</table></dl>
+</table>
 <p>
 <li>
-[Then click on this button][:]
-</li>
-<input type="submit" value="Ok">
-</dl>
-</form>
+[Then push this button][:]
+<input type="submit" value="OK">
 </ul>
+</form>
+</body>
+</html>

--- a/bin/setup/lang/lexicon.txt
+++ b/bin/setup/lang/lexicon.txt
@@ -521,13 +521,6 @@ it: Siete sicuri di voler cancellare queste basi ?
 lv: Vai Jûs patieðâm vçlaties dzçst sekojoðas datu bâzes?
 sv: Är du säker att du vill radera dessa databaser?
 
-    Ask for deleting branches whose size <= that value.
-aa: connex.htm
-co: Dumandà di squassà e ghjembe di dimensione <= à stu valore.
-de: Frage nach dem löschen von Zweigen dessen Größe <= diesem Wert sind.
-en: Ask for deleting branches whose size <= that value.
-fr: Demander à détruire les composantes de taille <= à cette valeur.
-
     Ask to indicate the updates in the welcome pages as a link "history of updates". <p> Remark (technical): the updates traces are saved in a file named "history" in the directory of the database (%a.gwb). This file grows indefinitively. You can edit it to remove the old information. Or you can also delete this file to restart empty.
 aa: gwf_1.htm
 co: Dumandà d’affissà e mudificazioni nant’à a pagina d’accolta sottu u liame « cronolugia di e mudificazioni ». <p> Rimarca (technica) : e traccie di e mudificazioni sò arregistrate in u schedariu chì si chjama « history » in u cartulare di a basa di dati (%a.gwb). A so dimensione cresce indefinitamente. Pudete mudificallu per caccià e vechje infurmazioni. O pudete dinù squassallu per riparte à viotu.
@@ -621,13 +614,6 @@ co: Fighjendu in a finestra chì s’hè aperta s’è ùn avete micca dumandatu
 de: durch das einsehen des Terminal Fensters wenn Sie nicht nach Ergebnis umleitung gefragt haben.
 en: By looking at the terminal window if you have not asked for result redirection.
 fr: En regardant dans la fenêtre qui s'est ouverte si vous n'avez pas demandé de redirection des résultats.
-
-    By origin file.
-aa: connex.htm
-co: Secondu à u schedariu d’origine.
-de: durch Originaldatei
-en: By origin file.
-fr: D'après le fichier origine.
 
     Can be useful in local, in order to be able to put an image for somebody, because the procedure installs automatically the image at the right place with the appropriate file name.
 aa: gwf_1.htm
@@ -1033,6 +1019,13 @@ it: Cancellazione di basi di dati
 lv: Datu bâþu dzçðana
 sv: Radering av databaser
 
+    Delete up to n branches of size <= -del value.
+aa: connex.htm
+co: Squassà finu à n ghjembe di dimensione <= valore -del.
+de: Bis zu n Zweige der Größe <= -del-Wert löschen.
+en: Delete up to n branches of size <= -del value.
+fr: Supprimer jusqu'à n branches de taille <= valeur -del.
+
     Destination directory and database
 aa: recover2.htm
 co: Cartulare è basa di dati di destinazione
@@ -1043,13 +1036,6 @@ fr: Répertoire et base d’arrivée
 it: Directory e base finale
 lv: Jaunais datu bâzes katalogs un datu bâze
 sv: Målkatalog och databas
-
-    Details for this length.
-aa: connex.htm
-co: Pruvede detaglii per sta longhezza.
-de: Details für diese länge.
-en: Details for this length.
-fr: Fournir détails pour cette taille.
 
     Differences computed
 aa: gwdiff_ok.htm
@@ -1598,6 +1584,13 @@ en: Go to your Web browser and open one of the following addresses:
 fr: Allez dans votre navigateur Web et ouvrez une des adresses suivantes:
 it: Lanciate il vostro navigatore Web e aprite uno dei seguenti indirizzi:
 
+    Group by origin file.
+aa: connex.htm
+co: Raggrupà secondu u schedariu d'origine.
+de: Nach Ursprungsdatei gruppieren.
+en: Group by origin file.
+fr: Grouper par fichier d’origine.
+
     Gwfixbase messages
 aa: gwfix_ok.htm
 co: Messaghji gwfixbase
@@ -1963,12 +1956,12 @@ it: Se non mettete niente il nome verrà dedotto da quello del file sorgente %G.
 lv: Ja nekas netiks ierakstîts, datu bâzes nosaukums tiks izveidots no %G resursdatnes nosaukuma.
 sv: Om du inte skriver någonting, kommer namnet att bli härlätt från %G källfilens namn.
 
-    Ignore this file.
+    Ignore this origin file.
 aa: connex.htm
-co: Ignurà stu schedariu.
-de: Ignoriere diese Datei.
-en: Ignore this file.
-fr: Ignorer ce fichier.
+co: Ignurà stu schedariu d'origine.
+de: Diese Ursprungsdatei ignorieren.
+en: Ignore this origin file.
+fr: Ignorer ce fichier d'origine.
 
     Images path
 aa: gwf_1.htm
@@ -2574,6 +2567,13 @@ de: Erzeuge Statistiken über verbundene Komponenten
 en: Produce connected components statistics.
 fr: Afficher les statistiques sur les composantes connexes.
 
+    Prompt for deleting branches of size <= this value.
+aa: connex.htm
+co: Dumandà di squassà e ghjembe di dimensione <= à stu valore.
+de: Zweige der Größe <= diesem Wert zum Löschen vorschlagen.
+en: Prompt for deleting branches of size <= this value.
+fr: Demander la suppression des branches de taille <= cette valeur.
+
     Push the below button to launch the operation
 aa: recover2.htm
 co: Primete nant’à u buttone quaghjò per lancià l’operazione.
@@ -3020,6 +3020,13 @@ fr: Activer cette option.
 it: Scegliere questa opzione.
 lv: Ieslçgt ðo iespçju
 sv: Sätt denna option.
+
+    Show detail for components of this size.
+aa: connex.htm
+co: Pruvede detaglii per e cumpunente di sta dimensione.
+de: Details für Komponenten dieser Größe anzeigen.
+en: Show detail for components of this size.
+fr: Afficher le détail des composantes de cette taille.
 
     Simple method
 aa: simple.htm
@@ -3961,6 +3968,13 @@ de: Wenn Nachfahren angezeigt werden, soll die Anzahl der angezeigten Generation
 en: When descendants are displayed, limit the number of displayed generations. By default, it is 12 generations, but you can indicate a different value here.
 fr: Quand on affiche les descendants, limite le nombre de générations affichables. C’est 12 par défaut, mais vous pouvez indiquer une valeur différente ici.
 it: Quando si visualizzano i discendenti, limita il numero delle parentele visualizzabili. Il numero per difetto è 12, ma potete indicare qui un valore diverso.
+
+    With -del, match size exactly instead of <=.
+aa: connex.htm
+co: Cù -del, currisponde à a dimensione esatta invece di <=.
+de: Mit -del, nur Zweige exakt dieser Größe löschen (nicht <=).
+en: With -del, match size exactly instead of <=.
+fr: Avec -del, ne supprimer que les branches de taille exacte (pas <=).
 
     with the simple method
 aa: main.htm

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -1013,38 +1013,17 @@ let cache_files ok_file conf =
 let connex_check conf = print_file conf "confirm.htm"
 
 let connex ok_file conf =
-  let ic = Unix.open_process_in "uname" in
-  let uname = input_line ic in
-  let () = close_in ic in
-  let rc =
-    let commnd1 =
-      "cd " ^ Sys.getcwd () ^ "; tput bel;"
-      ^ stringify (Filename.concat !bin_dir "connex")
-      ^ " " ^ parameters conf.env
-    in
-    let commnd2 =
-      stringify (Filename.concat !bin_dir "connex") ^ " " ^ parameters conf.env
-    in
-    if uname = "Darwin" then
-      if !no_o then
-        let launch = "tell application \"Terminal\" to do script " in
-        Sys.command ("osascript -e '" ^ launch ^ " \" " ^ commnd1 ^ " \"' ")
-      else exec_f conf commnd2
-    else if uname = "Linux" then
-      (* non testé ! *)
-      if !no_o then Sys.command ("xterm -e \" " ^ commnd1 ^ " \" ")
-      else exec_f conf commnd2
-    else if Sys.win32 then
-      (* à compléter et tester ! *)
-      if !no_o then Sys.command commnd1 else exec_f conf commnd2
-    else (
-      Printf.eprintf "%s (%s) %s (%s)\n" "Unknown Os_type" Sys.os_type
-        "or wrong uname response" uname;
-      flush stderr;
-      2)
+  let comm =
+    stringify (Filename.concat !bin_dir "connex") ^ " " ^ parameters conf.env
   in
+  let s = comm ^ " > comm.log" in
+  Printf.eprintf "$ cd \"%s\"\n" (Sys.getcwd ());
+  Printf.eprintf "$ %s\n" s;
   flush stderr;
-  if rc > 1 then print_file conf "err_standard.htm" else print_file conf ok_file
+  let rc = Sys.command s in
+  flush stderr;
+  if rc <> 0 then print_file conf "err_standard.htm"
+  else print_file conf ok_file
 
 let gwu_or_gwb2ged_check suffix conf =
   let in_file =


### PR DESCRIPTION
Bug fixes:
- Remove broken `[[?/?/0/?.0 ?]]` wiki links for unknown persons; emit only `<a href="%si=XX">i=XX</a>` using gwd `%s` macro for proper URL resolution in both direct and CGI modes.
- Remove `-server` and `-gwd_p`; URLs are now resolved by gwd at render time via `%s` macro, which also provides correct login suffix (`_w`/`_f`) on person links.
- Fix delete logic that was nested inside statistics branch, making -del only work when `-s` was active and a size seen twice.
- Skip interactive delete prompt when stdin is not a terminal (gwsetup/NUL context); require `-cnt` for non-interactive use.
- (Windows) Fix gwsetup connex handler: bypass `exec_f`/`infer_rc` which assumes output is a .gwb directory; connex outputs a text file, causing infer_rc to return rc=2 on successful runs. Remove broken uname-based OS detection (Cygwin mismatch).

Output modernization:
- HTML table layout (Origin/Size/Father/Mother) when -o is set; plain text to stderr otherwise (no HTML tags on console).
- Origin column auto-hidden when all components share one source.
- Components sorted by size descending (largest first).
- Use OCaml Unix.localtime instead of shelling out to `date`.

CLI cleanup:
- Rewrite all help strings for clarity and consistency.
- Add usage example line.
- Update connex.htm form and lexicon entries.

Closes #2553.