### PR TITLE
Do not disable warnings in search library

### DIFF
--- a/lib/search/dune
+++ b/lib/search/dune
@@ -1,6 +1,4 @@
 (library
  (public_name geneweb.search)
  (name geneweb_search)
- (libraries fmt)
- (flags
-  (:standard -w -44-68)))
+ (libraries fmt))


### PR DESCRIPTION
These warnings are not triggered on the latest OCaml compiler and dune.