### PR TITLE
birthday: limit family anniversaries by total relationship degree (&d=)

### DIFF
--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -451,7 +451,7 @@
                 <span class="fa fa-users fa-fw mr-2"></span>[*family/families]0</a>
               %if;(died = "" and (wizard or friend))
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="%prefix;%access;&m=C&t=AN"><span class="fa fa-cake-candles fa-fw mr-2"></span>[*family birthday]</a>
+                <a class="dropdown-item" href="%prefix;%access;&m=C&t=AN&d=6"><span class="fa fa-cake-candles fa-fw mr-2"></span>[*family birthday]</a>
               %end;
               <!-- Relationship graph builder -->
               <div class="dropdown-divider"></div>

--- a/lib/birthdayDisplay.ml
+++ b/lib/birthdayDisplay.ml
@@ -50,7 +50,64 @@ let print_anniversary_day conf base dead_people liste =
     liste;
   Output.print_sstring conf "</ul>"
 
-let gen_print conf base mois f_scan dead_people =
+let propose_months conf ?max_d mode =
+  let is_cousins = p_getenv conf.env "m" = Some "C" in
+  let d_val =
+    match p_getint conf.env "d" with Some d when d >= 0 -> d | _ -> 6
+  in
+  let max_d = match max_d with Some d -> d | None -> 250 in
+
+  let sel_month =
+    match p_getint conf.env "v" with
+    | Some v when v >= 1 && v <= 12 -> v
+    | _ -> conf.today.month
+  in
+  let month_options =
+    let buf = Buffer.create 256 in
+    for i = 1 to 12 do
+      Printf.bprintf buf {|<option value="%d"%s>%s</option>|} i
+        (if i = sel_month then " selected" else "")
+        (transl_nth conf "(month)" (i - 1)
+        |> Util.translate_eval |> Utf8.capitalize_fst)
+    done;
+    Buffer.contents buf
+  in
+  begin_centered conf;
+  Output.printf conf
+    {|<form class="form-inline justify-content-center my-3"
+method="get" action="%s">|}
+    conf.command;
+  Util.hidden_env conf;
+  mode ();
+  Output.printf conf
+    {|<label class="mr-2" for="v_month">%s</label>
+  <select class="form-control form-control-lg %s" name="v" id="v_month">%s</select>|}
+    (Utf8.capitalize_fst (transl_nth conf "year/month/day" 1))
+    (if is_cousins then "mr-3" else "mr-2")
+    month_options;
+  if is_cousins then
+    Output.printf conf
+      {|<label class="mx-2" for="d_deg">%s</label>
+  <div class="input-group input-group-lg">
+    <div class="input-group-prepend">
+      <button type="button" class="btn btn-outline-secondary"
+        onclick="var i=document.getElementById('d_deg');
+        i.value=Math.max(0,+i.value-1)">&minus;</button></div>
+    <input type="number" name="d" id="d_deg" class="form-control text-center"
+      value="%d" min="0" max="%d" style="width:4em">
+    <div class="input-group-append">
+      <button type="button" class="btn btn-outline-secondary"
+        onclick="var i=document.getElementById('d_deg');
+        i.value=Math.min(%d,+i.value+1)">+</button></div></div>|}
+      (Utf8.capitalize_fst (transl_nth conf "degree of kinship" 0))
+      d_val max_d max_d;
+  Output.printf conf
+    {|<button type="submit" class="btn btn-primary btn-lg ml-2">%s</button>
+</form>|}
+    (Utf8.capitalize_fst (transl_nth conf "validate/delete" 0));
+  end_centered conf
+
+let gen_print conf base mois f_scan ?max_d ?mode dead_people =
   let tab = Array.make 31 [] in
   let title _ =
     let lab =
@@ -130,6 +187,7 @@ let gen_print conf base mois f_scan dead_people =
       Output.print_sstring conf "</li>\n")
   done;
   Output.print_sstring conf "</ul>\n";
+  (match mode with Some m -> propose_months conf ?max_d m | None -> ());
   Hutil.trailer conf
 
 let print_anniversary_list conf base dead_people dt liste =
@@ -200,40 +258,6 @@ let print_birth_day conf base day_name fphrase wd dt list =
         (transl conf "the birthday");
       Output.print_sstring conf "...</p>";
       print_anniversary_list conf base false dt list
-
-let propose_months conf mode =
-  begin_centered conf;
-  Output.print_sstring conf "<span>";
-  transl conf "select a month to see all the anniversaries"
-  |> Utf8.capitalize_fst |> Output.print_sstring conf;
-  Output.print_sstring conf "</span>";
-  Output.print_sstring conf {|<table border="|};
-  Output.print_sstring conf (string_of_int conf.border);
-  Output.print_sstring conf {|"><tr><td>|};
-  Output.print_sstring conf {|<form class="form-inline" method="get" action="|};
-  Output.print_sstring conf conf.command;
-  Output.print_sstring conf {|"><p>|};
-  Util.hidden_env conf;
-  mode ();
-  Output.print_sstring conf
-    {|<select class="form-control form-control-lg" name="v">|};
-  for i = 1 to 12 do
-    Output.print_sstring conf {|<option value="|};
-    Output.print_sstring conf (string_of_int i);
-    Output.print_sstring conf {|"|};
-    Output.print_sstring conf
-      (if i = conf.today.month then {| selected="selected">|} else ">");
-    transl_nth conf "(month)" (i - 1)
-    |> Util.translate_eval |> Utf8.capitalize_fst |> Output.print_sstring conf;
-    Output.print_sstring conf "</option>"
-  done;
-  Output.print_sstring conf "</select>";
-  Output.print_sstring conf
-    {|<button type="submit" class="btn btn-primary btn-lg ml-2">|};
-  transl_nth conf "validate/delete" 0
-  |> Utf8.capitalize_fst |> Output.print_sstring conf;
-  Output.print_sstring conf "</button></p></form></td></tr></table>";
-  end_centered conf
 
 let day_after d =
   let day, r =

--- a/lib/birthdayDisplay.mli
+++ b/lib/birthdayDisplay.mli
@@ -8,14 +8,19 @@ val gen_print :
     Geneweb_db.Driver.base ->
     Geneweb_db.Driver.person ->
     Adef.safe_string)) ->
+  ?max_d:int ->
+  ?mode:(unit -> unit) ->
   bool ->
   unit
-(** [gen_print conf base month (next,txt_of) dead_people] displays anniversaries
-    for a given month separated by day. If [dead_people] is true then displays
-    birth/death anniversaries for dead people with death reason. Otherwise
-    displays birthdays for alive people. [next] is function that returns next
-    person from iterator and [txt_of] text/link that describes person's
-    information *)
+(** Display anniversaries for a given month, one section per day. [f_scan]
+    returns the next person and a function producing the display text/link for
+    that person; raises [Not_found] when exhausted. When [dead_people] is true,
+    lists birth and death anniversaries with death reason; otherwise lists
+    birthdays of living people only. [~max_d] is the maximum total relationship
+    degree reachable for the target person (passed to the month/degree form).
+    [~mode] emits hidden inputs specific to the calling context; when provided,
+    a month selector (and degree stepper in cousins context) is rendered after
+    the listing. *)
 
 val print_birth : Config.config -> Geneweb_db.Driver.base -> int -> unit
 (** Displays birthdays for alive people for a given month *)

--- a/lib/cousinsDisplay.ml
+++ b/lib/cousinsDisplay.ml
@@ -322,6 +322,9 @@ let print_anniv conf base p dead_people level =
         in
         loop set 0
   in
+  let max_deg =
+    match p_getint conf.env "d" with Some d when d > 0 -> d | _ -> 0
+  in
   let set =
     let module P = Pqueue.Make (struct
       type t = Driver.iper * int * int
@@ -329,12 +332,18 @@ let print_anniv conf base p dead_people level =
       let leq (_, lev1, _) (_, lev2, _) = lev1 <= lev2
     end) in
     let a = P.add (Driver.get_iper p, 0, 1) P.empty in
+    let max_asc = if max_deg > 0 then min level max_deg else level in
     let rec loop set a =
       if P.is_empty a then set
       else
         let (ip, n, up_sosa), a = P.take a in
-        let set = insert_desc set up_sosa [] (n + 3) ip in
-        if n >= level then set
+        let desc_lim =
+          if max_deg > 0 then min (n + 3) (max_deg - n) else n + 3
+        in
+        let set =
+          if desc_lim >= 0 then insert_desc set up_sosa [] desc_lim ip else set
+        in
+        if n >= max_asc then set
         else
           let a =
             match Driver.get_parents (pget conf base ip) with
@@ -396,7 +405,10 @@ let print_anniv conf base p dead_people level =
       (Adef.encoded (if dead_people then "AD" else "AN"))
   in
   match p_getint conf.env "v" with
-  | Some i -> BirthdayDisplay.gen_print conf base i f_scan dead_people
+  | Some i ->
+      BirthdayDisplay.gen_print conf base i f_scan
+        ~max_d:((2 * level) + 3)
+        ~mode dead_people
   | _ ->
       if dead_people then
         BirthdayDisplay.gen_print_menu_dead conf base f_scan mode


### PR DESCRIPTION
The birthday/anniversary tool (m=C&t=AN) traverses all relatives regardless of relationship distance, producing overwhelming lists on large databases. Add support for the &d= parameter to cap the total degree (ascending + descending) of collected relatives.

For an ancestor at level n, descent is limited to min(n+3, d-n). Ascending stops at min(level, d). Default set to d=6 in menubar link. Without &d in the URL, the original unlimited behavior is preserved for backward compatibility.

Modernize propose_months: remove legacy table/span markup, use labeled form controls with proper for/id attributes, pre-select current month when viewing a monthly listing, and add the degree stepper (visible only in cousins context m=C). Pass optional ~mode to gen_print so the form appears at the bottom of monthly listings (historically absent).