### PR TITLE
Add inline image embedding syntax for Notes wiki

### DIFF
--- a/lib/notes.ml
+++ b/lib/notes.ml
@@ -240,6 +240,7 @@ let update_notes_links_db base fnotes s =
             in
             loop list_nt list_ind (pos + 1) j
         | NotesLinks.WLwizard (j, _, _) -> loop list_nt list_ind pos j
+        | NotesLinks.WLimage (j, _, _, _) -> loop list_nt list_ind pos j
         | NotesLinks.WLnone (j, _) -> loop list_nt list_ind pos j
     in
     loop [] [] 1 0
@@ -430,7 +431,10 @@ let rewrite_key s oldk newk _file =
     if i >= slen then rs
     else
       match NotesLinks.misc_notes_link s i with
-      | WLpage (j, _, _, _, _) | WLwizard (j, _, _) | WLnone (j, _) ->
+      | WLpage (j, _, _, _, _)
+      | WLwizard (j, _, _)
+      | WLimage (j, _, _, _)
+      | WLnone (j, _) ->
           let ss = String.sub s i (j - i) in
           rebuild (rs ^ ss) j
       | WLperson (j, k, name, text, fam_marker) ->

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -28,6 +28,7 @@ type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
   | WLperson of int * key * string option * string option * int option
   | WLwizard of int * string * string
+  | WLimage of int * (string list * string) * string * string option
   | WLnone of int * string
 
 (* search in a note (s) wiki references

--- a/lib/notesLinks.ml
+++ b/lib/notesLinks.ml
@@ -115,6 +115,34 @@ let misc_notes_link s i =
             | None -> (b, "")
           in
           WLwizard (j, wiz, name)
+        else if spe = Some "image" then
+          (* Syntax: [[image:path/alt/width]]
+             where path uses ':' as directory separator (same as notes pages).
+             Fields are separated by '/': path, optional alt text, optional width. *)
+          let img_path, rest =
+            match String.index_opt b '/' with
+            | Some i ->
+                ( String.sub b 0 i,
+                  Some (String.sub b (i + 1) (String.length b - i - 1)) )
+            | None -> (b, None)
+          in
+          match check_file_name img_path with
+          | None -> wlnone j
+          | Some fpath ->
+              let alt, width_opt =
+                match rest with
+                | None -> ("", None)
+                | Some r -> (
+                    match String.index_opt r '/' with
+                    | None -> (r, None)
+                    | Some k ->
+                        ( String.sub r 0 k,
+                          let w =
+                            String.sub r (k + 1) (String.length r - k - 1)
+                          in
+                          if w = "" then None else Some w ))
+              in
+              WLimage (j, fpath, alt, width_opt)
         else
           try
             let k = 0 in

--- a/lib/notesLinks.mli
+++ b/lib/notesLinks.mli
@@ -3,13 +3,13 @@ type wiki_link =
   | WLperson of int * Def.NLDB.key * string option * string option * int option
   | WLwizard of int * string * string
   | WLimage of int * (string list * string) * string * string option
-      (** [WLimage (end_pos, fpath, alt, width_opt)] inline image from the notes
-          image directory. [fpath] is the validated path (same format as
-          WLpage), [alt] is the alt text (may be empty), [width_opt] is an
-          optional CSS width value (e.g. ["200px"]). Syntax:
-          {v [[image:notes:photo.jpg]] v}
-          {v [[image:notes:photo.jpg/alt text]] v}
-          {v [[image:notes:photo.jpg/alt text/200px]] v} *)
+      (** [WLimage (end_pos, fpath, alt, width_opt)] inline image from the image
+          directory and it's subdirectories. [fpath] is the validated path (same
+          format as WLpage), [alt] is the alt text (may be empty), [width_opt]
+          is an optional CSS width value (e.g. ["200px"]). Syntax:
+          {v [[image:photo.jpg]] v}
+          {v [[image:subdir:photo.jpg/alt text]] v}
+          {v [[image:subdir:photo.jpg/alt text/200px]] v} *)
   | WLnone of int * string
 
 val char_dir_sep : char

--- a/lib/notesLinks.mli
+++ b/lib/notesLinks.mli
@@ -2,6 +2,14 @@ type wiki_link =
   | WLpage of int * (string list * string) * string * string * string
   | WLperson of int * Def.NLDB.key * string option * string option * int option
   | WLwizard of int * string * string
+  | WLimage of int * (string list * string) * string * string option
+      (** [WLimage (end_pos, fpath, alt, width_opt)] inline image from the notes
+          image directory. [fpath] is the validated path (same format as
+          WLpage), [alt] is the alt text (may be empty), [width_opt] is an
+          optional CSS width value (e.g. ["200px"]). Syntax:
+          {v [[image:notes:photo.jpg]] v}
+          {v [[image:notes:photo.jpg/alt text]] v}
+          {v [[image:notes:photo.jpg/alt text/200px]] v} *)
   | WLnone of int * string
 
 val char_dir_sep : char

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2841,6 +2841,8 @@ let rec in_text case_sens s m =
           if in_text case_sens s text then true else loop false j
       | NotesLinks.WLperson (j, (fn, sn, _), None, _, _) ->
           if in_text case_sens s (fn ^ " " ^ sn) then true else loop false j
+      | NotesLinks.WLimage (j, _, alt, _) ->
+          if in_text case_sens s alt then true else loop false j
       | NotesLinks.WLnone (j, _) -> loop false j
     else
       match start_equiv_with case_sens s m i with

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -25,6 +25,10 @@ open Util
    [[first_name/surname]] link (oc = 0); 'first_name surname' displayed
    [[[notes_subfile/text]]] link to a sub-file; 'text' displayed
    [[[notes_subfile]]] link to a sub-file; 'notes_subfile' displayed
+   [[image:filename.jpg]] inline image from the notes image directory
+   [[image:subdir:filename.jpg]] image in a subdirectory (use ':' as separator)
+   [[image:filename.jpg/alt text]] image with alt text
+   [[image:filename.jpg/alt text/200px]] image with alt text and CSS max-width
    empty line : new paragraph
    lines starting with space : displayed as they are (providing 1/ there
      are at least two 2/ there is empty lines before and after the group
@@ -373,6 +377,25 @@ let syntax_links conf wi s =
           in
           Buffer.add_string buff t;
           loop quot_lev (pos + 1) j
+      | NotesLinks.WLimage (j, (dirs, file), alt, width_opt) ->
+          (* Build the path for the ?s= parameter by joining dirs and file
+             with '/' (the ':' directory separator is already split by
+             check_file_name into the dirs list). *)
+          let path = String.concat "/" (dirs @ [ file ]) in
+          let src =
+            Printf.sprintf "%sm=IM&s=%s" (commd conf :> string) (encode path)
+          in
+          let style =
+            match width_opt with
+            | None -> ""
+            | Some w -> Printf.sprintf " style=\"max-width:%s\"" (escape w)
+          in
+          let t =
+            Printf.sprintf {|<img src="%s" alt="%s"%s class="notes-image">|} src
+              (escape alt) style
+          in
+          Buffer.add_string buff t;
+          loop quot_lev pos j
       | NotesLinks.WLnone (j, none_s) ->
           Buffer.add_string buff none_s;
           loop quot_lev pos j
@@ -467,6 +490,7 @@ let remove_links s =
             in
             (Buff.mstore len text, j)
         | NotesLinks.WLwizard (j, _, text) -> (Buff.mstore len text, j)
+        | NotesLinks.WLimage (j, _, alt, _) -> (Buff.mstore len alt, j)
         | NotesLinks.WLnone (j, none_s) -> (Buff.mstore len none_s, j)
       in
       loop len i

--- a/lib/wiki.mli
+++ b/lib/wiki.mli
@@ -24,6 +24,10 @@ open Config
    [[first_name/surname]] link (oc = 0); 'first_name surname' displayed
    [[[notes_subfile/text]]] link to a sub-file; 'text' displayed
    [[[notes_subfile]]] link to a sub-file; 'notes_subfile' displayed
+   [[image:filename.jpg]] inline image from the notes image directory
+   [[image:subdir:filename.jpg]] image in a subdirectory (use ':' as separator)
+   [[image:filename.jpg/alt text]] image with alt text
+   [[image:filename.jpg/alt text/200px]] image with alt text and CSS max-width
    empty line : new paragraph
    lines starting with space : displayed as they are (providing 1/ there
      are at least two 2/ there is empty lines before and after the group

--- a/test/wiki_test.ml
+++ b/test/wiki_test.ml
@@ -6,8 +6,10 @@ let f s =
     if i = len then List.rev acc
     else
       match misc_notes_link s i with
-      | (WLpage (j, _, _, _, _) | WLperson (j, _, _, _, _) | WLwizard (j, _, _))
-        as x ->
+      | ( WLpage (j, _, _, _, _)
+        | WLperson (j, _, _, _, _)
+        | WLwizard (j, _, _)
+        | WLimage (j, _, _, _) ) as x ->
           loop (x :: acc) j
       | WLnone (j, _text) as wn -> loop (wn :: acc) j
   in
@@ -61,6 +63,18 @@ let l =
     ([ WLwizard (14, "hg", "henri") ], "[[w:hg/henri]]");
     ( [ WLnone (1, "["); WLnone (2, "["); WLwizard (16, "hg", "henri") ],
       "[[[[w:hg/henri]]" );
+    ([ WLimage (19, ([], "photo.jpg"), "", None) ], "[[image:photo.jpg]]");
+    ( [ WLimage (24, ([ "albums" ], "pic.jpg"), "", None) ],
+      "[[image:albums:pic.jpg]]" );
+    ( [ WLimage (28, ([], "photo.jpg"), "my photo", None) ],
+      "[[image:photo.jpg/my photo]]" );
+    ( [ WLimage (34, ([], "photo.jpg"), "my photo", Some "200px") ],
+      "[[image:photo.jpg/my photo/200px]]" );
+    ( [ WLimage (29, ([], "photo.jpg"), "my photo", None) ],
+      "[[image:photo.jpg/my photo/]]" );
+    ([ WLnone (22, "[[image:bad path.jpg]]") ], "[[image:bad path.jpg]]");
+    ( [ WLimage (21, ([ "a"; "b" ], "c.jpg"), "t", None) ],
+      "[[image:a:b:c.jpg/t]]" );
   ]
 
 let pp_token ppf tk =
@@ -77,6 +91,11 @@ let pp_token ppf tk =
         Fmt.(option ~none:(any "None") int)
         fam_marker
   | WLwizard (pos, wiz, name) -> Fmt.pf ppf "WLwizard (%d, %s, %s)" pos wiz name
+  | WLimage (pos, (p, fname), alt, width) ->
+      Fmt.pf ppf "WLimage (%d, ([%s], %s), %s, %a)" pos (String.concat "; " p)
+        fname alt
+        Fmt.(option ~none:(any "None") string)
+        width
   | WLnone (pos, s) -> Fmt.pf ppf "WLnone (%d, %s)" pos s
 
 let eq_token = ( = )


### PR DESCRIPTION
Introduces [[image:...]] syntax for embedding pictures inline in Notes fields. Images are served from the existing images directory via the m=IM handler, with a recommended notes/ subdirectory for organisation.

Syntax:
  [[image:photo.jpg]]                     plain image
  [[image:notes:photo.jpg/alt text]]      with alt text; ':' = subdir
  [[image:notes:photo.jpg/alt text/200px]]  with CSS max-width

Changes:
- notesLinks: add WLimage variant; parse [[image:path/alt/width]] links
- wiki: render WLimage as <img> tag; emit alt text in TOC stripping