### PR TITLE
Remove type aliases for some types of Adef

### DIFF
--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -100,10 +100,11 @@ let bench () =
                 in
                 for day = 1 to len do
                   let d =
-                    { Def.day; month; year; delta = 0; prec = Def.Sure }
+                    { Adef.day; month; year; delta = 0; prec = Adef.Sure }
                   in
                   (Sys.opaque_identity ignore)
-                    (Calendar.julian_of_sdn Def.Sure @@ Calendar.sdn_of_julian d)
+                    (Calendar.julian_of_sdn Adef.Sure
+                    @@ Calendar.sdn_of_julian d)
                 done
               done
           done)

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -492,30 +492,30 @@ let make_date n1 n2 n3 =
                 else 0, 0
       in
       let (d, m) = if m < 1 || m > 13 then 0, 0 else d, m in
-      {day = d; month = m; year = y; prec = Sure; delta = 0}
+      {Adef.day = d; month = m; year = y; prec = Sure; delta = 0}
   | None, Some m, Some y ->
       let m =
         match m with
           Right m -> m
         | Left m -> m
       in
-      {day = 0; month = m; year = y; prec = Sure; delta = 0}
+      {Adef.day = 0; month = m; year = y; prec = Sure; delta = 0}
   | None, None, Some y ->
-      {day = 0; month = 0; year = y; prec = Sure; delta = 0}
+      {Adef.day = 0; month = 0; year = y; prec = Sure; delta = 0}
   | Some y, None, None ->
-      {day = 0; month = 0; year = y; prec = Sure; delta = 0}
+      {Adef.day = 0; month = 0; year = y; prec = Sure; delta = 0}
   | _ -> raise (Stream.Error "bad date")
 
 let recover_date cal = function
-  | Dgreg (d, Dgregorian) ->
+  | Adef.Dgreg (d, Dgregorian) ->
     let d =
       match cal with
-      | Dgregorian -> d
+      | Adef.Dgregorian -> d
       | Djulian -> Calendar.gregorian_of_julian d
       | Dfrench -> Calendar.gregorian_of_french d
       | Dhebrew -> Calendar.gregorian_of_hebrew d
     in
-    Dgreg (d, cal)
+    Adef.Dgreg (d, cal)
   | d -> d
 
 [@@@ocaml.warning "-27"]
@@ -554,7 +554,7 @@ EXTEND
               let dmy2 =
                 match cal2 with
                 | Dgregorian ->
-                    {day2 = d2.day; month2 = d2.month;
+                    {Adef.day2 = d2.day; month2 = d2.month;
                      year2 = d2.year; delta2 = 0}
                 | Djulian ->
                     let dmy2 = Calendar.julian_of_gregorian d2 in
@@ -702,7 +702,7 @@ let preg_match pattern subject =
 
 let date_of_field d =
   if d = "" then None
-  else if preg_match "^[0-9]+$" d && String.length d > 8 then Some (Dtext d)
+  else if preg_match "^[0-9]+$" d && String.length d > 8 then Some (Adef.Dtext d)
   else
     let s = Stream.of_string (String.uppercase_ascii d) in
     date_str := d;
@@ -824,12 +824,12 @@ let this_year =
 
 let infer_death birth bapt =
   match birth, bapt with
-  | Some (Dgreg (d, _)), _ ->
+  | Some (Adef.Dgreg (d, _)), _ ->
     let a = this_year - d.year in
     if a > !dead_years then DeadDontKnowWhen
     else if a < !alive_years then NotDead
     else DontKnowIfDead
-  | _, Some (Dgreg (d, _)) ->
+  | _, Some (Adef.Dgreg (d, _)) ->
     let a = this_year - d.year in
     if a > !dead_years then DeadDontKnowWhen
     else if a < !alive_years then NotDead
@@ -3074,9 +3074,9 @@ let check_parents_sex persons families couples strings =
   done
 
 let neg_year_dmy = function
-  | {day = d; month = m; year = y; prec = OrYear dmy2; _} ->
+  | {Adef.day = d; month = m; year = y; prec = OrYear dmy2; _} ->
     let dmy2 = {dmy2 with year2 = -abs dmy2.year2} in
-    {day = d; month = m; year = -abs y; prec = OrYear dmy2; delta = 0}
+    {Adef.day = d; month = m; year = -abs y; prec = OrYear dmy2; delta = 0}
   | {day = d; month = m; year = y; prec = YearInt dmy2; _} ->
     let dmy2 = {dmy2 with year2 = -abs dmy2.year2} in
     {day = d; month = m; year = -abs y; prec = YearInt dmy2; delta = 0}
@@ -3084,7 +3084,7 @@ let neg_year_dmy = function
     {day = d; month = m; year = -abs y; prec = p; delta = 0}
 
 let neg_year = function
-  | Dgreg (d, cal) -> Dgreg (neg_year_dmy d, cal)
+  | Adef.Dgreg (d, cal) -> Adef.Dgreg (neg_year_dmy d, cal)
   | x -> x
 
 let neg_year_cdate cd = Date.cdate_of_date (neg_year (Date.date_of_cdate cd))
@@ -3255,7 +3255,7 @@ let speclist =
     , " Put untreated GEDCOM tags in notes" )
   ; ( "-ds", Arg.Set_string default_source
     , " Set the source field for persons and families without source data" )
-  ; ( "-dates", Arg.String (fun s -> 
+  ; ( "-dates", Arg.String (fun s ->
           if s = "dates_md" then month_number_dates := MonthDayDates
           else if s = "dates_dm" then month_number_dates := DayMonthDates)
     , " Interpret months-numbered dates as year only (default) or month/day/year or day/month/year" )

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -75,7 +75,7 @@ let hebrew_txt =
 
 let ged_month cal m =
   match cal with
-  | Dgregorian | Djulian ->
+  | Adef.Dgregorian | Djulian ->
       if m >= 1 && m <= Array.length month_txt then month_txt.(m - 1)
       else failwith "ged_month"
   | Dfrench ->
@@ -294,7 +294,7 @@ let ged_sex opts per =
   | Neuter -> ()
 
 let ged_calendar opts = function
-  | Dgregorian -> ()
+  | Adef.Dgregorian -> ()
   | Djulian -> Printf.ksprintf (oc opts) "@#DJULIAN@ "
   | Dfrench -> Printf.ksprintf (oc opts) "@#DFRENCH R@ "
   | Dhebrew -> Printf.ksprintf (oc opts) "@#DHEBREW@ "
@@ -307,7 +307,7 @@ let ged_year opts y =
   else Printf.ksprintf (oc opts) "%d %s" (-y) (ged_bce opts)
 
 let ged_date_dmy opts dt cal =
-  (match dt.prec with
+  (match dt.Adef.prec with
   | Sure -> ()
   | About -> Printf.ksprintf (oc opts) "ABT "
   | Maybe -> Printf.ksprintf (oc opts) "EST "
@@ -337,7 +337,7 @@ let ged_date_dmy opts dt cal =
   | _ -> ()
 
 let ged_date opts = function
-  | Dgreg (d, Dgregorian) -> ged_date_dmy opts d Dgregorian
+  | Adef.Dgreg (d, Dgregorian) -> ged_date_dmy opts d Dgregorian
   | Dgreg (d, Djulian) ->
       ged_date_dmy opts (Calendar.julian_of_gregorian d) Djulian
   | Dgreg (d, Dfrench) ->

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -32,7 +32,7 @@ type gw_syntax =
       * sex
       * (somebody * sex) list
       * (string gen_fam_event_name
-        * cdate
+        * Adef.cdate
         * string
         * string
         * string
@@ -66,7 +66,7 @@ type gw_syntax =
       somebody
       * sex
       * (string gen_pers_event_name
-        * cdate
+        * Adef.cdate
         * string
         * string
         * string
@@ -171,7 +171,7 @@ let date_of_string s i =
   in
   let precision, i =
     match s.[i] with
-    | '~' -> (About, succ i)
+    | '~' -> (Adef.About, succ i)
     | '?' -> (Maybe, succ i)
     | '>' -> (After, succ i)
     | '<' -> (Before, succ i)
@@ -217,13 +217,15 @@ let date_of_string s i =
             if month < 1 || month > 13 then error 2
             else if day < 1 || day > 31 then error 3
             else
-              let d = { day; month; year; prec = precision; delta = 0 } in
-              Some (Dgreg (d, Dgregorian), i)
+              let d = { Adef.day; month; year; prec = precision; delta = 0 } in
+              Some (Adef.Dgreg (d, Dgregorian), i)
         | None ->
             if year = 0 then None
             else if month < 1 || month > 13 then error 4
             else
-              let d = { day = 0; month; year; prec = precision; delta = 0 } in
+              let d =
+                { Adef.day = 0; month; year; prec = precision; delta = 0 }
+              in
               Some (Dgreg (d, Dgregorian), i))
     | None ->
         if undefined then
@@ -235,7 +237,9 @@ let date_of_string s i =
             Some (Dtext txt, String.length s)
           else failwith ("date_of_string " ^ s)
         else
-          let d = { day = 0; month = 0; year; prec = precision; delta = 0 } in
+          let d =
+            { Adef.day = 0; month = 0; year; prec = precision; delta = 0 }
+          in
           Some (Dgreg (d, Dgregorian), i)
   in
   let date =
@@ -245,12 +249,12 @@ let date_of_string s i =
         else if s.[i] = '|' then
           let year2, i = champ (succ i) in
           let (day2, month2, year2), i = dmy2 year2 i in
-          let dmy2 = { day2; month2; year2; delta2 = 0 } in
+          let dmy2 = { Adef.day2; month2; year2; delta2 = 0 } in
           Some (Dgreg ({ d with prec = OrYear dmy2 }, cal), i)
         else if i + 1 < String.length s && s.[i] = '.' && s.[i + 1] = '.' then
           let year2, i = champ (i + 2) in
           let (day2, month2, year2), i = dmy2 year2 i in
-          let dmy2 = { day2; month2; year2; delta2 = 0 } in
+          let dmy2 = { Adef.day2; month2; year2; delta2 = 0 } in
           Some (Dgreg ({ d with prec = YearInt dmy2 }, cal), i)
         else Some (dt, i)
     | Some ((Dtext _ as dt), i) -> Some (dt, i)
@@ -259,7 +263,7 @@ let date_of_string s i =
   let date =
     match date with
     | Some (Dgreg (d, _), i) -> (
-        if i = String.length s then Some (Dgreg (d, Dgregorian), i)
+        if i = String.length s then Some (Adef.Dgreg (d, Dgregorian), i)
         else
           match s.[i] with
           | 'G' -> Some (Dgreg (d, Dgregorian), i + 1)

--- a/bin/gwc/gwcomp.mli
+++ b/bin/gwc/gwcomp.mli
@@ -32,7 +32,7 @@ type gw_syntax =
       * sex
       * (somebody * sex) list
       * (string gen_fam_event_name
-        * cdate
+        * Adef.cdate
         * string
         * string
         * string
@@ -67,7 +67,7 @@ type gw_syntax =
       somebody
       * sex
       * (string gen_pers_event_name
-        * cdate
+        * Adef.cdate
         * string
         * string
         * string
@@ -113,5 +113,5 @@ val comp_families : string -> unit
 
 (* Ajout pour l'API *)
 
-val date_of_string : string -> int -> date option
+val date_of_string : string -> int -> Adef.date option
 (** Parses [Def.date] from string that starts at pos [i] inside [s] *)

--- a/bin/gwdiff/gwdiff.ml
+++ b/bin/gwdiff/gwdiff.ml
@@ -134,7 +134,7 @@ let dmy_to_sdn_range_l dmy =
       else
         let dmy2 =
           {
-            year =
+            Adef.year =
               (if dmy.month = 0 || (dmy.month = 12 && dmy.day = 0) then
                  dmy.year + 1
                else dmy.year);
@@ -154,7 +154,7 @@ let dmy_to_sdn_range_l dmy =
     (sdn, sdn2)
   in
   (* S: calls to sdn_of_dmy dmy can be factorized *)
-  match dmy.prec with
+  match dmy.Adef.prec with
   | Sure ->
       let sdn1, sdn2 = sdn_of_dmy dmy in
       [ (Some sdn1, Some sdn2) ]
@@ -224,13 +224,13 @@ let compatible_dmys dmy1 dmy2 =
 let compatible_dates date1 date2 =
   let compatible_cals cal1 cal2 =
     match (cal1, cal2) with
-    | Dgregorian, Djulian | Dgregorian, Dfrench -> true
+    | Adef.Dgregorian, Adef.Djulian | Dgregorian, Dfrench -> true
     | _ -> cal1 = cal2
   in
   if date1 = date2 then true
   else
     match (date1, date2) with
-    | Dgreg (dmy1, cal1), Dgreg (dmy2, cal2) ->
+    | Adef.Dgreg (dmy1, cal1), Dgreg (dmy2, cal2) ->
         compatible_dmys dmy1 dmy2 && compatible_cals cal1 cal2
     | Dgreg (_, _), Dtext _ -> false
     | Dtext _, _ -> true

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -115,7 +115,7 @@ let soy y = if y = 0 then "-0" else string_of_int y
 let oc opts = match opts.Gwexport.oc with _, oc, _ -> oc
 
 let print_date_dmy opts d =
-  (match d.prec with
+  (match d.Adef.prec with
   | About -> Printf.ksprintf (oc opts) "~"
   | Maybe -> Printf.ksprintf (oc opts) "?"
   | Before -> Printf.ksprintf (oc opts) "<"
@@ -193,7 +193,7 @@ let correct_string_no_colon base is =
   gen_correct_string false true (Driver.sou base is)
 
 let gen_print_date opts no_colon = function
-  | Dgreg (d, Dgregorian) -> print_date_dmy opts d
+  | Adef.Dgreg (d, Dgregorian) -> print_date_dmy opts d
   | Dgreg (d, Djulian) ->
       print_date_dmy opts (Calendar.julian_of_gregorian d);
       Printf.ksprintf (oc opts) "J"

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -519,8 +519,8 @@ let p_auth conf base p =
       | None -> none ()
       | Some d ->
           let a = Date.time_elapsed d conf.today in
-          if a.Def.year > lim then true
-          else if a.Def.year = 0 then a.month > 0 || a.day > 0
+          if a.Adef.year > lim then true
+          else if a.Adef.year = 0 then a.month > 0 || a.day > 0
           else none ()
     in
     check_date

--- a/lib/advSearchOk.ml
+++ b/lib/advSearchOk.ml
@@ -18,7 +18,8 @@ let reconstitute_date_dmy conf var =
           match get_number var "dd" conf.env with
           | Some d ->
               if d >= 1 && d <= 31 && m >= 1 && m <= 12 then
-                Some { day = d; month = m; year = y; prec = Sure; delta = 0 }
+                Some
+                  { Adef.day = d; month = m; year = y; prec = Sure; delta = 0 }
               else None
           | None ->
               if m >= 1 && m <= 12 then
@@ -29,7 +30,7 @@ let reconstitute_date_dmy conf var =
 
 let reconstitute_date conf var =
   match reconstitute_date_dmy conf var with
-  | Some d -> Some (Dgreg (d, Dgregorian))
+  | Some d -> Some (Adef.Dgreg (d, Dgregorian))
   | None -> None
 
 let rec skip_spaces x i =
@@ -168,9 +169,9 @@ let advanced_search conf base max_answers =
     authorized_age conf base p
     &&
     match (d1, d2) with
-    | Some (Dgreg (d1, _)), Some (Dgreg (d2, _)) -> (
+    | Some (Adef.Dgreg (d1, _)), Some (Adef.Dgreg (d2, _)) -> (
         match df () with
-        | Some (Dgreg (d, _)) ->
+        | Some (Adef.Dgreg (d, _)) ->
             Date.compare_dmy d d1 >= 0 && Date.compare_dmy d d2 <= 0
         | _ -> false)
     | Some (Dgreg (d1, _)), _ -> (

--- a/lib/ancStatsDisplay.ml
+++ b/lib/ancStatsDisplay.ml
@@ -95,7 +95,7 @@ let get_years base parent_ip =
   let p = Geneweb_db.Driver.poi base parent_ip in
   let year_of_cdate cd =
     match Date.od_of_cdate cd with
-    | Some (Def.Dgreg (dg, _)) -> Some dg.Def.year
+    | Some (Adef.Dgreg (dg, _)) -> Some dg.Adef.year
     | _ -> None
   in
   let birth = year_of_cdate (Geneweb_db.Driver.get_birth p) in

--- a/lib/birthDeath.ml
+++ b/lib/birthDeath.ml
@@ -13,15 +13,16 @@ let get_k conf =
       try int_of_string (List.assoc "latest_event" conf.base_env)
       with Not_found | Failure _ -> 20)
 
-let select (type a) (module Q : Pqueue.S with type elt = a * dmy * calendar)
-    nb_of iterator get get_date conf base =
+let select (type a)
+    (module Q : Pqueue.S with type elt = a * Adef.dmy * Adef.calendar) nb_of
+    iterator get get_date conf base =
   let n = min (max 0 (get_k conf)) (nb_of base) in
   let ref_date =
     match p_getint conf.env "by" with
     | Some by ->
         let bm = Option.value ~default:(-1) (p_getint conf.env "bm") in
         let bd = Option.value ~default:(-1) (p_getint conf.env "bd") in
-        Some { day = bd; month = bm; year = by; prec = Sure; delta = 0 }
+        Some { Adef.day = bd; month = bm; year = by; prec = Sure; delta = 0 }
     | None -> None
   in
   let q, len =
@@ -29,7 +30,7 @@ let select (type a) (module Q : Pqueue.S with type elt = a * dmy * calendar)
       (fun (q, len) i ->
         let x = get base i in
         match get_date x with
-        | Some (Dgreg (d, cal)) ->
+        | Some (Adef.Dgreg (d, cal)) ->
             let aft =
               match ref_date with
               | Some ref_date -> Date.compare_dmy ref_date d <= 0
@@ -52,13 +53,13 @@ let select (type a) (module Q : Pqueue.S with type elt = a * dmy * calendar)
   loop [] q
 
 module PQ = Pqueue.Make (struct
-  type t = Geneweb_db.Driver.person * Def.dmy * Def.calendar
+  type t = Geneweb_db.Driver.person * Adef.dmy * Adef.calendar
 
   let leq (_, x, _) (_, y, _) = Date.compare_dmy x y <= 0
 end)
 
 module PQ_oldest = Pqueue.Make (struct
-  type t = Geneweb_db.Driver.person * Def.dmy * Def.calendar
+  type t = Geneweb_db.Driver.person * Adef.dmy * Adef.calendar
 
   let leq (_, x, _) (_, y, _) = Date.compare_dmy y x <= 0
 end)
@@ -69,13 +70,13 @@ let select_person conf base get_date find_oldest =
     Driver.nb_of_persons Driver.ipers (pget conf) get_date conf base
 
 module FQ = Pqueue.Make (struct
-  type t = Geneweb_db.Driver.family * Def.dmy * Def.calendar
+  type t = Geneweb_db.Driver.family * Adef.dmy * Adef.calendar
 
   let leq (_, x, _) (_, y, _) = Date.compare_dmy x y <= 0
 end)
 
 module FQ_oldest = Pqueue.Make (struct
-  type t = Geneweb_db.Driver.family * Def.dmy * Def.calendar
+  type t = Geneweb_db.Driver.family * Adef.dmy * Adef.calendar
 
   let leq (_, x, _) (_, y, _) = Date.compare_dmy y x <= 0
 end)

--- a/lib/birthDeath.mli
+++ b/lib/birthDeath.mli
@@ -1,9 +1,9 @@
 val select_person :
   Config.config ->
   Geneweb_db.Driver.base ->
-  (Geneweb_db.Driver.person -> Def.date option) ->
+  (Geneweb_db.Driver.person -> Adef.date option) ->
   bool ->
-  (Geneweb_db.Driver.person * Def.dmy * Def.calendar) list * int
+  (Geneweb_db.Driver.person * Adef.dmy * Adef.calendar) list * int
 (** [select_person conf base get_date find_oldest] select 20 persons from the
     base according to the one of their date (birth, death, marriage, specific
     event, etc.) that could be get with [get_date]. Returns sorted by date
@@ -17,9 +17,9 @@ val select_person :
 val select_family :
   Config.config ->
   Geneweb_db.Driver.base ->
-  (Geneweb_db.Driver.family -> Def.date option) ->
+  (Geneweb_db.Driver.family -> Adef.date option) ->
   bool ->
-  (Geneweb_db.Driver.family * Def.dmy * Def.calendar) list * int
+  (Geneweb_db.Driver.family * Adef.dmy * Adef.calendar) list * int
 (** Same as [select_person] but dealing with families *)
 
 val death_date : Geneweb_db.Driver.person -> Adef.date option
@@ -29,7 +29,7 @@ val make_population_pyramid :
   nb_intervals:int ->
   interval:int ->
   limit:int ->
-  at_date:Def.dmy ->
+  at_date:Adef.dmy ->
   Config.config ->
   Geneweb_db.Driver.base ->
   int array * int array

--- a/lib/birthDeathDisplay.ml
+++ b/lib/birthDeathDisplay.ml
@@ -86,7 +86,7 @@ let print_death conf base =
             Output.print_string conf month_txt;
             Output.print_sstring conf "<ul>");
           let age, ages_sum, ages_nb =
-            let sure d = d.prec = Sure in
+            let sure d = d.Adef.prec = Sure in
             match Date.cdate_to_gregorian_dmy_opt (Driver.get_birth p) with
             | None -> (None, ages_sum, ages_nb)
             | Some d1 ->
@@ -198,12 +198,12 @@ let print_oldest_alive conf base =
     match Driver.get_death p with
     | NotDead -> (
         match Date.cdate_to_gregorian_dmy_opt (Driver.get_birth p) with
-        | Some d -> Some (Dgreg (d, Dgregorian))
+        | Some d -> Some (Adef.Dgreg (d, Dgregorian))
         | None -> None)
     | DontKnowIfDead when limit > 0 -> (
         match Date.cdate_to_gregorian_dmy_opt (Driver.get_birth p) with
         | Some d when conf.today.year - d.year <= limit ->
-            Some (Dgreg (d, Dgregorian))
+            Some (Adef.Dgreg (d, Dgregorian))
         | Some _ | None -> None)
     | Death _ | DontKnowIfDead | DeadYoung | DeadDontKnowWhen | OfCourseDead ->
         None
@@ -250,7 +250,7 @@ let print_longest_lived conf base =
           | None -> None
           | Some dd ->
               let te = Date.time_elapsed bd dd in
-              if te.year >= 0 then Some (Dgreg (te, Dgregorian)) else None)
+              if te.year >= 0 then Some (Adef.Dgreg (te, Dgregorian)) else None)
       | _ -> None
     else None
   in
@@ -268,7 +268,7 @@ let print_longest_lived conf base =
       Output.print_sstring conf "</strong>";
       Output.print_string conf (DateDisplay.short_dates_text conf base p);
       Output.print_sstring conf " (";
-      Output.print_sstring conf (string_of_int d.year);
+      Output.print_sstring conf (string_of_int d.Adef.year);
       Output.print_sstring conf " ";
       Output.print_sstring conf (transl conf "years old");
       Output.print_sstring conf ")";
@@ -566,7 +566,8 @@ let print_population_pyramid conf base =
   else
     let at_date =
       match p_getint conf.env "y" with
-      | Some i -> { year = i; month = 31; day = 12; prec = Sure; delta = 0 }
+      | Some i ->
+          { Adef.year = i; month = 31; day = 12; prec = Sure; delta = 0 }
       | None -> conf.today
     in
     let men, wom =

--- a/lib/birthdayDisplay.ml
+++ b/lib/birthdayDisplay.ml
@@ -191,7 +191,7 @@ let gen_print conf base mois f_scan ?max_d ?mode dead_people =
   Hutil.trailer conf
 
 let print_anniversary_list conf base dead_people dt liste =
-  let a_ref = dt.year in
+  let a_ref = dt.Adef.year in
   Output.print_sstring conf "<ul>\n";
   List.iter
     (fun (p, a, date_event, txt_of) ->
@@ -261,12 +261,12 @@ let print_birth_day conf base day_name fphrase wd dt list =
 
 let day_after d =
   let day, r =
-    if d.day >= Date.nb_days_in_month d.month d.year then (1, 1)
+    if d.Adef.day >= Date.nb_days_in_month d.month d.year then (1, 1)
     else (succ d.day, 0)
   in
   let month, r = if d.month + r > 12 then (1, 1) else (d.month + r, 0) in
   let year = d.year + r in
-  { day; month; year; prec = Sure; delta = 0 }
+  { Adef.day; month; year; prec = Sure; delta = 0 }
 
 let print_anniv conf base day_name fphrase wd dt = function
   | [] ->
@@ -391,7 +391,8 @@ let print_marriage_day conf base day_name fphrase wd dt = function
       print_anniversaries_of_marriage conf base list
 
 let match_dates conf base p d1 d2 =
-  if d1.day = d2.day && d1.month = d2.month then authorized_age conf base p
+  if d1.Adef.day = d2.Adef.day && d1.month = d2.month then
+    authorized_age conf base p
   else if
     d1.day = 29 && d1.month = 2 && d2.day = 1 && d2.month = 3
     && not (Date.leap_year d2.year)
@@ -541,7 +542,7 @@ let print_menu_dead conf base =
       Util.hidden_input conf "m" @@ Adef.encoded "AD")
 
 let match_mar_dates conf base cpl d1 d2 =
-  if d1.day = d2.day && d1.month = d2.month then
+  if d1.Adef.day = d2.Adef.day && d1.month = d2.month then
     authorized_age conf base (pget conf base (Driver.get_father cpl))
     && authorized_age conf base (pget conf base (Driver.get_mother cpl))
   else if

--- a/lib/calendarDisplay.ml
+++ b/lib/calendarDisplay.ml
@@ -1,5 +1,4 @@
 open Config
-open Def
 
 type 'a env_value = Vint of int | Vother of 'a | Vnone
 
@@ -9,7 +8,7 @@ let set_vother x = Vother x
 
 let dmy_of_sdn cal prec jd =
   match cal with
-  | Dgregorian -> Calendar.gregorian_of_sdn prec jd
+  | Adef.Dgregorian -> Calendar.gregorian_of_sdn prec jd
   | Djulian -> Calendar.julian_of_sdn prec jd
   | Dfrench -> Calendar.french_of_sdn prec jd
   | Dhebrew -> Calendar.hebrew_of_sdn prec jd
@@ -23,7 +22,7 @@ let eval_julian_day conf =
       | Some v -> (
           try
             let len = String.length v in
-            if cal = Djulian && len > 2 && v.[len - 2] = '/' then
+            if cal = Adef.Djulian && len > 2 && v.[len - 2] = '/' then
               int_of_string (String.sub v 0 (len - 2)) + 1
             else int_of_string v
           with Failure _ -> 0)
@@ -31,7 +30,7 @@ let eval_julian_day conf =
     in
     let mm = getint ("m" ^ var) in
     let dd = getint ("d" ^ var) in
-    let dt = { day = dd; month = mm; year = yy; prec = Sure; delta = 0 } in
+    let dt = { Adef.day = dd; month = mm; year = yy; prec = Sure; delta = 0 } in
     let skip_zero y dir = if y = 0 then dir else y in
 
     match Util.p_getenv conf.env ("t" ^ var) with
@@ -44,7 +43,7 @@ let eval_julian_day conf =
         else
           let jd = conv dt in
           let back = dmy_of_sdn cal Sure jd in
-          if back.Def.day <> dd || back.Def.month <> mm then
+          if back.Adef.day <> dd || back.month <> mm then
             Notif.warning
               ~title:(Util.transl conf "NOTIF_TT bad date")
               (Util.transl conf "NOTIF bad date corrected");
@@ -79,7 +78,7 @@ let eval_julian_day conf =
 
   let calendars =
     [
-      ("g", Dgregorian, Calendar.sdn_of_gregorian, 12);
+      ("g", Adef.Dgregorian, Calendar.sdn_of_gregorian, 12);
       ("j", Djulian, Calendar.sdn_of_julian, 12);
       ("f", Dfrench, Calendar.sdn_of_french, 13);
       ("h", Dhebrew, Calendar.sdn_of_hebrew, 13);

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -239,7 +239,7 @@ type check_date =
 
 let min_year_of p =
   let aux = function
-    | { prec = After; year; _ } -> CheckAfter year
+    | { Adef.prec = After; year; _ } -> CheckAfter year
     | { prec = Before; year; _ } -> CheckBefore year
     | { year; _ } -> CheckOther year
   in

--- a/lib/checkItem.ml
+++ b/lib/checkItem.ml
@@ -35,7 +35,7 @@ let strictly_before_dmy d1 d2 =
 
 let strictly_before d1 d2 =
   match (d1, d2) with
-  | Dgreg (d1, _), Dgreg (d2, _) -> strictly_before_dmy d1 d2
+  | Adef.Dgreg (d1, _), Adef.Dgreg (d2, _) -> strictly_before_dmy d1 d2
   | _ -> false
 
 let strictly_after_dmy d1 d2 =
@@ -43,21 +43,21 @@ let strictly_after_dmy d1 d2 =
 
 let strictly_after d1 d2 =
   match (d1, d2) with
-  | Dgreg (d1, _), Dgreg (d2, _) -> strictly_after_dmy d1 d2
+  | Adef.Dgreg (d1, _), Adef.Dgreg (d2, _) -> strictly_after_dmy d1 d2
   | _ -> false
 
 let strictly_younger age year =
-  match age.prec with
+  match age.Adef.prec with
   | After -> false
   | Sure | About | Maybe | Before | OrYear _ | YearInt _ -> age.year < year
 
 let strictly_older age year =
-  match age.prec with
+  match age.Adef.prec with
   | Before -> false
   | Sure | About | Maybe | After | OrYear _ | YearInt _ -> age.year > year
 
 let odate = function
-  | Some (Dgreg (d, _)) -> Some d
+  | Some (Adef.Dgreg (d, _)) -> Some d
   | Some (Dtext _) | None -> None
 
 let obirth x = Driver.get_birth x |> Date.cdate_to_dmy_opt
@@ -86,8 +86,8 @@ let check_person_age warning p =
   let aux d1 d2 =
     Date.time_elapsed_opt d1 d2
     |> Option.iter @@ fun a ->
-       if a.year < 0 then warning (BirthAfterDeath p)
-       else if d2.year > lim_date_death then (
+       if a.Adef.year < 0 then warning (BirthAfterDeath p)
+       else if d2.Adef.year > lim_date_death then (
          if strictly_older a max_death_after_lim_date_death then
            warning (DeadOld (p, a)))
        else if strictly_older a max_death_before_lim_date_death then
@@ -376,7 +376,7 @@ let close_siblings warning x np ifam =
           |> Option.iter @@ fun d ->
              (* On vérifie les jumeaux ou naissances proches. *)
              if
-               d.year = 0
+               d.Adef.year = 0
                && d.month < max_month_btw_sibl
                && (d.month <> 0 || d.day >= max_days_btw_sibl)
              then warning (CloseChildren (ifam, elder, x)))
@@ -509,9 +509,9 @@ let check_order_fevents base warning fam =
 
 let check_witness_pevents_aux warning origin evt date b d p witness_kind =
   match (b, d) with
-  | Some (Dgreg (d1, _)), _ when strictly_before_dmy date d1 ->
+  | Some (Adef.Dgreg (d1, _)), _ when strictly_before_dmy date d1 ->
       warning (PWitnessEventBeforeBirth (p, evt, origin))
-  | _, Some (Dgreg (d3, _)) when strictly_after_dmy date d3 ->
+  | _, Some (Adef.Dgreg (d3, _)) when strictly_after_dmy date d3 ->
       if
         witness_kind <> Def.Witness_Mentioned
         && witness_kind <> Def.Witness_Other
@@ -680,7 +680,7 @@ let check_siblings ?(onchange = true) base warning (ifam, fam) callback =
   | Some ((d1, p1), (d2, p2)) ->
       Date.time_elapsed_opt d1 d2
       |> Option.iter @@ fun e ->
-         if e.year > max_siblings_gap then
+         if e.Adef.year > max_siblings_gap then
            warning (DistantChildren (ifam, p1, p2))
   | _ -> ()
 
@@ -731,9 +731,9 @@ let check_sources base misc ifam fam =
 
 let check_witness_fevents_aux warning fam evt date b d p witness_kind =
   match (b, d) with
-  | Some (Dgreg (d1, _)), _ when strictly_before_dmy date d1 ->
+  | Some (Adef.Dgreg (d1, _)), _ when strictly_before_dmy date d1 ->
       warning (FWitnessEventBeforeBirth (p, evt, Driver.get_ifam fam))
-  | _, Some (Dgreg (d3, _)) when strictly_after_dmy date d3 ->
+  | _, Some (Adef.Dgreg (d3, _)) when strictly_after_dmy date d3 ->
       if
         witness_kind <> Def.Witness_Mentioned
         && witness_kind <> Def.Witness_Other

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -1,7 +1,5 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-open Def
-
 type auth_scheme_kind =
   | NoAuth
   | TokenAuth of token_auth_scheme
@@ -97,7 +95,7 @@ type config = {
   auth_file : string;
   border : int;
   mutable n_connect : (int * int * int * (string * float) list) option;
-  today : dmy;
+  today : Adef.dmy;
   today_wd : int;
   time : int * int * int;
   ctime : float; (* TODO verify usefulness *)
@@ -182,7 +180,7 @@ let empty =
     auth_file = "";
     border = 0;
     n_connect = None;
-    today = { Def.day = 0; month = 0; year = 0; delta = 0; prec = Def.Sure };
+    today = { Adef.day = 0; month = 0; year = 0; delta = 0; prec = Adef.Sure };
     today_wd = 0;
     time = (0, 0, 0);
     ctime = 0.;

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -1,5 +1,3 @@
-open Def
-
 (** Authentication scheme data type *)
 type auth_scheme_kind =
   | NoAuth
@@ -102,7 +100,7 @@ type config = {
   auth_file : string;
   border : int;
   mutable n_connect : (int * int * int * (string * float) list) option;
-  today : dmy;
+  today : Adef.dmy;
   today_wd : int;
   time : int * int * int;
   ctime : float;

--- a/lib/dateDisplay.ml
+++ b/lib/dateDisplay.ml
@@ -7,7 +7,7 @@ module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
 
 let get_wday conf = function
-  | Dgreg (({ prec = Sure; delta = 0; _ } as d), _)
+  | Adef.Dgreg (({ prec = Sure; delta = 0; _ } as d), _)
     when d.day <> 0 && d.month <> 0 ->
       let jd = Calendar.sdn_of_gregorian d in
       let wday =
@@ -65,7 +65,7 @@ let code_date conf encoding d m y =
 let code_dmy conf d =
   let encoding =
     let n =
-      if d.day = 1 then 0
+      if d.Adef.day = 1 then 0
       else if d.day != 0 then 1
       else if d.month != 0 then 2
       else 3
@@ -148,7 +148,7 @@ let code_hebrew_date conf d m y =
   s ^ (if s = "" then "" else " ") ^ string_of_int y
 
 let string_of_on_prec_dmy_aux conf sy sy2 d =
-  match d.prec with
+  match d.Adef.prec with
   | Sure ->
       if d.day = 0 && d.month = 0 then transl conf "in (year)" ^ " " ^ sy
       else if d.day = 0 then transl_decline conf "in (month year)" sy
@@ -206,7 +206,7 @@ let string_of_on_prec_dmy conf sy sy2 d =
   replace_spaces_by_nbsp r
 
 let string_of_on_french_dmy conf d =
-  let sy = code_french_date conf d.day d.month d.year in
+  let sy = code_french_date conf d.Adef.day d.month d.year in
   let sy2 =
     match d.prec with
     | OrYear d2 | YearInt d2 -> code_french_date conf d2.day2 d2.month2 d2.year2
@@ -215,9 +215,9 @@ let string_of_on_french_dmy conf d =
   string_of_on_prec_dmy conf sy sy2 d
 
 let string_of_on_hebrew_dmy conf d =
-  let sy = code_hebrew_date conf d.day d.month d.year in
+  let sy = code_hebrew_date conf d.Adef.day d.month d.year in
   let sy2 =
-    match d.prec with
+    match d.Adef.prec with
     | OrYear d2 | YearInt d2 -> code_hebrew_date conf d2.day2 d2.month2 d2.year2
     | _ -> ""
   in
@@ -226,7 +226,7 @@ let string_of_on_hebrew_dmy conf d =
 let string_of_prec_dmy conf s s2 d =
   Adef.safe
   @@
-  match d.prec with
+  match d.Adef.prec with
   | Sure -> Mutil.nominative s
   | About -> transl_decline conf "about (date)" s
   | Before -> transl_decline conf "before (date)" s
@@ -266,7 +266,7 @@ let string_of_dmy conf d = string_of_dmy_aux string_of_prec_dmy conf d
 let translate_dmy conf (fst, snd, trd) cal short =
   let translate_month m =
     match cal with
-    | Dfrench when m <> "" ->
+    | Adef.Dfrench when m <> "" ->
         if short then Util.short_f_month (int_of_string m)
         else french_month conf (int_of_string m)
     | Dhebrew when m <> "" ->
@@ -297,7 +297,7 @@ let translate_dmy conf (fst, snd, trd) cal short =
 let decode_dmy conf d =
   match transl conf "!dates order" with
   | "dmyyyy" ->
-      (string_of_int d.day, string_of_int d.month, string_of_int d.year)
+      (string_of_int d.Adef.day, string_of_int d.month, string_of_int d.year)
   | "mmddyyyy" -> (
       (* Si le jour et/ou le mois n'est pas sur 2 caractères, *)
       (* on rajoute les 0 nécessaires.                        *)
@@ -336,7 +336,7 @@ let decode_dmy conf d =
           (d, m, string_of_int year))
 
 let gregorian_precision conf d =
-  if d.delta = 0 then string_of_dmy conf d
+  if d.Adef.delta = 0 then string_of_dmy conf d
   else
     let d2 =
       Calendar.gregorian_of_sdn d.prec (Calendar.sdn_of_gregorian d + d.delta)
@@ -388,11 +388,11 @@ let string_of_date_aux ?(link = true) ?(dmy = string_of_dmy)
     @@ Printf.sprintf
          {|<a href="%sm=CAL&y%c=%d&m%c=%d&d%c=%d&t%c=1" class="date">%s</a>|}
          (commd conf :> string)
-         c d.year c d.month c d.day c
+         c d.Adef.year c d.month c d.day c
          (s :> string)
   in
   function
-  | Dgreg (d, Dgregorian) ->
+  | Adef.Dgreg (d, Dgregorian) ->
       let s = dmy conf d in
       if link && d.day > 0 then mk_link 'g' d s else s
   | Dgreg (d, Djulian) ->
@@ -441,7 +441,7 @@ let string_of_ondate ?link conf d =
   |> Util.translate_eval |> Adef.safe
 
 let string_of_date conf = function
-  | Dgreg (d, _) -> string_of_dmy conf d
+  | Adef.Dgreg (d, _) -> string_of_dmy conf d
   | Dtext t -> (Util.escape_html t :> Adef.safe_string)
 
 let string_slash_of_date conf date =
@@ -451,7 +451,7 @@ let string_slash_of_date conf date =
         (fun s accu -> if s <> "" then s ^ "/" ^ accu else accu)
         [ fst; snd ] trd
     in
-    match d.prec with
+    match d.Adef.prec with
     | OrYear d2 ->
         let sy = code fst snd trd in
         let d2 = Date.dmy_of_dmy2 d2 in
@@ -468,7 +468,7 @@ let string_slash_of_date conf date =
         (string_of_prec_dmy conf sy "" d :> string)
   in
   match date with
-  | Dtext t -> (Util.escape_html t :> Adef.safe_string)
+  | Adef.Dtext t -> (Util.escape_html t :> Adef.safe_string)
   | Dgreg (d, cal) -> (
       Adef.safe
       @@
@@ -476,16 +476,22 @@ let string_slash_of_date conf date =
       | Dgregorian -> slashify_dmy (decode_dmy conf d) d
       | Djulian ->
           let d1 = Calendar.julian_of_gregorian d in
-          slashify_dmy (translate_dmy conf (decode_dmy conf d1) Djulian true) d1
+          slashify_dmy
+            (translate_dmy conf (decode_dmy conf d1) Adef.Djulian true)
+            d1
           ^ " ("
           ^ transl_nth conf "gregorian/julian/french/hebrew" 1
           ^ ")"
       | Dfrench ->
           let d1 = Calendar.french_of_gregorian d in
-          slashify_dmy (translate_dmy conf (decode_dmy conf d1) Dfrench true) d1
+          slashify_dmy
+            (translate_dmy conf (decode_dmy conf d1) Adef.Dfrench true)
+            d1
       | Dhebrew ->
           let d1 = Calendar.french_of_gregorian d in
-          slashify_dmy (translate_dmy conf (decode_dmy conf d1) Dhebrew true) d1
+          slashify_dmy
+            (translate_dmy conf (decode_dmy conf d1) Adef.Dhebrew true)
+            d1
           ^ " ("
           ^ transl_nth conf "gregorian/julian/french/hebrew" 3
           ^ ")")
@@ -494,7 +500,7 @@ let string_of_age conf a =
   Adef.safe
   @@
   match a with
-  | { day = 0; month = 0; year = y; _ } ->
+  | { Adef.day = 0; month = 0; year = y; _ } ->
       if y > 1 then string_of_int y ^ " " ^ transl conf "years old"
       else if y = 1 then transl conf "one year old"
       else transl conf "birth"
@@ -523,7 +529,7 @@ let string_of_age conf a =
     - d : Def.dmy [Retour] : string [Rem] : Exporté en clair hors de ce module.
 *)
 let prec_text conf d =
-  match d.prec with
+  match d.Adef.prec with
   | About -> (
       (* On utilise le dictionnaire pour être sur *)
       (* que ce soit compréhensible de tous.      *)
@@ -545,7 +551,7 @@ let prec_text conf d =
 (** [Description] : Renvoie le mois d'une date. [Args] :
     - d : Def.dmy [Retour] : string [Rem] : Exporté en clair hors de ce module.
 *)
-let month_text d = if d.month = 0 then "" else string_of_int d.month
+let month_text d = if d.Adef.month = 0 then "" else string_of_int d.month
 
 (* ************************************************************************ *)
 (*  [Fonc] year_text conf : Def.dmy -> string                                    *)
@@ -556,7 +562,7 @@ let month_text d = if d.month = 0 then "" else string_of_int d.month
     - d : Def.dmy [Retour] : string [Rem] : Exporté en clair hors de ce module.
 *)
 let year_text conf d =
-  match d.prec with
+  match d.Adef.prec with
   | OrYear d2 when d.year <> d2.year2 ->
       string_of_bce_year conf d.year ^ "/" ^ string_of_bce_year conf d2.year2
   | YearInt d2 when d.year <> d2.year2 ->
@@ -575,7 +581,7 @@ let year_text conf d =
 *)
 let wrap_year_prec conf d year_str =
   let s =
-    match d.prec with
+    match d.Adef.prec with
     | About -> (
         match transl conf "about (short date)" with "ca" -> "ca " | s -> s)
     | Maybe -> "?"
@@ -588,14 +594,14 @@ let wrap_year_prec conf d year_str =
 let prec_year_text conf d = wrap_year_prec conf d (year_text conf d)
 
 let french_year_text conf d =
-  if d.month = 0 then code_french_year conf d.year
+  if d.Adef.month = 0 then code_french_year conf d.year
   else if d.month <= 3 then string_of_int (d.year + 1791)
   else if d.month = 4 then
     (if d.prec <> Maybe then "?" else "") ^ string_of_int (d.year + 1792)
   else string_of_int (d.year + 1792)
 
 let prec_year_text_cal conf d = function
-  | Dfrench when d.day = 0 -> (
+  | Adef.Dfrench when d.Adef.day = 0 -> (
       match d.prec with
       | OrYear _ | YearInt _ -> prec_year_text conf d
       | _ -> wrap_year_prec conf d (french_year_text conf d))

--- a/lib/dateDisplay.mli
+++ b/lib/dateDisplay.mli
@@ -1,12 +1,11 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
 open Config
-open Def
 
-val get_wday : config -> date -> string
+val get_wday : config -> Adef.date -> string
 (** [get_wday conf date] Return the day of the week for this [date] *)
 
-val code_dmy : config -> dmy -> string
+val code_dmy : config -> Adef.dmy -> string
 (** Returns textual representation of the date translated to the current
     language. Uses different encodings depending on day's, month's and year's
     accessibility. Doesn't consider precision. *)
@@ -15,47 +14,47 @@ val code_hebrew_date : config -> int -> int -> int -> string
 (** Returns textual representation of a day / month / year in the hebrew
     calendar translated to the current language. *)
 
-val string_of_dmy : Config.config -> Def.dmy -> Adef.safe_string
+val string_of_dmy : Config.config -> Adef.dmy -> Adef.safe_string
 (** Converts and translate date to the textual representation for the giving
     language. Considers precision. *)
 
-val string_of_date : config -> date -> Adef.safe_string
+val string_of_date : config -> Adef.date -> Adef.safe_string
 (** If date is [Dgreg] calls for [string_of_dmy] to convert date to the string
     else returns content of [Dtext]. Difference between calendars is not taken
     into the acount. *)
 
-val string_of_ondate : ?link:bool -> config -> date -> Adef.safe_string
+val string_of_ondate : ?link:bool -> config -> Adef.date -> Adef.safe_string
 (** Converts and translate date with considering different calendars with prefix
     "on" before dates (changes for other languages). Date precision is much more
     verbose then with [string_of_date]. Decline phrase if needed. If [link] is
     true then encapsulates result in HTML link to the page calendar's date
     converter. *)
 
-val string_of_on_french_dmy : config -> dmy -> Adef.safe_string
+val string_of_on_french_dmy : config -> Adef.dmy -> Adef.safe_string
 (** Translate a date in the french calendar with prefix "on" before dates
     (changes for other languages). *)
 
-val string_of_on_hebrew_dmy : config -> dmy -> Adef.safe_string
+val string_of_on_hebrew_dmy : config -> Adef.dmy -> Adef.safe_string
 (** Translate a date in the hebrew calendar with prefix "on" before dates
     (changes for other languages). *)
 
-val string_slash_of_date : config -> date -> Adef.safe_string
+val string_slash_of_date : config -> Adef.date -> Adef.safe_string
 (** Returns date in format dd/mm/yyyy. Format could be different for other
     languages (defined by [!dates order] keyword in the lexicon). *)
 
-val string_of_age : config -> dmy -> Adef.safe_string
+val string_of_age : config -> Adef.dmy -> Adef.safe_string
 (** Returns textual representation of the age represented by [dmy]. *)
 
-val prec_year_text : config -> dmy -> string
+val prec_year_text : config -> Adef.dmy -> string
 (** Returns textual representation of date's precision and year. *)
 
-val prec_text : config -> dmy -> string
+val prec_text : config -> Adef.dmy -> string
 (** Returns textual representation of date's precision *)
 
-val month_text : dmy -> string
+val month_text : Adef.dmy -> string
 (** Returns textual representation of date's month number. *)
 
-val year_text : config -> dmy -> string
+val year_text : config -> Adef.dmy -> string
 (** Returns textual representation of date's year. *)
 
 val short_dates_text :
@@ -100,10 +99,10 @@ val code_french_year : config -> int -> string
 
 val string_of_date_aux :
   ?link:bool ->
-  ?dmy:(Config.config -> Def.dmy -> Adef.safe_string) ->
+  ?dmy:(Config.config -> Adef.dmy -> Adef.safe_string) ->
   ?sep:Adef.safe_string ->
   Config.config ->
-  Def.date ->
+  Adef.date ->
   Adef.safe_string
 (** Same as [string_of_ondate] except :
     - Conversion function for [Def.dmy] could be passed in in [dmy] argument
@@ -120,7 +119,7 @@ val french_month : config -> int -> string
 *)
 
 val string_of_prec_dmy :
-  config -> Adef.safe_string -> Adef.safe_string -> dmy -> Adef.safe_string
+  config -> Adef.safe_string -> Adef.safe_string -> Adef.dmy -> Adef.safe_string
 (** [string_of_prec_dmy conf s s2 d] Takes two date representations (as strings)
     [s] and [s2] and returns translated phrase according to prec of [d]. [d] is
     only used to determine the precision *)

--- a/lib/db/driver.mli
+++ b/lib/db/driver.mli
@@ -155,7 +155,7 @@ val get_access : person -> Def.access
 val get_aliases : person -> istr list
 (** Get person's aliases ids *)
 
-val get_baptism : person -> Def.cdate
+val get_baptism : person -> Adef.cdate
 (** Get person's baptism date *)
 
 val get_baptism_note : person -> istr
@@ -167,7 +167,7 @@ val get_baptism_place : person -> istr
 val get_baptism_src : person -> istr
 (** Get person's baptism source id *)
 
-val get_birth : person -> Def.cdate
+val get_birth : person -> Adef.cdate
 (** Get person's birth date *)
 
 val get_birth_note : person -> istr
@@ -246,7 +246,7 @@ val get_image : person -> istr
 val get_iper : person -> iper
 (** Get person's id *)
 
-val get_marriage : family -> Def.cdate
+val get_marriage : family -> Adef.cdate
 (** Get family's marriage date *)
 
 val get_marriage_note : family -> istr

--- a/lib/db/gutil.mli
+++ b/lib/db/gutil.mli
@@ -85,7 +85,8 @@ val find_free_occ : Driver.base -> string -> string -> int
 (** Find first free occurence number for the person with specified first name
     and surname. *)
 
-val get_birth_death_date : Driver.person -> date option * date option * bool
+val get_birth_death_date :
+  Driver.person -> Adef.date option * Adef.date option * bool
 (** [get_birth_death p] Return [(birth, death, approx)]. If birth/death date can
     not be found, baptism/burial date is used and [approx] is set to [true] (it
     is [false] if both birth and death dates are found). *)

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -19,41 +19,6 @@ exception HttpExn of httpStatus * string
 (** Type that represents 2 possible choices *)
 type ('a, 'b) choice = Left of 'a | Right of 'b
 
-type cdate = Adef.cdate
-(** Alias to [Adef.cdate] *)
-
-(** Alias to [Adef.date] *)
-type date = Adef.date =
-  | Dgreg of dmy * calendar
-  (* textual form of the date *)
-  | Dtext of string
-
-(** Alias to [Adef.calendar] *)
-and calendar = Adef.calendar = Dgregorian | Djulian | Dfrench | Dhebrew
-
-and dmy = Adef.dmy = {
-  day : int;
-  month : int;
-  year : int;
-  prec : precision;
-  delta : int;
-}
-(** Alias to [Adef.dmy] *)
-
-and dmy2 = Adef.dmy2 = { day2 : int; month2 : int; year2 : int; delta2 : int }
-(** Alias to [Adef.dmy2] *)
-
-(** Alias to [Adef.precision] *)
-and precision = Adef.precision =
-  | Sure
-  | About
-  | Maybe
-  | Before
-  | After
-  | OrYear of dmy2
-  (* inteval *)
-  | YearInt of dmy2
-
 (** Relation kind between couple in the family *)
 type relation_kind =
   | Married
@@ -71,10 +36,10 @@ type relation_kind =
 (** Divorce status *)
 type divorce =
   | NotDivorced
-  | Divorced of cdate
+  | Divorced of Adef.cdate
   | Separated_old
   | NotSeparated
-  | Separated of cdate
+  | Separated of Adef.cdate
 
 (** Death reason *)
 type death_reason = Killed | Murdered | Executed | Disappeared | Unspecified
@@ -82,14 +47,14 @@ type death_reason = Killed | Murdered | Executed | Disappeared | Unspecified
 (** Death status *)
 type death =
   | NotDead
-  | Death of death_reason * cdate
+  | Death of death_reason * Adef.cdate
   | DeadYoung
   | DeadDontKnowWhen
   | DontKnowIfDead
   | OfCourseDead
 
 (** Burial information *)
-type burial = UnknownBurial | Buried of cdate | Cremated of cdate
+type burial = UnknownBurial | Buried of Adef.cdate | Cremated of Adef.cdate
 
 (** Rights for access to the personal data *)
 type access = IfTitles | Public | SemiPublic | Private
@@ -101,8 +66,8 @@ type 'string gen_title = {
   t_name : 'string gen_title_name;
   t_ident : 'string;
   t_place : 'string;
-  t_date_start : cdate;
-  t_date_end : cdate;
+  t_date_start : Adef.cdate;
+  t_date_end : Adef.cdate;
   t_nth : int;
 }
 (** Type that represents information about nobility title of a person *)
@@ -174,7 +139,7 @@ type 'string gen_pers_event_name =
 
 type ('person, 'string) gen_pers_event = {
   epers_name : 'string gen_pers_event_name;
-  epers_date : cdate;
+  epers_date : Adef.cdate;
   epers_place : 'string;
   epers_reason : 'string;
   epers_note : 'string;
@@ -201,7 +166,7 @@ type 'string gen_fam_event_name =
 
 type ('person, 'string) gen_fam_event = {
   efam_name : 'string gen_fam_event_name;
-  efam_date : cdate;
+  efam_date : Adef.cdate;
   efam_place : 'string;
   efam_reason : 'string;
   efam_note : 'string;
@@ -260,11 +225,11 @@ type ('iper, 'person, 'string) gen_person = {
   occupation : 'string;
   sex : sex;
   access : access;
-  birth : cdate;
+  birth : Adef.cdate;
   birth_place : 'string;
   birth_note : 'string;
   birth_src : 'string;
-  baptism : cdate;
+  baptism : Adef.cdate;
   baptism_place : 'string;
   baptism_note : 'string;
   baptism_src : 'string;
@@ -294,7 +259,7 @@ type 'person gen_descend = { children : 'person array }
 (** Children of the family *)
 
 type ('person, 'ifam, 'string) gen_family = {
-  marriage : cdate;
+  marriage : Adef.cdate;
   marriage_place : 'string;
   marriage_note : 'string;
   marriage_src : 'string;
@@ -324,7 +289,7 @@ type ('iper, 'person, 'family, 'descend, 'title, 'pevent, 'fevent) warning =
   | BigAgeBetweenSpouses of
       'person
       * 'person
-      * dmy (* Age differece between couples is greater then 50 years *)
+      * Adef.dmy (* Age differece between couples is greater then 50 years *)
   | BirthAfterDeath of 'person  (** Person is born after his death *)
   | IncoherentSex of 'person * int * int  (** Incoherent sex of person *)
   | ChangedOrderOfChildren of 'family * 'descend * 'iper array * 'iper array
@@ -340,7 +305,7 @@ type ('iper, 'person, 'family, 'descend, 'title, 'pevent, 'fevent) warning =
   | CloseChildren of 'family * 'person * 'person
       (** Age difference between two child is less then 7 month (except for
           twins) *)
-  | DeadOld of 'person * dmy
+  | DeadOld of 'person * Adef.dmy
       (** Dead old (at the age older then 109 after 1900 year and older then 100
           before) *)
   | DeadTooEarlyToBeFather of 'person * 'person
@@ -362,10 +327,10 @@ type ('iper, 'person, 'family, 'descend, 'title, 'pevent, 'fevent) warning =
       (** Children is born after his mother's death *)
   | ParentBornAfterChild of 'person * 'person
       (** Parent is born after one of his children *)
-  | ParentTooOld of 'person * dmy * 'person
+  | ParentTooOld of 'person * Adef.dmy * 'person
       (** Person became a parent at age older then 55 years for mother and 70
           for father *)
-  | ParentTooYoung of 'person * dmy * 'person
+  | ParentTooYoung of 'person * Adef.dmy * 'person
       (** Person became a parent at age younger then 11 years old *)
   | PEventOrder of 'person * 'pevent * 'pevent
       (** Personal events haven't been ordered correctly *)
@@ -383,9 +348,9 @@ type ('iper, 'person, 'family, 'descend, 'title, 'pevent, 'fevent) warning =
       (** Title's start date is after end date or person is born after title
           dates *)
   | UndefinedSex of 'person  (** Person has undefined sex (Neuter) *)
-  | YoungForMarriage of 'person * dmy * 'family
+  | YoungForMarriage of 'person * Adef.dmy * 'family
       (** Person is married before he was 12 years old *)
-  | OldForMarriage of 'person * dmy * 'family
+  | OldForMarriage of 'person * Adef.dmy * 'family
       (** Person is married after he was 100 years old *)
 
 (** Missing sources warning *)

--- a/lib/event.ml
+++ b/lib/event.ml
@@ -50,7 +50,7 @@ let sort_events get_name get_date events =
 
 type 'a event_item =
   'a event_name
-  * cdate
+  * Adef.cdate
   * Driver.istr
   * Driver.istr
   * Driver.istr

--- a/lib/event.mli
+++ b/lib/event.mli
@@ -6,7 +6,7 @@ type 'a event_name =
 
 type 'a event_item =
   'a event_name
-  * Def.cdate
+  * Adef.cdate
   * Geneweb_db.Driver.istr
   * Geneweb_db.Driver.istr
   * Geneweb_db.Driver.istr

--- a/lib/fixbase.ml
+++ b/lib/fixbase.ml
@@ -399,7 +399,7 @@ let fix_utf8_sequence ?report progress base =
   let ff i = i in
   let fs ifam iper i = normalize_utf_8 ifam iper i in
   let fd ifam iper = function
-    | Dtext d -> Dtext (normalize_utf_8_date ifam iper d)
+    | Adef.Dtext d -> Adef.Dtext (normalize_utf_8_date ifam iper d)
     | d -> d
   in
   Collection.iteri

--- a/lib/historyDiffDisplay.ml
+++ b/lib/historyDiffDisplay.ml
@@ -939,7 +939,8 @@ let eval_predefined_apply conf _env f vl =
         let month = int_of_string (String.sub date_txt 5 2) in
         let day = int_of_string (String.sub date_txt 8 2) in
         let date =
-          Dgreg ({ day; month; year; prec = Sure; delta = 0 }, Dgregorian)
+          Adef.Dgreg
+            ({ Adef.day; month; year; prec = Sure; delta = 0 }, Dgregorian)
         in
         let time = String.sub date_txt 11 8 in
         DateDisplay.string_of_date conf date ^>^ ", " ^ time

--- a/lib/json_export/json_converter.ml
+++ b/lib/json_export/json_converter.ml
@@ -52,7 +52,7 @@ module Make (D : ConverterDriver) = struct
   let conv_dmy dmy =
     obj
       [|
-        ("day", int dmy.day);
+        ("day", int dmy.Adef.day);
         ("delta", if dmy.delta = 0 then null else int dmy.delta);
         ("month", int dmy.month);
         ("year", int dmy.year);
@@ -61,12 +61,14 @@ module Make (D : ConverterDriver) = struct
   let conv_dmy2 dmy =
     obj
       [|
-        ("day", int dmy.day2); ("month", int dmy.month2); ("year", int dmy.year2);
+        ("day", int dmy.Adef.day2);
+        ("month", int dmy.month2);
+        ("year", int dmy.year2);
       |]
 
   let conv_date_cal dt cal =
     let prec =
-      match dt.prec with
+      match dt.Adef.prec with
       | Sure -> str "Sure"
       | About -> str "About"
       | Maybe -> str "Maybe"
@@ -91,7 +93,7 @@ module Make (D : ConverterDriver) = struct
 
   let conv_date oc =
     match oc with
-    | Dgreg (d, c) -> conv_date_cal d (Def_show.show_calendar c)
+    | Adef.Dgreg (d, c) -> conv_date_cal d (Def_show.show_calendar c)
     | Dtext t -> str t
 
   let conv_cdate cd =

--- a/lib/json_export/json_converter.mli
+++ b/lib/json_export/json_converter.mli
@@ -27,13 +27,13 @@ end
 
 (** Functor building JSON convertion functions of the Geneweb data types. *)
 module Make : functor (D : ConverterDriver) -> sig
-  val conv_dmy : Def.dmy -> D.t
+  val conv_dmy : Adef.dmy -> D.t
   (** Convert [dmy] to JSON *)
 
-  val conv_dmy2 : Def.dmy2 -> D.t
+  val conv_dmy2 : Adef.dmy2 -> D.t
   (** Convert [dmy2] to JSON *)
 
-  val conv_cdate : Def.cdate -> D.t
+  val conv_cdate : Adef.cdate -> D.t
   (** Convert [cdate] to JSON *)
 
   val conv_pevent_name : string Def.gen_pers_event_name -> D.t

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -24,11 +24,11 @@ let person_living_age conf p p_auth =
   | _ -> None
 
 let format_age conf age =
-  let y = age.Def.year in
-  let m = age.Def.month in
-  let d = age.Def.day in
+  let y = age.Adef.year in
+  let m = age.month in
+  let d = age.day in
   let prec_str =
-    match age.Def.prec with
+    match age.prec with
     | Sure -> ""
     | About | Maybe -> "~"
     | Before -> "<"
@@ -57,13 +57,13 @@ let format_age conf age =
   Adef.safe result
 
 let eval_age_field_var conf ?(before_birth = false) age = function
-  | [ "years" ] -> Templ.VVstring (string_of_int age.Def.year)
-  | [ "months" ] -> Templ.VVstring (string_of_int age.Def.month)
-  | [ "days" ] -> Templ.VVstring (string_of_int age.Def.day)
+  | [ "years" ] -> Templ.VVstring (string_of_int age.Adef.year)
+  | [ "months" ] -> Templ.VVstring (string_of_int age.month)
+  | [ "days" ] -> Templ.VVstring (string_of_int age.day)
   | [ "short" ] ->
-      let y = age.Def.year in
-      let m = age.Def.month in
-      let d = age.Def.day in
+      let y = age.year in
+      let m = age.month in
+      let d = age.day in
       let sign = if before_birth then "−" else "" in
       let s =
         if y > 0 then
@@ -86,7 +86,7 @@ let eval_age_field_var conf ?(before_birth = false) age = function
   | [ "sign" ] -> Templ.VVstring (if before_birth then "−" else "")
   | [ "before_birth" ] -> Templ.VVbool before_birth
   | [ "prec" ] -> (
-      match age.Def.prec with
+      match age.prec with
       | Sure -> Templ.VVstring ""
       | About | Maybe -> Templ.VVstring "~"
       | Before -> Templ.VVstring "<"
@@ -96,10 +96,10 @@ let eval_age_field_var conf ?(before_birth = false) age = function
   | _ -> raise Not_found
 
 let compare_dmy d1 d2 =
-  match compare d1.Def.year d2.Def.year with
+  match compare d1.Adef.year d2.Adef.year with
   | 0 -> (
-      match compare d1.Def.month d2.Def.month with
-      | 0 -> compare d1.Def.day d2.Def.day
+      match compare d1.Adef.month d2.Adef.month with
+      | 0 -> compare d1.Adef.day d2.Adef.day
       | c -> c)
   | c -> c
 
@@ -1375,8 +1375,8 @@ end)
 type ancestor_surname_info =
   | Branch of
       (string
-      * date option
-      * date option
+      * Adef.date option
+      * Adef.date option
       * string
       * Driver.person
       * Sosa.t list
@@ -1384,8 +1384,8 @@ type ancestor_surname_info =
   | Eclair of
       (string
       * Adef.safe_string
-      * date option
-      * date option
+      * Adef.date option
+      * Adef.date option
       * Driver.person
       * Driver.iper list
       * Loc.t)
@@ -1406,7 +1406,7 @@ type title_item =
   * Driver.istr gen_title_name
   * Driver.istr
   * Driver.istr list
-  * (date option * date option) list
+  * (Adef.date option * Adef.date option) list
 
 type path_mode = Paths_cnt_raw | Paths_cnt | Paths
 
@@ -2760,7 +2760,7 @@ and eval_title_field_var conf base env (_p, (nth, name, title, places, dates))
   | [ "dates" ] ->
       let date_opt_to_string d =
         match d with
-        | Some (Dgreg (dmy, _)) ->
+        | Some (Adef.Dgreg (dmy, _)) ->
             Some (DateDisplay.string_of_dmy conf dmy :> string)
         | Some (Dtext d) -> Some (d |> escape_html :> string)
         | None -> None
@@ -2780,7 +2780,7 @@ and eval_title_field_var conf base env (_p, (nth, name, title, places, dates))
       match dates with
       | [ (d, _) ] -> (
           match d with
-          | Some (Dgreg (dmy, _)) ->
+          | Some (Adef.Dgreg (dmy, _)) ->
               VVstring (DateDisplay.string_of_dmy conf dmy :> string)
           | Some (Dtext d) -> VVstring (d |> escape_html :> string)
           | None -> null_val)
@@ -2789,7 +2789,7 @@ and eval_title_field_var conf base env (_p, (nth, name, title, places, dates))
       match dates with
       | [ (_, d) ] -> (
           match d with
-          | Some (Dgreg (dmy, _)) ->
+          | Some (Adef.Dgreg (dmy, _)) ->
               VVstring (DateDisplay.string_of_dmy conf dmy :> string)
           | Some (Dtext d) -> VVstring (d |> escape_html :> string)
           | None -> null_val)
@@ -3456,7 +3456,9 @@ and eval_date_field_var conf d = function
   | [ "julian_day" ] | [ "sdn" ] -> (
       match d with
       | Dgreg (dmy, cal) ->
-          let from = if dmy.day > 0 && dmy.month > 0 then Dgregorian else cal in
+          let from =
+            if dmy.day > 0 && dmy.month > 0 then Adef.Dgregorian else cal
+          in
           VVstring (string_of_int (Date.to_sdn ~from dmy))
       | _ -> null_val)
   | [ "month" ] -> (
@@ -4028,7 +4030,7 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
         match Date.od_of_cdate (Driver.get_birth p) with
         | Some (Dgreg (birth_dmy, cal)) ->
             let from =
-              if birth_dmy.day > 0 && birth_dmy.month > 0 then Dgregorian
+              if birth_dmy.day > 0 && birth_dmy.month > 0 then Adef.Dgregorian
               else cal
             in
             let birth_sdn = Date.to_sdn ~from birth_dmy in
@@ -4036,7 +4038,8 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
               match Date.date_of_death (Driver.get_death p) with
               | Some (Dgreg (death_dmy, cal2)) ->
                   let from2 =
-                    if death_dmy.day > 0 && death_dmy.month > 0 then Dgregorian
+                    if death_dmy.day > 0 && death_dmy.month > 0 then
+                      Adef.Dgregorian
                     else cal2
                   in
                   Date.to_sdn ~from:from2 death_dmy

--- a/lib/perso.mli
+++ b/lib/perso.mli
@@ -177,7 +177,7 @@ val string_of_title :
   * Geneweb_db.Driver.istr Def.gen_title_name
   * Geneweb_db.Driver.istr
   * Geneweb_db.Driver.istr list
-  * (Def.date option * Def.date option) list ->
+  * (Adef.date option * Adef.date option) list ->
   Adef.safe_string
 (** Optionnal [link] argument is passed to {!val:DateDisplay.string_of_ondate}
 *)

--- a/lib/show/def_show.ml
+++ b/lib/show/def_show.ml
@@ -1,36 +1,46 @@
-type date = [%import: Def.date] [@@deriving show { with_path = false }]
-and calendar = [%import: Def.calendar] [@@deriving show { with_path = false }]
-and dmy = [%import: Def.dmy] [@@deriving show { with_path = false }]
-and dmy2 = [%import: Def.dmy2] [@@deriving show { with_path = false }]
-and precision = [%import: Def.precision] [@@deriving show { with_path = false }]
+type calendar = [%import: Adef.calendar] [@@deriving show { with_path = false }]
+type dmy2 = [%import: Adef.dmy2] [@@deriving show { with_path = false }]
 
-type cdate = Adef.cdate
+type date = [%import: Adef.date] [@@deriving show { with_path = false }]
+and dmy = [%import: Adef.dmy] [@@deriving show { with_path = false }]
 
-let pp_cdate fmt x =
-  match Date.od_of_cdate x with
-  | Some d -> pp_date fmt d
-  | None -> Format.fprintf fmt "None"
-
-let show_cdate x =
-  match Date.od_of_cdate x with Some d -> show_date d | None -> "None"
-
-type relation_kind = [%import: Def.relation_kind]
+and precision = [%import: Adef.precision]
 [@@deriving show { with_path = false }]
 
-type divorce = [%import: Def.divorce] [@@deriving show { with_path = false }]
+(* HACK: The type ['a gen_title] contains payloads of type [Adef.cdate]. So,
+   the printer generated par the ppx show is looking for [Adef.pp_cdate]. *)
+module Adef = struct
+  include Adef
 
-type death_reason = [%import: Def.death_reason]
-[@@deriving show { with_path = false }]
+  let pp_cdate fmt x =
+    match Date.od_of_cdate x with
+    | Some d -> pp_date fmt d
+    | None -> Format.fprintf fmt "None"
+end
 
-type death = [%import: Def.death] [@@deriving show { with_path = false }]
-type burial = [%import: Def.burial] [@@deriving show { with_path = false }]
-type access = [%import: Def.access] [@@deriving show { with_path = false }]
+let pp_cdate = Adef.pp_cdate
 
 type 'string gen_title_name = [%import: 'string Def.gen_title_name]
 [@@deriving show { with_path = false }]
 
 type 'string gen_title = [%import: 'string Def.gen_title]
 [@@deriving show { with_path = false }]
+
+type relation_type = [%import: Def.relation_type]
+[@@deriving show { with_path = false }]
+
+type ('person, 'string) gen_relation =
+  [%import: ('person, 'string) Def.gen_relation]
+[@@deriving show { with_path = false }]
+
+type sex = [%import: Def.sex] [@@deriving show { with_path = false }]
+type access = [%import: Def.access] [@@deriving show { with_path = false }]
+
+type death_reason = [%import: Def.death_reason]
+[@@deriving show { with_path = false }]
+
+type death = [%import: Def.death] [@@deriving show { with_path = false }]
+type burial = [%import: Def.burial] [@@deriving show { with_path = false }]
 
 type witness_kind = [%import: Def.witness_kind]
 [@@deriving show { with_path = false }]
@@ -42,6 +52,13 @@ type ('person, 'string) gen_pers_event =
   [%import: ('person, 'string) Def.gen_pers_event]
 [@@deriving show { with_path = false }]
 
+type ('iper, 'person, 'string) gen_person =
+  [%import: ('iper, 'person, 'string) Def.gen_person]
+[@@deriving show { with_path = false }]
+
+type relation_kind = [%import: Def.relation_kind]
+[@@deriving show { with_path = false }]
+
 type 'string gen_fam_event_name = [%import: 'string Def.gen_fam_event_name]
 [@@deriving show { with_path = false }]
 
@@ -49,44 +66,7 @@ type ('person, 'string) gen_fam_event =
   [%import: ('person, 'string) Def.gen_fam_event]
 [@@deriving show { with_path = false }]
 
-type relation_type = [%import: Def.relation_type]
-[@@deriving show { with_path = false }]
-
-type ('person, 'string) gen_relation =
-  [%import: ('person, 'string) Def.gen_relation]
-[@@deriving show { with_path = false }]
-
-type sex = [%import: Def.sex] [@@deriving show { with_path = false }]
-type place = [%import: Def.place] [@@deriving show { with_path = false }]
-
-type ('iper, 'person, 'string) gen_person =
-  [%import: ('iper, 'person, 'string) Def.gen_person]
-[@@deriving show { with_path = false }]
-
-type fix = Adef.fix
-
 let pp_fix fmt x = Format.fprintf fmt "%d" @@ Adef.fix_repr x
 let show_fix x = string_of_int @@ Adef.fix_repr x
 
-type 'family gen_ascend = 'family Def.gen_ascend = {
-  parents : 'family option;
-  consang : fix;
-}
-[@@deriving show { with_path = false }]
-
-type 'family gen_union = [%import: 'family Def.gen_union]
-[@@deriving show { with_path = false }]
-
-type ('person, 'ifam, 'string) gen_family =
-  [%import: ('person, 'ifam, 'string) Def.gen_family]
-[@@deriving show { with_path = false }]
-
-type 'person gen_couple =
-  ('person Adef.gen_couple
-  [@polyprinter
-    fun pp fmt x ->
-      fprintf fmt "[ %a ; %a ]" pp (Adef.father x) pp (Adef.mother x)])
-[@@deriving show { with_path = false }]
-
-type 'person gen_descend = [%import: 'person Def.gen_descend]
-[@@deriving show { with_path = false }]
+type divorce = [%import: Def.divorce] [@@deriving show { with_path = false }]

--- a/lib/show/def_show.mli
+++ b/lib/show/def_show.mli
@@ -1,448 +1,74 @@
-type date = Adef.date = Dgreg of dmy * calendar | Dtext of string
-and calendar = Adef.calendar = Dgregorian | Djulian | Dfrench | Dhebrew
-
-and dmy = Adef.dmy = {
-  day : int;
-  month : int;
-  year : int;
-  prec : precision;
-  delta : int;
-}
-
-and dmy2 = Adef.dmy2 = { day2 : int; month2 : int; year2 : int; delta2 : int }
-
-and precision = Adef.precision =
-  | Sure
-  | About
-  | Maybe
-  | Before
-  | After
-  | OrYear of dmy2
-  | YearInt of dmy2
-
-val pp_date : Format.formatter -> date -> unit
-(** Printer for [date] *)
-
-val show_date : date -> string
-(** Convert [date] to string. *)
-
-val pp_calendar : Format.formatter -> calendar -> unit
-(** Printer for [calendar] *)
-
-val show_calendar : calendar -> string
+val show_calendar : Adef.calendar -> string
 (** Convert [calendar] to string *)
-
-val pp_dmy : Format.formatter -> dmy -> unit
-(** Printer for [dmy] *)
-
-val show_dmy : dmy -> string
-(** Convert [dmy] to string *)
-
-val pp_dmy2 : Format.formatter -> dmy2 -> unit
-(** Printer for [dmy2] *)
-
-val show_dmy2 : dmy2 -> string
-(** Convert [dmy2] to string *)
-
-val pp_precision : Format.formatter -> precision -> unit
-(** Printer for [precision] *)
-
-val show_precision : precision -> string
-(** Convert [precision] to string *)
-
-type cdate = Adef.cdate
-
-val pp_cdate : Format.formatter -> Adef.cdate -> unit
-(** Printer for [cdate] *)
-
-val show_cdate : Adef.cdate -> string
-(** Convert [cdate] to string *)
-
-type relation_kind = Def.relation_kind =
-  | Married
-  | NotMarried
-  | Engaged
-  | NoSexesCheckNotMarried
-  | NoMention
-  | NoSexesCheckMarried
-  | MarriageBann
-  | MarriageContract
-  | MarriageLicense
-  | Pacs
-  | Residence
-
-val pp_relation_kind : Format.formatter -> relation_kind -> unit
-(** Printer for [relation_kind] *)
-
-val show_relation_kind : relation_kind -> string
-(** Convert [relation_kind] to string *)
-
-type divorce = Def.divorce =
-  | NotDivorced
-  | Divorced of cdate
-  | Separated_old
-  | NotSeparated
-  | Separated of cdate
-
-val pp_divorce : Format.formatter -> divorce -> unit
-(** Printer for [divorce] *)
-
-val show_divorce : divorce -> string
-(** Convert [divorce] to string *)
-
-type death_reason = Def.death_reason =
-  | Killed
-  | Murdered
-  | Executed
-  | Disappeared
-  | Unspecified
-
-val pp_death_reason : Format.formatter -> death_reason -> unit
-(** Printer for [death_reason] *)
-
-val show_death_reason : death_reason -> string
-(** Convert [death_reason] to string *)
-
-type death = Def.death =
-  | NotDead
-  | Death of death_reason * cdate
-  | DeadYoung
-  | DeadDontKnowWhen
-  | DontKnowIfDead
-  | OfCourseDead
-
-val pp_death : Format.formatter -> death -> unit
-(** Printer for [death] *)
-
-val show_death : death -> string
-(** Convert [death] to string *)
-
-type burial = Def.burial = UnknownBurial | Buried of cdate | Cremated of cdate
-
-val pp_burial : Format.formatter -> burial -> unit
-(** Printer for [burial] *)
-
-val show_burial : burial -> string
-(** Convert [burial] to string *)
-
-type access = Def.access = IfTitles | Public | SemiPublic | Private
-
-val pp_access : Format.formatter -> access -> unit
-(** Printer for [access] *)
-
-val show_access : access -> string
-(** Convert [access] to string *)
-
-type 'string gen_title_name = 'string Def.gen_title_name =
-  | Tmain
-  | Tname of 'string
-  | Tnone
-
-val pp_gen_title_name :
-  (Format.formatter -> 'string -> unit) ->
-  Format.formatter ->
-  'string gen_title_name ->
-  unit
-(** Printer for [gen_title_name] *)
-
-val show_gen_title_name :
-  (Format.formatter -> 'string -> unit) -> 'string gen_title_name -> string
-(** Convert [gen_title_name] to string *)
-
-type 'string gen_title = 'string Def.gen_title = {
-  t_name : 'string gen_title_name;
-  t_ident : 'string;
-  t_place : 'string;
-  t_date_start : cdate;
-  t_date_end : cdate;
-  t_nth : int;
-}
 
 val pp_gen_title :
   (Format.formatter -> 'string -> unit) ->
   Format.formatter ->
-  'string gen_title ->
+  'string Def.gen_title ->
   unit
 (** Printer for [gen_title] *)
-
-val show_gen_title :
-  (Format.formatter -> 'string -> unit) -> 'string gen_title -> string
-(** Convert [gen_title] to string *)
-
-type witness_kind = Def.witness_kind =
-  | Witness
-  | Witness_GodParent
-  | Witness_CivilOfficer
-  | Witness_ReligiousOfficer
-  | Witness_Informant
-  | Witness_Attending
-  | Witness_Mentioned
-  | Witness_Other
-
-val pp_witness_kind : Format.formatter -> witness_kind -> unit
-(** Printer for [witness_kind] *)
-
-val show_witness_kind : witness_kind -> string
-(** Convert [witness_kind] to string *)
-
-type 'string gen_pers_event_name = 'string Def.gen_pers_event_name =
-  | Epers_Birth
-  | Epers_Baptism
-  | Epers_Death
-  | Epers_Burial
-  | Epers_Cremation
-  | Epers_Accomplishment
-  | Epers_Acquisition
-  | Epers_Adhesion
-  | Epers_BaptismLDS
-  | Epers_BarMitzvah
-  | Epers_BatMitzvah
-  | Epers_Benediction
-  | Epers_ChangeName
-  | Epers_Circumcision
-  | Epers_Confirmation
-  | Epers_ConfirmationLDS
-  | Epers_Decoration
-  | Epers_DemobilisationMilitaire
-  | Epers_Diploma
-  | Epers_Distinction
-  | Epers_Dotation
-  | Epers_DotationLDS
-  | Epers_Education
-  | Epers_Election
-  | Epers_Emigration
-  | Epers_Excommunication
-  | Epers_FamilyLinkLDS
-  | Epers_FirstCommunion
-  | Epers_Funeral
-  | Epers_Graduate
-  | Epers_Hospitalisation
-  | Epers_Illness
-  | Epers_Immigration
-  | Epers_ListePassenger
-  | Epers_MilitaryDistinction
-  | Epers_MilitaryPromotion
-  | Epers_MilitaryService
-  | Epers_MobilisationMilitaire
-  | Epers_Naturalisation
-  | Epers_Occupation
-  | Epers_Ordination
-  | Epers_Property
-  | Epers_Recensement
-  | Epers_Residence
-  | Epers_Retired
-  | Epers_ScellentChildLDS
-  | Epers_ScellentParentLDS
-  | Epers_ScellentSpouseLDS
-  | Epers_VenteBien
-  | Epers_Will
-  | Epers_Name of 'string
-
-val pp_gen_pers_event_name :
-  (Format.formatter -> 'string -> unit) ->
-  Format.formatter ->
-  'string gen_pers_event_name ->
-  unit
-(** Printer for [gen_pers_event_name] *)
-
-val show_gen_pers_event_name :
-  (Format.formatter -> 'string -> unit) -> 'string gen_pers_event_name -> string
-(** Convert [gen_pers_event_name] to string *)
-
-type ('person, 'string) gen_pers_event =
-      ('person, 'string) Def.gen_pers_event = {
-  epers_name : 'string gen_pers_event_name;
-  epers_date : cdate;
-  epers_place : 'string;
-  epers_reason : 'string;
-  epers_note : 'string;
-  epers_src : 'string;
-  epers_witnesses : ('person * witness_kind) array;
-}
-
-val pp_gen_pers_event :
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'string -> unit) ->
-  Format.formatter ->
-  ('person, 'string) gen_pers_event ->
-  unit
-(** Printer for [gen_pers_event] *)
-
-val show_gen_pers_event :
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'string -> unit) ->
-  ('person, 'string) gen_pers_event ->
-  string
-(** Convert [gen_pers_event] to string *)
-
-type 'string gen_fam_event_name = 'string Def.gen_fam_event_name =
-  | Efam_Marriage
-  | Efam_NoMarriage
-  | Efam_NoMention
-  | Efam_Engage
-  | Efam_Divorce
-  | Efam_Separated
-  | Efam_Annulation
-  | Efam_MarriageBann
-  | Efam_MarriageContract
-  | Efam_MarriageLicense
-  | Efam_PACS
-  | Efam_Residence
-  | Efam_Name of 'string
-
-val pp_gen_fam_event_name :
-  (Format.formatter -> 'string -> unit) ->
-  Format.formatter ->
-  'string gen_fam_event_name ->
-  unit
-(** Printer for [gen_fam_event_name] *)
-
-val show_gen_fam_event_name :
-  (Format.formatter -> 'string -> unit) -> 'string gen_fam_event_name -> string
-(** Convert [gen_fam_event_name] to string *)
-
-type ('person, 'string) gen_fam_event = ('person, 'string) Def.gen_fam_event = {
-  efam_name : 'string gen_fam_event_name;
-  efam_date : cdate;
-  efam_place : 'string;
-  efam_reason : 'string;
-  efam_note : 'string;
-  efam_src : 'string;
-  efam_witnesses : ('person * witness_kind) array;
-}
-
-val pp_gen_fam_event :
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'string -> unit) ->
-  Format.formatter ->
-  ('person, 'string) gen_fam_event ->
-  unit
-(** Printer for [gen_fam_event] *)
-
-val show_gen_fam_event :
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'string -> unit) ->
-  ('person, 'string) gen_fam_event ->
-  string
-(** Convert [gen_fam_event] to string *)
-
-type relation_type = Def.relation_type =
-  | Adoption
-  | Recognition
-  | CandidateParent
-  | GodParent
-  | FosterParent
-
-val pp_relation_type : Format.formatter -> relation_type -> unit
-(** Printer for [relation_type] *)
-
-val show_relation_type : relation_type -> string
-(** Convert [relation_type] to string *)
-
-type ('person, 'string) gen_relation = ('person, 'string) Def.gen_relation = {
-  r_type : relation_type;
-  r_fath : 'person option;
-  r_moth : 'person option;
-  r_sources : 'string;
-}
 
 val pp_gen_relation :
   (Format.formatter -> 'person -> unit) ->
   (Format.formatter -> 'string -> unit) ->
   Format.formatter ->
-  ('person, 'string) gen_relation ->
+  ('person, 'string) Def.gen_relation ->
   unit
 (** Printer for [gen_relation] *)
 
-val show_gen_relation :
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'string -> unit) ->
-  ('person, 'string) gen_relation ->
-  string
-(** Convert [gen_relation] to string *)
-
-type sex = Def.sex = Male | Female | Neuter
-
-val pp_sex : Format.formatter -> sex -> unit
+val pp_sex : Format.formatter -> Def.sex -> unit
 (** Printer for [sex] *)
 
-val show_sex : sex -> string
-(** Convert [sex] to string *)
+val pp_access : Format.formatter -> Def.access -> unit
+(** Printer for [access] *)
 
-type place = Def.place = {
-  other : string;
-  town : string;
-  township : string;
-  canton : string;
-  district : string;
-  county : string;
-  region : string;
-  country : string;
-}
+val pp_cdate : Format.formatter -> Adef.cdate -> unit
+(** Printer for [cdate] *)
 
-val pp_place : Format.formatter -> place -> unit
-(** Printer for [place] *)
+val pp_death : Format.formatter -> Def.death -> unit
+(** Printer for [death] *)
 
-val show_place : place -> string
-(** Convert [place] to string *)
+val pp_burial : Format.formatter -> Def.burial -> unit
+(** Printer for [burial] *)
 
-type ('iper, 'person, 'string) gen_person =
-      ('iper, 'person, 'string) Def.gen_person = {
-  first_name : 'string;
-  surname : 'string;
-  occ : int;
-  image : 'string;
-  public_name : 'string;
-  qualifiers : 'string list;
-  aliases : 'string list;
-  first_names_aliases : 'string list;
-  surnames_aliases : 'string list;
-  titles : 'string gen_title list;
-  rparents : ('person, 'string) gen_relation list;
-  related : 'person list;
-  occupation : 'string;
-  sex : sex;
-  access : access;
-  birth : cdate;
-  birth_place : 'string;
-  birth_note : 'string;
-  birth_src : 'string;
-  baptism : cdate;
-  baptism_place : 'string;
-  baptism_note : 'string;
-  baptism_src : 'string;
-  death : death;
-  death_place : 'string;
-  death_note : 'string;
-  death_src : 'string;
-  burial : burial;
-  burial_place : 'string;
-  burial_note : 'string;
-  burial_src : 'string;
-  pevents : ('person, 'string) gen_pers_event list;
-  notes : 'string;
-  psources : 'string;
-  key_index : 'iper;
-}
+val pp_gen_pers_event_name :
+  (Format.formatter -> 'string -> unit) ->
+  Format.formatter ->
+  'string Def.gen_pers_event_name ->
+  unit
+(** Printer for [gen_pers_event_name] *)
 
-val pp_gen_person :
-  (Format.formatter -> 'iper -> unit) ->
+val show_relation_kind : Def.relation_kind -> string
+(** Convert [relation_kind] to string *)
+
+val show_gen_pers_event_name :
+  (Format.formatter -> 'string -> unit) ->
+  'string Def.gen_pers_event_name ->
+  string
+(** Convert [gen_pers_event_name] to string *)
+
+val show_witness_kind : Def.witness_kind -> string
+(** Convert [witness_kind] to string *)
+
+val show_gen_fam_event_name :
+  (Format.formatter -> 'string -> unit) ->
+  'string Def.gen_fam_event_name ->
+  string
+(** Convert [gen_fam_event_name] to string *)
+
+val pp_gen_pers_event :
   (Format.formatter -> 'person -> unit) ->
   (Format.formatter -> 'string -> unit) ->
   Format.formatter ->
-  ('iper, 'person, 'string) gen_person ->
+  ('person, 'string) Def.gen_pers_event ->
   unit
-(** Printer for [gen_person] *)
+(** Printer for [gen_pers_event] *)
 
-val show_gen_person :
-  (Format.formatter -> 'iper -> unit) ->
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'string -> unit) ->
-  ('iper, 'person, 'string) gen_person ->
-  string
-(** Convert [gen_person] to string *)
+val pp_relation_kind : Format.formatter -> Def.relation_kind -> unit
+(** Printer for [relation_kind] *)
 
-type fix = Adef.fix
+val show_relation_type : Def.relation_type -> string
+(** Convert [relation_type] to string *)
 
 val pp_fix : Format.formatter -> Adef.fix -> unit
 (** Printer for [fix] *)
@@ -450,92 +76,20 @@ val pp_fix : Format.formatter -> Adef.fix -> unit
 val show_fix : Adef.fix -> string
 (** Convert [fix] to string *)
 
-type 'family gen_ascend = 'family Def.gen_ascend = {
-  parents : 'family option;
-  consang : fix;
-}
+val pp_divorce : Format.formatter -> Def.divorce -> unit
+(** Printer for [divorce] *)
 
-val pp_gen_ascend :
-  (Format.formatter -> 'family -> unit) ->
-  Format.formatter ->
-  'family gen_ascend ->
-  unit
-(** Printer for [gen_ascend] *)
-
-val show_gen_ascend :
-  (Format.formatter -> 'family -> unit) -> 'family gen_ascend -> string
-(** Convert [gen_ascend] to string *)
-
-type 'family gen_union = 'family Def.gen_union = { family : 'family array }
-
-val pp_gen_union :
-  (Format.formatter -> 'family -> unit) ->
-  Format.formatter ->
-  'family gen_union ->
-  unit
-(** Printer for [gen_union] *)
-
-val show_gen_union :
-  (Format.formatter -> 'family -> unit) -> 'family gen_union -> string
-(** Convert [gen_union] to string *)
-
-type ('person, 'ifam, 'string) gen_family =
-      ('person, 'ifam, 'string) Def.gen_family = {
-  marriage : cdate;
-  marriage_place : 'string;
-  marriage_note : 'string;
-  marriage_src : 'string;
-  witnesses : 'person array;
-  relation : relation_kind;
-  divorce : divorce;
-  fevents : ('person, 'string) gen_fam_event list;
-  comment : 'string;
-  origin_file : 'string;
-  fsources : 'string;
-  fam_index : 'ifam;
-}
-
-val pp_gen_family :
-  (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'ifam -> unit) ->
+val pp_gen_fam_event_name :
   (Format.formatter -> 'string -> unit) ->
   Format.formatter ->
-  ('person, 'ifam, 'string) gen_family ->
+  'string Def.gen_fam_event_name ->
   unit
-(** Printer for [gen_family] *)
+(** Printer for [gen_fam_event_name] *)
 
-val show_gen_family :
+val pp_gen_fam_event :
   (Format.formatter -> 'person -> unit) ->
-  (Format.formatter -> 'ifam -> unit) ->
   (Format.formatter -> 'string -> unit) ->
-  ('person, 'ifam, 'string) gen_family ->
-  string
-(** Convert [gen_family] to string *)
-
-type 'person gen_couple = 'person Adef.gen_couple
-
-val pp_gen_couple :
-  (Format.formatter -> 'person -> unit) ->
   Format.formatter ->
-  'person gen_couple ->
+  ('person, 'string) Def.gen_fam_event ->
   unit
-(** Printer for [gen_couple] *)
-
-val show_gen_couple :
-  (Format.formatter -> 'person -> unit) -> 'person gen_couple -> string
-(** Convert [gen_couple] to string *)
-
-type 'person gen_descend = 'person Def.gen_descend = {
-  children : 'person array;
-}
-
-val pp_gen_descend :
-  (Format.formatter -> 'person -> unit) ->
-  Format.formatter ->
-  'person gen_descend ->
-  unit
-(** Printer for [gen_descend] *)
-
-val show_gen_descend :
-  (Format.formatter -> 'person -> unit) -> 'person gen_descend -> string
-(** Convert [gen_descend] to string *)
+(** Printer for [gen_fam_event] *)

--- a/lib/srcfileDisplay.ml
+++ b/lib/srcfileDisplay.ml
@@ -1,7 +1,6 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
 open Config
-open Def
 open Util
 module Driver = Geneweb_db.Driver
 
@@ -168,7 +167,7 @@ let string_of_start_date conf =
   let r = count conf in
   match extract_date r.start_date with
   | Some (d, m, y) ->
-      Dgreg
+      Adef.Dgreg
         ({ day = d; month = m; year = y; prec = Sure; delta = 0 }, Dgregorian)
       |> DateDisplay.string_of_date conf
   | _ -> Util.safe_html r.start_date

--- a/lib/title.ml
+++ b/lib/title.ml
@@ -11,8 +11,10 @@ module T = Driver.Istr.Table
 type date_search = JustSelf | AddSpouse | AddChildren
 
 let date_interval conf base t x =
-  let d1 = ref { day = 0; month = 0; year = max_int; prec = Sure; delta = 0 } in
-  let d2 = ref { day = 0; month = 0; year = 0; prec = Sure; delta = 0 } in
+  let d1 =
+    ref { Adef.day = 0; month = 0; year = max_int; prec = Sure; delta = 0 }
+  in
+  let d2 = ref { Adef.day = 0; month = 0; year = 0; prec = Sure; delta = 0 } in
   let found = ref false in
   let rec loop t x =
     let set d =

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -15,7 +15,7 @@ type update_error =
   | UERR_already_defined of Driver.base * Driver.person * string
   | UERR_own_ancestor of Driver.base * Driver.person
   | UERR_digest
-  | UERR_bad_date of Def.dmy
+  | UERR_bad_date of Adef.dmy
   | UERR_missing_field of Adef.safe_string
   | UERR_already_has_parents of Driver.base * Driver.person
   | UERR_missing_surname of Adef.safe_string
@@ -26,10 +26,10 @@ type update_error =
 exception ModErr of update_error
 
 type create_info = {
-  ci_birth_date : date option;
+  ci_birth_date : Adef.date option;
   ci_birth_place : string;
   ci_death : death;
-  ci_death_date : date option;
+  ci_death_date : Adef.date option;
   ci_death_place : string;
   ci_occupation : string;
   ci_public : bool;
@@ -52,7 +52,7 @@ let infer_death_from_cdate conf ?(max_age = maximum_lifespan) cdate =
 
 let infer_death_bb conf birth bapt =
   let infer_death_from_odate conf = function
-    | Some (Dgreg (d, _)) -> infer_death_from_dmy conf d
+    | Some (Adef.Dgreg (d, _)) -> infer_death_from_dmy conf d
     | Some (Dtext _) | None -> DontKnowIfDead
   in
   match infer_death_from_odate conf birth with
@@ -1105,7 +1105,7 @@ let reconstitute_date_dmy2 conf var =
       | Some m -> (
           match get_number var "orday" conf.env with
           | Some d ->
-              let dmy2 = { day2 = d; month2 = m; year2 = y; delta2 = 0 } in
+              let dmy2 = { Adef.day2 = d; month2 = m; year2 = y; delta2 = 0 } in
               if
                 dmy2.day2 >= 1 && dmy2.day2 <= 31 && dmy2.month2 >= 1
                 && dmy2.month2 <= 13
@@ -1114,7 +1114,7 @@ let reconstitute_date_dmy2 conf var =
                 let d = Date.dmy_of_dmy2 dmy2 in
                 bad_date conf d
           | None ->
-              let dmy2 = { day2 = 0; month2 = m; year2 = y; delta2 = 0 } in
+              let dmy2 = { Adef.day2 = 0; month2 = m; year2 = y; delta2 = 0 } in
               if dmy2.month2 >= 1 && dmy2.month2 <= 13 then dmy2
               else
                 let d = Date.dmy_of_dmy2 dmy2 in
@@ -1161,7 +1161,7 @@ let reconstitute_date_dmy conf var =
     | Some y -> (
         let prec =
           match prec with
-          | Some "about" -> About
+          | Some "about" -> Adef.About
           | Some "maybe" -> Maybe
           | Some "before" -> Before
           | Some "after" -> After
@@ -1183,12 +1183,16 @@ let reconstitute_date_dmy conf var =
         | Some m -> (
             match get_number var "dd" conf.env with
             | Some d ->
-                let d = { day = d; month = m; year = y; prec; delta = 0 } in
+                let d =
+                  { Adef.day = d; month = m; year = y; prec; delta = 0 }
+                in
                 if d.day >= 1 && d.day <= 31 && d.month >= 1 && d.month <= 13
                 then Some d
                 else bad_date conf d
             | None ->
-                let d = { day = 0; month = m; year = y; prec; delta = 0 } in
+                let d =
+                  { Adef.day = 0; month = m; year = y; prec; delta = 0 }
+                in
                 if d.month >= 1 && d.month <= 13 then Some d
                 else bad_date conf d)
         | None -> Some { day = 0; month = 0; year = y; prec; delta = 0 })
@@ -1237,7 +1241,7 @@ let check_missing_witnesses_names conf get list =
   loop list
 
 let check_greg_day conf d =
-  if d.day > Date.nb_days_in_month d.month d.year then bad_date conf d
+  if d.Adef.day > Date.nb_days_in_month d.month d.year then bad_date conf d
 
 let reconstitute_date conf var =
   match reconstitute_date_dmy conf var with
@@ -1246,16 +1250,16 @@ let reconstitute_date conf var =
         match p_getenv conf.env (var ^ "_cal") with
         | Some "G" | None ->
             check_greg_day conf d;
-            (d, Dgregorian)
+            (d, Adef.Dgregorian)
         | Some "J" -> (Calendar.gregorian_of_julian d, Djulian)
         | Some "F" -> (Calendar.gregorian_of_french d, Dfrench)
         | Some "H" -> (Calendar.gregorian_of_hebrew d, Dhebrew)
         | _ ->
             check_greg_day conf d;
-            (d, Dgregorian)
+            (d, Adef.Dgregorian)
       in
-      Some (Dgreg (d, cal))
-  | Some d, true -> Some (Dgreg (Calendar.gregorian_of_french d, Dfrench))
+      Some (Adef.Dgreg (d, cal))
+  | Some d, true -> Some (Adef.Dgreg (Calendar.gregorian_of_french d, Dfrench))
   | None, _ -> (
       match p_getenv conf.env (var ^ "_text") with
       | Some _ ->

--- a/lib/update.mli
+++ b/lib/update.mli
@@ -13,7 +13,7 @@ type update_error =
       Geneweb_db.Driver.base * Geneweb_db.Driver.person * string
   | UERR_own_ancestor of Geneweb_db.Driver.base * Geneweb_db.Driver.person
   | UERR_digest
-  | UERR_bad_date of Def.dmy
+  | UERR_bad_date of Adef.dmy
   | UERR_missing_field of Adef.safe_string
   | UERR_already_has_parents of
       Geneweb_db.Driver.base * Geneweb_db.Driver.person
@@ -25,10 +25,10 @@ type update_error =
 exception ModErr of update_error
 
 type create_info = {
-  ci_birth_date : date option;
+  ci_birth_date : Adef.date option;
   ci_birth_place : string;
   ci_death : death;
-  ci_death_date : date option;
+  ci_death_date : Adef.date option;
   ci_death_place : string;
   ci_occupation : string;
   ci_public : bool;
@@ -40,7 +40,7 @@ type key = string * string * int * create * string
 val infer_death :
   config -> Geneweb_db.Driver.base -> Geneweb_db.Driver.person -> death
 
-val infer_death_bb : config -> date option -> date option -> death
+val infer_death_bb : config -> Adef.date option -> Adef.date option -> death
 
 val infer_death_from_parents :
   config -> Geneweb_db.Driver.base -> Geneweb_db.Driver.family -> death
@@ -149,14 +149,14 @@ val digest_family :
     The optional [salt] parameter should be set to a secret value generated at
     server startup to strengthen security. *)
 
-val reconstitute_date : config -> string -> date option
+val reconstitute_date : config -> string -> Adef.date option
 
 val print_someone :
   config -> Geneweb_db.Driver.base -> Geneweb_db.Driver.person -> unit
 
 val update_conf : config -> config
-val bad_date : config -> dmy -> 'a
-val check_greg_day : config -> dmy -> unit
+val bad_date : config -> Adef.dmy -> 'a
+val check_greg_day : config -> Adef.dmy -> unit
 
 val check_missing_witnesses_names :
   config ->

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -276,7 +276,7 @@ let reconstitute_from_fevents (nsck : bool) (empty_string : 'string)
   in
   let found_marriage :
       (Def.relation_kind
-      * Def.cdate
+      * Adef.cdate
       * 'string
       * 'string
       * 'string

--- a/lib/updateFamOk.mli
+++ b/lib/updateFamOk.mli
@@ -2,7 +2,7 @@ val reconstitute_from_fevents :
   bool ->
   'string ->
   ('person, 'string) Def.gen_fam_event list ->
-  (Def.relation_kind * Def.cdate * 'string * 'string * 'string)
+  (Def.relation_kind * Adef.cdate * 'string * 'string * 'string)
   * Def.divorce
   * ('person * Def.witness_kind) array
 (** [reconstitute_from_fevents nsck empty_string family_events] Iterate over

--- a/lib/updateIndOk.mli
+++ b/lib/updateIndOk.mli
@@ -98,8 +98,8 @@ val update_relations_of_related :
 
 val reconstitute_death :
   config ->
-  Def.date option ->
-  Def.date option ->
+  Adef.date option ->
+  Adef.date option ->
   string ->
   Def.burial ->
   string ->
@@ -108,12 +108,12 @@ val reconstitute_death :
 val reconstitute_from_pevents :
   ('a, string) Def.gen_pers_event list ->
   bool ->
-  Def.cdate * string * string * string ->
-  Def.cdate * string * string * string ->
+  Adef.cdate * string * string * string ->
+  Adef.cdate * string * string * string ->
   Def.death * string * string * string ->
   Def.burial * string * string * string ->
-  (Def.cdate * string * string * string)
-  * (Def.cdate * string * string * string)
+  (Adef.cdate * string * string * string)
+  * (Adef.cdate * string * string * string)
   * (Def.death * string * string * string)
   * (Def.burial * string * string * string)
   * ('a, string) Def.gen_pers_event list

--- a/lib/update_util.ml
+++ b/lib/update_util.ml
@@ -3,10 +3,10 @@ open Def
 open Util
 
 type create_info = Update.create_info = {
-  ci_birth_date : date option;
+  ci_birth_date : Adef.date option;
   ci_birth_place : string;
   ci_death : death;
-  ci_death_date : date option;
+  ci_death_date : Adef.date option;
   ci_death_place : string;
   ci_occupation : string;
   ci_public : bool;
@@ -147,23 +147,23 @@ let eval_date_field = function
   | None -> None
   | Some d -> (
       match d with
-      | Dgreg (d, Dgregorian) -> Some d
+      | Adef.Dgreg (d, Dgregorian) -> Some d
       | Dgreg (d, Djulian) -> Some (Calendar.julian_of_gregorian d)
       | Dgreg (d, Dfrench) -> Some (Calendar.french_of_gregorian d)
       | Dgreg (d, Dhebrew) -> Some (Calendar.hebrew_of_gregorian d)
       | Dtext _ -> None)
 
 let eval_is_cal cal = function
-  | Some (Dgreg (_, x)) -> if x = cal then "1" else ""
+  | Some (Adef.Dgreg (_, x)) -> if x = cal then "1" else ""
   | Some (Dtext _) | None -> ""
 
 let eval_is_prec cond = function
-  | Some (Dgreg ({ prec = x; _ }, _)) -> if cond x then "1" else ""
+  | Some (Adef.Dgreg ({ prec = x; _ }, _)) -> if cond x then "1" else ""
   | Some (Dtext _) | None -> ""
 
 let add_precision s p =
   match p with
-  | Maybe -> "?" ^ s
+  | Adef.Maybe -> "?" ^ s
   | Before -> "&lt;" ^ s
   | After -> "&gt;" ^ s
   | About -> "/" ^ s ^ "/"
@@ -176,54 +176,54 @@ let eval_date_var od s =
   match s with
   | "calendar" -> (
       match od with
-      | Some (Dgreg (_, Dgregorian)) -> "gregorian"
+      | Some (Adef.Dgreg (_, Dgregorian)) -> "gregorian"
       | Some (Dgreg (_, Djulian)) -> "julian"
       | Some (Dgreg (_, Dfrench)) -> "french"
       | Some (Dgreg (_, Dhebrew)) -> "hebrew"
       | _ -> "")
   | "day" -> (
       match eval_date_field od with
-      | Some d -> if d.day = 0 then "" else string_of_int d.day
+      | Some d -> if d.Adef.day = 0 then "" else string_of_int d.Adef.day
       | None -> "")
   | "month" -> (
       match eval_date_field od with
       | Some d -> (
-          if d.month = 0 then ""
+          if d.Adef.month = 0 then ""
           else
             match od with
-            | Some (Dgreg (_, Dfrench)) -> short_f_month d.month
-            | _ -> string_of_int d.month)
+            | Some (Adef.Dgreg (_, Dfrench)) -> short_f_month d.Adef.month
+            | _ -> string_of_int d.Adef.month)
       | None -> "")
   | "orday" -> (
       match eval_date_field od with
       | Some d -> (
-          match d.prec with
-          | OrYear d2 | YearInt d2 ->
+          match d.Adef.prec with
+          | Adef.OrYear d2 | YearInt d2 ->
               if d2.day2 = 0 then "" else string_of_int d2.day2
           | _ -> "")
       | None -> "")
   | "ormonth" -> (
       match eval_date_field od with
       | Some d -> (
-          match d.prec with
+          match d.Adef.prec with
           | OrYear d2 | YearInt d2 -> (
               if d2.month2 = 0 then ""
               else
                 match od with
-                | Some (Dgreg (_, Dfrench)) -> short_f_month d2.month2
+                | Some (Adef.Dgreg (_, Dfrench)) -> short_f_month d2.month2
                 | _ -> string_of_int d2.month2)
           | _ -> "")
       | None -> "")
   | "oryear" -> (
       match eval_date_field od with
       | Some d -> (
-          match d.prec with
+          match d.Adef.prec with
           | OrYear d2 | YearInt d2 -> string_of_int d2.year2
           | _ -> "")
       | None -> "")
   | "prec" -> (
       match od with
-      | Some (Dgreg ({ prec = Sure; _ }, _)) -> "sure"
+      | Some (Adef.Dgreg ({ prec = Sure; _ }, _)) -> "sure"
       | Some (Dgreg ({ prec = About; _ }, _)) -> "about"
       | Some (Dgreg ({ prec = Maybe; _ }, _)) -> "maybe"
       | Some (Dgreg ({ prec = Before; _ }, _)) -> "before"
@@ -237,21 +237,23 @@ let eval_date_var od s =
       | Some (Dgreg _) | None -> "")
   | "year" -> (
       match eval_date_field od with
-      | Some d -> string_of_int d.year
+      | Some d -> string_of_int d.Adef.year
       | None -> "")
-  | "cal_french" -> eval_is_cal Dfrench od
-  | "cal_gregorian" -> eval_is_cal Dgregorian od
-  | "cal_hebrew" -> eval_is_cal Dhebrew od
-  | "cal_julian" -> eval_is_cal Djulian od
+  | "cal_french" -> eval_is_cal Adef.Dfrench od
+  | "cal_gregorian" -> eval_is_cal Adef.Dgregorian od
+  | "cal_hebrew" -> eval_is_cal Adef.Dhebrew od
+  | "cal_julian" -> eval_is_cal Adef.Djulian od
   | "prec_no" -> if od = None then "1" else ""
-  | "prec_sure" -> eval_is_prec (function Sure -> true | _ -> false) od
-  | "prec_about" -> eval_is_prec (function About -> true | _ -> false) od
-  | "prec_maybe" -> eval_is_prec (function Maybe -> true | _ -> false) od
-  | "prec_before" -> eval_is_prec (function Before -> true | _ -> false) od
-  | "prec_after" -> eval_is_prec (function After -> true | _ -> false) od
-  | "prec_oryear" -> eval_is_prec (function OrYear _ -> true | _ -> false) od
+  | "prec_sure" -> eval_is_prec (function Adef.Sure -> true | _ -> false) od
+  | "prec_about" -> eval_is_prec (function Adef.About -> true | _ -> false) od
+  | "prec_maybe" -> eval_is_prec (function Adef.Maybe -> true | _ -> false) od
+  | "prec_before" ->
+      eval_is_prec (function Adef.Before -> true | _ -> false) od
+  | "prec_after" -> eval_is_prec (function Adef.After -> true | _ -> false) od
+  | "prec_oryear" ->
+      eval_is_prec (function Adef.OrYear _ -> true | _ -> false) od
   | "prec_yearint" ->
-      eval_is_prec (function YearInt _ -> true | _ -> false) od
+      eval_is_prec (function Adef.YearInt _ -> true | _ -> false) od
   | _ -> raise Not_found
 
 (* TODO : looks bad *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -808,7 +808,7 @@ let nobtit conf base p =
   Driver.nobtitles base conf.allowed_titles conf.denied_titles p
 
 let strictly_after_private_years a lim =
-  if a.year > lim then true
+  if a.Adef.year > lim then true
   else if a.year < lim then false
   else a.month > 0 || a.day > 0
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -136,7 +136,7 @@ val nobtit :
     respects constraints imposed by [conf.allowed_titles] and
     [conf.denied_titles] *)
 
-val strictly_after_private_years : dmy -> int -> bool
+val strictly_after_private_years : Adef.dmy -> int -> bool
 
 val authorized_age :
   config -> Geneweb_db.Driver.base -> Geneweb_db.Driver.person -> bool
@@ -447,13 +447,13 @@ val get_approx_birth_date_place :
   config ->
   Geneweb_db.Driver.base ->
   Geneweb_db.Driver.person ->
-  date option * Adef.safe_string
+  Adef.date option * Adef.safe_string
 
 val get_approx_death_date_place :
   config ->
   Geneweb_db.Driver.base ->
   Geneweb_db.Driver.person ->
-  date option * Adef.safe_string
+  Adef.date option * Adef.safe_string
 
 type ('a, 'b) format2 = ('a, unit, string, 'b) format4
 

--- a/lib/util/calendar.ml
+++ b/lib/util/calendar.ml
@@ -7,7 +7,7 @@ let of_sdn : type a. a Calendars.kind -> Calendars.sdn -> a Calendars.date =
   | Calendars.Hebrew -> Calendars.hebrew_of_sdn sdn
   | Calendars.Islamic -> Calendars.islamic_of_sdn sdn
 
-let to_calendar_date kind { Def.day; month; year; delta; _ } =
+let to_calendar_date kind { Adef.day; month; year; delta; _ } =
   let day = max 1 day in
   let month = max 1 month in
   match Calendars.make kind ~day ~month ~year ~delta with
@@ -24,9 +24,10 @@ let to_calendar_date kind { Def.day; month; year; delta; _ } =
         (Printf.sprintf "Invalid date: %s"
            (Calendars.Unsafe.to_string err.value))
 
-let of_calendars : type a. ?prec:Def.precision -> a Calendars.date -> Def.dmy =
- fun ?(prec = Def.Sure) { Calendars.day; month; year; delta; _ } ->
-  { Def.day; month; year; delta; prec }
+let of_calendars : type a. ?prec:Adef.precision -> a Calendars.date -> Adef.dmy
+    =
+ fun ?(prec = Adef.Sure) { Calendars.day; month; year; delta; _ } ->
+  { Adef.day; month; year; delta; prec }
 
 let sdn_of_gregorian d =
   Calendars.to_sdn (to_calendar_date Calendars.Gregorian d)
@@ -41,38 +42,38 @@ let french_of_sdn prec sdn = of_calendars ~prec (Calendars.french_of_sdn sdn)
 let sdn_of_hebrew d = Calendars.to_sdn (to_calendar_date Calendars.Hebrew d)
 let hebrew_of_sdn prec sdn = of_calendars ~prec (Calendars.hebrew_of_sdn sdn)
 
-let dmy_of_dmy2 { Def.day2; month2; year2; delta2 } =
+let dmy_of_dmy2 { Adef.day2; month2; year2; delta2 } =
   {
-    Def.day = day2;
+    Adef.day = day2;
     month = month2;
     year = year2;
-    prec = Def.Sure;
+    prec = Adef.Sure;
     delta = delta2;
   }
 
-let dmy2_of_dmy { Def.day; month; year; delta; _ } =
-  { Def.day2 = day; month2 = month; year2 = year; delta2 = delta }
+let dmy2_of_dmy { Adef.day; month; year; delta; _ } =
+  { Adef.day2 = day; month2 = month; year2 = year; delta2 = delta }
 
 let convert_via_sdn from_sdn to_of_sdn d =
   let convert_dmy2 d2 =
-    if d2.Def.day2 = 0 || d2.Def.month2 = 0 then d2
+    if d2.Adef.day2 = 0 || d2.Adef.month2 = 0 then d2
     else
       let sdn = from_sdn (dmy_of_dmy2 d2) in
       let c = of_calendars (to_of_sdn sdn) in
       {
-        Def.day2 = c.Def.day;
-        month2 = c.Def.month;
-        year2 = c.Def.year;
-        delta2 = c.Def.delta;
+        Adef.day2 = c.Adef.day;
+        month2 = c.month;
+        year2 = c.year;
+        delta2 = c.delta;
       }
   in
   let prec =
-    match d.Def.prec with
-    | Def.OrYear d2 -> Def.OrYear (convert_dmy2 d2)
-    | Def.YearInt d2 -> Def.YearInt (convert_dmy2 d2)
+    match d.Adef.prec with
+    | Adef.OrYear d2 -> Adef.OrYear (convert_dmy2 d2)
+    | YearInt d2 -> YearInt (convert_dmy2 d2)
     | prec -> prec
   in
-  if d.Def.day = 0 || d.Def.month = 0 then { d with Def.prec }
+  if d.Adef.day = 0 || d.month = 0 then { d with Adef.prec }
   else
     let sdn = from_sdn d in
     of_calendars ~prec (to_of_sdn sdn)

--- a/lib/util/calendar.mli
+++ b/lib/util/calendar.mli
@@ -24,62 +24,62 @@
     Partial dates (day=0 or month=0) bypass SDN conversion entirely in
     convert_via_sdn, as SDN cannot encode unknown components. *)
 (* Calendar conversions using Calendars library (>= 2.0.0)
-   
+
    This module wraps the external Calendars library to provide
-   conversions between Geneweb's Def.dmy type and Serial Day Numbers (SDN).
-   
+   conversions between Geneweb's Adef.dmy type and Serial Day Numbers (SDN).
+
    SDN (Serial Day Number) is a day numbering system where:
    - SDN 1 = November 25, 4714 BC (Gregorian proleptic)
    - Enables calendar-neutral date arithmetic
    - Used for inter-calendar conversions
 *)
 
-val gregorian_of_sdn : Def.precision -> int -> Def.dmy
+val gregorian_of_sdn : Adef.precision -> int -> Adef.dmy
 (** Returns date of gregorian calendar from SDN and specified precision. *)
 
-val julian_of_sdn : Def.precision -> int -> Def.dmy
+val julian_of_sdn : Adef.precision -> int -> Adef.dmy
 (** Returns date of julian calendar from SDN and specified precision. *)
 
-val french_of_sdn : Def.precision -> int -> Def.dmy
+val french_of_sdn : Adef.precision -> int -> Adef.dmy
 (** Returns date of french calendar from SDN and specified precision. *)
 
-val hebrew_of_sdn : Def.precision -> int -> Def.dmy
+val hebrew_of_sdn : Adef.precision -> int -> Adef.dmy
 (** Returns date of hebrew calendar from SDN and specified precision. *)
 
-val sdn_of_gregorian : Def.dmy -> int
+val sdn_of_gregorian : Adef.dmy -> int
 (** Returns SDN of the date of gregorian calendar. *)
 
-val sdn_of_julian : Def.dmy -> int
+val sdn_of_julian : Adef.dmy -> int
 (** Returns SDN of the date of julian calendar. *)
 
-val sdn_of_french : Def.dmy -> int
+val sdn_of_french : Adef.dmy -> int
 (** Returns SDN of the date of french calendar. *)
 
-val sdn_of_hebrew : Def.dmy -> int
+val sdn_of_hebrew : Adef.dmy -> int
 (** Returns SDN of the date of hebrew calendar. *)
 
-val dmy_of_dmy2 : Def.dmy2 -> Def.dmy
+val dmy_of_dmy2 : Adef.dmy2 -> Adef.dmy
 (** Convert [dmy2] to [dmy] with precision [Sure]. *)
 
-val dmy2_of_dmy : Def.dmy -> Def.dmy2
+val dmy2_of_dmy : Adef.dmy -> Adef.dmy2
 (** Extract [dmy2] fields from [dmy], discarding precision. *)
 
-val gregorian_of_julian : Def.dmy -> Def.dmy
+val gregorian_of_julian : Adef.dmy -> Adef.dmy
 (** Converts julian calendar's date to gregorian. *)
 
-val julian_of_gregorian : Def.dmy -> Def.dmy
+val julian_of_gregorian : Adef.dmy -> Adef.dmy
 (** Converts gregorian calendar's date to julian date. *)
 
-val gregorian_of_french : Def.dmy -> Def.dmy
+val gregorian_of_french : Adef.dmy -> Adef.dmy
 (** Converts french calendar's date to gregorian date. *)
 
-val french_of_gregorian : Def.dmy -> Def.dmy
+val french_of_gregorian : Adef.dmy -> Adef.dmy
 (** Converts gregorian calendar's date to french date. *)
 
-val gregorian_of_hebrew : Def.dmy -> Def.dmy
+val gregorian_of_hebrew : Adef.dmy -> Adef.dmy
 (** Converts hebrew calendar's date to gregorian date. *)
 
-val hebrew_of_gregorian : Def.dmy -> Def.dmy
+val hebrew_of_gregorian : Adef.dmy -> Adef.dmy
 (** Converts gregorian calendar's date to hebrew date. *)
 
 (** Moon phases *)

--- a/lib/util/date.ml
+++ b/lib/util/date.ml
@@ -8,7 +8,7 @@ type cdate = Adef.cdate =
   | Cfrench of int
   | Chebrew of int
   | Ctext of string
-  | Cdate of date
+  | Cdate of Adef.date
   | Cnone
 
 (* Compress concrete date into integer if simple precision.
@@ -21,7 +21,7 @@ type cdate = Adef.cdate =
      mod 13 so max storable is 12 *)
 let compress d =
   let simple =
-    match d.prec with
+    match d.Adef.prec with
     | Sure | About | Maybe | Before | After ->
         d.day >= 0 && d.month >= 0 && d.year > 0 && d.year < 2500 && d.delta = 0
     | OrYear _ | YearInt _ -> false
@@ -45,16 +45,16 @@ let uncompress x =
   let day, x = (x mod 32, x / 32) in
   let prec =
     match x with
-    | 1 -> About
+    | 1 -> Adef.About
     | 2 -> Maybe
     | 3 -> Before
     | 4 -> After
     | _ -> Sure
   in
-  { day; month; year; prec; delta = 0 }
+  { Adef.day; month; year; prec; delta = 0 }
 
 let date_of_cdate = function
-  | Cgregorian i -> Dgreg (uncompress i, Dgregorian)
+  | Cgregorian i -> Adef.Dgreg (uncompress i, Dgregorian)
   | Cjulian i -> Dgreg (uncompress i, Djulian)
   | Cfrench i -> Dgreg (uncompress i, Dfrench)
   | Chebrew i -> Dgreg (uncompress i, Dhebrew)
@@ -63,7 +63,7 @@ let date_of_cdate = function
   | Cnone -> failwith "date_of_cdate"
 
 let cdate_of_date = function
-  | Dtext t -> Ctext t
+  | Adef.Dtext t -> Ctext t
   | Dgreg (g, cal) as d -> (
       match compress g with
       | None -> Cdate d
@@ -80,7 +80,7 @@ let cdate_None = cdate_of_od None
 
 let dmy_of_dmy2 dmy2 =
   {
-    day = dmy2.day2;
+    Adef.day = dmy2.Adef.day2;
     month = dmy2.month2;
     year = dmy2.year2;
     prec = Sure;
@@ -100,8 +100,8 @@ let nb_days_in_month m a =
    works only for Gregorian calendar and partial dates. *)
 let time_elapsed d1 d2 =
   let prec =
-    match (d1.prec, d2.prec) with
-    | Sure, Sure -> Sure
+    match (d1.Adef.prec, d2.Adef.prec) with
+    | Adef.Sure, Sure -> Adef.Sure
     | (Maybe | Sure | About), (Maybe | Sure | About) -> Maybe
     | (About | Maybe | Sure | Before), (After | Sure | Maybe | About) -> After
     | (About | Maybe | Sure | After), (Before | Sure | Maybe | About) -> Before
@@ -115,7 +115,7 @@ let time_elapsed d1 d2 =
   in
   match (d1, d2) with
   | { day = 0; month = 0; year = a1; _ }, { year = a2; _ } ->
-      { day = 0; month = 0; year = a2 - a1; prec; delta = 0 }
+      { Adef.day = 0; month = 0; year = a2 - a1; prec; delta = 0 }
   | { day = 0; month = _; year = a1; _ }, { day = 0; month = 0; year = a2; _ }
     ->
       { day = 0; month = 0; year = a2 - a1; prec; delta = 0 }
@@ -140,7 +140,7 @@ let time_elapsed d1 d2 =
       { day; month; year = a2 - a1 - r2; prec; delta = 0 }
 
 let time_elapsed_opt d1 d2 =
-  match (d1.prec, d2.prec) with
+  match (d1.Adef.prec, d2.Adef.prec) with
   | After, After | Before, Before -> None
   | _ -> Some (time_elapsed d1 d2)
 
@@ -148,15 +148,15 @@ let time_elapsed_opt d1 d2 =
 (* use strict = false to compare date as if they are points on a timeline.
    use strict = true to compare date by taking precision in account. This makes some dates not comparable, do not use to sort a list *)
 let rec compare_dmy_opt ?(strict = false) dmy1 dmy2 =
-  match compare dmy1.year dmy2.year with
+  match compare dmy1.Adef.year dmy2.Adef.year with
   | 0 -> compare_month_or_day ~is_day:false strict dmy1 dmy2
   | x -> eval_strict strict dmy1 dmy2 x
 
 and compare_month_or_day ~is_day strict dmy1 dmy2 =
   (* compare a known month|day with a unknown one (0) *)
   let compare_with_unknown_value ~strict ~unknown ~known =
-    match unknown.prec with
-    | After -> Some 1
+    match unknown.Adef.prec with
+    | Adef.After -> Some 1
     | Before -> Some (-1)
     | _other -> if strict then None else compare_prec false unknown known
   in
@@ -206,21 +206,21 @@ let compare_dmy_strict dmy1 dmy2 = compare_dmy_opt ~strict:true dmy1 dmy2
 
 let compare_date d1 d2 =
   match (d1, d2) with
-  | Dgreg (dmy1, _), Dgreg (dmy2, _) -> compare_dmy dmy1 dmy2
+  | Adef.Dgreg (dmy1, _), Adef.Dgreg (dmy2, _) -> compare_dmy dmy1 dmy2
   | Dgreg (_, _), Dtext _ -> 1
   | Dtext _, Dgreg (_, _) -> -1
   | Dtext _, Dtext _ -> 0
 
 let compare_date_strict d1 d2 =
   match (d1, d2) with
-  | Dgreg (dmy1, _), Dgreg (dmy2, _) -> compare_dmy_strict dmy1 dmy2
+  | Adef.Dgreg (dmy1, _), Adef.Dgreg (dmy2, _) -> compare_dmy_strict dmy1 dmy2
   | Dgreg (_, _), Dtext _ | Dtext _, Dgreg (_, _) | Dtext _, Dtext _ -> None
 
 let cdate_to_dmy_opt cdate =
   match od_of_cdate cdate with Some (Dgreg (d, _)) -> Some d | _ -> None
 
 let max_month_of = function
-  | Dgregorian | Djulian -> 12
+  | Adef.Dgregorian | Djulian -> 12
   | Dfrench | Dhebrew -> 13
 
 let partial_date_upper_bound ~from ~day ~month ~year =
@@ -232,7 +232,7 @@ let partial_date_upper_bound ~from ~day ~month ~year =
   | day, month -> (day, month, year)
 
 let to_sdn ~from ?(lower = true) d =
-  let { day; month; year; delta; _ } = d in
+  let { Adef.day; month; year; delta; _ } = d in
   let day, month, year =
     if lower then (max 1 day, max 1 month, year)
     else partial_date_upper_bound ~from ~day ~month ~year
@@ -253,8 +253,8 @@ let french_of_sdn ~prec sdn = Calendar.french_of_sdn prec sdn
 let hebrew_of_sdn ~prec sdn = Calendar.hebrew_of_sdn prec sdn
 
 let approx_gregorian ~from d =
-  if from = Dgregorian then d
-  else if d.day > 0 && d.month > 0 then d
+  if from = Adef.Dgregorian then d
+  else if d.Adef.day > 0 && d.month > 0 then d
   else
     let sdn_lo = to_sdn ~from ~lower:true d in
     let sdn_hi = to_sdn ~from ~lower:false d - 1 in
@@ -277,13 +277,13 @@ let convert ~from ~to_ dmy =
     let via_gregorian d =
       let g =
         match from with
-        | Dgregorian -> d
+        | Adef.Dgregorian -> d
         | Djulian -> Calendar.gregorian_of_julian d
         | Dfrench -> Calendar.gregorian_of_french d
         | Dhebrew -> Calendar.gregorian_of_hebrew d
       in
       match to_ with
-      | Dgregorian -> g
+      | Adef.Dgregorian -> g
       | Djulian -> Calendar.julian_of_gregorian g
       | Dfrench -> Calendar.french_of_gregorian g
       | Dhebrew -> Calendar.hebrew_of_gregorian g
@@ -292,35 +292,41 @@ let convert ~from ~to_ dmy =
       Calendar.dmy2_of_dmy (via_gregorian (Calendar.dmy_of_dmy2 d2))
     in
     let prec =
-      match dmy.prec with
-      | OrYear d2 -> OrYear (convert_dmy2 d2)
+      match dmy.Adef.prec with
+      | Adef.OrYear d2 -> Adef.OrYear (convert_dmy2 d2)
       | YearInt d2 -> YearInt (convert_dmy2 d2)
       | p -> p
     in
     { (via_gregorian dmy) with prec }
 
 let days_between ~from d1 d2 =
-  if d1.day = 0 || d1.month = 0 || d2.day = 0 || d2.month = 0 then None
+  if d1.Adef.day = 0 || d1.month = 0 || d2.Adef.day = 0 || d2.month = 0 then
+    None
   else
     let sdn1 = to_sdn ~from d1 in
     let sdn2 = to_sdn ~from d2 in
     if sdn2 >= sdn1 then Some (sdn2 - sdn1) else None
 
 let time_elapsed_cal ~from d1 d2 =
-  if from = Dgregorian then time_elapsed d1 d2
+  if from = Adef.Dgregorian then time_elapsed d1 d2
   else
     let d1 = convert ~from ~to_:Dgregorian d1 in
     let d2 = convert ~from ~to_:Dgregorian d2 in
     time_elapsed d1 d2
 
-type age = { nb_year : int; nb_month : int; nb_day : int; prec : precision }
+type age = {
+  nb_year : int;
+  nb_month : int;
+  nb_day : int;
+  prec : Adef.precision;
+}
 
 let age_of_dmy d =
-  { nb_year = d.year; nb_month = d.month; nb_day = d.day; prec = d.prec }
+  { nb_year = d.Adef.year; nb_month = d.month; nb_day = d.day; prec = d.prec }
 
 let age_between ~from d1 d2 =
   let valid =
-    if d1.day > 0 && d1.month > 0 && d2.day > 0 && d2.month > 0 then
+    if d1.Adef.day > 0 && d1.month > 0 && d2.Adef.day > 0 && d2.month > 0 then
       let sdn1 = to_sdn ~from d1 in
       let sdn2 = to_sdn ~from d2 in
       sdn2 >= sdn1

--- a/lib/util/date.mli
+++ b/lib/util/date.mli
@@ -1,7 +1,5 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-open Def
-
 val leap_year : int -> bool
 (** Says if the given year is a leap year. *)
 
@@ -12,7 +10,7 @@ val nb_days_in_month : int -> int -> int
     (Hebrew embolismic, French complementary) are not supported by this
     function. *)
 
-val time_elapsed : Def.dmy -> Def.dmy -> Def.dmy
+val time_elapsed : Adef.dmy -> Adef.dmy -> Adef.dmy
 (** [time_elapsed start stop] Compute the time elapsed between [start] and
     [stop]. If [stop] is prior to [start], resulting [dmy]'s field are negative
     (but correct). Resulting [prec] can be:
@@ -29,7 +27,7 @@ val time_elapsed : Def.dmy -> Def.dmy -> Def.dmy
     Note: The result is a [dmy] structure used to represent duration, not an
     actual date. *)
 
-val time_elapsed_opt : Def.dmy -> Def.dmy -> Def.dmy option
+val time_elapsed_opt : Adef.dmy -> Adef.dmy -> Adef.dmy option
 (** Same as [time_elapsed], but will return [None] if computation is not
     possible (e.g. time_elapsed_opt /1839 /1859). *)
 
@@ -39,10 +37,10 @@ val dmy_of_death : Def.death -> Adef.dmy option
 val date_of_death : Def.death -> Adef.date option
 (** Returns date of death if present. *)
 
-val dmy_of_dmy2 : dmy2 -> dmy
+val dmy_of_dmy2 : Adef.dmy2 -> Adef.dmy
 (** [dmy_of_dmy2 dmy2] Convert a [dmy2] to [dmy] using [Sure] as precision. *)
 
-val compare_dmy : dmy -> dmy -> int
+val compare_dmy : Adef.dmy -> Adef.dmy -> int
 (** [compare_dmy d1 d2] Compare two dates as points on a timeline. Return a
     negative integer if [d1] is prior to [d2], [0] if [d1] is equal to [d2], and
     a positive integer if [d2] is prior to [d1]. Date precision is handled
@@ -50,7 +48,7 @@ val compare_dmy : dmy -> dmy -> int
     comparable with precise dates. This function always returns a result and can
     be used for sorting. *)
 
-val compare_dmy_strict : dmy -> dmy -> int option
+val compare_dmy_strict : Adef.dmy -> Adef.dmy -> int option
 (** [compare_dmy_strict d1 d2] Compare two dates with strict precision handling.
     Return [None] if dates cannot be reliably compared due to incompatible
     precision (e.g. comparing [2019] with [07/2019], or [Before 1850] with
@@ -58,82 +56,87 @@ val compare_dmy_strict : dmy -> dmy -> int option
     comparison is meaningful. Do not use for sorting lists as it may return
     [None]. *)
 
-val compare_date : date -> date -> int
+val compare_date : Adef.date -> Adef.date -> int
 (** [compare_date d1 d2] Compare two dates using [compare_dmy] if both are
     [Dgreg] dates. [Dtext] dates are always considered prior to any [Dgreg]
     date, and equal to any other [Dtext] date. Always returns a result and can
     be used for sorting. *)
 
-val compare_date_strict : date -> date -> int option
+val compare_date_strict : Adef.date -> Adef.date -> int option
 (** [compare_date_strict d1 d2] Strict comparison of dates. Return [None] if
     dates are not reliably comparable (different types, or incompatible
     precision for [Dgreg] dates). Return [Some x] with same semantics as
     [compare_date] otherwise. Do not use for sorting lists. *)
 
-val cdate_None : cdate
+val cdate_None : Adef.cdate
 (** Absent compressed date *)
 
-val date_of_cdate : cdate -> date
+val date_of_cdate : Adef.cdate -> Adef.date
 (** Convert [cdate] to [date]; fail if [cdate] is [Cnone] *)
 
-val od_of_cdate : cdate -> date option
+val od_of_cdate : Adef.cdate -> Adef.date option
 (** Optional date from [cdate] *)
 
-val cdate_to_dmy_opt : cdate -> dmy option
+val cdate_to_dmy_opt : Adef.cdate -> Adef.dmy option
 (** [cdate_to_dmy_opt d] is [Some dmy] iff [d] resolve to [Dgreg (dmy,_)] *)
 
-val cdate_of_date : date -> cdate
+val cdate_of_date : Adef.date -> Adef.cdate
 (** Convert [date] to [cdate] *)
 
-val cdate_of_od : date option -> cdate
+val cdate_of_od : Adef.date option -> Adef.cdate
 (** Optional date to [cdate] *)
 
 (* TODO date_to_dmy? *)
 
-val to_sdn : from:calendar -> ?lower:bool -> dmy -> int
+val to_sdn : from:Adef.calendar -> ?lower:bool -> Adef.dmy -> int
 (** Convert [dmy] in calendar [from] to SDN (Serial Day Number). For partial
     dates (day=0 or month=0), returns lower bound by default. Set [lower:false]
     for upper bound. Includes [delta] in result. *)
 
-val convert : from:calendar -> to_:calendar -> dmy -> dmy
+val convert : from:Adef.calendar -> to_:Adef.calendar -> Adef.dmy -> Adef.dmy
 (** Convert [dmy] between calendars via Gregorian pivot. Partial dates pass
     through unchanged (no valid SDN representation). Preserves [prec] including
     OrYear/YearInt variants. *)
 
-val gregorian_of_sdn : prec:precision -> int -> dmy
+val gregorian_of_sdn : prec:Adef.precision -> int -> Adef.dmy
 (** Convert SDN to Gregorian [dmy] with given precision. *)
 
-val julian_of_sdn : prec:precision -> int -> dmy
+val julian_of_sdn : prec:Adef.precision -> int -> Adef.dmy
 (** Convert SDN to Julian [dmy] with given precision. *)
 
-val french_of_sdn : prec:precision -> int -> dmy
+val french_of_sdn : prec:Adef.precision -> int -> Adef.dmy
 (** Convert SDN to French Republican [dmy] with given precision. *)
 
-val hebrew_of_sdn : prec:precision -> int -> dmy
+val hebrew_of_sdn : prec:Adef.precision -> int -> Adef.dmy
 (** Convert SDN to Hebrew [dmy] with given precision. *)
 
-val approx_gregorian : from:calendar -> dmy -> dmy
+val approx_gregorian : from:Adef.calendar -> Adef.dmy -> Adef.dmy
 (** [approx_gregorian ~from d] ensures [d] contains meaningful Gregorian values.
     For complete non-Gregorian dates, returns [d] unchanged (already converted
     at import). For partial non-Gregorian dates (day=0 or month=0), converts via
     SDN midpoint of the period preserving partial fields. *)
 
-val cdate_to_gregorian_dmy_opt : cdate -> dmy option
+val cdate_to_gregorian_dmy_opt : Adef.cdate -> Adef.dmy option
 (** Like [cdate_to_dmy_opt] but ensures the returned [dmy] contains Gregorian
     values even for partial non-Gregorian dates. *)
 
-val days_between : from:calendar -> dmy -> dmy -> int option
+val days_between : from:Adef.calendar -> Adef.dmy -> Adef.dmy -> int option
 (** Total days between two complete dates. Returns [None] if either date is
     partial (day=0 or month=0) or if d2 < d1. *)
 
-val time_elapsed_cal : from:calendar -> dmy -> dmy -> dmy
+val time_elapsed_cal : from:Adef.calendar -> Adef.dmy -> Adef.dmy -> Adef.dmy
 (** Like [time_elapsed] but converts dates to Gregorian first if needed. Allows
     computing intervals between dates in any calendar. *)
 
-type age = { nb_year : int; nb_month : int; nb_day : int; prec : precision }
+type age = {
+  nb_year : int;
+  nb_month : int;
+  nb_day : int;
+  prec : Adef.precision;
+}
 (** Age/interval result with named fields. *)
 
-val age_between : from:calendar -> dmy -> dmy -> age option
+val age_between : from:Adef.calendar -> Adef.dmy -> Adef.dmy -> age option
 (** Compute age between two dates. Returns [None] if d2 < d1. Uses SDN for
     validation on complete dates. *)
 
@@ -142,7 +145,8 @@ type relative_pos =
   | After of age
   | Same  (** Position of target relative to reference date. *)
 
-val relative_age : from:calendar -> ref:dmy -> dmy -> relative_pos option
+val relative_age :
+  from:Adef.calendar -> ref:Adef.dmy -> Adef.dmy -> relative_pos option
 (** Position and distance of date relative to reference. [Before age] means date
     is [age] before ref. [After age] means date is [age] after ref. Returns
     [None] if comparison impossible (incompatible partial dates). *)

--- a/lib/util/futil.mli
+++ b/lib/util/futil.mli
@@ -3,13 +3,13 @@
 open Def
 
 val map_title_strings :
-  ?fd:(Def.date -> Def.date) -> ('a -> 'b) -> 'a gen_title -> 'b gen_title
+  ?fd:(Adef.date -> Adef.date) -> ('a -> 'b) -> 'a gen_title -> 'b gen_title
 (** Convert generic type used to represent name, id and the place of
     [Def.gen_title] into another one. If [fd] is present, apply it on the date
     of the start and date of the end of a title *)
 
 val map_pers_event :
-  ?fd:(Def.date -> Def.date) ->
+  ?fd:(Adef.date -> Adef.date) ->
   ('a -> 'c) ->
   ('b -> 'd) ->
   ('a, 'b) gen_pers_event ->
@@ -23,7 +23,7 @@ val map_pers_event :
       date of the personal event. *)
 
 val map_fam_event :
-  ?fd:(Def.date -> Def.date) ->
+  ?fd:(Adef.date -> Adef.date) ->
   ('a -> 'c) ->
   ('b -> 'd) ->
   ('a, 'b) gen_fam_event ->
@@ -46,7 +46,7 @@ val map_relation_ps :
       one. *)
 
 val map_person_ps :
-  ?fd:(Def.date -> Def.date) ->
+  ?fd:(Adef.date -> Adef.date) ->
   ('b -> 'd) ->
   ('c -> 'e) ->
   ('a, 'b, 'c) gen_person ->
@@ -69,7 +69,7 @@ val map_union_f : ('a -> 'b) -> 'a gen_union -> 'b gen_union
     [Def.gen_union] into another one. *)
 
 val map_family_ps :
-  ?fd:(Def.date -> Def.date) ->
+  ?fd:(Adef.date -> Adef.date) ->
   ('a -> 'b) ->
   ('c -> 'd) ->
   ('e -> 'f) ->

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -1,7 +1,6 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
 open Config
-open Def
 open Util
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
@@ -129,15 +128,15 @@ let print_wizards_by_date conf list =
         fun tm ->
           let dmy =
             {
-              year = tm.Unix.tm_year + 1900;
+              Adef.year = tm.Unix.tm_year + 1900;
               month = tm.Unix.tm_mon + 1;
               day = 0;
               prec = Sure;
               delta = 0;
             }
           in
-          Dgreg (dmy, Dgregorian)
-          |> (DateDisplay.string_of_ondate conf :> Def.date -> string)
+          Adef.Dgreg (dmy, Dgregorian)
+          |> (DateDisplay.string_of_ondate conf :> Adef.date -> string)
           |> Utf8.capitalize_fst |> Output.print_sstring conf );
       ( (fun tm -> tm.Unix.tm_year),
         fun tm ->
@@ -387,7 +386,7 @@ let print_whole_wiznote conf base auth_file wz wfile (s, date) ho =
     let tm = Unix.localtime date in
     let dmy =
       {
-        day = tm.Unix.tm_mday;
+        Adef.day = tm.Unix.tm_mday;
         month = tm.Unix.tm_mon + 1;
         year = 1900 + tm.Unix.tm_year;
         prec = Sure;

--- a/plugins/forum/forum.ml
+++ b/plugins/forum/forum.ml
@@ -2,12 +2,11 @@
 
 open Geneweb
 open Config
-open Def
 open Util
 
 type message = {
   m_time : string;
-  m_date : date;
+  m_date : Adef.date;
   m_hour : string;
   m_waiting : bool;
   m_from : string;
@@ -265,8 +264,9 @@ let read_message conf ic =
         let y = int_of_string (String.sub date 0 4) in
         let m = int_of_string (String.sub date 5 2) in
         let d = int_of_string (String.sub date 8 2) in
-        Dgreg
-          ({ year = y; month = m; day = d; prec = Sure; delta = 0 }, Dgregorian)
+        Adef.Dgreg
+          ( { Adef.year = y; month = m; day = d; prec = Sure; delta = 0 },
+            Dgregorian )
       with Failure _ | Invalid_argument _ -> Dtext date
     in
     let moderator, s = get_var ic "Moderator:" s in

--- a/plugins/forum/forumDisplay.ml
+++ b/plugins/forum/forumDisplay.ml
@@ -2,7 +2,6 @@
 
 open Geneweb
 open Config
-open Def
 open Util
 open Forum
 module Gutil = Geneweb_db.Gutil

--- a/plugins/gwxjg/gwxjg_data.ml
+++ b/plugins/gwxjg/gwxjg_data.ml
@@ -170,7 +170,7 @@ and dtext_eq =
     (Jg_runtime.jg_obj_lookup d1 "__str__"
     = Jg_runtime.jg_obj_lookup d2 "__str__")
 
-and mk_dmy { Def.day; month; year; delta; prec } =
+and mk_dmy { Adef.day; month; year; delta; prec } =
   let day = Tint day in
   let month = Tint month in
   let year = Tint year in
@@ -186,7 +186,7 @@ and mk_dmy { Def.day; month; year; delta; prec } =
     | _ -> raise Not_found)
 
 and mk_date = function
-  | Def.Dtext s ->
+  | Adef.Dtext s ->
       Tpat
         (function
         | "__str__" -> Tstr s
@@ -195,19 +195,19 @@ and mk_date = function
         | "__Dtext__" -> Tbool true
         | _ -> raise Not_found)
   | Dgreg (d, c) ->
-      let year = Tint d.Def.year in
-      let month = Tint d.Def.month in
-      let day = Tint d.Def.day in
-      let prec = to_prec d.Def.prec in
+      let year = Tint d.Adef.year in
+      let month = Tint d.month in
+      let day = Tint d.day in
+      let prec = to_prec d.prec in
       let d2 =
-        match d.Def.prec with
+        match d.prec with
         | OrYear d2 | YearInt d2 ->
             mk_dmy
               {
-                Def.day = d2.Def.day2;
-                month = d2.Def.month2;
-                year = d2.Def.year2;
-                prec = Def.Sure;
+                Adef.day = d2.Adef.day2;
+                month = d2.month2;
+                year = d2.year2;
+                prec = Adef.Sure;
                 delta = 0;
               }
         | _ -> Tnull
@@ -234,7 +234,7 @@ and mk_date = function
 and to_dmy d =
   let int s = match Jg_runtime.jg_obj_lookup d s with Tint i -> i | _ -> 0 in
   {
-    Def.day = int "day";
+    Adef.day = int "day";
     month = int "month";
     year = int "year";
     prec = of_prec d;
@@ -243,10 +243,15 @@ and to_dmy d =
 
 and to_dmy2 d =
   let int s = match Jg_runtime.jg_obj_lookup d s with Tint i -> i | _ -> 0 in
-  { Def.day2 = int "day"; month2 = int "month"; year2 = int "year"; delta2 = 0 }
+  {
+    Adef.day2 = int "day";
+    month2 = int "month";
+    year2 = int "year";
+    delta2 = 0;
+  }
 
 and to_prec = function
-  | Def.Sure -> Tsafe "sure"
+  | Adef.Sure -> Tsafe "sure"
   | About -> Tsafe "about"
   | Maybe -> Tsafe "maybe"
   | Before -> Tsafe "before"
@@ -256,7 +261,7 @@ and to_prec = function
 
 and of_prec d =
   match Jg_runtime.jg_obj_lookup d "prec" with
-  | Tsafe "sure" -> Def.Sure
+  | Tsafe "sure" -> Adef.Sure
   | Tsafe "about" -> About
   | Tsafe "maybe" -> Maybe
   | Tsafe "before" -> Before
@@ -276,10 +281,10 @@ and to_gregorian_aux calendar d =
 
 and of_calendar d =
   match Jg_runtime.jg_obj_lookup d "calendar" with
-  | Tsafe "Dgregorian" -> Def.Dgregorian
-  | Tsafe "Djulian" -> Def.Djulian
-  | Tsafe "Dfrench" -> Def.Dfrench
-  | Tsafe "Dhebrew" -> Def.Dhebrew
+  | Tsafe "Dgregorian" -> Adef.Dgregorian
+  | Tsafe "Djulian" -> Djulian
+  | Tsafe "Dfrench" -> Dfrench
+  | Tsafe "Dhebrew" -> Dhebrew
   | _ -> assert false
 
 and module_DATE conf =
@@ -301,7 +306,7 @@ and module_DATE conf =
   let death_symbol = Tsafe (DateDisplay.death_symbol conf) in
   let string_of_date_aux fn =
     func_arg1_no_kw @@ fun d ->
-    try safe (Def.Dgreg (to_dmy d, of_calendar d) |> fn conf)
+    try safe (Adef.Dgreg (to_dmy d, of_calendar d) |> fn conf)
     with e ->
       if Jg_runtime.jg_obj_lookup d "__Dtext__" = Tbool true then
         Jg_runtime.jg_obj_lookup d "__str__"

--- a/test/calendar_test.ml
+++ b/test/calendar_test.ml
@@ -20,57 +20,54 @@
    - 200k-day stress roundtrip (greg, jul, french, hebrew) *)
 
 let pp_dmy fmt d =
-  Format.fprintf fmt "{day=%d;month=%d;year=%d;delta=%d;prec=...}" d.Def.day
-    d.Def.month d.Def.year d.Def.delta
+  Format.fprintf fmt "{day=%d;month=%d;year=%d;delta=%d;prec=...}" d.Adef.day
+    d.month d.year d.delta
 
 let testable_dmy = Alcotest.testable pp_dmy ( = )
 
 let data_complete =
   [
-    Def.{ day = 1; month = 1; year = 1900; delta = 0; prec = Sure };
-    Def.{ day = 15; month = 6; year = 2000; delta = 0; prec = Sure };
-    Def.{ day = 29; month = 2; year = 2000; delta = 0; prec = Sure };
+    { Adef.day = 1; month = 1; year = 1900; delta = 0; prec = Sure };
+    { day = 15; month = 6; year = 2000; delta = 0; prec = Sure };
+    { day = 29; month = 2; year = 2000; delta = 0; prec = Sure };
   ]
 
 let data_partial =
   [
-    Def.{ day = 0; month = 1; year = 1900; delta = 0; prec = Sure };
-    Def.{ day = 0; month = 0; year = 1900; delta = 0; prec = Sure };
+    { Adef.day = 0; month = 1; year = 1900; delta = 0; prec = Sure };
+    { day = 0; month = 0; year = 1900; delta = 0; prec = Sure };
   ]
 
 let data_oryear =
   [
-    Def.
-      {
-        day = 1;
-        month = 1;
-        year = 1900;
-        delta = 0;
-        prec = OrYear { day2 = 1; month2 = 1; year2 = 1901; delta2 = 0 };
-      };
-    Def.
-      {
-        day = 0;
-        month = 1;
-        year = 1900;
-        delta = 0;
-        prec = OrYear { day2 = 0; month2 = 1; year2 = 1901; delta2 = 0 };
-      };
-    Def.
-      {
-        day = 0;
-        month = 0;
-        year = 1900;
-        delta = 0;
-        prec = OrYear { day2 = 0; month2 = 0; year2 = 1901; delta2 = 0 };
-      };
+    {
+      Adef.day = 1;
+      month = 1;
+      year = 1900;
+      delta = 0;
+      prec = OrYear { day2 = 1; month2 = 1; year2 = 1901; delta2 = 0 };
+    };
+    {
+      Adef.day = 0;
+      month = 1;
+      year = 1900;
+      delta = 0;
+      prec = OrYear { day2 = 0; month2 = 1; year2 = 1901; delta2 = 0 };
+    };
+    {
+      Adef.day = 0;
+      month = 0;
+      year = 1900;
+      delta = 0;
+      prec = OrYear { day2 = 0; month2 = 0; year2 = 1901; delta2 = 0 };
+    };
   ]
 
 open Alcotest
 open Calendar
 
 let mk ?(delta = 0) day month year =
-  Def.{ day; month; year; delta; prec = Sure }
+  { Adef.day; month; year; delta; prec = Sure }
 
 (* -- Year zero rejection -- *)
 
@@ -139,7 +136,7 @@ let bc_gregorian () =
 let year1_to_bc_julian () =
   let sdn = sdn_of_julian (mk 1 1 1) in
   let prev = julian_of_sdn Sure (sdn - 1) in
-  (check int) "year before AD 1 is -1" (-1) prev.Def.year
+  (check int) "year before AD 1 is -1" (-1) prev.Adef.year
 
 (* -- Julian/Gregorian transition -- *)
 
@@ -162,12 +159,12 @@ let french_epoch () =
 let french_non_sextile () =
   let compl5 = mk 5 13 2 in
   let sdn5 = sdn_of_french compl5 in
-  let next = gregorian_of_sdn Def.Sure (sdn5 + 1) in
-  let vend1_an3 = gregorian_of_sdn Def.Sure (sdn_of_french (mk 1 1 3)) in
+  let next = gregorian_of_sdn Sure (sdn5 + 1) in
+  let vend1_an3 = gregorian_of_sdn Sure (sdn_of_french (mk 1 1 3)) in
   (check testable_dmy) "jour after 5 compl II = 1 vend III" vend1_an3 next
 
 let french_last_historical () =
-  let greg = gregorian_of_sdn Def.Sure (sdn_of_french (mk 11 4 14)) in
+  let greg = gregorian_of_sdn Sure (sdn_of_french (mk 11 4 14)) in
   (check testable_dmy) "11 nivose XIV = 1 jan 1806" (mk 1 1 1806) greg
 
 let french_sextile_an3 () =
@@ -225,12 +222,12 @@ let hebrew_19_cycle () =
 
 let partial_day_zero () =
   let conv = Calendar.gregorian_of_julian (mk 0 6 2000) in
-  (check int) "day preserved" 0 conv.Def.day
+  (check int) "day preserved" 0 conv.Adef.day
 
 let partial_month_zero () =
   let conv = Calendar.gregorian_of_julian (mk 0 0 1900) in
-  (check int) "month preserved" 0 conv.Def.month;
-  (check int) "day preserved" 0 conv.Def.day
+  (check int) "month preserved" 0 conv.Adef.month;
+  (check int) "day preserved" 0 conv.day
 
 (* -- JDN reference values -- *)
 
@@ -258,12 +255,12 @@ let stress_roundtrip () =
   let errors = ref [] in
   for sdn = start to start + 199999 do
     let check_cal name of_sdn sdn_of =
-      let d = of_sdn Def.Sure sdn in
+      let d = of_sdn Adef.Sure sdn in
       let sdn2 = sdn_of d in
       if sdn <> sdn2 then
         errors :=
-          Printf.sprintf "%s SDN %d -> %d/%d/%d -> %d" name sdn d.Def.day
-            d.Def.month d.Def.year sdn2
+          Printf.sprintf "%s SDN %d -> %d/%d/%d -> %d" name sdn d.Adef.day
+            d.month d.year sdn2
           :: !errors
     in
     check_cal "greg" gregorian_of_sdn sdn_of_gregorian;
@@ -303,7 +300,7 @@ let round_trip of_ to_ l () =
   List.iter (fun d -> (check testable_dmy) "" d (f d)) l
 
 let sdn_round_trip name of_sdn sdn_of =
-  test_case name `Quick (round_trip (of_sdn Def.Sure) sdn_of data_complete)
+  test_case name `Quick (round_trip (of_sdn Adef.Sure) sdn_of data_complete)
 
 let v =
   [

--- a/test/util_test.ml
+++ b/test/util_test.ml
@@ -174,7 +174,6 @@ let util_escape_html _ =
       :> string)
 
 let datedisplay_string_of_date _ =
-  let open Def in
   let conf = Config.empty in
   let conf =
     {
@@ -189,7 +188,7 @@ let datedisplay_string_of_date _ =
     "ghjennaghju/ferraghju/marzu/aprile/maghju/ghjugnu/lugliu/aostu/sittembre/uttobre/nuvembre/dicembre";
   let test aaa cal (d, m, y) =
     let date =
-      Dgreg ({ day = d; month = m; year = y; prec = Sure; delta = 0 }, cal)
+      Adef.Dgreg ({ day = d; month = m; year = y; prec = Sure; delta = 0 }, cal)
     in
     let bbb :> string = DateDisplay.string_of_date conf date in
     (check string) "" aaa bbb


### PR DESCRIPTION
These aliases are annoying and useless. In modern OCaml, type inference allows to important record labels without opening modules. For instance,
```ocaml
module X = struct
  type t = { foo : string; bar : string }
  ...
end

...

let x = { X.foo = "toto"; bar = "tata" }
...
(* We don't need to specify the module X here as the type is sufficient
to find labels. *)
let () = print_endline x.foo
```