### PR TITLE
Do not read synchro_patches files if we don't need it

### DIFF
--- a/lib/db/database.ml
+++ b/lib/db/database.ml
@@ -974,7 +974,6 @@ let with_database ?(read_only = false) bname k =
         prerr_endline msg;
         (empty_patch_ht (), RDONLY)
   in
-  let synchro = input_synchro bname in
   let fname = bname // "particles.txt" in
   let particles =
     if Sys.file_exists fname then Mutil.input_particles fname
@@ -1109,6 +1108,7 @@ let with_database ?(read_only = false) bname k =
       try Secure.open_out_bin tmp_fname
       with Sys_error _ -> raise (Failure "the database is not writable")
     in
+    let synchro = input_synchro bname in
     let synchro =
       let timestamp = string_of_float (Unix.time ()) in
       let timestamp = String.sub timestamp 0 (String.index timestamp '.') in


### PR DESCRIPTION
Each `with_database` calls read entirely the `synchro_patches` file even if we do not call `commit` later. Avoiding this reading makes a huge difference and small perso pages. On my database, the size of `synchro_patches` is about 50 Mio and reading it adds 400 ms per request.

Notice that the first request is always slower because we compute sosa numbers beforing caching this result. In my case:
1s -> 0.5s -> 0.5s -> ...
before the patch on small perso pages and
0.9s -> 0.1s -> 0.1s -> ...
after the patch on these pages.

I used the following command to evaluate the impact of this patch:
```command 
dune build @install
dune exec --profile=release -- bin/gwd/gwd.exe -cache-in-memory roglo-v7 -n_workers 0
```