### PR TITLE
src_images_list: guard against missing images directory

### DIFF
--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1392,22 +1392,26 @@ and print_simple_variable conf = function
       let query_time = Unix.gettimeofday () -. conf.query_start in
       Util.time_debug conf query_time !GWPARAM.nb_errors !GWPARAM.errors_undef
         !GWPARAM.errors_other !GWPARAM.set_vars
-  | "src_images_list" ->
+  | "src_images_list" -> (
       let dir = !GWPARAM.images_d conf.bname in
-      let f_list = Sys.readdir dir |> Array.to_list |> List.sort compare in
-      let res =
-        List.fold_left
-          (fun acc f ->
+      try
+        let f_list = Sys.readdir dir |> Array.to_list |> List.sort compare in
+        List.iter
+          (fun f ->
             let full_path = Filename.concat dir f in
             if
               (Unix.stat full_path).st_kind = Unix.S_REG
               && f.[0] <> '.'
               && f.[0] <> '~'
-            then acc ^ Format.sprintf "<option>%s\n" f
-            else acc)
-          "" f_list
-      in
-      Output.print_sstring conf res
+            then
+              Output.printf conf "<option>%s\n" (Util.escape_html f :> string))
+          f_list
+      with
+      | Sys_error msg ->
+          Log.warn (fun k -> k "src_images_list: %s (%s)" msg dir)
+      | Unix.Unix_error (err, _, _) ->
+          Log.warn (fun k ->
+              k "src_images_list: %s (%s)" (Unix.error_message err) dir))
   | _ -> raise Not_found
 
 and print_variable conf sl =


### PR DESCRIPTION
Sys.readdir raises Sys_error when the directory does not exist. Since print_simple_variable only catches Not_found, the uncaught exception aborts template rendering mid-output, producing a blank page. Wrap the whole block in try/with to handle both Sys_error and Unix_error gracefully. Also escape filenames in option values and replace fold_left string concatenation with direct iteration.