### PR TITLE
Read the full payload in RPC repl and server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,17 +15,19 @@
       let
         pkgs = import nixpkgs {
           system = "${system}";
-          overlays = [(_: prev: {
-            ocamlPackages = prev.ocaml-ng.ocamlPackages_5_4.overrideScope (_: p: {
-              cmdliner = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/cmdliner.nix { };
-              unidecode = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/unidecode.nix { };
-              calendars = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/calendars.nix { };
-              not-ocamlfind = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/not-ocamlfind.nix { };
-              odoc = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/odoc.nix { };
-              ancient = ocaml-ancient.outputs.packages.${system}.ancient;
-              ocaml = p.ocaml.override { framePointerSupport = true; };
-            });
-          })];
+          overlays = [
+            (_: prev: {
+              ocamlPackages = prev.ocaml-ng.ocamlPackages_5_4.overrideScope (_: p: {
+                cmdliner = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/cmdliner.nix { };
+                unidecode = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/unidecode.nix { };
+                calendars = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/calendars.nix { };
+                not-ocamlfind = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/not-ocamlfind.nix { };
+                odoc = prev.ocaml-ng.ocamlPackages_5_4.callPackage ./nix/odoc.nix { };
+                ancient = ocaml-ancient.outputs.packages.${system}.ancient;
+                ocaml = p.ocaml.override { framePointerSupport = true; };
+              });
+            })
+          ];
         };
 
         ocamlPackages = pkgs.ocamlPackages;
@@ -121,7 +123,11 @@
         formatter = pkgs.nixpkgs-fmt;
 
         devShells.default = pkgs.mkShell {
-          packages = [ ocamlWrapped ] ++ (with ocamlPackages; [
+          packages = [
+            ocamlWrapped
+          ] ++ (with pkgs; [
+            rlwrap
+          ]) ++ (with ocamlPackages; [
             qcheck
             qcheck-alcotest
             findlib

--- a/nix/cmdliner.nix
+++ b/nix/cmdliner.nix
@@ -1,8 +1,8 @@
-{
-  lib,
-  stdenv,
-  fetchurl,
-  ocaml,
+{ lib
+, stdenv
+, fetchurl
+, ocaml
+,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/nix/logs-syslog.nix
+++ b/nix/logs-syslog.nix
@@ -1,4 +1,7 @@
-{ buildDunePackage, logs, syslog-message, ptime
+{ buildDunePackage
+, logs
+, syslog-message
+, ptime
 }:
 
 buildDunePackage (finalAttrs: {

--- a/nix/odoc.nix
+++ b/nix/odoc.nix
@@ -1,21 +1,21 @@
-{
-  lib,
-  buildDunePackage,
-  ocaml-crunch,
-  astring,
-  cmdliner,
-  cppo,
-  fpath,
-  result,
-  tyxml,
-  markup,
-  yojson,
-  sexplib0,
-  jq,
-  odoc-parser,
-  ppx_expect,
-  bash,
-  fmt,
+{ lib
+, buildDunePackage
+, ocaml-crunch
+, astring
+, cmdliner
+, cppo
+, fpath
+, result
+, tyxml
+, markup
+, yojson
+, sexplib0
+, jq
+, odoc-parser
+, ppx_expect
+, bash
+, fmt
+,
 }:
 
 buildDunePackage {

--- a/rpc/server/rpc.ml
+++ b/rpc/server/rpc.ml
@@ -3,6 +3,7 @@ module Headers = Httpun.Headers
 module Reqd = Httpun.Reqd
 module Response = Httpun.Response
 module Status = Httpun.Status
+module Payload = Httpun_ws.Payload
 module S = Httpun_lwt_unix.Server
 module Y = Yojson.Safe
 module U = Yojson.Safe.Util
@@ -85,34 +86,45 @@ let log_ws_handler_exn sockaddr exn =
       k "Exception raised while processing request for %a:@ %a" Util.pp_sockaddr
         sockaddr Util.pp_exn exn)
 
-let ws_handler manager fd rpc_handler sockaddr target wsd =
-  let on_read ~kind content ~off:_ ~len:_ =
-    let () = Fd_manager.ping manager fd in
+let read_full_payload ~total payload k =
+  let buf = Bigstringaf.create total in
+  let rec on_read ~pos content ~off ~len =
+    Bigstringaf.blit content ~src_off:off buf ~dst_off:pos ~len;
+    let pos = pos + len in
+    if pos < total then schedule_read ~pos else k @@ Bigstringaf.to_string buf
+  and schedule_read ~pos =
+    Payload.schedule_read payload ~on_eof:ignore ~on_read:(on_read ~pos)
+  in
+  schedule_read ~pos:0
+
+let ws_handler ~max_payload_size manager fd rpc_handler sockaddr target wsd =
+  let on_read content =
+    Fd_manager.ping manager fd;
     Lwt.dont_wait
       (fun () ->
-        rpc_handler sockaddr target @@ Bigstringaf.to_string content
-        >>= fun content ->
-        let len = String.length content in
-        let content = Bigstringaf.of_string ~off:0 ~len content in
-        Lwt.return @@ Httpun_ws.Wsd.schedule wsd ~kind content ~off:0 ~len)
+        rpc_handler sockaddr target content >>= fun response ->
+        let len = String.length response in
+        let response = Bigstringaf.of_string ~off:0 ~len response in
+        Lwt.return
+        @@ Httpun_ws.Wsd.schedule wsd ~kind:`Text response ~off:0 ~len)
       (log_ws_handler_exn sockaddr)
   in
-  let frame ~opcode ~is_fin:_ ~len:_ payload =
-    match (opcode : Httpun_ws.Websocket.Opcode.t) with
-    | #Httpun_ws.Websocket.Opcode.standard_non_control as opcode ->
-        Httpun_ws.Payload.schedule_read payload ~on_eof:ignore
-          ~on_read:(on_read ~kind:opcode)
-    | `Connection_close -> Httpun_ws.Wsd.close wsd
-    | `Ping -> Httpun_ws.Wsd.send_pong wsd
-    | `Pong | `Other _ -> ()
+  let frame ~opcode ~is_fin ~len payload =
+    if not is_fin then (
+      Logs.err (fun k ->
+          k "The RPC server does not support fragmented message yet.");
+      Httpun_ws.Wsd.close wsd)
+    else
+      match (opcode : Httpun_ws.Websocket.Opcode.t) with
+      | #Httpun_ws.Websocket.Opcode.standard_non_control ->
+          if len > max_payload_size then
+            Logs.err (fun k -> k "Too long message")
+          else read_full_payload ~total:len payload on_read
+      | `Connection_close -> Httpun_ws.Wsd.close wsd
+      | `Ping -> Httpun_ws.Wsd.send_pong wsd
+      | `Pong | `Other _ -> ()
   in
-  let eof ?error () =
-    match error with
-    | Some _ -> assert false
-    | None ->
-        Logs.err (fun k -> k "EOF");
-        Httpun_ws.Wsd.close wsd
-  in
+  let eof ?error:_ () = assert false in
   { Httpun_ws.Websocket_connection.frame; eof }
 
 module Request = Httpun.Request
@@ -171,7 +183,7 @@ let resolve_addr interface port =
     [ Unix.(AI_FAMILY PF_INET) ]
 
 let start ~interface ~port ?max_connection ?idle_timeout ?task_timeout
-    ?(tls = false) ?certfile ?keyfile user_handler =
+    ?(tls = false) ?certfile ?keyfile ?max_payload_size user_handler =
   let create_connection_handler =
     match (tls, certfile, keyfile) with
     | true, Some certfile, Some keyfile ->
@@ -184,11 +196,13 @@ let start ~interface ~port ?max_connection ?idle_timeout ?task_timeout
             ~error_handler:http_error_handler
     | _ -> Fmt.invalid_arg "start"
   in
-  let task_timeout = match task_timeout with Some f -> f | None -> 0. in
+  let task_timeout = Option.value ~default:0. task_timeout in
+  let max_payload_size = Option.value ~default:max_int max_payload_size in
   let connection_handler fd_manager sockaddr fd =
     if%lwt Fd_manager.add fd_manager fd then
       let request_handler =
-        http_request_handler @@ ws_handler fd_manager fd
+        http_request_handler
+        @@ ws_handler ~max_payload_size fd_manager fd
         @@ rpc_handler ~task_timeout @@ user_handler
       in
       try%lwt

--- a/rpc/server/rpc.mli
+++ b/rpc/server/rpc.mli
@@ -15,6 +15,7 @@ val start :
   ?tls:bool ->
   ?certfile:string ->
   ?keyfile:string ->
+  ?max_payload_size:int ->
   handler ->
   unit
 (** [start ~interface ~port hdl] initializes an asynchronous RPC server based on
@@ -36,6 +37,7 @@ val start :
     - [tls]: Enables TLS support if set to [true] and valid certificates and
       private key files are provided. If [tls] is [true], connections are
       accepted only through TLS.
+    - [max_payload_size]: Specifies a maximum size for the payload per frame.
 
     @raise Invalid_argument
       if [tls] is [true] but [certfile] and [keyfile] is missing. *)

--- a/rpc/test/rpc_test.ml
+++ b/rpc/test/rpc_test.ml
@@ -1,117 +1,114 @@
 module Y = Yojson.Safe
 module U = Yojson.Safe.Util
 module Json_rpc = Geneweb_rpc.Json_rpc
-open Lwt.Infix
+module Payload = Httpun_ws.Payload
 
-exception Syntax_error
-exception Eof
+module Parser = struct
+  exception Syntax_error
+  exception Eof
 
-type input = { content : string; mutable offset : int }
+  type input = { content : string; mutable offset : int }
 
-let make_input content = { content; offset = 0 }
+  let make_input content = { content; offset = 0 }
 
-let next_char ({ content; offset } as input) =
-  if offset >= String.length content then raise Eof
-  else
-    let r = content.[offset] in
-    input.offset <- input.offset + 1;
-    r
+  let next_char ({ content; offset } as input) =
+    if offset >= String.length content then raise Eof
+    else
+      let r = content.[offset] in
+      input.offset <- input.offset + 1;
+      r
 
-let char_to_int c = Char.code c - 48
+  let char_to_int c = Char.code c - 48
 
-let rec next_token input =
-  let rec tokenize_int x =
+  let rec next_token input =
+    let rec tokenize_int x =
+      match next_char input with
+      | '0' .. '9' as c -> tokenize_int ((10 * x) + char_to_int c)
+      | ' ' | (exception Eof) -> `Int x
+      | _ -> raise Syntax_error
+    in
+    let rec tokenize_quoted_string buf =
+      match next_char input with
+      | '"' -> `String (Buffer.contents buf)
+      | _ as c ->
+          Buffer.add_char buf c;
+          tokenize_quoted_string buf
+      | exception Eof -> raise Syntax_error
+    in
+    let rec tokenize_unquoted_string buf =
+      match next_char input with
+      | ' ' | (exception Eof) -> `String (Buffer.contents buf)
+      | _ as c ->
+          Buffer.add_char buf c;
+          tokenize_unquoted_string buf
+    in
     match next_char input with
-    | '0' .. '9' as c -> tokenize_int ((10 * x) + char_to_int c)
-    | ' ' | (exception Eof) -> `Int x
-    | _ -> raise Syntax_error
-  in
-  let rec tokenize_quoted_string buf =
-    match next_char input with
-    | '"' -> `String (Buffer.contents buf)
+    | '0' .. '9' as c -> tokenize_int (char_to_int c)
+    | '"' -> tokenize_quoted_string (Buffer.create 17)
+    | ' ' -> next_token input
     | _ as c ->
-        Buffer.add_char buf c;
-        tokenize_quoted_string buf
-    | exception Eof -> raise Syntax_error
-  in
-  let rec tokenize_unquoted_string buf =
-    match next_char input with
-    | ' ' | (exception Eof) -> `String (Buffer.contents buf)
-    | _ as c ->
+        let buf = Buffer.create 17 in
         Buffer.add_char buf c;
         tokenize_unquoted_string buf
-  in
-  match next_char input with
-  | '0' .. '9' as c -> tokenize_int (char_to_int c)
-  | '"' -> tokenize_quoted_string (Buffer.create 17)
-  | ' ' -> next_token input
-  | _ as c ->
-      let buf = Buffer.create 17 in
-      Buffer.add_char buf c;
-      tokenize_unquoted_string buf
 
-let parse_input s =
-  let input = make_input s in
-  let rec loop tokens =
-    match next_token input with
-    | exception Eof -> List.rev tokens
-    | tk -> loop (tk :: tokens)
-  in
-  loop []
+  let parse_input s =
+    let input = make_input s in
+    let rec loop tokens =
+      match next_token input with
+      | exception Eof -> List.rev tokens
+      | tk -> loop (tk :: tokens)
+    in
+    loop []
+end
 
-let rpc_handler content =
-  try
-    let j = Y.from_string content in
-    match Json_rpc.Response.of_json j with
-    | Ok r -> Fmt.pr "%a@." Json_rpc.Response.pp r
-    | Error err -> Fmt.pr "%s@." err
-  with U.Type_error (s, _) ->
-    Fmt.pr "The server sent an invalid JSON message:@ %s@ Parser error:@ %s@."
-      content s
-
-(* FIXME: hackish synchronisation for logs. This may fail
-   if the server answer to quickly. *)
-let condition : unit Lwt_condition.t = Lwt_condition.create ()
-
-let wait_answer ~timeout () =
-  Lwt.pick [ Lwt_unix.sleep timeout; Lwt_condition.wait condition ]
-
-let rec loop wsd i () =
-  let open Lwt.Syntax in
-  let write wsd content =
-    let len = String.length content in
-    Httpun_ws.Wsd.schedule wsd ~kind:`Text ~off:0 ~len
-    @@ Bigstringaf.of_string content ~off:0 ~len
-  in
-  let* () = if i > 0 then wait_answer ~timeout:5.0 () else Lwt.return_unit in
-  let* () = Lwt_io.write Lwt_io.stdout "rpc> " in
-  let* s = Lwt_io.read_line Lwt_io.stdin in
-  match parse_input s with
+let prompt i =
+  Fmt.pr "rpc> @?";
+  match Parser.parse_input @@ read_line () with
   | `String meth :: args ->
       let params = `List args in
       let request = Json_rpc.Request.make ~params (`Int i) meth in
-      let content =
-        Json_rpc.Request.to_json request |> Y.(to_string ~std:true)
-      in
-      write wsd content;
-      loop wsd (i + 1) ()
-  | (exception Syntax_error) | _ ->
-      Fmt.pr "Syntax error@.";
-      loop wsd i ()
+      Ok (Json_rpc.Request.to_json request |> Y.(to_string ~std:true))
+  | (exception Parser.Syntax_error) | _ -> Error "Syntax error"
 
-let ws_handler _u wsd =
-  let on_read ~kind:_ content ~off:_ ~len:_ =
-    Lwt_condition.signal condition ();
-    rpc_handler @@ Bigstringaf.to_string content
+let receive response =
+  match Json_rpc.Response.of_json @@ Y.from_string response with
+  | Ok r -> Fmt.pr "%a@." Json_rpc.Response.pp r
+  | Error err -> Fmt.epr "%s" err
+  | exception U.Type_error (s, _) ->
+      Fmt.epr
+        "The server sent an invalid JSON message:@ %s@ Parser error:@ %s@."
+        response s
+
+let read_full_payload ~total payload k =
+  let buf = Bigstringaf.create total in
+  let rec on_read ~pos content ~off ~len =
+    Bigstringaf.blit content ~src_off:off buf ~dst_off:pos ~len;
+    let pos = pos + len in
+    if pos < total then schedule_read ~pos else k @@ Bigstringaf.to_string buf
+  and schedule_read ~pos =
+    Payload.schedule_read payload ~on_eof:ignore ~on_read:(on_read ~pos)
   in
-  let frame ~opcode ~is_fin:_ ~len:_ payload =
-    Httpun_ws.Payload.schedule_read payload ~on_eof:ignore
-      ~on_read:(on_read ~kind:opcode)
+  schedule_read ~pos:0
+
+let ws_handler ~send ~receive wsd =
+  let cnt = ref 0 in
+  let write () =
+    match send !cnt with
+    | Ok content ->
+        let len = String.length content in
+        Httpun_ws.Wsd.schedule wsd ~kind:`Text ~off:0 ~len
+        @@ Bigstringaf.of_string content ~off:0 ~len
+    | Error e -> Fmt.epr "%s@." e
   in
-  let eof ?error () =
-    match error with Some _ -> assert false | None -> assert false
+  let frame ~opcode ~is_fin ~len payload =
+    assert (opcode = `Text && is_fin);
+    read_full_payload ~total:len payload @@ fun response ->
+    receive response;
+    incr cnt;
+    write ()
   in
-  Lwt.async (loop wsd 0);
+  let eof ?error:_ () = assert false in
+  write ();
   Httpun_ws.Websocket_connection.{ frame; eof }
 
 let error_handler = function
@@ -119,16 +116,48 @@ let error_handler = function
   | `Invalid_response_body_length _ -> Fmt.pr "Invalid response body length@."
   | `Exn exn -> Fmt.pr "Uncaught exception:@ %s@." (Printexc.to_string exn)
 
-let default_interface = "localhost"
-let default_port = 8080
-let default_service = "search"
+let ask_upgrade_request ~interface ~port ~service conn =
+  let nonce = "0123456789ABCDEF" in
+  let headers =
+    Httpun.Headers.(of_list [ ("host", String.concat ":" [ interface; port ]) ])
+  in
+  let upgrade_request =
+    Httpun_ws.Handshake.create_request ~nonce ~headers (Fmt.str "/%s" service)
+  in
+  let handler = ws_handler ~send:prompt ~receive in
+  let request_body =
+    Httpun_lwt_unix.Client.request conn ~error_handler
+      ~response_handler:(fun _response _response_body ->
+        let ws_conn = Httpun_ws.Client_connection.create handler in
+        Httpun_lwt_unix.Client.upgrade conn
+          (Gluten.make (module Httpun_ws.Client_connection) ws_conn))
+      upgrade_request
+  in
+  Httpun.Body.Writer.close request_body
 
-let () =
+let establish_http_connection ~interface ~port =
+  let open Lwt.Syntax in
+  let* addresses =
+    Lwt_unix.getaddrinfo interface port [ Unix.(AI_FAMILY PF_INET) ]
+  in
+  let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  let* () = Lwt_unix.connect socket (List.hd addresses).Unix.ai_addr in
+  Httpun_lwt_unix.Client.create_connection socket
+
+let main ~interface ~port ~service =
+  let open Lwt.Syntax in
+  let* conn = establish_http_connection ~interface ~port in
+  ask_upgrade_request ~interface ~port ~service conn;
+  fst @@ Lwt.wait ()
+
+let parse_cmd () =
+  let default_interface = "localhost" in
+  let default_port = 8080 in
+  let default_service = "search" in
   let interface = ref default_interface in
   let port = ref default_port in
   let service = ref default_service in
   let usage = "rpc_test.exe -i INTERFACE -p PORT -s SERVICE" in
-
   Arg.parse
     [
       ( "-i",
@@ -141,34 +170,8 @@ let () =
     ]
     (fun (_ : string) -> ())
     usage;
+  (!interface, string_of_int !port, !service)
 
-  let p =
-    Lwt_unix.getaddrinfo !interface (string_of_int !port)
-      [ Unix.(AI_FAMILY PF_INET) ]
-    >>= fun addresses ->
-    let socket = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-    Lwt_unix.connect socket (List.hd addresses).Unix.ai_addr >>= fun () ->
-    let nonce = "0123456789ABCDEF" in
-    Httpun_lwt_unix.Client.create_connection socket >>= fun conn ->
-    let headers =
-      Httpun.Headers.(
-        of_list
-          [ ("host", String.concat ":" [ !interface; string_of_int !port ]) ])
-    in
-    let upgrade_request =
-      Httpun_ws.Handshake.create_request ~nonce ~headers
-        (Fmt.str "/%s" !service)
-    in
-    let p, u = Lwt.wait () in
-    let request_body =
-      Httpun_lwt_unix.Client.request conn ~error_handler
-        ~response_handler:(fun _response _response_body ->
-          let ws_conn = Httpun_ws.Client_connection.create (ws_handler u) in
-          Httpun_lwt_unix.Client.upgrade conn
-            (Gluten.make (module Httpun_ws.Client_connection) ws_conn))
-        upgrade_request
-    in
-    Httpun.Body.Writer.close request_body;
-    p
-  in
-  Lwt_main.run p
+let () =
+  let interface, port, service = parse_cmd () in
+  Lwt_main.run @@ main ~interface ~port ~service


### PR DESCRIPTION
While working on #2592, I noticed that the RPC repl client was broken on too long messages. This PR fixes it and ensures 
that the RPC server read the full payload too. 