### PR TITLE
Fix English lexicon typo: phonétic → phonetic

### DIFF
--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -15623,7 +15623,7 @@ tr: aynı adı taşıyan kişiler
 
     phonetic variants
 de: Phonetische Varianten
-en: phonétic variants
+en: phonetic variants
 fr: variantes phonétiques
 
     disordered firstnames


### PR DESCRIPTION
## Summary

- Fix typo in `hd/lang/lexicon.txt`: the English translation for "phonetic variants" had a French accent (`phonétic` → `phonetic`)
- Visible in the search tooltip ("Partial matches, phonétic variants") on the welcome/home page

## Test plan

- [x] Open a database home page, hover over the "Partials" checkbox — tooltip should read "phonetic" not "phonétic"

🤖 Generated with [Claude Code](https://claude.com/claude-code)