### PR TITLE
revert hutil: remove buffer pools, template cache, static parts modules

### DIFF
--- a/lib/checkDataDisplay.ml
+++ b/lib/checkDataDisplay.ml
@@ -546,10 +546,10 @@ let print conf base =
     }
   in
   Hutil.header conf title;
-  Hutil.HtmlBuffer.wrap_measured conf (fun conf ->
-      Util.print_loading_overlay conf ();
-      Output.printf conf
-        {|<form method="get" action="%s" class="mt-2" id="chk-data-form">
+
+  Util.print_loading_overlay conf ();
+  Output.printf conf
+    {|<form method="get" action="%s" class="mt-2" id="chk-data-form">
   %s
   <input type="hidden" name="m" value="CHK_DATA">
   <div class="d-flex justify-content-center mb-3">
@@ -585,56 +585,56 @@ let print conf base =
         <abbr title="%s"><i class="fa fa-circle-question mr-1"></i>↑↓</abbr>
       </div>
       <div class="card-body d-flex flex-column">|}
-        (Util.commd conf :> string)
-        (if conf.cgi then
-           let b_value =
-             if conf.cgi_passwd = "" then conf.bname
-             else conf.bname ^ "_" ^ conf.cgi_passwd
-           in
-           Printf.sprintf {|<input type="hidden" name="b" value="%s">|} b_value
-         else "")
-        (t conf "chk_data books to check")
-        (List.length params.selected_dicts)
-        (render_dict_checkboxes_two_columns conf params.selected_dicts)
-        (t conf "toggle all")
-        (t conf "chk_data error types")
-        (List.length params.sel_err_types)
-        (render_error_checkboxes conf params.sel_err_types)
-        (t conf "toggle all") (t conf "options")
-        (t conf "chk_data keyboard navigation tooltip");
-      if not params.is_roglo then
-        Output.printf conf
-          {|
+    (Util.commd conf :> string)
+    (if conf.cgi then
+       let b_value =
+         if conf.cgi_passwd = "" then conf.bname
+         else conf.bname ^ "_" ^ conf.cgi_passwd
+       in
+       Printf.sprintf {|<input type="hidden" name="b" value="%s">|} b_value
+     else "")
+    (t conf "chk_data books to check")
+    (List.length params.selected_dicts)
+    (render_dict_checkboxes_two_columns conf params.selected_dicts)
+    (t conf "toggle all")
+    (t conf "chk_data error types")
+    (List.length params.sel_err_types)
+    (render_error_checkboxes conf params.sel_err_types)
+    (t conf "toggle all") (t conf "options")
+    (t conf "chk_data keyboard navigation tooltip");
+  if not params.is_roglo then
+    Output.printf conf
+      {|
           <div class="form-check mb-1">
             <input class="form-check-input" type="checkbox" name="nocache" id="use-db" value="1"%s>
             <label class="form-check-label" for="use-db">
               <i class="fa fa-database mr-2"></i>%s
             </label>
           </div>|}
-          (if params.nocache_checked then " checked" else "")
-          (tn conf "chk_data use database/cache" 0);
-      Output.printf conf
-        {|
+      (if params.nocache_checked then " checked" else "")
+      (tn conf "chk_data use database/cache" 0);
+  Output.printf conf
+    {|
           <div class="form-group mb-0">
             <label for="max-results" class="mb-0">%s%s</label>
             <input type="number" class="form-control" name="max" id="max-results" min="1" step="1" value="%s"%s>%s
           </div>|}
-        (t conf "chk_data max results")
-        (t conf ":")
-        (match params.form_max with Some n -> string_of_int n | None -> "")
-        (match params.config_max with
-        | Some n -> Printf.sprintf {| max="%d"|} n
-        | None -> "")
-        (match params.config_max with
-        | Some c ->
-            Printf.sprintf {|<small class="ml-1 text-muted">%s</small>|}
-              (Utf8.capitalize_fst
-                 (Printf.sprintf
-                    (Util.ftransl conf "chk_data limited to %d results")
-                    c))
-        | None -> "");
-      Output.printf conf
-        {|
+    (t conf "chk_data max results")
+    (t conf ":")
+    (match params.form_max with Some n -> string_of_int n | None -> "")
+    (match params.config_max with
+    | Some n -> Printf.sprintf {| max="%d"|} n
+    | None -> "")
+    (match params.config_max with
+    | Some c ->
+        Printf.sprintf {|<small class="ml-1 text-muted">%s</small>|}
+          (Utf8.capitalize_fst
+             (Printf.sprintf
+                (Util.ftransl conf "chk_data limited to %d results")
+                c))
+    | None -> "");
+  Output.printf conf
+    {|
           <div class="text-center py-1 px-3 mt-auto">
             <button type="submit" class="btn btn-primary w-100" data-action="validate-submit">
               <i class="fa fa-magnifying-glass mr-2"></i>%s
@@ -644,24 +644,24 @@ let print conf base =
       </div>
     </div>
   </form>|}
-        (t conf "chk_data check data");
-      if params.selected_dicts <> [] && params.sel_err_types <> [] then (
-        let cache_index = if params.nocache_checked then 1 else 2 in
-        Output.printf conf
-          {|
+    (t conf "chk_data check data");
+  if params.selected_dicts <> [] && params.sel_err_types <> [] then (
+    let cache_index = if params.nocache_checked then 1 else 2 in
+    Output.printf conf
+      {|
   <div class="alert alert-info mt-3">
     <i class="fa fa-database mr-2"></i>%s
   </div>
   <div id="cd" data-ok-title="%s">
 |}
-          (tn conf "chk_data use database/cache" cache_index)
-          (tn conf "validate/delete" 0);
-        display_results conf base params.selected_dicts params.sel_err_types
-          params.max_results;
-        Output.print_sstring conf {|
+      (tn conf "chk_data use database/cache" cache_index)
+      (tn conf "validate/delete" 0);
+    display_results conf base params.selected_dicts params.sel_err_types
+      params.max_results;
+    Output.print_sstring conf {|
   </div>
 |});
-      Hutil.trailer conf)
+  Hutil.trailer conf
 
 type chk_result =
   | Success of {
@@ -867,30 +867,30 @@ let print_result_as_html conf result =
       Hutil.header conf (fun _ ->
           Output.print_sstring conf
             ("✓ " ^ t conf ~c:0 "modification successful"));
-      Hutil.HtmlBuffer.wrap_measured conf (fun conf ->
-          print_status_message conf ~success:true
-            ~content:(t conf "modification successful");
-          if r.cache_updated then
-            Output.printf conf
-              {|<div class="text-muted mt-2"><i class="fa fa-check-circle mr-1"></i>%s</div>|}
-              (t conf "cache updated");
-          (match (r.nb_modified, r.elapsed) with
-          | Some n, Some time when n > 1 ->
-              let modif_word =
-                Util.transl_nth conf "modification/modifications" 1
-              in
-              Output.printf conf
-                {|<div class="text-info mt-2"><i class="fa fa-info-circle mr-1"></i>%d %s — %.1f s</div>|}
-                n modif_word time
-          | _ -> ());
-          send_validation_result_to_opener conf result);
+
+      print_status_message conf ~success:true
+        ~content:(t conf "modification successful");
+      if r.cache_updated then
+        Output.printf conf
+          {|<div class="text-muted mt-2"><i class="fa fa-check-circle mr-1"></i>%s</div>|}
+          (t conf "cache updated");
+      (match (r.nb_modified, r.elapsed) with
+      | Some n, Some time when n > 1 ->
+          let modif_word =
+            Util.transl_nth conf "modification/modifications" 1
+          in
+          Output.printf conf
+            {|<div class="text-info mt-2"><i class="fa fa-info-circle mr-1"></i>%d %s — %.1f s</div>|}
+            n modif_word time
+      | _ -> ());
+      send_validation_result_to_opener conf result;
       Hutil.trailer conf
   | Error msg ->
       Hutil.header conf (fun _ ->
           Output.print_sstring conf ("✗ " ^ t conf ~c:0 "modification failed"));
-      Hutil.HtmlBuffer.wrap_measured conf (fun conf ->
-          print_status_message conf ~success:false ~content:msg;
-          send_validation_result_to_opener conf result);
+
+      print_status_message conf ~success:false ~content:msg;
+      send_validation_result_to_opener conf result;
       Hutil.trailer conf
 
 let print_chk_ok conf base =

--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -1,278 +1,10 @@
+(* Copyright (c) 2007 INRIA *)
+
 open Config
 open Def
 
-type 'a value = Vint of int | Vother of 'a | Vnone
-
-let get_env v env = try Templ.Env.find v env with Not_found -> Vnone
-let get_vother = function Vother x -> Some x | _ -> None
-let set_vother x = Vother x
-
-module BufferPool = struct
-  let small_pool = Queue.create ()
-  let small_pool_max = 20
-  let small_size = 2048
-  let page_pool = Queue.create ()
-  let page_pool_max = 5
-  let page_size = 65536
-
-  let acquire_small () =
-    try
-      let buf = Queue.pop small_pool in
-      Buffer.clear buf;
-      buf
-    with Queue.Empty -> Buffer.create small_size
-
-  let release_small buf =
-    if Queue.length small_pool < small_pool_max && Buffer.length buf < 8192 then
-      Queue.push buf small_pool
-
-  let acquire_page () =
-    try
-      let buf = Queue.pop page_pool in
-      Buffer.clear buf;
-      buf
-    with Queue.Empty -> Buffer.create page_size
-
-  let release_page buf =
-    if Queue.length page_pool < page_pool_max then (
-      if Buffer.length buf > 524288 then Buffer.reset buf else Buffer.clear buf;
-      Queue.push buf page_pool)
-
-  let with_buffer f =
-    let buf = acquire_small () in
-    try
-      let result = f buf in
-      release_small buf;
-      result
-    with e ->
-      release_small buf;
-      raise e
-end
-
-module TemplateCache = struct
-  type entry = {
-    content : string;
-    size : int;
-    mutable last_access : float;
-    mutable access_count : int;
-  }
-
-  let cache = Hashtbl.create 64
-  let max_cache_size = 10_485_760
-  let current_size = ref 0
-  let enabled = ref true
-  let hits = ref 0
-  let misses = ref 0
-
-  let evict_lru () =
-    let entries =
-      Hashtbl.fold (fun k v acc -> (k, v) :: acc) cache []
-      |> List.sort (fun (_, a) (_, b) -> compare a.last_access b.last_access)
-    in
-    match entries with
-    | (oldest_key, oldest_entry) :: _ ->
-        Hashtbl.remove cache oldest_key;
-        current_size := !current_size - oldest_entry.size
-    | [] -> ()
-
-  let get_cached name =
-    try
-      let entry = Hashtbl.find cache name in
-      incr hits;
-      entry.last_access <- Unix.time ();
-      entry.access_count <- entry.access_count + 1;
-      Some entry.content
-    with Not_found ->
-      incr misses;
-      None
-
-  let add_to_cache name content =
-    let size = String.length content in
-    if size > max_cache_size / 4 then None
-    else (
-      while !current_size + size > max_cache_size && Hashtbl.length cache > 0 do
-        evict_lru ()
-      done;
-      let entry =
-        { content; size; last_access = Unix.time (); access_count = 0 }
-      in
-      Hashtbl.replace cache name entry;
-      current_size := !current_size + size;
-      Some content)
-
-  let get_or_load conf name =
-    if not !enabled then None
-    else
-      match get_cached name with
-      | Some content -> Some content
-      | None -> (
-          try
-            BufferPool.with_buffer (fun buf ->
-                let output_conf_buf =
-                  { conf.output_conf with body = Buffer.add_string buf }
-                in
-                let conf_buf = { conf with output_conf = output_conf_buf } in
-                Templ.output_simple conf_buf Templ.Env.empty name;
-                let content = Buffer.contents buf in
-                add_to_cache name content)
-          with _ -> None)
-end
-
-module StaticParts = struct
-  let doctype_html = lazy "<!DOCTYPE html>\n"
-  let head_open = lazy "<head>\n  <title>"
-  let title_close = lazy "</title>\n"
-  let head_close = lazy "</head>\n"
-  let body_close = lazy "</body>\n</html>\n"
-  let container_close = lazy "</div><!-- container end -->\n"
-  let h1_close = lazy "</h1>\n"
-  let script_open = lazy "<script>\n"
-  let script_close = lazy "\n</script>\n"
-
-  let meta_viewport =
-    "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, \
-     shrink-to-fit=no\">\n"
-
-  let meta_robots_index = "  <meta name=\"robots\" content=\"index,follow\">\n"
-  let meta_robots_none = "  <meta name=\"robots\" content=\"none\">\n"
-  let meta_robots robot = if robot then meta_robots_index else meta_robots_none
-  let container_normal = "<div class=\"container\">\n"
-  let container_fluid = "<div class=\"container-fluid mx-3\">\n"
-  let container fluid = if fluid then container_fluid else container_normal
-  let h1_open_normal = "<h1>"
-  let h1_open_error = "<h1 class=\"error\">"
-  let h1_open error = if error then h1_open_error else h1_open_normal
-  let html_cache = Hashtbl.create 8
-  let charset_cache = Hashtbl.create 4
-  let favicon_cache = Hashtbl.create 8
-  let body_cache = Hashtbl.create 16
-
-  let html_open lang =
-    try Hashtbl.find html_cache lang
-    with Not_found ->
-      let result = Printf.sprintf "  <html lang=\"%s\">\n" lang in
-      Hashtbl.add html_cache lang result;
-      result
-
-  let meta_charset charset =
-    try Hashtbl.find charset_cache charset
-    with Not_found ->
-      let result = Printf.sprintf "  <meta charset=\"%s\">\n" charset in
-      Hashtbl.add charset_cache charset result;
-      result
-
-  let favicon prefix =
-    try Hashtbl.find favicon_cache prefix
-    with Not_found ->
-      let result =
-        Printf.sprintf
-          "  <link rel=\"shortcut icon\" href=\"%s/favicon_gwd.png\">\n\
-           <link rel=\"apple-touch-icon\" href=\"%s/favicon_gwd.png\">\n"
-          prefix prefix
-      in
-      Hashtbl.add favicon_cache prefix result;
-      result
-
-  let body_open dir_attr body_prop =
-    let key = dir_attr ^ "|" ^ body_prop in
-    try Hashtbl.find body_cache key
-    with Not_found ->
-      let result = Printf.sprintf "<body%s%s>\n" dir_attr body_prop in
-      Hashtbl.add body_cache key result;
-      result
-end
-
-module HtmlBuffer = struct
-  let create_buffered_conf ?(initial_size = 65536) conf =
-    let buffer = Buffer.create initial_size in
-    let original_output = conf.output_conf in
-    let buffered_output =
-      {
-        original_output with
-        body = Buffer.add_string buffer;
-        flush =
-          (fun () ->
-            let content = Buffer.contents buffer in
-            if String.length content > 0 then (
-              original_output.body content;
-              original_output.flush ();
-              Buffer.clear buffer));
-      }
-    in
-    { conf with output_conf = buffered_output }
-
-  let wrap conf f =
-    let buffer = BufferPool.acquire_page () in
-    let original_output = conf.output_conf in
-    let buffered_output =
-      {
-        original_output with
-        body = Buffer.add_string buffer;
-        flush =
-          (fun () ->
-            let content = Buffer.contents buffer in
-            if String.length content > 0 then (
-              original_output.body content;
-              original_output.flush ();
-              Buffer.clear buffer));
-      }
-    in
-    let buffered_conf = { conf with output_conf = buffered_output } in
-    try
-      let result = f buffered_conf in
-      buffered_conf.output_conf.flush ();
-      BufferPool.release_page buffer;
-      result
-    with e ->
-      buffered_conf.output_conf.flush ();
-      BufferPool.release_page buffer;
-      raise e
-
-  let wrap_measured conf f =
-    let start_time = Unix.gettimeofday () in
-    let bytes_before = Gc.allocated_bytes () in
-    let buffer_size = ref 0 in
-    let write_count = ref 0 in
-
-    let buffer = BufferPool.acquire_page () in
-    let original_output = conf.output_conf in
-    let measuring_output =
-      {
-        original_output with
-        body =
-          (fun s ->
-            incr write_count;
-            buffer_size := !buffer_size + String.length s;
-            Buffer.add_string buffer s);
-        flush =
-          (fun () ->
-            let content = Buffer.contents buffer in
-            if String.length content > 0 then (
-              original_output.body content;
-              original_output.flush ();
-              Buffer.clear buffer));
-      }
-    in
-    let measuring_conf = { conf with output_conf = measuring_output } in
-
-    try
-      let result = f measuring_conf in
-      measuring_conf.output_conf.flush ();
-      BufferPool.release_page buffer;
-
-      (if List.mem_assoc "debug_buffer" conf.env then
-         let bytes_after = Gc.allocated_bytes () in
-         let time_elapsed = Unix.gettimeofday () -. start_time in
-         let bytes_allocated = bytes_after -. bytes_before in
-         Printf.eprintf
-           "Buffer stats: %d bytes, %d writes, %.3fs, %.0f bytes allocated\n"
-           !buffer_size !write_count time_elapsed bytes_allocated);
-      result
-    with e ->
-      measuring_conf.output_conf.flush ();
-      BufferPool.release_page buffer;
-      raise e
-end
+let get_vother x = x
+let set_vother x = Some x
 
 let incorrect_request ?(comment = "") conf =
   GWPARAM.output_error conf Def.Bad_Request ~content:(Adef.safe comment)
@@ -309,62 +41,76 @@ let link_to_referer conf =
       :> Adef.safe_string)
   else Adef.safe ""
 
+let header_without_http_nor_home conf title =
+  let robot = List.assoc_opt "robot_index" conf.base_env = Some "yes" in
+  let str1 =
+    Printf.sprintf {|<!DOCTYPE html>
+<html lang="%s">
+<head>
+<title>|} conf.lang
+  in
+  let str2 =
+    Printf.sprintf
+      {|</title>
+%s
+<meta charset="%s">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<link rel="shortcut icon" href="%s/favicon_gwd.png">
+<link rel="apple-touch-icon" href="%s/favicon_gwd.png">
+|}
+      (if robot then {|<meta name="robots" content="index,follow">|}
+       else {|<meta name="robots" content="none">|})
+      conf.charset
+      (Util.images_prefix conf :> string)
+      (Util.images_prefix conf :> string)
+  in
+  Output.print_sstring conf str1;
+  title true;
+  Output.print_sstring conf str2;
+  Templ.output_simple conf Templ.Env.empty "css";
+  Output.print_sstring conf "</head>\n";
+  let s =
+    try " dir=\"" ^ Hashtbl.find conf.lexicon "!dir" ^ "\""
+    with Not_found -> ""
+  in
+  let s = s ^ Util.body_prop conf in
+  Output.printf conf "<body%s>\n" s;
+  Templ.output_simple conf Templ.Env.empty "hed";
+  Util.message_to_wizard conf
+
 let is_fluid conf =
   (try List.assoc "wide" conf.env = Adef.encoded "on" with Not_found -> false)
   || try List.assoc "wide" conf.base_env = "on" with Not_found -> false
 
-let rec header_without_http_nor_home conf title =
-  let robot = List.assoc_opt "robot_index" conf.base_env = Some "yes" in
-  let prefix = (Util.images_prefix conf :> string) in
-
-  Output.print_sstring conf (Lazy.force StaticParts.doctype_html);
-  Output.print_sstring conf (StaticParts.html_open conf.lang);
-  Output.print_sstring conf (Lazy.force StaticParts.head_open);
-  title true;
-  Output.print_sstring conf (Lazy.force StaticParts.title_close);
-
-  BufferPool.with_buffer (fun buf ->
-      Buffer.add_string buf (StaticParts.meta_robots robot);
-      Buffer.add_string buf (StaticParts.meta_charset conf.charset);
-      Buffer.add_string buf StaticParts.meta_viewport;
-      Buffer.add_string buf (StaticParts.favicon prefix);
-      Output.print_sstring conf (Buffer.contents buf));
-
-  Templ.output_simple conf Templ.Env.empty "css";
-  Output.print_sstring conf (Lazy.force StaticParts.head_close);
-
-  let dir_attr =
-    try " dir=\"" ^ Hashtbl.find conf.lexicon "!dir" ^ "\""
-    with Not_found -> ""
-  in
-  Output.print_sstring conf
-    (StaticParts.body_open dir_attr (Util.body_prop conf));
-  Templ.output_simple conf Templ.Env.empty "hed";
-  Util.message_to_wizard conf
-
-and header_without_title conf =
+let header_without_title conf =
   let fluid = is_fluid conf in
   Util.html conf;
   header_without_http_nor_home conf (fun _ -> ());
   include_home_template conf;
-  Output.print_sstring conf (StaticParts.container fluid)
+  Output.print_sstring conf
+    (if fluid then "<div class=\"container-fluid mx-3\">\n"
+     else "<div class=\"container\">\n")
 
-and header_with_title ?(error = false) ?(fluid = false) conf title =
+let header_with_title ?(error = false) ?(fluid = false) conf title =
   let fluid = fluid || is_fluid conf in
   Util.html conf;
   header_without_http_nor_home conf title;
   include_home_template conf;
-  Output.print_sstring conf (StaticParts.container fluid);
-  Output.print_sstring conf (StaticParts.h1_open error);
+  Output.print_sstring conf
+    (if fluid then "<div class=\"container-fluid mx-3\">\n"
+     else "<div class=\"container\">\n");
+  Output.print_sstring conf (if error then "<h1 class=\"error\">" else "<h1>");
   title false;
-  Output.print_sstring conf (Lazy.force StaticParts.h1_close)
+  Output.print_sstring conf "</h1>\n"
 
 let header_with_adaptive_title ?(fluid = false) conf title_content =
   let fluid = fluid || is_fluid conf in
   Util.html conf;
   header_without_http_nor_home conf (fun _ -> ());
   include_home_template conf;
-  Output.print_sstring conf (StaticParts.container fluid);
+  Output.print_sstring conf
+    (if fluid then "<div class=\"container-fluid mx-3\">\n"
+     else "<div class=\"container\">\n");
   let title_length = String.length title_content in
   let header_class =
     if title_length > 2000 then "h5"
@@ -375,18 +121,20 @@ let header_with_adaptive_title ?(fluid = false) conf title_content =
   if header_class = "" then Output.printf conf "<h1>%s</h1>" title_content
   else Output.printf conf {|<h1 class="%s">%s</h1>|} header_class title_content
 
-and header_fluid conf title = header_with_title ~fluid:true conf title
+let header_fluid conf title = header_with_title ~fluid:true conf title
 
-and header_without_home conf title =
+let header_without_home conf title =
   let fluid = is_fluid conf in
   Util.html conf;
   header_without_http_nor_home conf title;
-  Output.print_sstring conf (StaticParts.container fluid);
-  Output.print_sstring conf (StaticParts.h1_open false);
+  Output.print_sstring conf
+    (if fluid then "<div class=\"container-fluid mx-3\">\n"
+     else "<div class=\"container\">\n");
+  Output.print_sstring conf "<h1>";
   title false;
-  Output.print_sstring conf (Lazy.force StaticParts.h1_close)
+  Output.print_sstring conf "</h1>\n"
 
-and header_with_conf_title conf _title =
+let header_with_conf_title conf _title =
   let title _ =
     match Util.p_getenv conf.env "p_title" with
     | None | Some "" -> ()
@@ -394,58 +142,57 @@ and header_with_conf_title conf _title =
   in
   header_with_title conf title
 
-and header ?(error = false) ?(fluid = false) conf title =
+let header ?(error = false) ?(fluid = false) conf title =
   header_with_title ~error ~fluid conf title
 
-and rheader conf title = header_with_title ~error:true conf title
+let rheader conf title = header_with_title ~error:true conf title
 
-and trailer conf =
+let trailer conf =
   let conf = { conf with is_printed_by_template = false } in
   Templ.output_simple conf Templ.Env.empty "trl";
   Templ.output_simple conf Templ.Env.empty "copyr";
-  Output.print_sstring conf (Lazy.force StaticParts.container_close);
+  Output.print_sstring conf "</div>\n";
   Templ.output_simple conf Templ.Env.empty "js";
   let query_time = Unix.gettimeofday () -. conf.query_start in
   Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
     !GWPARAM.errors_other !GWPARAM.set_vars;
-  Output.print_sstring conf (Lazy.force StaticParts.body_close)
+  Output.print_sstring conf "</body>\n</html>\n"
 
-and trailer_with_extra_js conf extra_js_sources =
+let trailer_with_extra_js conf extra_js_sources =
   let conf = { conf with is_printed_by_template = false } in
   Templ.output_simple conf Templ.Env.empty "trl";
   Templ.output_simple conf Templ.Env.empty "copyr";
-  Output.print_sstring conf (Lazy.force StaticParts.container_close);
-  if extra_js_sources <> "" then (
-    let sources = String.split_on_char '|' extra_js_sources in
-    List.iter
-      (fun source ->
-        let source = String.trim source in
-        if source <> "" then
-          if Filename.check_suffix source ".js" then
-            let js_path =
-              Filename.concat conf.etc_prefix (Filename.concat "js" source)
-            in
-            match Util.open_etc_file conf js_path with
-            | Some (ic, fname) -> (
-                close_in ic;
-                match Util.hash_file_cached fname with
-                | Some hash ->
-                    Output.printf conf {|<script src="js/%s?hash=%s"></script>|}
-                      (* TODO manage etc prefix *)
-                      source hash
-                | None ->
-                    Output.printf conf {|<script src="%sjs/%s"></script>|}
-                      conf.etc_prefix source)
-            | None -> ()
-          else
-            try
-              Output.print_sstring conf (Lazy.force StaticParts.script_open);
-              Templ.output_simple conf Templ.Env.empty source;
-              Output.print_sstring conf (Lazy.force StaticParts.script_close)
-            with _ -> ())
-      sources;
-    Templ.output_simple conf Templ.Env.empty "js";
-    let query_time = Unix.gettimeofday () -. conf.query_start in
-    Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
-      !GWPARAM.errors_other !GWPARAM.set_vars;
-    Output.print_sstring conf (Lazy.force StaticParts.body_close))
+  Output.print_sstring conf "</div>\n";
+  (if extra_js_sources <> "" then
+     let sources = String.split_on_char '|' extra_js_sources in
+     List.iter
+       (fun source ->
+         let source = String.trim source in
+         if source <> "" then
+           if Filename.check_suffix source ".js" then
+             let js_path =
+               Filename.concat conf.etc_prefix (Filename.concat "js" source)
+             in
+             match Util.open_etc_file conf js_path with
+             | Some (ic, fname) -> (
+                 close_in ic;
+                 match Util.hash_file_cached fname with
+                 | Some hash ->
+                     Output.printf conf
+                       {|<script src="js/%s?hash=%s"></script>|} source hash
+                 | None ->
+                     Output.printf conf {|<script src="%sjs/%s"></script>|}
+                       conf.etc_prefix source)
+             | None -> ()
+           else
+             try
+               Output.print_sstring conf "<script>\n";
+               Templ.output_simple conf Templ.Env.empty source;
+               Output.print_sstring conf "\n</script>\n"
+             with _ -> ())
+       sources);
+  Templ.output_simple conf Templ.Env.empty "js";
+  let query_time = Unix.gettimeofday () -. conf.query_start in
+  Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
+    !GWPARAM.errors_other !GWPARAM.set_vars;
+  Output.print_sstring conf "</body>\n</html>\n"

--- a/lib/hutil.mli
+++ b/lib/hutil.mli
@@ -1,124 +1,55 @@
+(* Copyright (c) 2007 INRIA *)
+
 open Config
 
-type 'a value =
-  | Vint of int
-  | Vother of 'a
-  | Vnone  (** Polymorphic value type for template environment *)
-
-module BufferPool : sig
-  val with_buffer : (Buffer.t -> 'a) -> 'a
-  (** [with_buffer f] provides a buffer from the pool to [f], automatically
-      returning it to the pool after use. Uses small buffer pool (2KB) for
-      efficiency. *)
-end
-
-module TemplateCache : sig
-  val get_or_load : Config.config -> string -> string option
-  (** [get_or_load conf name] retrieves template [name] from cache or loads it
-      if not present. Returns [None] if template doesn't exist. Uses LRU
-      eviction when cache exceeds 10MB. *)
-end
-
-module HtmlBuffer : sig
-  val create_buffered_conf : ?initial_size:int -> Config.config -> Config.config
-  (** [create_buffered_conf ~initial_size conf] returns a config with buffered
-      output. All writes accumulate in a buffer until [flush] is called.
-      @param initial_size Initial buffer size in bytes (default: 65536) *)
-
-  val wrap : Config.config -> (Config.config -> 'a) -> 'a
-  (** [wrap ~initial_size conf f] executes [f] with a buffered config,
-      automatically flushing at the end or on exception. Uses page buffer pool
-      for efficiency. *)
-
-  val wrap_measured : Config.config -> (Config.config -> 'a) -> 'a
-  (** [wrap_measured conf f] like [wrap] but collects performance metrics. If
-      ["debug_buffer"] is in [conf.env], prints statistics to stderr:
-      - Number of writes
-      - Total bytes written
-      - Time elapsed
-      - Memory allocated *)
-end
-
-val get_env : string -> 'a value Templ.Env.t -> 'a value
-(** [get_env key env] retrieves value from template environment. Returns [Vnone]
-    if key doesn't exist. *)
-
-val get_vother : 'a value -> 'a option
-(** [get_vother v] extracts value if [v = Vother x], else [None]. *)
-
-val set_vother : 'a -> 'a value
-(** [set_vother x] wraps value in [Vother] constructor. *)
-
 val header_without_http_nor_home : config -> (bool -> unit) -> unit
-(** Base header without HTTP headers or home template. The boolean parameter
-    determines if title is printed in <title> tag. *)
 
 val header_with_title :
   ?error:bool -> ?fluid:bool -> config -> (bool -> unit) -> unit
-(** Complete header with title.
-    @param error Display title in red if [true] (default: false)
-    @param fluid Use container-fluid if [true] (default: false)
-    @param conf Base configuration
-    @param title Title function (bool indicates <title> vs <h1>) *)
+(** Prints HTTP header, HTML page header with <!DOCTYPE>, <head>, <body>, home
+    template, container <div>, and <h1> title.
+    @param error red title if [true]
+    @param fluid container-fluid if [true] *)
 
 val header_with_adaptive_title : ?fluid:bool -> config -> string -> unit
-(** Header with adaptive title size based on content length.
-    @param fluid Use container-fluid if [true] (default: false)
-    @param conf Base configuration
-    @param title_content Title text content (HTML) *)
+(** Header with adaptive title size based on content length. Uses h3/h4/h5 class
+    on <h1> for long titles. *)
 
 val header_fluid : config -> (bool -> unit) -> unit
 (** Shortcut for [header_with_title ~fluid:true]. *)
 
 val header_with_conf_title : config -> (bool -> unit) -> unit
-(** Header that gets title from [conf.env "p_title"]. *)
+(** Same as [header] but takes page title from [conf.env]. *)
 
 val header_without_title : config -> unit
-(** Complete header without <h1> title element. *)
+(** Similar to [header] but without any <h1> title element. *)
 
 val header_without_home : config -> (bool -> unit) -> unit
 (** Like [header_with_title] but without home.txt inclusion. *)
 
 val header : ?error:bool -> ?fluid:bool -> config -> (bool -> unit) -> unit
-(** Main header interface. Alias for [header_with_title].
-    @param error Display title in red if [true]
-    @param fluid Use container-fluid if [true] *)
+(** Main header. [title true] prints in <title>, [title false] prints in <h1>.
+*)
 
 val rheader : config -> (bool -> unit) -> unit
-(** Alias for [header ~error:true]. Shows error title (red). *)
+(** Same as [header ~error:true]. *)
 
 val trailer : config -> unit
-(** Standard HTML page footer. Outputs in order:
-    - "trl" template (user trailer)
-    - "copyr" template (copyright)
-    - Container closure
-    - "js" template (JavaScript)
-    - Debug timing if enabled
-    - </body></html> tags *)
+(** Prints trl, copyr, closes container, js, timing, </body>. *)
 
 val trailer_with_extra_js : config -> string -> unit
-(** [trailer_with_extra_js conf sources] outputs trailer with additional
-    JavaScript injection before main js.txt.
-
-    @param sources
-      JavaScript sources to inject:
-      - Single template: ["template_name"]
-      - Multiple templates: ["templ1|templ2|templ3"]
-      - Inline JavaScript: ["<script>...</script>"]
-
-    Templates are cached for performance. *)
+(** Like [trailer] but injects extra JS before main js.txt. Sources separated by
+    ['|']: .js file paths or template names for inline <script> blocks. *)
 
 val link_to_referer : config -> Adef.safe_string
-(** Returns HTML link to previous page (referer). Returns empty string if no
-    referer available. *)
+(** HTML link to previous page (referer). Empty if none. *)
 
 val incorrect_request : ?comment:string -> config -> unit
-(** Sends HTTP 400 Bad Request response.
-    @param comment Optional error message *)
+(** Sends HTTP 400 Bad Request. *)
 
 val error_cannot_access : config -> string -> unit
-(** Sends HTTP 404 Not Found when template cannot be accessed.
-    @param fname Name of inaccessible file *)
+(** Sends HTTP 404 for inaccessible template file. *)
 
 val include_home_template : config -> unit
-(** Includes home.txt template if available. Silent if file doesn't exist. *)
+(** Includes home.txt template via Templ.output. Shows error page if template
+    cannot be loaded. *)


### PR DESCRIPTION
Partial revert of dbe6ba9 ("refactor hutil: buffer pools, template cache, extract calendar module"). Removes BufferPool, TemplateCache, StaticParts, and HtmlBuffer modules from hutil.ml following Halbaroth's review:
- Lazy string literals add a closure over .rodata constants for no gain
- BufferPool double-buffers over already-buffered out_channel/Output.
- TemplateCache introduces mutable global state (Hashtbl, refs, Unix.time) per worker process with no cross-worker sharing.
- StaticParts sprintf caches add global Hashtbl for negligible sprintf cost.
- HtmlBuffer.wrap_measured ships debug instrumentation (Gc.allocated_bytes).

Restore header/trailer functions to direct Output.print_sstring/printf calls. Remove HtmlBuffer.wrap_measured usage from checkDataDisplay.ml. Simplify env_value type to plain option (Vint/Vnone no longer needed after calendar extraction).

Kept from dbe6ba9: CalendarDisplay module extraction, calendar.txt HTML fixes, request.ml routing update, trailer_with_extra_js, is_fluid helper, header_with_adaptive_title.