### PR TITLE
Add a library to manager platform-specific directories

### DIFF
--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -1,5 +1,6 @@
 module Driver = Geneweb_db.Driver
 module Collection = Geneweb_db.Collection
+module Dirs = Geneweb_dirs
 
 type checkdata_entry = Driver.istr * string
 
@@ -254,7 +255,7 @@ let speclist =
       Arg.String Secure.set_base_dir,
       Fmt.str
         "<DIR> Specify where the 'bases' directory is installed (default %S)"
-        Secure.default_base_dir );
+        (Dirs.name Secure.default_base_dir) );
     ("", Arg.Unit (fun () -> ()), "");
     ("-fn", Arg.Set fnames, " first names");
     ("-fna", Arg.Set fname_aliases, " first name aliases (only with -checkdata)");

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -4,6 +4,7 @@ open Geneweb
 open Def
 
 module Driver = Geneweb_db.Driver
+module Dirs = Geneweb_dirs
 
 type person = (int, int, int) Def.gen_person
 type ascend = int Def.gen_ascend
@@ -3181,7 +3182,7 @@ let speclist =
       Arg.String Secure.set_base_dir,
       Fmt.str
       "<DIR> Specify where the “bases” directory with databases is installed \
-       (default if empty is %S)." Secure.default_base_dir )
+       (default if empty is %S)." (Dirs.name Secure.default_base_dir) )
   ; ( "-o", Arg.Set_string out_file,
       "<file> Output database (default: <input file name>.gwb, a.gwb if not \
        available). Alphanumerics and -" )
@@ -3255,7 +3256,7 @@ let speclist =
     , " Put untreated GEDCOM tags in notes" )
   ; ( "-ds", Arg.Set_string default_source
     , " Set the source field for persons and families without source data" )
-  ; ( "-dates", Arg.String (fun s -> 
+  ; ( "-dates", Arg.String (fun s ->
           if s = "dates_md" then month_number_dates := MonthDayDates
           else if s = "dates_dm" then month_number_dates := DayMonthDates)
     , " Interpret months-numbered dates as year only (default) or month/day/year or day/month/year" )

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -1,5 +1,7 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
+module Dirs = Geneweb_dirs
+
 (** Checks a .gwo header and prints fails if header is absent or not compatible.
 *)
 let check_magic fname ic =
@@ -128,7 +130,7 @@ let speclist =
       Fmt.str
         "<DIR> Specify where the “bases” directory with databases is installed \
          (default if empty is %S)."
-        Secure.default_base_dir );
+        Dirs.(name Secure.default_base_dir) );
     ( "-bnotes",
       Arg.Set_string bnotes,
       " [drop|erase|first|merge] Behavior for base notes of the next file. \

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -9,6 +9,7 @@ module StrSet = Mutil.StrSet
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
 module Sites = Geneweb_sites.Sites
+module Dirs = Geneweb_dirs
 module Plugin = Geneweb_plugin
 
 type opened_file = { path : string; mutable oc : out_channel }
@@ -2511,7 +2512,7 @@ let parse_cmd () =
         Fmt.str
           "<DIR> Specify where the “bases” directory with databases is \
            installed (default if empty is %S)."
-          Secure.default_base_dir );
+          (Dirs.name Secure.default_base_dir) );
       ( "-wd",
         Arg.String make_sock_dir,
         "<DIR> Directory for socket communication (Windows) and access count."

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -3,6 +3,7 @@ open Def
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
 module Collection = Geneweb_db.Collection
+module Dirs = Geneweb_dirs
 
 let debug = ref false
 let fname = ref ""
@@ -15,7 +16,7 @@ let speclist =
       Fmt.str
         "<DIR> Specify where the bases directory with databases is installed \
          (default if empty is %S)."
-        Secure.default_base_dir );
+        (Dirs.name Secure.default_base_dir) );
     ("-debug", Arg.Set debug, " Debug mode.");
   ]
 

--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,6 @@
     digestif
     pp_loc
     dune-site
-    xdg
     (utop :with-dev-setup)
     (ocamlformat (and :with-dev-setup (= "0.28.1")))
   )

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,6 @@
               benchmark
               calendars
               dune-site
-              xdg
               camlp5
               camlp-streams
               decompress

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -40,7 +40,6 @@ depends: [
   "digestif"
   "pp_loc"
   "dune-site"
-  "xdg"
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "odoc" {with-doc}

--- a/geneweb_colab.ipynb
+++ b/geneweb_colab.ipynb
@@ -75,7 +75,7 @@
         "!opam -y init --bare --shell-setup\n",
         "!opam switch create 4.14.3\n",
         "!eval $(opam env --switch=4.14.3)\n",
-        "!opam install -y calendars.2.0.0 camlp-streams camlp5 cppo decompress digestif dune dune-site jingoo markup oUnit pp_loc ppx_blob ppx_deriving ppx_import stdlib-shims logs logs-syslog unidecode.0.2.0 uri uucp uutf uunf xdg yojson"
+        "!opam install -y calendars.2.0.0 camlp-streams camlp5 cppo decompress digestif dune dune-site jingoo markup oUnit pp_loc ppx_blob ppx_deriving ppx_import stdlib-shims logs logs-syslog unidecode.0.2.0 uri uucp uutf uunf yojson"
       ]
     },
     {

--- a/lib/dirs/dune
+++ b/lib/dirs/dune
@@ -1,0 +1,20 @@
+(executable
+ (name generate_flags)
+ (modules generate_flags))
+
+(rule
+ (with-stdout-to
+  flags.dune
+  (run ./generate_flags.exe %{ocaml-config:os_type})))
+
+(library
+ (package geneweb)
+ (name geneweb_dirs)
+ (modules geneweb_dirs var xdg)
+ (foreign_stubs
+  (language c)
+  (flags
+   (:standard
+    (:include flags.dune)))
+  (names windows_stubs))
+ (libraries fmt))

--- a/lib/dirs/dune
+++ b/lib/dirs/dune
@@ -11,10 +11,10 @@
  (package geneweb)
  (name geneweb_dirs)
  (modules geneweb_dirs var xdg)
+ (c_library_flags
+  (:standard
+   (:include flags.dune)))
  (foreign_stubs
   (language c)
-  (flags
-   (:standard
-    (:include flags.dune)))
   (names windows_stubs))
  (libraries fmt))

--- a/lib/dirs/generate_flags.ml
+++ b/lib/dirs/generate_flags.ml
@@ -1,0 +1,4 @@
+let () =
+  match Sys.argv.(1) with
+  | "Win32" -> print_string "(-lshell32 -lole32 -luuid)"
+  | _ -> print_string "()"

--- a/lib/dirs/geneweb_dirs.ml
+++ b/lib/dirs/geneweb_dirs.ml
@@ -1,0 +1,39 @@
+type known_folder = InternetCache | LocalAppData | Profile | Documents
+
+external get_known_folder_path : known_folder -> string option
+  = "geneweb__get_known_folder_path"
+
+include Xdg
+
+let windows_path ~getenv name known_folder =
+  match getenv name with
+  | Some s -> s
+  | None -> (
+      match get_known_folder_path known_folder with
+      | Some s -> s
+      | None -> Filename.current_dir_name)
+
+let getenv_windows ~getenv s =
+  match s with
+  | "HOME" -> Some (windows_path ~getenv s Profile)
+  | "XDG_DATA_HOME" -> Some (windows_path ~getenv s Documents)
+  | "XDG_CONFIG_HOME" -> Some (windows_path ~getenv s LocalAppData)
+  | "XDG_STATE_HOME" -> Some (windows_path ~getenv s LocalAppData)
+  | "XDG_CACHE_HOME" -> Some (windows_path ~getenv s InternetCache)
+  | "XDG_DATA_DIRS" -> Some (windows_path ~getenv s Documents)
+  | "XDG_CONFIG_DIRS" -> Some (windows_path ~getenv s LocalAppData)
+  | _ -> None
+
+let make ?(getenv = Sys.getenv_opt) () =
+  let getenv = if Sys.unix then getenv else getenv_windows ~getenv in
+  Xdg.make ~getenv ()
+
+type one = Var.one
+type many = Var.many
+type 'a var = 'a Var.t
+
+let name = Var.name
+let path = Var.path
+let paths = Var.paths
+let concat = Var.concat
+let ( // ) = concat

--- a/lib/dirs/geneweb_dirs.mli
+++ b/lib/dirs/geneweb_dirs.mli
@@ -1,0 +1,24 @@
+type one
+type many
+type 'a var
+
+val name : 'a var -> string
+(** [name v] returns the standard name of the variable. *)
+
+val path : one var -> string
+(** [path v] returns the path contained in the variable. *)
+
+val concat : one var -> string -> one var
+(** [concat v s] returns a new variable whose the path is suffixed by [s]. *)
+
+val ( // ) : one var -> string -> one var
+(** Alias of [concat]. *)
+
+val paths : many var -> string list
+(** [paths v] returns the list of paths contained in the variable. *)
+
+type t
+
+val make : ?getenv:(string -> string option) -> unit -> t
+val data_home : t -> one var
+val cache_home : t -> one var

--- a/lib/dirs/var.ml
+++ b/lib/dirs/var.ml
@@ -1,0 +1,19 @@
+type one
+type many
+
+type _ content =
+  | One : string -> one content
+  | Many : string list -> many content
+
+type 'a t = { name : string; content : 'a content }
+
+let ( // ) = Filename.concat
+let name { name; _ } = Fmt.str "$%s" name
+
+let concat { name; content = One s } suffix =
+  let name = name // suffix in
+  let content = One (s // suffix) in
+  { name; content }
+
+let[@inline] path { content = One v; _ } = v
+let[@inline] paths { content = Many l; _ } = l

--- a/lib/dirs/windows_stubs.c
+++ b/lib/dirs/windows_stubs.c
@@ -1,0 +1,102 @@
+// This code is extracted from the xdg library of the Dune project. It is
+// distrubuted under the terms of the MIT license.
+//
+// Copyright (c) 2026 OCamlPro SAS, <contact@ocamlpro.com>
+//
+// Copyright (c) 2016 Jane Street Group, LLC <opensource@janestreet.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+
+#ifdef _WIN32
+
+/*  Windows Vista functions enabled */
+
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+
+#include <windows.h>
+#include <knownfolders.h>
+#include <shlobj.h>
+
+value geneweb__get_known_folder_path(value v_known_folder)
+{
+  CAMLparam1(v_known_folder);
+  CAMLlocal2(v_res, v_path);
+  WCHAR* wcp = NULL;
+  HRESULT res;
+  int wlen, len;
+  const KNOWNFOLDERID *rfid;
+
+  v_res = Val_int(0);
+
+  switch (Int_val(v_known_folder)) {
+    case 0:
+      rfid = &FOLDERID_InternetCache;
+      break;
+    case 1:
+      rfid = &FOLDERID_LocalAppData;
+      break;
+    case 2:
+      rfid = &FOLDERID_Profile;
+      break;
+    case 3:
+      rfid = &FOLDERID_Documents;
+      break;
+    default:
+      caml_invalid_argument("get_known_folder_path");
+      break;
+  }
+
+  res = SHGetKnownFolderPath(rfid, 0, NULL, &wcp);
+
+  if (res != S_OK)
+    goto done;
+
+  wlen = wcslen(wcp);
+  len = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wcp, wlen, NULL, 0, NULL, NULL);
+
+  if (!len)
+    goto done;
+
+  v_path = caml_alloc_string(len);
+
+  if (!WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wcp, wlen, (char *)String_val(v_path), len, NULL, NULL))
+    goto done;
+
+  v_res = caml_alloc_small(1, 0);
+  Field(v_res, 0) = v_path;
+
+ done:
+  CoTaskMemFree(wcp);
+  CAMLreturn(v_res);
+}
+
+#else /* _WIN32 */
+
+value geneweb__get_known_folder_path(value v_unit) {
+  (void)v_unit;
+  caml_invalid_argument("get_known_folder_path: not implemented");
+}
+
+#endif /* _WIN32 */

--- a/lib/dirs/xdg.ml
+++ b/lib/dirs/xdg.ml
@@ -1,0 +1,89 @@
+type one = Var.one
+type many = Var.many
+
+type t = {
+  data_home : one Var.t;
+  config_home : one Var.t;
+  state_home : one Var.t;
+  cache_home : one Var.t;
+  runtime_dir : one Var.t option;
+  data_dirs : many Var.t;
+  config_dirs : many Var.t;
+}
+
+let make_one_path ~getenv ~default name =
+  let v =
+    match getenv name with
+    | Some v when Filename.is_relative v -> default
+    | None -> default
+    | Some v -> v
+  in
+  { Var.name; content = One v }
+
+let parse s =
+  let l = String.split_on_char ':' s in
+  List.filter (fun x -> not @@ Filename.is_relative x) l
+
+let make_many_path ~getenv ~default name =
+  let l = match getenv name with Some s -> parse s | None -> default in
+  { Var.name; content = Many l }
+
+let ( // ) = Filename.concat
+let root_dir = "/"
+let[@inline] default_data_home home = home // ".local" // "share"
+let[@inline] default_config_home home = home // ".config"
+let[@inline] default_state_home home = home // ".local" // "state"
+let[@inline] default_cache_home home = home // ".cache"
+
+let default_data_dirs =
+  [ root_dir // "usr" // "local" // "share"; root_dir // "usr" // "share" ]
+
+let default_config_dirs = [ root_dir // "etc" // "xdg" ]
+
+let make ?runtime_dir ~getenv () =
+  let home = Option.get @@ getenv "HOME" in
+  if Filename.is_relative home then failwith "make";
+  let data_home =
+    make_one_path ~getenv ~default:(default_data_home home) "XDG_DATA_HOME"
+  in
+  let config_home =
+    make_one_path ~getenv ~default:(default_config_home home) "XDG_CONFIG_HOME"
+  in
+  let state_home =
+    make_one_path ~getenv ~default:(default_state_home home) "XDG_STATE_HOME"
+  in
+  let cache_home =
+    make_one_path ~getenv ~default:(default_cache_home home) "XDG_CACHE_HOME"
+  in
+  let runtime_dir =
+    let name = "XDG_RUNTIME_DIR" in
+    let o =
+      match getenv name with
+      | Some s -> Some (Var.One s)
+      | None -> Option.bind runtime_dir @@ fun s -> Some (Var.One s)
+    in
+    Option.bind o (fun content -> Some { Var.name; content })
+  in
+  let data_dirs =
+    make_many_path ~getenv ~default:default_data_dirs "XDG_DATA_DIRS"
+  in
+  let config_dirs =
+    make_many_path ~getenv ~default:default_config_dirs "XDG_CONFIG_DIRS"
+  in
+  {
+    data_home;
+    config_home;
+    state_home;
+    cache_home;
+    runtime_dir;
+    data_dirs;
+    config_dirs;
+  }
+
+let[@inline] data_home { data_home; _ } = data_home
+let[@inline] config_home { config_home; _ } = config_home
+let[@inline] state_home { state_home; _ } = state_home
+let[@inline] cache_home { cache_home; _ } = cache_home
+let[@inline] runtime_dir { runtime_dir; _ } = runtime_dir
+let[@inline] data_dirs { data_dirs; _ } = data_dirs
+let[@inline] config_dirs { config_dirs; _ } = config_dirs

--- a/lib/dirs/xdg.mli
+++ b/lib/dirs/xdg.mli
@@ -1,0 +1,48 @@
+(* This module is intended to implement version 0.8 of the XDG Base Directory
+   specification for UNIX-like systems.
+
+   Note that this module does not perform any checks regarding directory
+   permissions or existence. Such sanity checks must be handled by the
+   calling binary.
+
+   See: https://specifications.freedesktop.org/basedir/0.8/ *)
+
+type t
+(** Type of XDG environment. *)
+
+val make : ?runtime_dir:string -> getenv:(string -> string option) -> unit -> t
+(** [make ?runtime_dir ~getenv ()] creates a XDG environment using [getenv] to
+    read the environment variables.
+
+    If [runtime_dir] is specified, it must be owned by the user with 700
+    permissions. *)
+
+val data_home : t -> Var.one Var.t
+(** [data_home] defines the base directory relative to which user-specific data
+    files should be stored. *)
+
+val config_home : t -> Var.one Var.t
+(** [config_home] defines the base directory relative to which user-specific
+    configuration files should be stored. *)
+
+val state_home : t -> Var.one Var.t
+(** [state_home] defines the base directory relative to which user-specific
+    files should be stored. *)
+
+val cache_home : t -> Var.one Var.t
+(** [cache_home] defines the base directory relative to which user-specific
+    non-essential data files should be stored. *)
+
+val runtime_dir : t -> Var.one Var.t option
+(** [runtime_dir] defines the base directory relative to which user-specific
+    non-essential runtime files and other file objects (such as sockets, named
+    pipes, ...) should be stored. *)
+
+val data_dirs : t -> Var.many Var.t
+(** [data_dirs] defines the preference-ordered set of base directories to search
+    for data files in addition to the [data_home] base directory. *)
+
+val config_dirs : t -> Var.many Var.t
+(** [config_dirs] defines the preference-ordered set of base directories to
+    search for configuration files in addition to the [config_home] base
+    directory. *)

--- a/lib/util/dune
+++ b/lib/util/dune
@@ -10,10 +10,10 @@
   unidecode
   geneweb_def
   geneweb_compat
+  geneweb_dirs
   re
   unix
   uucp
   uunf
   uutf
-  digestif
-  xdg))
+  digestif))

--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -5,15 +5,16 @@
    this is an extra security: the program should check for
    correct open instead of hoping Secure do it for it *)
 
+module Dirs = Geneweb_dirs
+
 let ok_r = ref []
 let assets_r = ref [ "gw" ]
-let ( // ) = Filename.concat
 
 let default_base_dir =
-  let t = Xdg.create ~env:Sys.getenv_opt () in
-  Xdg.data_dir t // "geneweb" // "bases"
+  let t = Dirs.make () in
+  Dirs.(data_home t // "geneweb" // "base")
 
-let bd_r = ref default_base_dir
+let bd_r = ref (Dirs.path default_base_dir)
 
 (* [decompose: string -> string list] decompose a path into a list of
    directory and a basename. "a/b/c" -> [ "a" ; "b"; "c" ] *)

--- a/lib/util/secure.mli
+++ b/lib/util/secure.mli
@@ -3,7 +3,7 @@
 val assets : unit -> string list
 (** Returns list of allowed to acces assets *)
 
-val default_base_dir : string
+val default_base_dir : Geneweb_dirs.one Geneweb_dirs.var
 (** Default value for the base directory. *)
 
 val base_dir : unit -> string


### PR DESCRIPTION
This PR is a part of the effort to ease the system-wide  installation of GeneWeb. During the 
last sprint, we discuss about platform-specific directories and how to handle them. The xdg library of the Dune project 
is convenient on Linux platform but we want to change some default paths, in particular on macOS platform or Windows platform.

This PR is heavily inspired by the xdg library, with slightly difference. It includes a implementation of the XDG specification in 
the private module `Xdg` and default directories for Windows.