### PR TITLE
fix display of partial French Republican dates

### DIFF
--- a/lib/util/date.ml
+++ b/lib/util/date.ml
@@ -252,6 +252,25 @@ let julian_of_sdn ~prec sdn = Calendar.julian_of_sdn prec sdn
 let french_of_sdn ~prec sdn = Calendar.french_of_sdn prec sdn
 let hebrew_of_sdn ~prec sdn = Calendar.hebrew_of_sdn prec sdn
 
+let approx_gregorian ~from d =
+  if from = Dgregorian then d
+  else if d.day > 0 && d.month > 0 then d
+  else
+    let sdn_lo = to_sdn ~from ~lower:true d in
+    let sdn_hi = to_sdn ~from ~lower:false d - 1 in
+    let sdn = sdn_lo + ((sdn_hi - sdn_lo) / 2) in
+    let g = Calendar.gregorian_of_sdn d.prec sdn in
+    {
+      g with
+      day = (if d.day = 0 then 0 else g.day);
+      month = (if d.month = 0 then 0 else g.month);
+    }
+
+let cdate_to_gregorian_dmy_opt cdate =
+  match od_of_cdate cdate with
+  | Some (Dgreg (d, cal)) -> Some (approx_gregorian ~from:cal d)
+  | _ -> None
+
 let convert ~from ~to_ dmy =
   if from = to_ then dmy
   else

--- a/lib/util/date.mli
+++ b/lib/util/date.mli
@@ -112,6 +112,16 @@ val french_of_sdn : prec:precision -> int -> dmy
 val hebrew_of_sdn : prec:precision -> int -> dmy
 (** Convert SDN to Hebrew [dmy] with given precision. *)
 
+val approx_gregorian : from:calendar -> dmy -> dmy
+(** [approx_gregorian ~from d] ensures [d] contains meaningful Gregorian values.
+    For complete non-Gregorian dates, returns [d] unchanged (already converted
+    at import). For partial non-Gregorian dates (day=0 or month=0), converts via
+    SDN midpoint of the period preserving partial fields. *)
+
+val cdate_to_gregorian_dmy_opt : cdate -> dmy option
+(** Like [cdate_to_dmy_opt] but ensures the returned [dmy] contains Gregorian
+    values even for partial non-Gregorian dates. *)
+
 val days_between : from:calendar -> dmy -> dmy -> int option
 (** Total days between two complete dates. Returns [None] if either date is
     partial (day=0 or month=0) or if d2 < d1. *)


### PR DESCRIPTION
Regression introduced by Calendars 2.0 migration: partial French Republican dates (year-only or month+year) stored unconverted French values in the Gregorian dmy slot, causing both short and long date displays to show raw French year numbers instead of Gregorian equivalents.

Short dates: compute Gregorian year arithmetically from French year and month. Year-only shows "an XI", months 1-3 (Sep-Dec) map to year+1791, month 4 (Nivôse, straddles Dec-Jan) shows "?" prefix when precision is not already Maybe, months 5-13 map to year+1792.

Long dates: convert partial French dates to SDN range bounds, then format as Gregorian "between X and Y". When both bounds fall in the same Gregorian year, omit the year from the first date to avoid redundancy (e.g. "entre le 22 novembre et le 21 décembre 1799").

Closes #2597