### PR TITLE
Support compression of assets with dune

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -48,6 +48,7 @@
     digestif
     pp_loc
     dune-site
+    conf-brotli
     (utop :with-dev-setup)
     (ocamlformat (and :with-dev-setup (= "0.28.1")))
   )

--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,7 @@
             ocamlWrapped
           ] ++ (with pkgs; [
             rlwrap
+            brotli
           ]) ++ (with ocamlPackages; [
             qcheck
             qcheck-alcotest

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -42,6 +42,7 @@ depends: [
   "digestif"
   "pp_loc"
   "dune-site"
+  "conf-brotli"
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup & = "0.28.1"}
   "odoc" {with-doc}

--- a/hd/dune
+++ b/hd/dune
@@ -4,6 +4,6 @@
   (site
    (geneweb hd)))
  (files
-  (glob_files_rec etc/*)
+  (glob_files_rec etc/{*.html,*.txt,*.woff,*.woff2,*.js,*.css,*.gz,*.br})
   (glob_files_rec images/*)
   (glob_files_rec lang/*)))

--- a/hd/etc/css/dune
+++ b/hd/etc/css/dune
@@ -1,0 +1,14 @@
+(include dune.inc)
+
+(rule
+ (deps
+  (glob_files_rec ./*.css))
+ (action
+  (with-stdout-to
+   dune.inc.gen
+   (run ../generate_dune_inc.exe .))))
+
+(rule
+ (alias default)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/hd/etc/css/dune.inc
+++ b/hd/etc/css/dune.inc
@@ -1,0 +1,61 @@
+
+(rule
+  (target datatables.min.css.gz)
+  (deps (:input datatables.min.css))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target datatables.min.css.br)
+  (deps (:input datatables.min.css))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target bootstrap.min.css.gz)
+  (deps (:input bootstrap.min.css))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target bootstrap.min.css.br)
+  (deps (:input bootstrap.min.css))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target select2.min.css.gz)
+  (deps (:input select2.min.css))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target select2.min.css.br)
+  (deps (:input select2.min.css))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target all.min.css.gz)
+  (deps (:input all.min.css))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target all.min.css.br)
+  (deps (:input all.min.css))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target css.css.gz)
+  (deps (:input css.css))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target css.css.br)
+  (deps (:input css.css))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target fanchart.css.gz)
+  (deps (:input fanchart.css))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target fanchart.css.br)
+  (deps (:input fanchart.css))
+  (action
+    (run brotli -f -q 11 %{input})))

--- a/hd/etc/dune
+++ b/hd/etc/dune
@@ -1,0 +1,3 @@
+(executable
+ (name generate_dune_inc)
+ (libraries unix))

--- a/hd/etc/generate_dune_inc.ml
+++ b/hd/etc/generate_dune_inc.ml
@@ -1,0 +1,33 @@
+let add_extension path ext = Format.sprintf "%s%s" path ext
+
+let pp_rule path =
+  let target_gzip = add_extension path ".gz" in
+  let target_brotli = add_extension path ".br" in
+  Format.printf
+    {|
+(rule
+  (target %s)
+  (deps (:input %s))
+  (action
+    (run gzip -9 -k -f %%{input})))
+(rule
+  (target %s)
+  (deps (:input %s))
+  (action
+    (run brotli -f -q 11 %%{input})))@?|}
+    target_gzip path target_brotli path
+
+let () =
+  let handle = Unix.opendir Sys.argv.(1) in
+  Fun.protect ~finally:(fun () -> Unix.closedir handle) @@ fun () ->
+  let rec loop () =
+    match Unix.readdir handle with
+    | exception End_of_file -> ()
+    | s -> (
+        match Filename.extension s with
+        | ".css" | ".js" ->
+            pp_rule s;
+            loop ()
+        | _ -> loop ())
+  in
+  loop ()

--- a/hd/etc/js/dune
+++ b/hd/etc/js/dune
@@ -1,0 +1,14 @@
+(include dune.inc)
+
+(rule
+ (deps
+  (glob_files_rec ./*.js))
+ (action
+  (with-stdout-to
+   dune.inc.gen
+   (run ../generate_dune_inc.exe .))))
+
+(rule
+ (alias default)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/hd/etc/js/dune.inc
+++ b/hd/etc/js/dune.inc
@@ -1,0 +1,211 @@
+
+(rule
+  (target select2-maximize-height.min.js.gz)
+  (deps (:input select2-maximize-height.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target select2-maximize-height.min.js.br)
+  (deps (:input select2-maximize-height.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target chart.umd.min.js.gz)
+  (deps (:input chart.umd.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target chart.umd.min.js.br)
+  (deps (:input chart.umd.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target bootstrap.bundle.min.js.gz)
+  (deps (:input bootstrap.bundle.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target bootstrap.bundle.min.js.br)
+  (deps (:input bootstrap.bundle.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target datatables.min.js.gz)
+  (deps (:input datatables.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target datatables.min.js.br)
+  (deps (:input datatables.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target regex.min.js.gz)
+  (deps (:input regex.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target regex.min.js.br)
+  (deps (:input regex.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target checkdata.min.js.gz)
+  (deps (:input checkdata.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target checkdata.min.js.br)
+  (deps (:input checkdata.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target fanchart.min.js.gz)
+  (deps (:input fanchart.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target fanchart.min.js.br)
+  (deps (:input fanchart.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target checkdata.js.gz)
+  (deps (:input checkdata.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target checkdata.js.br)
+  (deps (:input checkdata.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target p_mod.min.js.gz)
+  (deps (:input p_mod.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target p_mod.min.js.br)
+  (deps (:input p_mod.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target copylink.js.gz)
+  (deps (:input copylink.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target copylink.js.br)
+  (deps (:input copylink.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target rlm_builder.js.gz)
+  (deps (:input rlm_builder.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target rlm_builder.js.br)
+  (deps (:input rlm_builder.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target fanchart.js.gz)
+  (deps (:input fanchart.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target fanchart.js.br)
+  (deps (:input fanchart.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target p_mod.js.gz)
+  (deps (:input p_mod.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target p_mod.js.br)
+  (deps (:input p_mod.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target select2.min.js.gz)
+  (deps (:input select2.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target select2.min.js.br)
+  (deps (:input select2.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target jquery.min.js.gz)
+  (deps (:input jquery.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target jquery.min.js.br)
+  (deps (:input jquery.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target jquery.maphilight.min.js.gz)
+  (deps (:input jquery.maphilight.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target jquery.maphilight.min.js.br)
+  (deps (:input jquery.maphilight.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target jquery.line.js.gz)
+  (deps (:input jquery.line.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target jquery.line.js.br)
+  (deps (:input jquery.line.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target relationmatrix.js.gz)
+  (deps (:input relationmatrix.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target relationmatrix.js.br)
+  (deps (:input relationmatrix.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target clearinput.js.gz)
+  (deps (:input clearinput.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target clearinput.js.br)
+  (deps (:input clearinput.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target relationmatrix.min.js.gz)
+  (deps (:input relationmatrix.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target relationmatrix.min.js.br)
+  (deps (:input relationmatrix.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))
+(rule
+  (target autosize.min.js.gz)
+  (deps (:input autosize.min.js))
+  (action
+    (run gzip -9 -k -f %{input})))
+(rule
+  (target autosize.min.js.br)
+  (deps (:input autosize.min.js))
+  (action
+    (run brotli -f -q 11 %{input})))

--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -12,7 +12,7 @@ let assets_r = ref [ "gw" ]
 
 let default_base_dir =
   let t = Dirs.make () in
-  Dirs.(data_home t // "geneweb" // "base")
+  Dirs.(data_home t // "geneweb" // "bases")
 
 let bd_r = ref (Dirs.path default_base_dir)
 

--- a/test/gwc/run.t
+++ b/test/gwc/run.t
@@ -9,7 +9,7 @@
     source files end with .gw
     object files end with .gwo
   and [options] are:
-    -bd <DIR>                     Specify where the “bases” directory with databases is installed (default if empty is "$XDG_DATA_HOME/geneweb/base").
+    -bd <DIR>                     Specify where the “bases” directory with databases is installed (default if empty is "$XDG_DATA_HOME/geneweb/bases").
     -bnotes                       [drop|erase|first|merge] Behavior for base notes of the next file. [drop]: dropped. [erase]: erase the current content. [first]: dropped if current content is not empty. [merge]: concatenated to the current content. Default: merge
     -c                            Only compiling
     -cg                           Compute consanguinity


### PR DESCRIPTION
The css/js assets are compressed by the distribution target in the Makefile. This PR ensures that `dune exec -- ...` and `opam install` will use compression too.

Changes:
- Compression of assets when you call `dune build`.
- Add `conf-brotli` as a dependency of `geneweb` to ensure that `brotli` is installed on the computer.
- Fix a misspelling in the XDG directory for bases.

In particular, running `gwd` with `dune exec -- ./bin/gwd/gwd.exe ...` will use them.