### PR TITLE
Optimize heap structure

### DIFF
--- a/lib/search/heap.ml
+++ b/lib/search/heap.ml
@@ -23,38 +23,43 @@ module Make (O : OrderedType) = struct
 
   exception Empty
 
-  let[@inline always] get { tree; _ } i = Array.unsafe_get tree i
-  let[@inline always] set { tree; _ } i v = Array.unsafe_set tree i v
+  let[@inline] get { tree; _ } i = Array.unsafe_get tree i
+  let[@inline] set { tree; _ } i v = Array.unsafe_set tree i v
+  let[@inline] create cap = { tree = Array.init cap (fun _ -> O.dummy); sz = 0 }
+  let[@inline] full { tree; sz; _ } = Array.length tree = sz
+  let[@inline] empty { sz; _ } = sz = 0
+  let[@inline] left i = (2 * i) + 1
+  let[@inline] right i = (2 * i) + 2
+  let[@inline] parent i = (i - 1) / 2
 
-  let[@inline always] create cap =
-    { tree = Array.init cap (fun _ -> O.dummy); sz = 0 }
-
-  let[@inline always] full { tree; sz; _ } = Array.length tree = sz
-  let[@inline always] empty { sz; _ } = sz = 0
-  let[@inline always] left i = (2 * i) + 1
-  let[@inline always] right i = (2 * i) + 2
-  let[@inline always] parent i = (i - 1) / 2
-
-  let swap t i p =
-    let tmp = get t i in
-    set t i (get t p);
-    set t p tmp
-
-  let rec percolate_up t i =
-    let p = parent i in
-    if O.compare (get t i) (get t p) < 0 then (
-      swap t i p;
-      percolate_up t p)
-
-  let rec percolate_down t i =
-    let l = left i and r = right i in
-    let min = if l < t.sz && O.compare (get t l) (get t i) < 0 then l else i in
-    let min =
-      if r < t.sz && O.compare (get t r) (get t min) < 0 then r else min
+  let percolate_up t i =
+    let vi = get t i in
+    let rec loop j =
+      let p = parent j in
+      let vp = get t p in
+      if j > 0 && O.compare vi vp < 0 then (
+        set t j vp;
+        loop p)
+      else set t j vi
     in
-    if i <> min then (
-      swap t i min;
-      percolate_down t min)
+    loop i
+
+  let percolate_down t i =
+    let vi = get t i in
+    let rec loop j =
+      let l = left j and r = right j in
+      let mi =
+        if l < t.sz && O.compare (get t l) vi < 0 then
+          if r < t.sz && O.compare (get t r) (get t l) < 0 then r else l
+        else if r < t.sz && O.compare (get t r) vi < 0 then r
+        else i
+      in
+      if i <> mi then (
+        set t j (get t mi);
+        loop mi)
+      else set t j vi
+    in
+    loop i
 
   let insert t d =
     if full t then invalid_arg "Heap.insert"
@@ -63,6 +68,11 @@ module Make (O : OrderedType) = struct
       set t i d;
       t.sz <- i + 1;
       percolate_up t i
+
+  let[@inline] swap t i p =
+    let tmp = get t i in
+    set t i (get t p);
+    set t p tmp
 
   let delete_min t =
     if empty t then raise Empty

--- a/lib/search/heap.ml
+++ b/lib/search/heap.ml
@@ -48,15 +48,17 @@ module Make (O : OrderedType) = struct
     let vi = get t i in
     let rec loop j =
       let l = left j and r = right j in
-      let mi =
+      (* Find the smallest child to bubble up, or stay at [j] if the heap
+         property is satisfied. *)
+      let s =
         if l < t.sz && O.compare (get t l) vi < 0 then
           if r < t.sz && O.compare (get t r) (get t l) < 0 then r else l
         else if r < t.sz && O.compare (get t r) vi < 0 then r
-        else i
+        else j
       in
-      if i <> mi then (
-        set t j (get t mi);
-        loop mi)
+      if s <> j then (
+        set t j (get t s);
+        loop s)
       else set t j vi
     in
     loop i
@@ -69,16 +71,11 @@ module Make (O : OrderedType) = struct
       t.sz <- i + 1;
       percolate_up t i
 
-  let[@inline] swap t i p =
-    let tmp = get t i in
-    set t i (get t p);
-    set t p tmp
-
   let delete_min t =
     if empty t then raise Empty
     else
       let d = get t 0 in
-      swap t 0 (t.sz - 1);
+      set t 0 (get t (t.sz - 1));
       t.sz <- t.sz - 1;
       percolate_down t 0;
       d

--- a/test/dune
+++ b/test/dune
@@ -15,9 +15,7 @@
   (:dict ./dict.txt))
  (name search_test)
  (package geneweb)
- (modules search_test)
  (libraries
-  alcotest
   fmt
   qcheck
   qcheck-alcotest
@@ -26,3 +24,7 @@
   geneweb_search)
  (action
   (run %{test} %{dict})))
+
+(test
+ (name heap_test)
+ (libraries qcheck qcheck-alcotest geneweb_compat geneweb_search))

--- a/test/heap_test.ml
+++ b/test/heap_test.ml
@@ -1,0 +1,31 @@
+module A = Alcotest
+module Q = QCheck
+
+module H = Geneweb_search.Heap.Make (struct
+  type t = int
+
+  let dummy = 0
+  let compare = Int.compare
+end)
+
+let heap_sort l =
+  let hp = H.create @@ List.length l in
+  List.iter (H.insert hp) l;
+  let rec loop acc =
+    match H.delete_min hp with
+    | exception H.Empty -> List.rev acc
+    | v -> loop (v :: acc)
+  in
+  loop []
+
+let heap_sort_test =
+  let gen = Q.Gen.(list_size nat int) in
+  let qtst =
+    Q.Test.make ~count:1000 ~name:"random heap sort" (Q.make gen) @@ fun l ->
+    let l1 = heap_sort l in
+    let l2 = List.sort Int.compare l in
+    Geneweb_compat.List.equal Int.equal l1 l2
+  in
+  QCheck_alcotest.to_alcotest qtst
+
+let () = A.run __FILE__ [ ("heap tests", [ heap_sort_test ]) ]


### PR DESCRIPTION
The heap structure in `lib/search/heap.mli` does redundant write accesses to its underlying array. This commit reduces the number of writes by half.

A randomized test with `QCheck` have been added to ensure this optimization maintains correctness of the structure.