### PR TITLE
add death age pyramid (m=POP_PYR&t=D)

### DIFF
--- a/hd/etc/css/css.css
+++ b/hd/etc/css/css.css
@@ -1610,18 +1610,19 @@ li.desc
 
 
 /* --------------------------- Pyramide des Ã¢ges -------------------------- */
-.pyramid_center
-{
-  padding-left: 6px;
-  padding-right: 6px;
+#table_pop_pyr {
+  border-collapse:collapse;
+  margin:auto;
 }
 
-
-.pyramid_nb
-{
-  font-style: italic;
+#table_pop_pyr td{
+  padding:1px 0;
 }
 
+#table_pop_pyr.pyr-compact td{
+  font-size:11px;
+  line-height:.9;
+}
 
 /* --------------------------------- wiki -------------------------------- */
 div.summary ul

--- a/hd/etc/stats.txt
+++ b/hd/etc/stats.txt
@@ -43,6 +43,7 @@
 %if;(wizard or friend)
   <ul>
     <li><a href="%prefix;m=POP_PYR">[population pyramid]</a></li>
+    <li><a href="%prefix;m=POP_PYR&t=D&from=1900&to=2025">[death pyramid]</a></li>
   </ul>
 %end;
 

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -3864,7 +3864,7 @@ sl: od zaveze id
 sv: från commit id
 tr: kayıt kimliğinden
 zh: 从提交 ID
-    
+
     branch %s compiled on %s from commit
 af: tak %s saamgestel op %s vanaf commit id
 ar: فرع %s تم تجميعه في %s من commit %s
@@ -9292,6 +9292,34 @@ de: vom Karussell
 en: from carrousel
 fr: du carrousel
 
+    from/to (date year)
+bg: от/до
+co: da/à
+cs: od/do
+da: fra/til
+de: von/bis
+en: from/to
+eo: de/ĝis
+es: de/a
+et: alates/kuni
+fi: alkaen/asti
+fr: de/à
+he: מ/עד
+it: da/a
+lt: nuo/iki
+lv: no/līdz
+nl: van/tot
+no: fra/til
+oc: de/a
+pl: od/do
+pt: de/a
+ro: de la/până la
+ru: от/до
+sk: od/do
+sl: od/do
+sv: från/till
+tr: itibaren/kadar
+
     from the %s (gen)
 af: van die %s
 ar: من الـ%s
@@ -14570,6 +14598,34 @@ ru: количество событий
 sv: antal händelser
 tr: etkinliklerin sayısı
 
+    number of deceased persons
+bg: брой на починалите лица
+co: numeru di persone morte
+cs: počet zemřelých osob
+da: antal afdøde personer
+de: Anzahl der verstorbenen Personen
+en: number of deceased individuals
+eo: nombro de la mortintaj personoj
+es: número de personas fallecidas
+et: surnud isikuid
+fi: kuolleiden lukumäärä
+fr: nombre d'individus décédés
+he: מספר הנפטרים
+it: numero di persone decedute
+lt: mirusiųjų skaičius
+lv: mirušo personu skaits
+nl: aantal overleden personen
+no: antall avdøde personer
+oc: nombre de personas defuntas
+pl: liczba osób zmarłych
+pt: número de pessoas falecidas
+ro: numărul de persoane decedate
+ru: количество умерших персон
+sk: počet zosnulých osôb
+sl: število umrlih oseb
+sv: antal avlidna personer
+tr: vefat eden bireylerin sayısı
+
     number of living persons
 bg: брой на живите лица
 co: numeru di persone vive
@@ -15659,6 +15715,34 @@ sk: populačná pyramída
 sl: populacijska piramida
 sv: befolkningspyramid
 tr: nüfus piramidi
+
+    death pyramid
+bg: пирамида на възрастта при смъртта
+co: piramida di l'età à a morte
+cs: pyramida věku při úmrtí
+da: dødspyramide
+de: Sterbealter-Pyramide
+en: death age pyramid
+eo: piramido de mortaĝo
+es: pirámide de edad al fallecer
+et: surmapüramiid
+fi: kuolinpyramidi
+fr: pyramide des âges au décès
+he: פירמידת גיל פטירה
+it: piramide dell'età al decesso
+lt: mirties amžiaus piramidė
+lv: nāves vecuma piramīda
+nl: piramide overlijdensleeftijd
+no: dødspyramide
+oc: piramida de las edats al decòs
+pl: piramida wieku zgonu
+pt: pirâmide de idade ao óbito
+ro: piramida vârstei la deces
+ru: пирамида возраста смерти
+sk: pyramída veku pri úmrtí
+sl: piramida starosti ob smrti
+sv: dödsålderspyramid
+tr: ölüm yaşı piramidi
 
     portrait
 co: ritrattu

--- a/lib/birthDeath.ml
+++ b/lib/birthDeath.ml
@@ -114,3 +114,27 @@ let make_population_pyramid ~nb_intervals ~interval ~limit ~at_date conf base =
                 else wom.(j) <- wom.(j) + 1)
     (Driver.ipers base);
   (men, wom)
+
+let make_death_pyramid ~nb_intervals ~interval ~limit ~from_year ~to_year conf
+    base =
+  let men = Array.make (nb_intervals + 1) 0 in
+  let wom = Array.make (nb_intervals + 1) 0 in
+  Collection.iter
+    (fun i ->
+      let p = pget conf base i in
+      let sex = Driver.get_sex p in
+      if sex <> Neuter then
+        match Date.dmy_of_death (Driver.get_death p) with
+        | None -> ()
+        | Some dd -> (
+            if dd.year >= from_year && dd.year <= to_year then
+              match Date.cdate_to_dmy_opt (Driver.get_birth p) with
+              | None -> ()
+              | Some bd ->
+                  let a = Date.time_elapsed bd dd in
+                  if limit = 0 || a.year <= limit then
+                    let j = min nb_intervals (a.year / interval) in
+                    if sex = Male then men.(j) <- men.(j) + 1
+                    else wom.(j) <- wom.(j) + 1))
+    (Driver.ipers base);
+  (men, wom)

--- a/lib/birthDeath.mli
+++ b/lib/birthDeath.mli
@@ -42,3 +42,16 @@ val make_population_pyramid :
     persons that are considered in pyramid should be alive at this date. [limit]
     allows to limit persons by age (those that has age greater then limit aren't
     taken into the account) *)
+
+val make_death_pyramid :
+  nb_intervals:int ->
+  interval:int ->
+  limit:int ->
+  from_year:int ->
+  to_year:int ->
+  Config.config ->
+  Geneweb_db.Driver.base ->
+  int array * int array
+(** Counts deceased persons by age-at-death bucket. Only persons with both a
+    Gregorian birth date and a death date falling in [from_year..to_year] are
+    counted. *)


### PR DESCRIPTION
New feature: age-at-death pyramid alongside existing living population pyramid, inspired by [INSEE Focus n°364 demographic analysis, Oct. 2025, p. 4](https://www.bnsp.insee.fr/ark:/12148/bc6p09ssrzq/f1.pdf).

- Add make_death_pyramid in birthDeath.ml: counts deceased persons by age-at-death bucket for a given year range (from/to parameters)
- Refactor print_population_pyramid in birthDeathDisplay.ml: extract shared helpers (print_pyramid_table, print_pyramid_totals, print_pyramid_form_tail) to eliminate code duplication between living and death pyramid modes
- Switch button in page title toggles between pyramid types
- Totals line shows gender breakdown with thousand separators
- Compact rendering for small intervals (1-2): reduced font size and row height
- Death mode uses center-only age ordinate; living mode keeps lateral year labels
- New lexicon entries: death pyramid, from/to (date year), number of deceased persons for 26 languages