### PR TITLE
deprecate %suffix; template variable

### DIFF
--- a/hd/etc/templm/tools.txt
+++ b/hd/etc/templm/tools.txt
@@ -337,7 +337,7 @@
           %if;(wizard and e.m = "RLM")
             <li><a href="%url_set.m_iz_upddag_templ_pz_nz_ocz.U_0_on;">[*modify::tree]</a></li>
           %end;
-          <li><a href="%prefix;%suffix;&notab=on" accesskey="/"
+          <li><a href="%url_set.notab.on;" accesskey="/"
              title="[display by slices/slice width/overlap/total width]0 (/)"
              >[*display by slices/slice width/overlap/total width]0</a></li>
         </ul>

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -422,7 +422,7 @@ and eval_simple_variable conf = function
       let s = (s :> string) in
       if s = "" then s else s ^ "/"
   | "suffix" ->
-      (* On supprime de env toutes les paires qui sont dans (henv @ senv) *)
+      Log.warn (fun k -> k "%%suffix; is deprecated, use %%url_set instead");
       let l =
         List.fold_left
           (fun accu (k, _) -> List.remove_assoc k accu)


### PR DESCRIPTION
Replace the only usage of `%suffix;` in tools.txt with `%url_set.notab.on;` which properly handles URL parameter construction without leaking POST data after base modifications.

Add deprecation warning log for `%suffix;` while keeping the implementation for backward compatibility with custom user templates.

Closes #234.