### PR TITLE
ci: restore cache-opam step id for build summary reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           command: start-timer
 
       - name: Cache Opam dependencies
+        id: cache-opam
         uses: actions/cache@v5
         with:
           path: ${{ runner.os == 'Windows' && 'C:\\.opam' || '~/.opam' }}


### PR DESCRIPTION
The id was accidentally removed in 5886e39, causing steps.cache-opam.outputs.cache-hit to resolve to empty in the collect-metrics step, displaying cache as missed in the CI build summary despite successful cache restoration.