### PR TITLE
fix(update_nldb): missing case for pattern-matching

### DIFF
--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -45,6 +45,7 @@ let notes_links s =
           in
           loop list_nt list_ind (pos + 1) j
       | NotesLinks.WLwizard (j, _, _) -> loop list_nt list_ind (pos + 1) j
+      | NotesLinks.WLimage (j, _, _, _) -> loop list_nt list_ind pos j
       | NotesLinks.WLnone (j, _) -> loop list_nt list_ind pos j
   in
   loop [] [] 1 0


### PR DESCRIPTION
remove warning 8 introduced by 3f2abd7c7474546401698095a28825c0658cab64