### PR TITLE
skip processing of empty TCP pre-connections from browsers

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2104,7 +2104,8 @@ let connection ~secret_salt (addr, request) script_name contents0 =
           try (Unix.gethostbyaddr iaddr).Unix.h_name
           with _ -> Unix.string_of_inet_addr iaddr)
   in
-  if script_name = "robots.txt" then robots_txt printer_conf
+  if request = [] then ()
+  else if script_name = "robots.txt" then robots_txt printer_conf
   else if excluded from then refuse_log printer_conf from
   else
     let accept =


### PR DESCRIPTION
Modern browsers (Firefox, Chrome) open speculative TCP pre-connections to servers they expect to send requests to shortly. These connections carry no HTTP data: the socket is opened then closed without sending a GET or POST line.

With the worker pool model (Pool.start), each such connection is accepted by a worker which then reads an empty stream, producing request=[], script_name="", contents="".

The existing `should_log_request` filter (added in #2505) suppresses the visible symptom (noisy "(<pid>) ?" lines in gwd.log), but the empty connection still runs the full conf_and_connection pipeline: build_env, make_conf, Robot.check with lock file acquisition, before discovering there is nothing to do.

Guard on request=[] at the top of connection to return immediately. This is precise: a valid HTTP request always produces a non-empty request list from get_request, even for GET / with no query string.