### PR TITLE
Add info RPC function in the Search service

### DIFF
--- a/lib/search/index.ml
+++ b/lib/search/index.ml
@@ -4,6 +4,7 @@ module type S = sig
   type word
   type entry
 
+  val cardinal : t -> int
   val of_seq : (word * entry) Seq.t -> t
   val mem : word -> t -> bool
   val search : word list -> t -> entry Seq.t
@@ -57,6 +58,8 @@ module Make (W : Word.S) (E : Entry) = struct
   module Flatset = Flatset.Make (HE)
 
   type t = Flatset.t Trie.t
+
+  let cardinal = Trie.cardinal
 
   let of_seq =
     let module SE = Set.Make (HE) in

--- a/lib/search/index.mli
+++ b/lib/search/index.mli
@@ -7,6 +7,9 @@ module type S = sig
   type word
   type entry
 
+  val cardinal : t -> int
+  (** [cardinal t] returns the number of words in the index. *)
+
   val of_seq : (word * entry) Seq.t -> t
   (** [of_seq s] creates a new inverted index from the sequence [s]. The
       sequence [s] is forced. *)

--- a/rpc/lib/service.ml
+++ b/rpc/lib/service.ml
@@ -74,16 +74,22 @@ module Index = Geneweb_search.Index.Default
 module Analyze = Geneweb_search.Analyze
 
 module Search = struct
-  let lookup ~fuel idx =
+  let info indexes =
+    decl "info"
+      Desc.Syntax.(ret (list (tup2 string int)))
+      (Lwt_result.return
+      @@ List.map (fun (name, idx) -> (name, Index.cardinal idx)) indexes)
+
+  let lookup ~fuel indexes =
     decl "lookup"
       Desc.Syntax.(string @-> string @-> int @-> ret (list string))
       (fun name s size ->
-        match List.assoc name idx with
+        match List.assoc name indexes with
         | exception Not_found ->
             (* TODO: Methods could fail and emit errors. We can implement
                this by changing the return type of methods to Lwt_result.t *)
             Lwt_result.return []
-        | i ->
+        | idx ->
             let words =
               List.map
                 (fun Analyze.{ content; _ } -> content)
@@ -103,12 +109,12 @@ module Search = struct
               (* BUG: We can introduce duplicate in the output here. *)
               @@ List.to_seq
                    [
-                     Index.search words i;
-                     Index.search_prefix words i;
-                     Index.fuzzy_search ~max_dist:1 words i;
+                     Index.search words idx;
+                     Index.search_prefix words idx;
+                     Index.fuzzy_search ~max_dist:1 words idx;
                    ]
             in
             Lwt_result.return r)
 
-  let make ~fuel idx = empty |> add (lookup ~fuel idx)
+  let make ~fuel idx = empty |> add (info idx) |> add (lookup ~fuel idx)
 end

--- a/rpc/lib/service.mli
+++ b/rpc/lib/service.mli
@@ -62,6 +62,11 @@ module Search : sig
   (** [make ~fuel l] prepares a search service with a list [l] of inverted
       indexes, each with its name.
 
+      The service exposes two methods:
+      - [lookup name s size] searches the string [s] in the index [name] and
+        stops after at most [size] results.
+      - [info] returns the list of loaded indexes with their cardinals.
+
       The [fuel] argument sets an upper bound on the number of results returned
       by the lookup operation. If the requested size exceeds this limit, the
       request is not fully honored and at most [fuel] results are returned. *)


### PR DESCRIPTION
The RPC function `info` returns the list of indexes with their cardinal. The cardinal of an index is its number of exact words.