### PR TITLE
fix(ged2gwb): include PACS in secondary family event types

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -2099,7 +2099,8 @@ let primary_fevents =
   ["ANUL"; "DIV"; "ENGA"; "MARR"; "MARB"; "MARC"; "MARL"; "RESI"; "SEP"]
 
 (* Types d'évènement présents seulement dans les tags de niveau 2 (2 TYPE). *)
-let secondary_fevent_types = [Efam_NoMarriage; Efam_NoMention]
+let secondary_fevent_types =
+  [Efam_NoMarriage; Efam_NoMention; Efam_PACS]
 
 let treat_fam_fevent gen ifath r =
   let check_place_unmarried efam_name place r =


### PR DESCRIPTION
EVEN+TYPE events for "unmarried", "nomen" and "pacs" are secondary family events that may legitimately carry no date, place, note or source. The previous fix included NoMarriage and NoMention but missed PACS, causing empty PACS events to be silently dropped during GEDCOM import.

Closes #620.