### PR TITLE
detect UTF-16 encoding without BOM in ged2gwb

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -2680,9 +2680,15 @@ let open_in_bin_with_bom_check fname =
    | Bom.Utf8 -> charset_option := Some Utf8
    | bom when Bom.is_unsupported bom ->
        close_in ic;
-       Printf.fprintf !log_oc "Error: %s encoding not supported\n"
+       let base = Filename.remove_extension fname in
+       let ext = Filename.extension fname in
+       Printf.fprintf !log_oc
+         "Error: %s encoding detected, not supported\n"
          (Bom.to_string bom);
-       Printf.fprintf !log_oc "Convert file to UTF-8 or ANSEL first\n";
+       Printf.fprintf !log_oc
+         "Convert to UTF-8 first:\n\
+          iconv -f %s -t UTF-8 %s > %s_UTF8%s\n"
+         (Bom.to_string bom) fname base ext;
        flush !log_oc;
        exit 2
    | _ -> ());
@@ -3289,8 +3295,10 @@ let main () =
   Arg.parse speclist anonfun errmsg;
   if not (Array.mem "-bd" Sys.argv) then Secure.set_base_dir ".";
   in_file :=
-    if !in_file <> "" then
+    if !in_file <> "" then begin
+      close_in (open_in_bin_with_bom_check !in_file);
       Filename.remove_extension !in_file
+    end
     else !in_file;
   if !in_file <> "" && (not (Array.mem "-o" Sys.argv)) then out_file := !in_file;
   out_file := Filename.basename !out_file |> Filename.remove_extension;

--- a/lib/util/bom.ml
+++ b/lib/util/bom.ml
@@ -12,10 +12,13 @@ let check ic =
         let b2 = input_byte ic in
         let b3 = input_byte ic in
         if b2 = 0x00 && b3 = 0x00 then Utf32_le else Utf16_le
-      else if b0 = 0x00 && b1 = 0x00 then
-        let b2 = input_byte ic in
-        let b3 = input_byte ic in
-        if b2 = 0xFE && b3 = 0xFF then Utf32_be else None
+      else if b0 = 0x00 then
+        if b1 = 0x00 then
+          let b2 = input_byte ic in
+          let b3 = input_byte ic in
+          if b2 = 0xFE && b3 = 0xFF then Utf32_be else None
+        else Utf16_be
+      else if b1 = 0x00 then Utf16_le
       else None
     with End_of_file -> None
   in
@@ -24,10 +27,10 @@ let check ic =
 
 let to_string = function
   | Utf8 -> "UTF-8"
-  | Utf16_le -> "UTF-16 LE"
-  | Utf16_be -> "UTF-16 BE"
-  | Utf32_le -> "UTF-32 LE"
-  | Utf32_be -> "UTF-32 BE"
+  | Utf16_le -> "UTF-16LE"
+  | Utf16_be -> "UTF-16BE"
+  | Utf32_le -> "UTF-32LE"
+  | Utf32_be -> "UTF-32BE"
   | None -> ""
 
 let is_unsupported = function


### PR DESCRIPTION
GEDCOM files encoded in UTF-16 without a BOM were silently
misinterpreted. Heuristic based on the first two bytes: a leading
null indicates UTF-16 BE, a trailing null indicates UTF-16 LE.
Error message now shows a ready-to-use iconv command.
Also validate encoding before creating the base to avoid touching
.gwf configuration on unsupported files.

Fixes #2580.