### PR TITLE
fix: prevent user_iper lookup on empty userkey + fix relmenu condition

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -327,21 +327,23 @@ let make_henv conf base =
     else conf
   in
   let conf =
-    let fn, oc, sn = GWPARAM.split_key conf.userkey in
-    match
-      Geneweb_db.Driver.person_of_key base fn sn
-        (if oc = "" then 0 else int_of_string oc)
-    with
-    | Some ip ->
-        {
-          conf with
-          semi_public =
-            (if conf.semi_public then
-               Driver.get_access (Driver.poi base ip) = SemiPublic
-             else true);
-          user_iper = Some ip;
-        }
-    | None -> conf
+    if conf.userkey = "" then conf
+    else
+      let fn, oc, sn = GWPARAM.split_key conf.userkey in
+      match
+        Geneweb_db.Driver.person_of_key base fn sn
+          (if oc = "" then 0 else int_of_string oc)
+      with
+      | Some ip ->
+          {
+            conf with
+            semi_public =
+              (if conf.semi_public then
+                 Driver.get_access (Driver.poi base ip) = SemiPublic
+               else true);
+            user_iper = Some ip;
+          }
+      | None -> conf
   in
   let aux param conf =
     match Util.p_getenv conf.env param with

--- a/hd/etc/relmenu.txt
+++ b/hd/etc/relmenu.txt
@@ -42,7 +42,7 @@
       <input type="hidden" name="m" value="R">
       <span>[*relationship shortcut][:]</span>
       <div class="mt-1 ml-2">
-        %if;((user.index!="" and not browsing_with_sosa_ref) or (browsing_with_sosa_ref and user.index!=sosa_ref.index))
+        %if;(user.index!="" and (not browsing_with_sosa_ref or user.index!=sosa_ref.index))
           <div class="custom-control custom-radio">
             <input type="radio" class="custom-control-input" id="sel_user" name="select" value="%user.index;" onclick="main()">
             <label class="custom-control-label" for="sel_user">%user.ident; ([user/password/cancel]0)</label>


### PR DESCRIPTION
Two related issues with user.index in templates:

1. request.ml: when authenticating without a personal .auth entry (generic password, or .auth entry without |key), conf.userkey is empty. split_key "" produces ("?","","?") and person_of_key may resolve to a stub person on bases where "? ?" is indexed (create_all_keys, some GEDCOM imports), setting user_iper incorrectly. Guard the lookup with conf.userkey <> "".

2. relmenu.txt: the browsing_with_sosa_ref branch was missing the user.index!="" guard. When user.index is empty, the comparison user.index!=sosa_ref.index evaluated to true, showing a non-functional radio button. Factor user.index!="" to cover both branches.