### PR TITLE
Restore locations in Templ parser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,13 @@
 root = true
 
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 [*.t]
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[test/templ/*.html]
 trim_trailing_whitespace = false
 insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,7 +16,7 @@
 *.ml text
 *.mli text
 *.opam text
-*.sh text
+*.sh text eol=lf
 *.txt text
 *.1 text
 

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -7,6 +7,7 @@ module Ast = Geneweb_templ.Ast
 module Loc = Geneweb_templ.Loc
 module Driver = Geneweb_db.Driver
 
+exception UnboundVar
 exception BadApplyArity
 exception NamedArgumentNotMatched of string
 
@@ -31,7 +32,8 @@ let pp_exception ppf (e, bt) =
   in
   match e with
   | Exc_located (loc, e) ->
-      Fmt.pf ppf "@[%a@ %s@ %a@]" pp_header () (Printexc.to_string e) Loc.pp loc
+      Fmt.pf ppf "@[%a@ %s@ %a@]" pp_header () (Printexc.to_string e)
+        Loc.pp_with_source loc
   | _ ->
       Fmt.pf ppf "@[%a@ %s@ %a@]" pp_header () (Printexc.to_string e)
         Fmt.(list ~sep:cut string)
@@ -739,9 +741,7 @@ let rec eval_expr ((conf, eval_var, eval_apply) as ceva) Ast.{ desc; loc } =
       try eval_var loc (s :: sl)
       with Not_found -> (
         try templ_eval_var conf (s :: sl)
-        with Not_found ->
-          raise_with_loc loc
-            (Failure ("unbound var: " ^ String.concat "." (s :: sl)))))
+        with Not_found -> raise_with_loc loc UnboundVar))
   | Atransl (upp, s, c) -> VVstring (eval_transl conf upp s c)
   | Aapply (s, ell) ->
       let vl =

--- a/lib/templ/ast.ml
+++ b/lib/templ/ast.ml
@@ -87,12 +87,12 @@ let pp_source ppf src =
   | `File f -> Fmt.pf ppf "File (%s)" f
   | `Raw s -> Fmt.pf ppf "Raw (%s)" s
 
-let pp_list pp_elt = Fmt.(brackets @@ list ~sep:semi pp_elt)
-let pp_pair pp1 pp2 = Fmt.(braces @@ pair ~sep:comma pp1 pp2)
+let pp_list pp_elt = Fmt.(box ~indent:2 @@ brackets @@ list ~sep:semi pp_elt)
+let pp_pair pp1 pp2 = Fmt.(box ~indent:2 @@ braces @@ pair ~sep:comma pp1 pp2)
 
 let rec pp_desc ppf t =
   match t with
-  | Atext s -> Fmt.pf ppf "Atext (%s)" s
+  | Atext s -> Fmt.pf ppf "Atext (%S)" s
   | Avar (s, sx) -> Fmt.pf ppf "Avar (%s,@ %a)" s (pp_list Fmt.string) sx
   | Atransl (b, s1, s2) -> Fmt.pf ppf "Atransl (%b,@ %s,@ %s)" b s1 s2
   | Awid_hei s -> Fmt.pf ppf "Awid_hei (%s)" s
@@ -121,25 +121,26 @@ let rec pp_desc ppf t =
   | Apack l -> Fmt.pf ppf "Apack (%a)" (pp_list pp) l
 
 and pp ppf { desc; loc } =
-  Fmt.pf ppf "{ desc = %a; loc = %a }" pp_desc desc Loc.pp loc
+  if Loc.is_dummy loc then (Fmt.box @@ pp_desc) ppf desc
+  else Fmt.pf ppf "@[{ desc = %a;@, loc = %a }@]" pp_desc desc Loc.pp loc
 
 let pp = Fmt.(box @@ pp)
-let[@inline always] mk ?(loc = Loc.dummy) desc = { desc; loc }
-let[@inline always] mk_text ?loc x = mk ?loc (Atext x)
-let[@inline always] mk_var ?loc x y = mk ?loc (Avar (x, y))
-let[@inline always] mk_transl ?loc x y z = mk ?loc (Atransl (x, y, z))
-let[@inline always] mk_wid_hei ?loc x = mk ?loc (Awid_hei x)
-let[@inline always] mk_foreach ?loc x y z = mk ?loc (Aforeach (x, y, z))
-let[@inline always] mk_for ?loc x y z t = mk ?loc (Afor (x, y, z, t))
-let[@inline always] mk_if ?loc x y z = mk ?loc (Aif (x, y, z))
-let[@inline always] mk_define ?loc x y z t = mk ?loc (Adefine (x, y, z, t))
-let[@inline always] mk_apply ?loc x y = mk ?loc (Aapply (x, y))
-let[@inline always] mk_let ?loc x y z = mk ?loc (Alet (x, y, z))
-let[@inline always] mk_op1 ?loc x y = mk ?loc (Aop1 (x, y))
-let[@inline always] mk_op2 ?loc x y z = mk ?loc (Aop2 (x, y, z))
-let[@inline always] mk_int ?loc x = mk ?loc (Aint x)
-let[@inline always] mk_include ?loc x = mk ?loc (Ainclude x)
-let[@inline always] mk_pack ?loc l = mk ?loc (Apack l)
+let[@inline] mk ?(loc = Loc.dummy) desc = { desc; loc }
+let[@inline] mk_text ?loc x = mk ?loc (Atext x)
+let[@inline] mk_var ?loc x y = mk ?loc (Avar (x, y))
+let[@inline] mk_transl ?loc x y z = mk ?loc (Atransl (x, y, z))
+let[@inline] mk_wid_hei ?loc x = mk ?loc (Awid_hei x)
+let[@inline] mk_foreach ?loc x y z = mk ?loc (Aforeach (x, y, z))
+let[@inline] mk_for ?loc x y z t = mk ?loc (Afor (x, y, z, t))
+let[@inline] mk_if ?loc x y z = mk ?loc (Aif (x, y, z))
+let[@inline] mk_define ?loc x y z t = mk ?loc (Adefine (x, y, z, t))
+let[@inline] mk_apply ?loc x y = mk ?loc (Aapply (x, y))
+let[@inline] mk_let ?loc x y z = mk ?loc (Alet (x, y, z))
+let[@inline] mk_op1 ?loc x y = mk ?loc (Aop1 (x, y))
+let[@inline] mk_op2 ?loc x y z = mk ?loc (Aop2 (x, y, z))
+let[@inline] mk_int ?loc x = mk ?loc (Aint x)
+let[@inline] mk_include ?loc x = mk ?loc (Ainclude x)
+let[@inline] mk_pack ?loc l = mk ?loc (Apack l)
 
 let rec subst_desc sf desc =
   match desc with

--- a/lib/templ/lexer.mll
+++ b/lib/templ/lexer.mll
@@ -1,10 +1,48 @@
 {
 
-(* let pos lex = !current_file, Lexing.lexeme_start lex, Lexing.lexeme_end lex *)
+module State : sig
+  type t = private {
+    src : Loc.source;
+    lexbuf : Lexing.lexbuf;
+    start : int;
+    tokens : Ast.t list;
+  }
+
+  val create : src:Loc.source -> Lexing.lexbuf -> t
+  val update_loc : t -> t
+  val current_loc : t -> Loc.t
+  val push_token : Ast.t -> t -> t
+  val tokens : t -> Ast.t list
+end = struct
+  type t = {
+    src : Loc.source;
+    lexbuf : Lexing.lexbuf;
+    start : int;
+    tokens : Ast.t list;
+  }
+
+  let[@inline] offset lexbuf =
+    lexbuf.Lexing.lex_abs_pos + lexbuf.Lexing.lex_start_pos
+
+  let create ~src lexbuf =
+    { src; lexbuf; start = offset lexbuf; tokens = [] }
+
+  let update_loc st =
+    { st with start = offset st.lexbuf }
+
+  let current_loc (st : t) =
+    let stop = st.lexbuf.Lexing.lex_abs_pos + st.lexbuf.Lexing.lex_curr_pos in
+    Loc.of_offsets st.src st.start stop
+
+  let push_token tk st =
+    { st with tokens = tk :: st.tokens }
+
+  let tokens st = List.rev st.tokens
+end
 
 (* Leading ([' ' '\t' '\r']* '\n') will be removed, except if
    the previous node is a Atransl. *)
-let flush ast b _lexbuf =
+let flush b st =
   let s = Buffer.contents b in
   let trim s =
     let rec loop i =
@@ -17,17 +55,16 @@ let flush ast b _lexbuf =
     in
     loop 0
   in
-  let s = match ast with
+  let s = match st.State.tokens with
     | Ast.{ desc = Atransl _; _ } :: _ | { desc = Awid_hei _; _ } :: _ -> s
     | _ -> trim s
   in
-  let ast =
-    if s = "" then ast
-    else Ast.mk_text s :: ast
+  let st =
+    if s = "" then st
+    else State.push_token (Ast.mk_text s) st
   in
-  let () = Buffer.reset b in
-  ast
-
+  Buffer.reset b;
+  st
 }
 
 let ws = ([ ' ' '\n' '\t' '\r' ])
@@ -40,69 +77,86 @@ let var = (r_ident ('.' (r_ident|num))*)
 
 let value = ([^ ' ' '>' ';' '\n' '\r'  '\t' ]+)
 
-rule parse_ast b closing ast = parse
+rule parse_ast b closing st = parse
 
   (* Special variable: strip whitespaces coming after this. *)
   | "%sq;" ws* {
-      parse_ast b closing ast lexbuf
+      parse_ast b closing st lexbuf
     }
 
   (* Special variable: strip on newline and its surrounding whitespaces. *)
   | "%nn;" [ ' ' '\t' '\r' ]* '\n'? [ ' ' '\t' '\r' ]* {
-      parse_ast b closing ast lexbuf
+      parse_ast b closing st lexbuf
     }
 
   | '%' {
+      let st = State.update_loc st in
       match match variable lexbuf with `variable [] -> `escaped '%' | x -> x with
-      | `escaped c -> Buffer.add_char b c ; parse_ast b closing ast lexbuf
-      | `comment -> parse_ast b closing ast lexbuf
+      | `escaped c ->
+          Buffer.add_char b c;
+          parse_ast b closing st lexbuf
+      | `comment ->
+          parse_ast b closing st lexbuf
       | x ->
-        let loc = Loc.of_lexbuf lexbuf in
-        let ast = flush ast b lexbuf in
+        let st = flush b st in
         match x with
-        | `variable [v] when List.mem v closing -> List.rev ast, v
-        | `variable ["define"] -> parse_define b closing ast lexbuf
-        | `variable ["let"] -> parse_let b closing ast lexbuf
-        | `variable ["include"] -> parse_include b closing ast lexbuf
+        | `variable [v] when List.mem v closing ->
+            State.tokens st, v
+        | `variable ["define"] ->
+            parse_define b closing st lexbuf
+        | `variable ["let"] ->
+            parse_let b closing st lexbuf
+        | `variable ["include"] ->
+            parse_include b closing st lexbuf
         | x ->
           let a = match x with
-            | `variable ["if"] -> parse_if b lexbuf
-            | `variable ["foreach"] -> parse_foreach b lexbuf
-            | `variable ["apply"] -> parse_apply b lexbuf
-            | `variable ["expr"] -> parse_expr_stmt lexbuf
-            | `variable ["for"] -> parse_for b lexbuf
-            | `variable ["wid_hei"] -> Ast.mk_wid_hei (value lexbuf)
-            | `variable (hd :: tl) -> Ast.mk_var ~loc hd tl
-            | `variable [] | `escaped _ | `comment -> assert false
+            | `variable ["if"] ->
+                parse_if b st lexbuf
+            | `variable ["foreach"] ->
+                parse_foreach b st lexbuf
+            | `variable ["apply"] ->
+                parse_apply b st lexbuf
+            | `variable ["expr"] ->
+                parse_expr_stmt st lexbuf
+            | `variable ["for"] ->
+                parse_for b st lexbuf
+            | `variable ["wid_hei"] ->
+                Ast.mk_wid_hei ~loc:(State.current_loc st) (value lexbuf)
+            | `variable (hd :: tl) ->
+                Ast.mk_var ~loc:(State.current_loc st) hd tl
+            | `variable [] | `escaped _ | `comment ->
+                assert false
           in
-          parse_ast b closing (a :: ast) lexbuf
+          let st = State.push_token a st in
+          parse_ast b closing st lexbuf
     }
 
   | '[' {
-      let ast = flush ast b lexbuf in
+      let st = flush b st in
       let a =
-        let loc = Loc.of_lexbuf lexbuf in
         let (upp, s, n) = lexicon_word lexbuf in
         if String.length s > 1 && (s.[0] = '[' || s.[0] = '@') then
-            Ast.mk_include ~loc (`Raw s)
+            Ast.mk_include (`Raw s)
         else
-          Ast.mk_transl ~loc upp s n
+          Ast.mk_transl upp s n
       in
-      parse_ast b closing (a :: ast) lexbuf
+      let st = State.push_token a st in
+      parse_ast b closing st lexbuf
     }
 
   | '\n' [ ' ' '\n' '\t' '\r' ]* {
-      let () = Buffer.add_char b '\n' in
-      parse_ast b closing ast lexbuf
+      Buffer.add_char b '\n';
+      parse_ast b closing st lexbuf
     }
 
   | _ as c {
-      let () = Buffer.add_char b c in
-      parse_ast b closing ast lexbuf
+      Buffer.add_char b c;
+      parse_ast b closing st lexbuf
     }
 
   | eof {
-      List.rev (flush ast b lexbuf), ""
+      let st = flush b st in
+      State.tokens st, ""
     }
 
 and parse_ident_list = parse
@@ -113,177 +167,167 @@ and parse_ident_list = parse
       []
     }
 
-and parse_expr = parse
+and parse_expr st = parse
   | "" {
-      parse_expr_if lexbuf
+      parse_expr_if st lexbuf
     }
 
-and parse_expr_if = parse
+and parse_expr_if st = parse
   | ws* "if" {
-      let e1 = parse_expr_or lexbuf in
-      parse_expr_if_1 e1 lexbuf
+      let e1 = parse_expr_or st lexbuf in
+      parse_expr_if_1 e1 st lexbuf
     }
   | "" {
-      parse_expr_or lexbuf
+      parse_expr_or st lexbuf
     }
-and parse_expr_if_1 e1 = parse
+and parse_expr_if_1 e1 st = parse
   | ws* "then" {
-      let e2 = parse_expr_or lexbuf in
-      parse_expr_if_2 e1 e2 lexbuf
+      let e2 = parse_expr_or st lexbuf in
+      parse_expr_if_2 e1 e2 st lexbuf
     }
-and parse_expr_if_2 e1 e2 = parse
+and parse_expr_if_2 e1 e2 st = parse
   | ws* "else" {
-      let e3 = parse_expr_or lexbuf in
+      let e3 = parse_expr_or st lexbuf in
       Ast.mk_if e1 [e2] [e3]
     }
 
-and parse_expr_or = parse
+and parse_expr_or st = parse
   | ws* {
-      let e1 = parse_expr_and lexbuf in
-      parse_expr_or_1 e1 lexbuf
+      let e1 = parse_expr_and st lexbuf in
+      parse_expr_or_1 e1 st lexbuf
     }
-and parse_expr_or_1 e1 = parse
+and parse_expr_or_1 e1 st = parse
   | ws* "or" {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_expr_or lexbuf in
-      Ast.mk_op2 ~loc "or" e1 e2
+      let e2 = parse_expr_or st lexbuf in
+      Ast.mk_op2 "or" e1 e2
     }
   | ws* {
       e1
     }
 
-and parse_expr_and = parse
+and parse_expr_and st = parse
   | ws* {
-      let e1 = parse_expr_is_substr lexbuf in
-      parse_expr_and_1 e1 lexbuf
+      let e1 = parse_expr_is_substr st lexbuf in
+      parse_expr_and_1 e1 st lexbuf
     }
-and parse_expr_and_1 e1 = parse
+and parse_expr_and_1 e1 st = parse
   | ws* "and" {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_expr_and lexbuf in
-      Ast.mk_op2 ~loc "and" e1 e2
+      let e2 = parse_expr_and st lexbuf in
+      Ast.mk_op2 "and" e1 e2
     }
   | ws* {
       e1
     }
 
-and parse_expr_is_substr = parse
+and parse_expr_is_substr st = parse
   | ws* {
-      let e1 = parse_expr_in lexbuf in
-      parse_expr_is_substr_1 e1 lexbuf
+      let e1 = parse_expr_in st lexbuf in
+      parse_expr_is_substr_1 e1 st lexbuf
     }
-and parse_expr_is_substr_1 e1 = parse
+and parse_expr_is_substr_1 e1 st = parse
   | ws* "is_substr" {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_expr_is_substr lexbuf in
-      Ast.mk_op2 ~loc "is_substr" e1 e2
+      let e2 = parse_expr_is_substr st lexbuf in
+      Ast.mk_op2 "is_substr" e1 e2
     }
   | ws* {
       e1
     }
 
-and parse_expr_in = parse
+and parse_expr_in st = parse
   | ws* {
-      let e1 = parse_expr_3 lexbuf in
-      parse_expr_in_1 e1 lexbuf
+      let e1 = parse_expr_3 st lexbuf in
+      parse_expr_in_1 e1 st lexbuf
     }
-and parse_expr_in_1 e1 = parse
+and parse_expr_in_1 e1 st = parse
   | ws* "in" {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_expr_in lexbuf in
-      Ast.mk_op2 ~loc "in" e1 e2
+      let e2 = parse_expr_in st lexbuf in
+      Ast.mk_op2 "in" e1 e2
     }
   | ws* {
       e1
     }
 
-and parse_expr_3 = parse
+and parse_expr_3 st = parse
   | ws* {
-      let e1 = parse_expr_4 lexbuf in
-      parse_expr_3_1 e1 lexbuf
+      let e1 = parse_expr_4 st lexbuf in
+      parse_expr_3_1 e1 st lexbuf
     }
-and parse_expr_3_1 e1 = parse
+and parse_expr_3_1 e1 st = parse
   | ws* (("="|"!="|">"|">="|"<"|"<=") as op) {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_expr_4 lexbuf in
-      Ast.mk_op2 ~loc op e1 e2
+      let e2 = parse_expr_4 st lexbuf in
+      Ast.mk_op2 op e1 e2
     }
   | ws* {
       e1
     }
 
-and parse_expr_4 = parse
+and parse_expr_4 st = parse
   | ws* {
-      let e1 = parse_expr_5 lexbuf in
-      parse_expr_4_1 e1 lexbuf
+      let e1 = parse_expr_5 st lexbuf in
+      parse_expr_4_1 e1 st lexbuf
     }
-and parse_expr_4_1 e1 = parse
+and parse_expr_4_1 e1 st = parse
   | ws* (("+"|"-") as op) ws* {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_expr_5 lexbuf in
-      let a = Ast.mk_op2 ~loc (String.make 1 op) e1 e2 in
-      parse_expr_4_1 a lexbuf
+      let e2 = parse_expr_5 st lexbuf in
+      let a = Ast.mk_op2 (String.make 1 op) e1 e2 in
+      parse_expr_4_1 a st lexbuf
     }
   | ws*  { e1 }
 
-and parse_expr_5 = parse
+and parse_expr_5 st = parse
   | ws* {
-      let e1 = parse_simple_expr lexbuf in
-      parse_expr_5_1 e1 lexbuf
+      let e1 = parse_simple_expr st lexbuf in
+      parse_expr_5_1 e1 st lexbuf
     }
 
-and parse_expr_5_1 e1 = parse
+and parse_expr_5_1 e1 st = parse
   | ws* (("*" | "^" | "/" | "|" | "%" |"/.") as op) {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e2 = parse_simple_expr lexbuf in
-      let a = Ast.mk_op2 ~loc op e1 e2 in
-      parse_expr_5_1 a lexbuf
+      let e2 = parse_simple_expr st lexbuf in
+      let a = Ast.mk_op2 op e1 e2 in
+      parse_expr_5_1 a st lexbuf
     }
   | ws* {
       e1
     }
 
-and parse_simple_expr = parse
+and parse_simple_expr st = parse
   | ws* '(' {
-      let e = parse_expr lexbuf in
-      let () = discard_RPAREN lexbuf in
+      let e = parse_expr st lexbuf in
+      discard_RPAREN lexbuf;
       e
     }
   | ws* "not" {
-      let loc = Loc.of_lexbuf lexbuf in
-      let e = parse_simple_expr lexbuf in
-      Ast.mk_op1 ~loc "not" e
+      let e = parse_simple_expr st lexbuf in
+      Ast.mk_op1 "not" e
     }
   | ws* '"' ([^'"']* as s) '"' {
-      let loc = Loc.of_lexbuf lexbuf in
-      Ast.mk_text ~loc s
+      Ast.mk_text s
     }
   | ws* (num as s) {
-      let loc = Loc.of_lexbuf lexbuf in
-      Ast.mk_int ~loc s
+      Ast.mk_int s
     }
   | ws* '[' {
-      let loc = Loc.of_lexbuf lexbuf in
+      let st = State.update_loc st in
       let u, w, n = lexicon_word lexbuf in
-      Ast.mk_transl ~loc u w n
+      Ast.mk_transl ~loc:(State.current_loc st) u w n
     }
   | ws* (var as id) {
-      let loc = Loc.of_lexbuf lexbuf in
+      let st = State.update_loc st in
       match String.split_on_char '.' id with
       | hd :: tl -> (
         (* FIXME: This hack introduces backtracking in the parser. We should
            parse our syntax without backtracking at all. *)
         try
-          let l = List.map (fun v -> None, v) (parse_tuple lexbuf) in
-          Ast.mk_apply ~loc hd l
-        with _ -> Ast.mk_var ~loc hd tl)
+          let l = List.map (fun v -> None, v) (parse_tuple st lexbuf) in
+          Ast.mk_apply ~loc:(State.current_loc st) hd l
+        with _ -> Ast.mk_var ~loc:(State.current_loc st) hd tl)
       | [] -> assert false
     }
 
-and parse_simple_expr_1 = parse
+and parse_simple_expr_1 st = parse
   | ws* {
-      let e = parse_expr lexbuf in
-      let () = discard_RPAREN lexbuf in
+      let e = parse_expr st lexbuf in
+      discard_RPAREN lexbuf;
       e
     }
 
@@ -292,64 +336,64 @@ and discard_RPAREN = parse
       ()
     }
 
-and parse_apply_tuple = parse
+and parse_apply_tuple st = parse
   | ws* '(' ws* ')' {
       []
     }
   | ws* '(' {
-     parse_apply_tuple_1 lexbuf
+     parse_apply_tuple_1 st lexbuf
   }
-and parse_apply_tuple_1 = parse
+and parse_apply_tuple_1 st = parse
   | ws* (r_ident as id) ws* ':' {
-      let e = parse_expr_3 lexbuf in
-      (Some id, [e]) :: parse_apply_tuple_2 lexbuf
+      let e = parse_expr_3 st lexbuf in
+      (Some id, [e]) :: parse_apply_tuple_2 st lexbuf
     }
   | ws* {
-     let e = parse_expr_3 lexbuf in
-     (None, [e]) :: parse_apply_tuple_2 lexbuf
+     let e = parse_expr_3 st lexbuf in
+     (None, [e]) :: parse_apply_tuple_2 st lexbuf
     }
-and parse_apply_tuple_2 = parse
+and parse_apply_tuple_2 st = parse
   | ws* ',' {
-    parse_apply_tuple_1 lexbuf
+    parse_apply_tuple_1 st lexbuf
     }
   | ws* ')' {
       []
     }
 
-and parse_tuple = parse
+and parse_tuple st = parse
   | ws* '(' {
-      parse_tuple_1 lexbuf
+      parse_tuple_1 st lexbuf
     }
-and parse_tuple_1 = parse
+and parse_tuple_1 st = parse
   | ws* ')' {
       []
     }
   | ws* {
-      let r = parse_expr_list lexbuf in
-      let () = discard_RPAREN lexbuf in
+      let r = parse_expr_list st lexbuf in
+      discard_RPAREN lexbuf;
       r
     }
-and parse_expr_list = parse
+and parse_expr_list st = parse
   | ws* {
-      let x = parse_expr_3 lexbuf in
-      parse_expr_list_1 x lexbuf
+      let x = parse_expr_3 st lexbuf in
+      parse_expr_list_1 x st lexbuf
     }
-and parse_expr_list_1 x = parse
+and parse_expr_list_1 x st = parse
   | ws* ',' {
-      let tl = parse_expr_list lexbuf in
+      let tl = parse_expr_list st lexbuf in
       [x] :: tl
     }
   | ws* {
       [[x]]
     }
 
-and parse_char_stream_semi fn fn2 = parse
+and parse_char_stream_semi fn fn2 st = parse
   | '(' {
-      fn2 lexbuf
+      fn2 st lexbuf
     }
   | ws* {
-      let r = fn lexbuf in
-      let () = discard_opt_semi lexbuf in
+      let r = fn st lexbuf in
+      discard_opt_semi lexbuf;
       r
     }
 
@@ -460,116 +504,130 @@ and comment = parse
       comment lexbuf
     }
 
-and parse_define b closing ast = parse
+and parse_define b closing st = parse
   | ws* (r_ident as f) ws* '(' {
-      let args = parse_params lexbuf in
-      let (a, _) = parse_ast b ["end"] [] lexbuf in
-      let (k, t) = parse_ast b closing [] lexbuf in
-      let u = Ast.mk_define f args a k in
-      (List.rev (u :: ast), t)
+      let args = parse_params st lexbuf in
+      let nst = State.create ~src:st.src lexbuf in
+      let (a, _) = parse_ast b ["end"] nst lexbuf in
+      (* We do not include the body of the underlying let-expression in the
+         computation of the location. *)
+      let loc = State.current_loc st in
+      let nst = State.create ~src:st.src lexbuf in
+      let (k, t) = parse_ast b closing nst lexbuf in
+      let u = Ast.mk_define ~loc f args a k in
+      let st = State.push_token u st in
+      State.tokens st, t
     }
-and parse_params = parse
+and parse_params st = parse
   | ws* (r_ident as a) ws* '=' ws* {
-      let e = parse_simple_expr lexbuf in
-      (a, Some e) :: parse_params_1 lexbuf
+      let e = parse_simple_expr st lexbuf in
+      (a, Some e) :: parse_params_1 st lexbuf
     }
   | ws* (r_ident as a) {
-      (a, None) :: parse_params_1 lexbuf
+      (a, None) :: parse_params_1 st lexbuf
     }
   | ws* ')' ws* {
       []
     }
-and parse_params_1 = parse
+and parse_params_1 st = parse
   | ws* ',' ws* (r_ident as a) ws* '=' {
-      let e = parse_simple_expr lexbuf in
-      (a, Some e) :: parse_params_1 lexbuf
+      let e = parse_simple_expr st lexbuf in
+      (a, Some e) :: parse_params_1 st lexbuf
     }
   | ws* ',' ws* (r_ident as a) {
-      (a, None) :: parse_params_1 lexbuf
+      (a, None) :: parse_params_1 st lexbuf
     }
   | ws* ')' ws* {
       []
     }
 
-and parse_let b closing ast = parse
+and parse_let b closing st = parse
   |  ws* (r_ident as k) ';' ws* {
-      let (v, _) = parse_ast b ["in"] [] lexbuf in
-      let (a, t) = parse_ast b closing [] lexbuf in
-      let u = Ast.mk_let k v a in
-      (List.rev (u :: ast), t)
+      let nst = State.create ~src:st.src lexbuf in
+      let (v, _) = parse_ast b ["in"] nst lexbuf in
+      (* We do not include the body of the let-expression in the
+         computation of the location. *)
+      let loc = State.current_loc st in
+      let nst = State.create ~src:st.src lexbuf in
+      let (a, t) = parse_ast b closing nst lexbuf in
+      let u = Ast.mk_let ~loc k v a in
+      let st = State.push_token u st in
+      State.tokens st, t
     }
 
-and parse_include b closing ast = parse
+and parse_include b closing st = parse
   | value as file {
-    let loc = Loc.of_lexbuf lexbuf in
-    let a = Ast.mk_include ~loc (`File file) in
-    parse_ast b closing (a :: ast) lexbuf
+    let u = Ast.mk_include ~loc:(State.current_loc st) (`File file) in
+    let st = State.push_token u st in
+    parse_ast b closing st lexbuf
   }
 
-and parse_apply b = parse
+and parse_apply b st = parse
   | (r_ident as f) '%' {
-      let loc = Loc.of_lexbuf lexbuf in
       assert (`variable ["with"] = variable lexbuf) ;
       let app =
         let rec loop () =
-          match parse_ast b ["and"; "end"] [] lexbuf with
+          let nst = State.create ~src:st.src lexbuf in
+          match parse_ast b ["and"; "end"] nst lexbuf with
           | a, "and" -> a :: loop ()
           | a, _ -> [ a ]
         in loop ()
       in
-      Ast.mk_apply ~loc f (List.map (fun v -> None, v) app)
+      Ast.mk_apply ~loc:(State.current_loc st) f (List.map (fun v -> None, v) app)
     }
   | (r_ident as f) {
-      let loc = Loc.of_lexbuf lexbuf in
-      let app = parse_apply_tuple lexbuf in
-      Ast.mk_apply ~loc f app
+      let app = parse_apply_tuple st lexbuf in
+      Ast.mk_apply ~loc:(State.current_loc st) f app
     }
 
-and parse_expr_stmt = parse
+and parse_expr_stmt st = parse
   | "" {
-      parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf
+      parse_char_stream_semi parse_simple_expr parse_simple_expr_1 st lexbuf
     }
 
-and parse_if b = parse
+and parse_if b st = parse
   | "" {
-      let e = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
+      let e = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 st lexbuf in
       let (a1, a2) =
         let rec loop () =
-          let (a1, t) = parse_ast b ["elseif"; "else"; "end"] [] lexbuf in
+          let nst = State.create ~src:st.src lexbuf in
+          let (a1, t) = parse_ast b ["elseif"; "else"; "end"] nst lexbuf in
           match t with
           | "elseif" ->
-            let e2 = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
+            let e2 = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 st lexbuf in
             let (a2, a3) = loop () in
             a1, [ Ast.mk_if e2 a2 a3 ]
           | "else" ->
-            let (a2, _) = parse_ast b ["end"] [] lexbuf in
+            let nst = State.create ~src:st.src lexbuf in
+            let (a2, _) = parse_ast b ["end"] nst lexbuf in
             a1, a2
           | _ -> a1, []
         in loop ()
       in
-      Ast.mk_if e a1 a2
+      Ast.mk_if ~loc:(State.current_loc st) e a1 a2
     }
 
-and parse_for b = parse
+and parse_for b st = parse
   | (r_ident as iterator) ';' {
-      let min = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
-      let max = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 lexbuf in
-      let (a, _) = parse_ast b ["end"] [] lexbuf in
-      Ast.mk_for iterator min max a
+      let min = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 st lexbuf in
+      let max = parse_char_stream_semi parse_simple_expr parse_simple_expr_1 st lexbuf in
+      let nst = State.create ~src:st.src lexbuf in
+      let (a, _) = parse_ast b ["end"] nst lexbuf in
+      Ast.mk_for ~loc:(State.current_loc st) iterator min max a
     }
 
-and parse_foreach b = parse
+and parse_foreach b st = parse
   | "" {
-      let loc = Loc.of_lexbuf lexbuf in
       let [@warning "-8"] hd :: tl = compound_var lexbuf in
-      let params = parse_foreach_params lexbuf in
-      let (a, _) = parse_ast b ["end"] [] lexbuf in
-      Ast.mk_foreach ~loc (hd, tl) params a
+      let params = parse_foreach_params st lexbuf in
+      let nst = State.create ~src:st.src lexbuf in
+      let (a, _) = parse_ast b ["end"] nst lexbuf in
+      Ast.mk_foreach ~loc:(State.current_loc st) (hd, tl) params a
     }
 
-and parse_foreach_params = parse
+and parse_foreach_params st = parse
   | '(' {
-      parse_tuple_1 lexbuf
+      parse_tuple_1 st lexbuf
     }
   | ';'? {
       []

--- a/lib/templ/loc.ml
+++ b/lib/templ/loc.ml
@@ -1,46 +1,56 @@
-type source = [ `File of string | `In_channel of in_channel | `Raw of string ]
+module Compat = Geneweb_compat
+
+type source = [ `File of string | `Raw of string ]
 
 let equal_source src1 src2 =
   match (src1, src2) with
   | `File f1, `File f2 -> String.equal f1 f2
   | `File _, _ | _, `File _ -> false
-  | `In_channel ic1, `In_channel ic2 -> ic1 = ic2
-  | `In_channel _, _ | _, `In_channel _ -> false
   | `Raw s1, `Raw s2 -> String.equal s1 s2
 
 let pp_source ppf src =
-  match src with
-  | `File f -> Fmt.string ppf f
-  | `In_channel _ -> Fmt.pf ppf "<in_channel>"
-  | `Raw _ -> Fmt.pf ppf "<raw>"
+  match src with `File f -> Fmt.string ppf f | `Raw _ -> Fmt.pf ppf "<raw>"
 
 type t = { src : source; start : int; stop : int }
 
 let dummy = { src = `File "<dummy>"; start = -1; stop = -1 }
-
-let of_lexbuf lexbuf =
-  let f = (Lexing.lexeme_start_p lexbuf).pos_fname in
-  let start = Lexing.lexeme_start lexbuf in
-  let stop = Lexing.lexeme_start lexbuf in
-  { src = `File f; start; stop }
+let[@inline] is_dummy t = t == dummy
+let[@inline] of_offsets src start stop = { src; start; stop }
 
 let equal { src = s11; start = s12; stop = s13 }
     { src = s21; start = s22; stop = s23 } =
   s12 = s22 && s13 = s23 && equal_source s11 s21
 
-let pp ppf ({ src; start; stop } as t) =
-  if t == dummy then Fmt.pf ppf "<dummy>"
-  else Fmt.pf ppf "%a:%d:%d" pp_source src start stop
+(* Compute the number of colomn starting at 1. *)
+let[@inline] compute_cnum (p : Lexing.position) = p.pos_cnum - p.pos_bol + 1
 
-let pp_with_input ppf ({ src; start; stop } as t) =
-  if t == dummy then Fmt.pf ppf "No location implemented"
+let pp_lexing_position ppf (p : Lexing.position) =
+  Fmt.pf ppf "(%d, %d)" p.pos_lnum (compute_cnum p)
+
+let with_pp_loc_input src k =
+  match src with
+  | `File f ->
+      (* [Pp_loc.Input.file] opens templates in binary mode, but the Parser module
+          open them in text mode. On Windows, text mode normalizes line endings
+          to the UNIX format. We must use the same mode to print correct line
+          and column numbers. *)
+      Compat.In_channel.with_open_text f @@ fun ic ->
+      k (Pp_loc.Input.in_channel ic)
+  | `Raw s -> k (Pp_loc.Input.string s)
+
+let pp ppf ({ src; start; stop } as t) =
+  if is_dummy t then Fmt.pf ppf "<dummy>"
   else
-    let input =
-      match src with
-      | `File f -> Pp_loc.Input.file f
-      | `In_channel ic -> Pp_loc.Input.in_channel ic
-      | `Raw s -> Pp_loc.Input.string s
-    in
-    let start = Pp_loc.Position.of_offset start in
-    let stop = Pp_loc.Position.of_offset stop in
-    Pp_loc.pp ~input ppf [ (start, stop) ]
+    with_pp_loc_input src @@ fun input ->
+    let start = Pp_loc.Position.(to_lexing input @@ of_offset start) in
+    let stop = Pp_loc.Position.(to_lexing input @@ of_offset stop) in
+    Fmt.pf ppf "%a:%a:%a" pp_source src pp_lexing_position start
+      pp_lexing_position stop
+
+let pp_quote ppf ({ src; start; stop } as t) =
+  if is_dummy t then Fmt.nop ppf ()
+  else
+    with_pp_loc_input src @@ fun input ->
+    Pp_loc.pp ~input ppf [ Pp_loc.Position.(of_offset start, of_offset stop) ]
+
+let pp_with_source ppf t = Fmt.pf ppf "%a:@ %a" pp t pp_quote t

--- a/lib/templ/loc.mli
+++ b/lib/templ/loc.mli
@@ -1,7 +1,7 @@
 type t
 (** Type of locations. *)
 
-type source = [ `File of string | `In_channel of in_channel | `Raw of string ]
+type source = [ `File of string | `Raw of string ]
 (** Type of sources. *)
 
 val equal_source : source -> source -> bool
@@ -14,9 +14,12 @@ val pp_source : source Fmt.t
 val dummy : t
 (** Dummy location. *)
 
-val of_lexbuf : Lexing.lexbuf -> t
-(** [of_lexbuf lexbuf] creates a location from the current state of the lexing
-    buffer [lexbuf]. *)
+val is_dummy : t -> bool
+(** [is_dummy t] checks if [t] is the dummy location. *)
+
+val of_offsets : source -> int -> int -> t
+(** [of_offsets src start stop] creates a location for the source [src] starting
+    at [start] and ending at [stop]. *)
 
 val equal : t -> t -> bool
 (** [equal t1 t2] checks if the locations [t1] and [t2] are equal. *)
@@ -25,7 +28,7 @@ val pp : t Fmt.t
 (** [pp ppf t] prints a string representation of the location on the formatter
     [ppf]. *)
 
-val pp_with_input : t Fmt.t
-(** [pp_with_input ppf t] prints the lines referenced by [t] on the formatter
+val pp_with_source : t Fmt.t
+(** [pp_with_source ppf t] prints the lines referenced by [t] on the formatter
     [ppf] using Pp_loc library. For channel sources, this assumes that
     unrestricted seeking operations on channels. *)

--- a/lib/templ/parser.ml
+++ b/lib/templ/parser.ml
@@ -10,21 +10,24 @@ let with_cache (type a b) (f : a -> b) : a -> b =
         r
     | r -> r
 
-let parse_ast lexbuf = Lexer.parse_ast (Buffer.create 1024) [] [] lexbuf |> fst
+let parse_ast ~src lexbuf =
+  let st = Lexer.State.create ~src lexbuf in
+  Lexer.parse_ast (Buffer.create 1024) [] st lexbuf |> fst
 
-let parse_file s =
-  Compat.In_channel.with_open_text s @@ fun ic ->
-  let lexbuf = Lexing.from_channel ic in
-  (* TODO: This function is not available in OCaml 4.08. We should
-     find a workaround after fixing locations in the parser. *)
-  (* Lexing.set_filename lexbuf s; *)
-  parse_ast lexbuf
+let parse_file ~src fl =
+  Compat.In_channel.with_open_text fl @@ fun ic ->
+  (* We do not use position feature of the Lexing module as our lexer does not
+     produce a single token per call. Instead, we rely on
+     `lex_abs_pos`, `lex_start_pos` and `lex_curr_pos` of [lexbuf] to compute
+     locations. *)
+  let lexbuf = Lexing.from_channel ~with_positions:false ic in
+  parse_ast ~src lexbuf
 
 let parse_source ~cached src =
   match src with
-  | `File s -> if cached then with_cache parse_file s else parse_file s
-  | `In_channel ic -> parse_ast @@ Lexing.from_channel ic
-  | `Raw s -> parse_ast @@ Lexing.from_string s
+  | `File fl ->
+      if cached then with_cache (parse_file ~src) fl else parse_file ~src fl
+  | `Raw s -> parse_ast ~src (Lexing.from_string ~with_positions:false s)
 
 let comment fl =
   let s =

--- a/test/templ/dune
+++ b/test/templ/dune
@@ -1,0 +1,17 @@
+(executable
+ (name templ_test)
+ (libraries fmt geneweb_templ))
+
+(rule
+ (deps
+  (:template ./template.html)
+  (glob_files ./*.html))
+ (action
+  (with-stdout-to
+   template.out
+   (run ./templ_test.exe %{template}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff template.expected template.out)))

--- a/test/templ/included.html
+++ b/test/templ/included.html
@@ -1,0 +1,1 @@
+%base.bar

--- a/test/templ/templ_test.ml
+++ b/test/templ/templ_test.ml
@@ -1,0 +1,11 @@
+module Parser = Geneweb_templ.Parser
+module Ast = Geneweb_templ.Ast
+
+let parse_file fl =
+  let resolve_include _loc s = s in
+  Parser.parse ~cached:false ~on_exn:Printexc.raise_with_backtrace
+    ~resolve_include (`File fl)
+
+let () =
+  let ast = parse_file Sys.argv.(1) in
+  Fmt.pr "@[%a@]@." Fmt.(list ~sep:semi Ast.pp) ast

--- a/test/templ/template.expected
+++ b/test/templ/template.expected
@@ -1,0 +1,69 @@
+Atext ("<html>\n<head>");
+{ desc = Avar (base, [name]); loc = template.html:(2, 9):(2, 19) };
+Atext ("   </head>\n<link rel=\"icon\" href=\"");
+{ desc = Avar (image_prefx, []); loc = template.html:(3, 26):(3, 39) };
+Atext ("favicon.png\"/>\n<body>\n");
+{ desc = Adefine (foo, [{x, }], [Atext ("foo_x")],
+[Atext ("<span id=\"apply_1\">");
+ { desc = Aapply (foo, [{, [Atext ("bar")]}]);
+  loc = template.html:(7, 24):(7, 41) }; Atext ("</span>\n");
+ { desc = Adefine (bar, [{x, }; {y, }], [Atext ("bar_x_y")],
+ [{ desc = Adefine (foobar, [{x, }],
+  [{ desc = Adefine (toto, [{y, }], [Atext ("x_y\n")], []);
+    loc = template.html:(12, 7):(14, 12) }],
+  [Atext ("<span id=\"apply_2\">");
+   { desc = Aapply (bar, [{, [Atext ("Hello")]}; {, [Atext ("World")]}]);
+    loc = template.html:(17, 24):(17, 52) };
+   Atext ("</span>\n<span id=\"apply_3\">");
+   { desc = Aapply (bar, [{, [Atext ("Hello")]}; {, [Atext ("World")]}]);
+    loc = template.html:(19, 24):(19, 60) }; Atext ("</span>\n");
+   { desc = Aif (Aop2 (=,
+                 { desc = Avar (lang, []);
+                  loc = template.html:(21, 10):(21, 14) }, Atext ("fr")),
+   [Atext ("<span>french!</span>")], []);
+    loc = template.html:(21, 5):(21, 45) };
+   Apack ([Atext ("<!-- included.html -->\n");
+           { desc = Apack ([{ desc = Avar (base, [bar]);
+                             loc = included.html:(1, 1):(1, 10) }]);
+            loc = template.html:(23, 5):(23, 27) };
+           Atext ("<!-- included.html -->\n")]);
+   { desc = Afor (i, Aint (0), Aint (10),
+   [{ desc = Alet (h,
+    [{ desc = Aapply (foo,
+     [{, [{ desc = Avar (bar, []); loc = template.html:(27, 22):(27, 25) }]}]);
+      loc = template.html:(27, 11):(27, 26) }]
+    [{ desc = Aif (Aop2 (!=,
+                   { desc = Avar (h, []);
+                    loc = template.html:(29, 12):(29, 13) }, Atext ("toto")),
+     [Atext ("<span>boom</span>\n")], []);
+      loc = template.html:(29, 7):(31, 12) }]);
+     loc = template.html:(26, 7):(28, 11) }]);
+    loc = template.html:(25, 5):(32, 10) };
+   { desc = Aforeach ((blabla, []), [], [Atext ("<span>toto</span>\n")]);
+    loc = template.html:(34, 5):(36, 10) };
+   { desc = Alet (x,
+   [{ desc = Aapply (foo,
+    [{, [{ desc = Avar (bar, []); loc = template.html:(39, 20):(39, 23) }]}]);
+     loc = template.html:(39, 9):(39, 24) };
+    { desc = Alet (y,
+    [{ desc = Aapply (foo,
+     [{, [{ desc = Avar (bar, []); loc = template.html:(41, 22):(41, 25) }]}]);
+      loc = template.html:(41, 11):(41, 26) }]
+    [Atext ("x y\n")]); loc = template.html:(40, 7):(42, 11) }]
+   [Atext ("<span id=\"nn\">   </span>    \n<span id=\"transl_1\">");
+    Atransl (false, connect  , );
+    Atext ("   </span>\n<span id=\"transl_2\">\n");
+    Atransl (false, disconnect, ); Atext ("  \ntext\n</span>\n");
+    { desc = Aif ({ desc = Avar (c1, []);
+                   loc = template.html:(57, 9):(57, 11) },
+    [],
+    [Aif ({ desc = Avar (c2, []); loc = template.html:(58, 13):(58, 15) },
+     [],
+     [{ desc = Aif ({ desc = Avar (c3, []);
+                     loc = template.html:(60, 11):(60, 13) },
+      [], []); loc = template.html:(60, 7):(62, 12) }])]);
+     loc = template.html:(57, 5):(63, 10) }; Atext ("</body>\n</html>")]);
+    loc = template.html:(38, 5):(44, 9) }]);
+   loc = template.html:(11, 5):(15, 10) }]);
+  loc = template.html:(9, 5):(9, 34) }]);
+ loc = template.html:(5, 5):(5, 29) }

--- a/test/templ/template.html
+++ b/test/templ/template.html
@@ -1,0 +1,65 @@
+<html>
+  <head>%base.name   </head>
+  <link rel="icon" href="%image_prefx;favicon.png"/>
+  <body>
+    %define;foo(x)foo_x%end;
+
+    <span id="apply_1">%apply;foo("bar")</span>
+
+    %define;bar(x, y)bar_x_y%end;
+
+    %define;foobar(x)
+      %define;toto(y)
+        x_y
+      %end;
+    %end;
+    
+    <span id="apply_2">%apply;bar("Hello", "World")</span>
+
+    <span id="apply_3">%apply;bar%with;Hello%and;World%end;</span>
+
+    %if;(lang="fr")<span>french!</span>%end;
+
+    %include;included.html
+
+    %for;i;0;10;
+      %let;
+        h;%apply;foo(bar)
+      %in;
+      %if;(h!="toto")
+        <span>boom</span>
+      %end;
+    %end;
+
+    %foreach;blabla;
+      <span>toto</span>
+    %end;
+
+    %let;
+      x;%apply;foo(bar)
+      %let;
+        y;%apply;foo(bar)
+      %in;
+      x y
+    %in;
+
+    %sq;     
+
+    <span id="nn">   %nn;   </span>    
+
+    <span id="transl_1">[connect  ]   </span>
+  
+    <span id="transl_2">
+    [disconnect]  
+    text
+    </span>
+
+    %if;c1;
+    %elseif;c2;
+    %else;
+      %if;c3;
+      %else;
+      %end; 
+    %end;
+  </body>
+</html>


### PR DESCRIPTION
This PR restores locations for many nodes of `Geneweb_templ.Ast`. The feature has been broken by myself while refactoring this code in #2232. 

The main issue comes from a undocumented aspect of `Lexing` module. The field `lex_start_pos` and `lex_curr_pos` are relative a hidden buffer of `lexbuf`. If you use `Lexing.from_string`, the buffer contains all the input and everything works as expected. If you use `Lexing.from_channel`, the buffer contains a chunk of the input and you must add `lex_abs_pos` to retrieve the correct location in the input.

#### How to test this PR:
- Introduce an error in a templates. For instance, apply this patch
```patch
diff --git a/hd/etc/welcome.txt b/hd/etc/welcome.txt
index d745bff05..9ae245cf7 100644
--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -85,7 +85,7 @@
     </div>
   </div>
 %end;
-<div class="d-flex flex-column flex-md-row align-items-center justify-content-lg-around mt-1 mt-lg-%if;roglo;1%else;3%end;">
+<div class="d-flex flex-column flex-md-row align-items-center justify-content-lg-around mt-1 mt-lg-%if;rigolo;1%else;3%end;">
   <div class="col-md-3 order-2 order-md-1 align-self-center mt-3 mt-md-0">
     <div class="d-flex justify-content-center">
       %if;roglo;
```
- Build and run the server
```command
dune build @install && dune exec -- bin/gwd/gwd.exe -debug -n_workers 1
```
- Go to the wrong page, you should get an error of this form:
```
gwd.exe: [DEBUG] Uncaught exception in templates: Geneweb.Templ.UnboundVar
                 /home/tiky/git/geneweb/restore-error-location-templ/_build/install/default/share/geneweb/hd/etc/welcome.txt:(88, 104):(88, 110):
                 88 | <div class="d-flex flex-column flex-md-row align-items-center justify-content-lg-around mt-1 mt-lg-%if;rigolo;1%else;3%end;">
                                                                                                                             ^^^^^^
```  

Now you have a precise error with the file and the precise location in the file. In the above example:
```
.../etc/welcome.txt:(88, 104):(88, 110)
```
means that the wrong variable name starts at the line 88 and column 104 and ends at the line 88 and column 110 exclusive.

Other changes:
- Add a type for the internal state of the parser,
- Prints errors with sources in `Templ`,
- Add a test for `Geneweb_templ`. The test coverage is not complete at all and you can add extra syntax in 
`template.html` and check that the output is correct with `dune runtest`,
- Remove `In_channel` source in `Geneweb_templ.Loc` as we don't use it,
- Fix the `.editorconfig` file in order to eliminate all the trailing whitespaces in most of the files but preserve them 
in `test/templ/template.html` as the parser trims them,
- Improve printers of `Geneweb_templ.Ast` for easier readability.
- Do not normalize shell scripts to DOS format. We commit shell scripts in the UNIX format but we normalized them to the DOS format on Windows while checking the branch out. Notice that `git add --renormalize .` does not help to get the UNIX version on Windows as we already commit the right version. If you have already checked out a DOS version, you can erase it and restore it to get the UNIX version: 
```
rm lib/generate_version.sh 
git restore lib/generate_version.sh
```