### PR TITLE
Do not allocate the empty string everywhere

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -1,10 +1,11 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-open Geneweb
-open Def
-
+module Compat = Geneweb_compat
 module Driver = Geneweb_db.Driver
 module Dirs = Geneweb_dirs
+
+open Geneweb
+open Def
 
 type person = (int, int, int) Def.gen_person
 type ascend = int Def.gen_ascend
@@ -51,7 +52,7 @@ let month_number_dates = ref NoMonthNumberDates
 let no_public_if_titles = ref false
 let first_names_brackets = ref None
 let untreated_in_notes = ref false
-let default_source = ref ""
+let default_source = ref Compat.String.empty
 let relation_status = ref Married
 let no_picture = ref false
 let do_check = ref true
@@ -61,7 +62,7 @@ let no_warn = ref false
 (* Reading input *)
 
 let line_cnt = ref 1
-let in_file = ref ""
+let in_file = ref Compat.String.empty
 
 let print_location pos =
   Printf.fprintf !log_oc "File \"%s\", line %d:\n" !in_file pos
@@ -273,7 +274,7 @@ and parse_text n r1 =
   parser
     [< r2 = get_to_eoln 0;
        l = get_lev_list [] (Char.chr (Char.code n + 1)) (* ? "get lev list" *) >] ->
-      (r1, r2, "", l)
+      (r1, r2, Compat.String.empty, l)
 and get_lev_list l n =
   parser
   | [< x = get_lev n; s >] -> get_lev_list (x :: l) n s
@@ -345,7 +346,7 @@ let strip c str =
     loop (String.length str - 1)
   in
   if start = 0 && stop = String.length str then str
-  else if start >= stop then ""
+  else if start >= stop then Compat.String.empty
   else String.sub str start (stop - start)
 
 let strip_spaces = strip ' '
@@ -362,7 +363,7 @@ let parse_name =
   let (f, s) = if invert then (s, f) else (f, s) in
   let f = strip_spaces f in
   let s = strip_spaces s in
-  ((if f = "" then "x" else f), (if s = "" then "?" else s))
+  ((if Compat.String.is_empty f then "x" else f), (if Compat.String.is_empty s then "?" else s))
 
 let rec find_field lab =
   function
@@ -391,10 +392,10 @@ let rec lexing_date =
   | [< ''0'..'9' as c; n = number (Buff.store 0 c) >] -> ("INT", n)
   | [< ''A'..'Z' as c; i = ident (Buff.store 0 c) >] -> ("ID", i)
   | [< ''('; len = text 0 >] -> ("TEXT", Buff.get len)
-  | [< ''.' >] -> ("", ".")
+  | [< ''.' >] -> (Compat.String.empty, ".")
   | [< '' ' | '\t' | '\013'; s >] -> lexing_date s
-  | [< _ = Stream.empty >] -> ("EOI", "")
-  | [< 'x >] -> ("", String.make 1 x)
+  | [< _ = Stream.empty >] -> ("EOI", Compat.String.empty)
+  | [< 'x >] -> (Compat.String.empty, String.make 1 x)
 and number len =
   parser
   | [< ''0'..'9' as c; a = number (Buff.store len c) >] -> a
@@ -461,7 +462,7 @@ let roman_int =
   in
   Grammar.Entry.of_parser date_g "roman int" p
 
-let date_str = ref ""
+let date_str = ref Compat.String.empty
 
 let make_date n1 n2 n3 =
   let n3 =
@@ -702,7 +703,7 @@ let preg_match pattern subject =
   try ignore (Str.search_forward re subject 0); true with Not_found -> false
 
 let date_of_field d =
-  if d = "" then None
+  if Compat.String.is_empty d then None
   else if preg_match "^[0-9]+$" d && String.length d > 8 then Some (Adef.Dtext d)
   else
     let s = Stream.of_string (String.uppercase_ascii d) in
@@ -747,7 +748,7 @@ let add_string gen s =
   try Hashtbl.find gen.g_hstr s
   with Not_found ->
     let i = gen.g_str.tlen in
-    assume_tab gen.g_str "";
+    assume_tab gen.g_str Compat.String.empty;
     gen.g_str.arr.(i) <- s;
     gen.g_str.tlen <- gen.g_str.tlen + 1;
     Hashtbl.add gen.g_hstr s i;
@@ -768,7 +769,7 @@ let per_index gen lab =
   try Hashtbl.find gen.g_hper lab
   with Not_found ->
     let i = gen.g_per.tlen in
-    assume_tab gen.g_per (Left3 "");
+    assume_tab gen.g_per (Left3 Compat.String.empty);
     gen.g_per.arr.(i) <- Left3 lab;
     gen.g_per.tlen <- gen.g_per.tlen + 1;
     Hashtbl.add gen.g_hper lab i;
@@ -780,7 +781,7 @@ let fam_index gen lab =
   try Hashtbl.find gen.g_hfam lab
   with Not_found ->
     let i = gen.g_fam.tlen in
-    assume_tab gen.g_fam (Left3 "");
+    assume_tab gen.g_fam (Left3 Compat.String.empty);
     gen.g_fam.arr.(i) <- Left3 lab;
     gen.g_fam.tlen <- gen.g_fam.tlen + 1;
     Hashtbl.add gen.g_hfam lab i;
@@ -799,7 +800,7 @@ let unknown_per i sex =
 let phony_per gen sex =
   let i = gen.g_per.tlen in
   let (person, ascend, union) = unknown_per i sex in
-  assume_tab gen.g_per (Left3 "");
+  assume_tab gen.g_per (Left3 Compat.String.empty);
   gen.g_per.tlen <- gen.g_per.tlen + 1;
   gen.g_per.arr.(i) <- Right3 (person, ascend, union);
   i
@@ -815,7 +816,7 @@ let unknown_fam gen i =
 let phony_fam gen =
   let i = gen.g_fam.tlen in
   let (fam, cpl, des) = unknown_fam gen i in
-  assume_tab gen.g_fam (Left3 "");
+  assume_tab gen.g_fam (Left3 Compat.String.empty);
   gen.g_fam.tlen <- gen.g_fam.tlen + 1;
   gen.g_fam.arr.(i) <- Right3 (fam, cpl, des);
   i
@@ -928,22 +929,22 @@ let uppercase_name = aux Utf8.uppercase
 let get_lev0 (strm__ : _ Stream.t) =
   let _ = line_start '0' strm__ in
   let _ =
-    try skip_space strm__ with Stream.Failure -> raise (Stream.Error "")
+    try skip_space strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let r1 =
-    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error "")
+    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let r2 =
-    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error "")
+    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let r3 =
-    try get_to_eoln 0 strm__ with Stream.Failure -> raise (Stream.Error "")
+    try get_to_eoln 0 strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let l =
     try get_lev_list [] '1' strm__ with
-      Stream.Failure -> raise (Stream.Error "")
+      Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
-  let (rlab, rval) = if r2 = "" then r1, "" else r2, r1 in
+  let (rlab, rval) = if Compat.String.is_empty r2 then r1, Compat.String.empty else r2, r1 in
   let rval = utf8_of_string rval in
   let rcont = utf8_of_string r3 in
   {rlab = rlab; rval = rval; rcont = rcont; rsons = List.rev l;
@@ -984,7 +985,7 @@ let extract_notes gen rl =
        List.fold_right
          (fun r lines ->
             r.rused <- true;
-            if r.rlab = "NOTE" && r.rval <> "" && r.rval.[0] = '@' then
+            if r.rlab = "NOTE" && not @@ Compat.String.is_empty r.rval && r.rval.[0] = '@' then
               let addr = extract_addr r.rval in
               match find_notes_record gen addr with
                 Some r ->
@@ -1007,7 +1008,7 @@ let rebuild_text r =
        let n = e.rval in
        let end_spc =
          if String.length n > 1 && n.[String.length n - 1] = ' ' then " "
-         else ""
+         else Compat.String.empty
        in
        let n = strip_spaces n in
        match e.rlab with
@@ -1020,14 +1021,14 @@ let notes_from_source_record rl =
   let title =
     match find_field "TITL" rl with
       Some l ->
-        let s = rebuild_text l in if s = "" then "" else "<b>" ^ s ^ "</b>"
-    | None -> ""
+        let s = rebuild_text l in if Compat.String.is_empty s then Compat.String.empty else "<b>" ^ s ^ "</b>"
+    | None -> Compat.String.empty
   in
   let text =
     match find_field "TEXT" rl with
       Some l ->
-        let s = rebuild_text l in if title = "" then s else "<br>\n" ^ s
-    | None -> ""
+        let s = rebuild_text l in if Compat.String.is_empty title then s else "<br>\n" ^ s
+    | None -> Compat.String.empty
   in
   title ^ text
 
@@ -1043,20 +1044,20 @@ let treat_notes gen rl =
          if Buffer.length buf = 0 then
            begin
              Buffer.add_string buf n;
-             Buffer.add_string buf (if end_spc then " " else "")
+             Buffer.add_string buf (if end_spc then " " else Compat.String.empty)
            end
          else if lab = "CONT" || lab = "NOTE" then
            begin
              Buffer.add_string buf "<br>\n";
              Buffer.add_string buf n;
-             Buffer.add_string buf (if end_spc then " " else "")
+             Buffer.add_string buf (if end_spc then " " else Compat.String.empty)
            end
-         else if n = "" then ()
+         else if Compat.String.is_empty n then ()
          else
            begin
-             Buffer.add_string buf (if spc then "\n" else "");
+             Buffer.add_string buf (if spc then "\n" else Compat.String.empty);
              Buffer.add_string buf n;
-             Buffer.add_string buf (if end_spc then " " else "")
+             Buffer.add_string buf (if end_spc then " " else Compat.String.empty)
            end)
       lines
   in
@@ -1070,18 +1071,19 @@ let treat_source gen r =
           let titl =
             match find_field "TITL" v.rsons with
               Some l -> rebuild_text l
-            | None -> ""
+            | None -> Compat.String.empty
           in
           let text =
             match find_field "TEXT" v.rsons with
               Some l -> rebuild_text l
-            | None -> ""
+            | None -> Compat.String.empty
           in
           let rcont = strip_spaces v.rcont in
-          if titl <> "" && text <> "" then "{" ^ titl ^ "} " ^ text
-          else if titl <> "" then titl
-          else if text <> "" then text
-          else if rcont <> "" then rcont
+          if not @@ Compat.String.is_empty titl && not @@ Compat.String.is_empty text then
+            "{" ^ titl ^ "} " ^ text
+          else if not @@ Compat.String.is_empty titl then titl
+          else if not @@ Compat.String.is_empty text then text
+          else if not @@ Compat.String.is_empty rcont then rcont
           else r.rval
         in
         src, v.rsons
@@ -1089,13 +1091,13 @@ let treat_source gen r =
         print_location r.rpos;
         Printf.fprintf !log_oc "Source %s not found\n" r.rval;
         flush !log_oc;
-        "", []
+        Compat.String.empty, []
   else strip_spaces r.rval, r.rsons
 
 let source gen r =
   match find_field "SOUR" r.rsons with
     Some r -> treat_source gen r
-  | _ -> "", []
+  | _ -> Compat.String.empty, []
 
 let p_index_from s i c =
   if i >= String.length s then String.length s
@@ -1108,10 +1110,10 @@ let decode_title s =
   let i2 = p_index_from s (i1 + 1) ',' in
   let title = strip_sub s 0 i1 in
   let (place, nth) =
-    if i1 = String.length s then "", 0
+    if i1 = String.length s then Compat.String.empty, 0
     else if i2 = String.length s then
       let s1 = strip_sub s (i1 + 1) (i2 - i1 - 1) in
-      try "", int_of_string s1 with Failure _ -> s1, 0
+      try Compat.String.empty, int_of_string s1 with Failure _ -> s1, 0
     else
       let s1 = strip_sub s (i1 + 1) (i2 - i1 - 1) in
       let s2 = strip_sub s (i2 + 1) (String.length s - i2 - 1) in
@@ -1133,9 +1135,10 @@ let list_of_string s =
 let purge_list list =
   List.fold_right
     (fun s list ->
-       match strip_spaces s with
-         "" -> list
-       | s -> s :: list)
+      if Compat.String.is_empty @@ strip_spaces s then
+        list
+      else
+        s :: list)
     list []
 
 let decode_date_interval pos s =
@@ -1157,7 +1160,7 @@ let treat_indi_title gen public_name r =
   let (name, title, place) =
     match find_field "NOTE" r.rsons with
       Some r ->
-        if title = "" then Tnone, strip_spaces r.rval, ""
+        if Compat.String.is_empty title then Tnone, strip_spaces r.rval, Compat.String.empty
         else if r.rval = public_name then Tmain, title, place
         else Tname (add_string gen (strip_spaces r.rval)), title, place
     | None -> Tnone, title, place
@@ -1169,7 +1172,7 @@ let treat_indi_title gen public_name r =
 let forward_adop gen ip lab which_parent =
   Hashtbl.add
     gen.g_adop lab
-    (ip, match which_parent with Some r when r.rval <> "" -> r.rval | _ -> "BOTH")
+    (ip, match which_parent with Some r when not @@ Compat.String.is_empty r.rval -> r.rval | _ -> "BOTH")
 
 let adop_parent gen ip r =
   let i = per_index gen r.rval in
@@ -1243,10 +1246,10 @@ let html_text_of_tags text rl =
     let len = Buff.store len ' ' in
     let len = Buff.mstore len r.rlab in
     let len =
-      if r.rval = "" then len else Buff.mstore (Buff.store len ' ') r.rval
+      if Compat.String.is_empty r.rval then len else Buff.mstore (Buff.store len ' ') r.rval
     in
     let len =
-      if r.rcont = "" then len else Buff.mstore (Buff.store len ' ') r.rcont
+      if Compat.String.is_empty r.rcont then len else Buff.mstore (Buff.store len ' ') r.rcont
     in
     totl len (lev + 1) r.rsons
   and totl len lev rl =
@@ -1254,7 +1257,7 @@ let html_text_of_tags text rl =
       (fun len r -> let len = Buff.store len '\n' in tot len lev r) len rl
   in
   let title =
-    if text = "" then "-- GEDCOM --" else "-- GEDCOM (" ^ text ^ ") --"
+    if Compat.String.is_empty text then "-- GEDCOM --" else "-- GEDCOM (" ^ text ^ ") --"
   in
   let len = 0 in
   let len = Buff.mstore len title in let len = totl len 1 rl in Buff.get len
@@ -1425,23 +1428,23 @@ let treat_indi_pevent gen ip r =
               let place =
                 match find_field "PLAC" r.rsons with
                   Some r -> strip_spaces r.rval
-                | _ -> ""
+                | _ -> Compat.String.empty
               in
-              let reason = "" in
+              let reason = Compat.String.empty in
               let note =
                 match find_all_fields "NOTE" r.rsons with
-                  [] -> ""
+                  [] -> Compat.String.empty
                 | rl -> treat_notes gen rl
               in
               (* Si le tag 1 XXX a des infos, on les ajoutes. *)
               let note =
                 let name_info = strip_spaces r.rval in
-                if name_info = "" || r.rval = "Y" then note
+                if Compat.String.is_empty name_info || r.rval = "Y" then note
                 else name_info ^ "<br>\n" ^ note
               in
               let src =
                 match find_all_fields "SOUR" r.rsons with
-                  [] -> ""
+                  [] -> Compat.String.empty
                 | rl ->
                     let rec loop first src rl =
                       match rl with
@@ -1454,7 +1457,7 @@ let treat_indi_pevent gen ip r =
                           in
                           loop false src rl
                     in
-                    loop true "" rl
+                    loop true Compat.String.empty rl
               in
               let witnesses = find_event_witness gen "INDI" ip r in
               let evt =
@@ -1466,7 +1469,9 @@ let treat_indi_pevent gen ip r =
               in
               (* On ajoute que les évènements non vides, sauf *)
               (* s'il est spécifié qu'il faut l'ajouter.      *)
-              if date <> None || place <> "" || note <> "" || src <> "" ||
+              if date <> None || not @@ Compat.String.is_empty place ||
+              not @@ Compat.String.is_empty note ||
+              not @@ Compat.String.is_empty src ||
                  witnesses <> [| |] || r.rval = "Y"
               then
                 if name = Epers_Occupation then
@@ -1481,7 +1486,7 @@ let treat_indi_pevent gen ip r =
       (fun events r ->
          match find_field "TYPE" r.rsons with
            Some rr ->
-             if rr.rval <> "" then
+             if not @@ Compat.String.is_empty rr.rval then
                let name =
                  if List.mem rr.rval primary_pevents then
                    find_pevent_name_from_tag gen rr.rval rr.rval
@@ -1497,23 +1502,23 @@ let treat_indi_pevent gen ip r =
                let place =
                  match find_field "PLAC" r.rsons with
                    Some r -> strip_spaces r.rval
-                 | _ -> ""
+                 | _ -> Compat.String.empty
                in
-               let reason = "" in
+               let reason = String.empty in
                let note =
                  match find_all_fields "NOTE" r.rsons with
-                   [] -> ""
+                   [] -> Compat.String.empty
                  | rl -> treat_notes gen rl
                in
                (* Si le tag 1 XXX a des infos, on les ajoutes. *)
                let note =
                  let name_info = strip_spaces r.rval in
-                 if name_info = "" || r.rval = "Y" then note
+                 if Compat.String.is_empty name_info || r.rval = "Y" then note
                  else name_info ^ "<br>\n" ^ note
                in
                let src =
                  match find_all_fields "SOUR" r.rsons with
-                   [] -> ""
+                   [] -> Compat.String.empty
                  | rl ->
                      let rec loop first src rl =
                        match rl with
@@ -1526,7 +1531,7 @@ let treat_indi_pevent gen ip r =
                            in
                            loop false src rl
                      in
-                     loop true "" rl
+                     loop true Compat.String.empty rl
                in
                let witnesses = find_event_witness gen "INDI" ip r in
                let evt =
@@ -1543,8 +1548,10 @@ let treat_indi_pevent gen ip r =
                    Epers_Name n -> n <> string_empty
                  | _ -> false
                in
-               if has_epers_name || date <> None || place <> "" ||
-                  note <> "" || src <> "" || witnesses <> [| |]
+               if has_epers_name || date <> None ||
+                  not @@ Compat.String.is_empty place ||
+                  not @@ Compat.String.is_empty note ||
+                  not @@ Compat.String.is_empty src || witnesses <> [| |]
                then
                  evt :: events
                else events
@@ -1637,15 +1644,15 @@ let add_indi gen r =
       Some n ->
       begin match find_field "GIVN" n.rsons with
           Some r -> r.rval
-        | None -> ""
+        | None -> Compat.String.empty
       end
-    | None -> ""
+    | None -> Compat.String.empty
   in
   let (first_name, surname, occ, public_name, first_names_aliases) =
     match name_sons with
     | Some n ->
       let (f, s) = parse_name (Stream.of_string n.rval) in
-      let pn = "" in
+      let pn = Compat.String.empty in
       let fal = if givn = f then [] else [givn] in
       let (f, fal) =
         match !first_names_brackets with
@@ -1668,13 +1675,13 @@ let add_indi gen r =
               let (fn, fa) = first_enclosed ff in
               let accu =
                 if first then fn
-                else if fn <> "" then accu ^ " " ^ fn
+                else if not @@ Compat.String.is_empty fn then accu ^ " " ^ fn
                 else accu
               in
               loop false fa accu
             with Not_found -> if f = ff then f, fal else accu, ff :: fal
           in
-          loop true f ""
+          loop true f Compat.String.empty
         | None -> f, fal
       in
       let (f, pn, fal) =
@@ -1684,10 +1691,10 @@ let add_indi gen r =
           if j = String.length f then f, pn, fal
           else
             let fn = String.sub f i (j - i) in
-            if pn = "" && !extract_public_names then
+            if Compat.String.is_empty pn && !extract_public_names then
               if is_a_public_name f j then fn, f, fal
-              else if !extract_first_names then fn, "", f :: fal
-              else f, "", fal
+              else if !extract_first_names then fn, Compat.String.empty, f :: fal
+              else f, Compat.String.empty, fal
             else fn, pn, f :: fal
         else f, pn, fal
       in
@@ -1695,7 +1702,7 @@ let add_indi gen r =
       let fal =
         if !lowercase_first_names then List.map capitalize_name fal else fal
       in
-      let pn = if capitalize_name pn = f then "" else pn in
+      let pn = if capitalize_name pn = f then Compat.String.empty else pn in
       let pn = if !lowercase_first_names then capitalize_name pn else pn in
       let fal =
         List.fold_right (fun fa fal -> if fa = pn then fal else fa :: fal) fal []
@@ -1721,9 +1728,9 @@ let add_indi gen r =
       Some n ->
       begin match find_field "NICK" n.rsons with
           Some r -> r.rval
-        | None -> ""
+        | None -> Compat.String.empty
       end
-    | None -> ""
+    | None -> Compat.String.empty
   in
   let surname_aliases =
     match name_sons with
@@ -1755,10 +1762,10 @@ let add_indi gen r =
     match find_field "OBJE" r.rsons with
       Some r ->
       begin match find_field "FILE" r.rsons with
-          Some r -> if !no_picture then "" else r.rval
-        | None -> ""
+          Some r -> if !no_picture then Compat.String.empty else r.rval
+        | None -> Compat.String.empty
       end
-    | None -> ""
+    | None -> Compat.String.empty
   in
   let parents =
     match find_field "FAMC" r.rsons with
@@ -1776,7 +1783,7 @@ let add_indi gen r =
   in
   let notes =
     match find_all_fields "NOTE" r.rsons with
-      [] -> ""
+      [] -> Compat.String.empty
     | rl -> treat_notes gen rl
   in
   let titles =
@@ -1853,15 +1860,15 @@ let add_indi gen r =
       let p =
         match find_field "PLAC" r.rsons with
           Some r -> strip_spaces r.rval
-        | _ -> ""
+        | _ -> Compat.String.empty
       in
       let note =
         match find_all_fields "NOTE" r.rsons with
-          [] -> ""
+          [] -> Compat.String.empty
         | rl -> treat_notes gen rl
       in
       d, p, (note, []), source gen r
-    | None -> None, "", ("", []), ("", [])
+    | None -> None, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
   in
   let (bapt, bapt_place, (bapt_note, _), (bapt_src, bapt_nt)) =
     let ro =
@@ -1879,22 +1886,22 @@ let add_indi gen r =
       let p =
         match find_field "PLAC" r.rsons with
           Some r -> strip_spaces r.rval
-        | _ -> ""
+        | _ -> Compat.String.empty
       in
       let note =
         match find_all_fields "NOTE" r.rsons with
-          [] -> ""
+          [] -> Compat.String.empty
         | rl -> treat_notes gen rl
       in
       d, p, (note, []), source gen r
-    | None -> None, "", ("", []), ("", [])
+    | None -> None, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
   in
   let (death, death_place, (death_note, _), (death_src, death_nt)) =
     match find_field "DEAT" r.rsons with
     | Some r ->
       if r.rsons = [] then
-        if r.rval = "Y" then DeadDontKnowWhen, "", ("", []), ("", [])
-        else infer_death birth bapt, "", ("", []), ("", [])
+        if r.rval = "Y" then DeadDontKnowWhen, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
+        else infer_death birth bapt, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
       else
         let d =
           match find_field "DATE" r.rsons with
@@ -1908,15 +1915,15 @@ let add_indi gen r =
         let p =
           match find_field "PLAC" r.rsons with
           | Some r -> strip_spaces r.rval
-          | None -> ""
+          | None -> Compat.String.empty
         in
         let note =
           match find_all_fields "NOTE" r.rsons with
-          | [] -> ""
+          | [] -> Compat.String.empty
           | rl -> treat_notes gen rl
         in
         d, p, (note, []), source gen r
-    | None -> infer_death birth bapt, "", ("", []), ("", [])
+    | None -> infer_death birth bapt, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
   in
   let (burial, burial_place, (burial_note, _), (burial_src, burial_nt)) =
     let (buri, buri_place, (buri_note, _), (buri_src, buri_nt)) =
@@ -1924,8 +1931,8 @@ let add_indi gen r =
         Some r ->
         if r.rsons = [] then
           if r.rval = "Y" then
-            Buried Date.cdate_None, "", ("", []), ("", [])
-          else UnknownBurial, "", ("", []), ("", [])
+            Buried Date.cdate_None, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
+          else UnknownBurial, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
         else
           let d =
             match find_field "DATE" r.rsons with
@@ -1935,23 +1942,23 @@ let add_indi gen r =
           let p =
             match find_field "PLAC" r.rsons with
               Some r -> strip_spaces r.rval
-            | _ -> ""
+            | _ -> Compat.String.empty
           in
           let note =
             match find_all_fields "NOTE" r.rsons with
-              [] -> ""
+              [] -> Compat.String.empty
             | rl -> treat_notes gen rl
           in
           Buried (Date.cdate_of_od d), p, (note, []), source gen r
-      | None -> UnknownBurial, "", ("", []), ("", [])
+      | None -> UnknownBurial, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
     in
     let (crem, crem_place, (crem_note, _), (crem_src, crem_nt)) =
       match find_field "CREM" r.rsons with
         Some r ->
         if r.rsons = [] then
           if r.rval = "Y" then
-            Cremated Date.cdate_None, "", ("", []), ("", [])
-          else UnknownBurial, "", ("", []), ("", [])
+            Cremated Date.cdate_None, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
+          else UnknownBurial, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
         else
           let d =
             match find_field "DATE" r.rsons with
@@ -1961,15 +1968,15 @@ let add_indi gen r =
           let p =
             match find_field "PLAC" r.rsons with
               Some r -> strip_spaces r.rval
-            | _ -> ""
+            | _ -> Compat.String.empty
           in
           let note =
             match find_all_fields "NOTE" r.rsons with
-              [] -> ""
+              [] -> Compat.String.empty
             | rl -> treat_notes gen rl
           in
           Cremated (Date.cdate_of_od d), p, (note, []), source gen r
-      | None -> UnknownBurial, "", ("", []), ("", [])
+      | None -> UnknownBurial, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, [])
     in
     match buri, crem with
       UnknownBurial, Cremated _ ->
@@ -1980,14 +1987,20 @@ let add_indi gen r =
   let bapt =Date.cdate_of_od bapt in
   let (psources, psources_nt) =
     let (s, s_nt) = source gen r in
-    if s = "" then !default_source, s_nt else s, s_nt
+    if Compat.String.is_empty s then !default_source, s_nt else s, s_nt
   in
   let ext_notes =
     let concat_text s1 s2 s_sep =
-      let s = if s1 = "" && notes = "" || s2 = "" then "" else s_sep in
+      let s =
+        if Compat.String.is_empty s1 &&
+           Compat.String.is_empty notes || Compat.String.is_empty s2 then
+          Compat.String.empty
+        else
+          s_sep
+      in
       s1 ^ s ^ s2
     in
-    let text = concat_text "" (notes_from_source_record birth_nt) "<br>\n" in
+    let text = concat_text Compat.String.empty (notes_from_source_record birth_nt) "<br>\n" in
     let text = concat_text text (notes_from_source_record bapt_nt) "<br>\n" in
     let text =
       concat_text text (notes_from_source_record death_nt) "<br>\n"
@@ -2004,13 +2017,13 @@ let add_indi gen r =
         if rtl = [] then init
         else concat_text init (html_text_of_tags text rtl) "\n"
       in
-      let nt = remain_tags_in_notes "INDI" "" r.rsons in
+      let nt = remain_tags_in_notes "INDI" Compat.String.empty r.rsons in
       let nt = remain_tags_in_notes "BIRT SOUR" nt birth_nt in
       let nt = remain_tags_in_notes "BAPT SOUR" nt bapt_nt in
       let nt = remain_tags_in_notes "DEAT SOUR" nt death_nt in
       let nt = remain_tags_in_notes "BURI/CREM SOUR" nt burial_nt in
       let nt = remain_tags_in_notes "SOUR SOUR" nt psources_nt in
-      if nt = "" then text else text ^ "<pre>\n" ^ nt ^ "\n</pre>"
+      if Compat.String.is_empty nt then text else text ^ "<pre>\n" ^ nt ^ "\n</pre>"
     else text
   in
   (* Mise à jour des évènements principaux. *)
@@ -2051,7 +2064,8 @@ let add_indi gen r =
      surname = add_string gen surname; occ = occ;
      public_name = add_string gen public_name; image = add_string gen image;
      qualifiers =
-       if qualifier <> "" then [add_string gen qualifier] else [];
+       if not @@ Compat.String.is_empty qualifier then
+         [add_string gen qualifier] else [];
      aliases = List.map (add_string gen) aliases;
      first_names_aliases = List.map (add_string gen) first_names_aliases;
      surnames_aliases = List.map (add_string gen) surname_aliases;
@@ -2108,7 +2122,7 @@ let treat_fam_fevent gen ifath r =
     match find_all_fields "PLAC" r.rsons with
       r :: rl ->
         if String.uncapitalize_ascii r.rval = "unmarried" then
-          Efam_NoMarriage, ""
+          Efam_NoMarriage, Compat.String.empty
         else
           let place = strip_spaces r.rval in
           let rec loop =
@@ -2136,23 +2150,23 @@ let treat_fam_fevent gen ifath r =
               let place =
                 match find_field "PLAC" r.rsons with
                   Some r -> strip_spaces r.rval
-                | _ -> ""
+                | _ -> Compat.String.empty
               in
-              let reason = "" in
+              let reason = Compat.String.empty in
               let note =
                 match find_all_fields "NOTE" r.rsons with
-                  [] -> ""
+                  [] -> Compat.String.empty
                 | rl -> treat_notes gen rl
               in
               (* Si le tag 1 XXX a des infos, on les ajoutes. *)
               let note =
                 let name_info = strip_spaces r.rval in
-                if name_info = "" || r.rval = "Y" then note
+                if Compat.String.is_empty name_info || r.rval = "Y" then note
                 else name_info ^ "<br>\n" ^ note
               in
               let src =
                 match find_all_fields "SOUR" r.rsons with
-                  [] -> ""
+                  [] -> Compat.String.empty
                 | rl ->
                     let rec loop first src rl =
                       match rl with
@@ -2165,7 +2179,7 @@ let treat_fam_fevent gen ifath r =
                           in
                           loop false src rl
                     in
-                    loop true "" rl
+                    loop true Compat.String.empty rl
               in
               let witnesses = find_fevent_witness gen "INDI" ifath r in
               (* Vérification du mariage. *)
@@ -2201,7 +2215,7 @@ let treat_fam_fevent gen ifath r =
       (fun events r ->
          match find_field "TYPE" r.rsons with
            Some rr ->
-             if rr.rval <> "" then
+             if not @@ Compat.String.is_empty rr.rval then
                let name =
                  if List.mem rr.rval primary_fevents then
                    find_fevent_name_from_tag gen rr.rval rr.rval
@@ -2217,23 +2231,23 @@ let treat_fam_fevent gen ifath r =
                let place =
                  match find_field "PLAC" r.rsons with
                    Some r -> strip_spaces r.rval
-                 | _ -> ""
+                 | _ -> Compat.String.empty
                in
-               let reason = "" in
+               let reason = Compat.String.empty in
                let note =
                  match find_all_fields "NOTE" r.rsons with
-                   [] -> ""
+                   [] -> Compat.String.empty
                  | rl -> treat_notes gen rl
                in
                (* Si le tag 1 XXX a des infos, on les ajoutes. *)
                let note =
                  let name_info = strip_spaces r.rval in
-                 if name_info = "" || r.rval = "Y" then note
+                 if Compat.String.is_empty name_info || r.rval = "Y" then note
                  else name_info ^ "<br>\n" ^ note
                in
                let src =
                  match find_all_fields "SOUR" r.rsons with
-                   [] -> ""
+                   [] -> Compat.String.empty
                  | rl ->
                      let rec loop first src rl =
                        match rl with
@@ -2246,7 +2260,7 @@ let treat_fam_fevent gen ifath r =
                            in
                            loop false src rl
                      in
-                     loop true "" rl
+                     loop true Compat.String.empty rl
                in
                let witnesses = find_fevent_witness gen "INDI" ifath r in
                let evt =
@@ -2264,8 +2278,10 @@ let treat_fam_fevent gen ifath r =
                    Efam_Name n -> n <> string_empty
                  | _ -> false
                in
-               if has_efam_name || date <> None || place <> "" ||
-                  note <> "" || src <> "" || witnesses <> [| |] ||
+               if has_efam_name || date <> None ||
+                  not @@ Compat.String.is_empty place ||
+                  not @@ Compat.String.is_empty note ||
+                  not @@ Compat.String.is_empty src || witnesses <> [| |] ||
                   List.mem name secondary_fevent_types
                then
                  evt :: events
@@ -2318,7 +2334,7 @@ let reconstitute_from_fevents gen gay fevents marr witn div =
               in
               (* Pour différencier le fait qu'on recopie le *)
               (* mariage, on ne met pas de lieu.            *)
-              let place = add_string gen "" in
+              let place = add_string gen Compat.String.empty in
               let marr = Married, date, place, evt.efam_note, evt.efam_src in
               let () = found_marriage := true in loop l marr witn div
         | Efam_NoMention | Efam_MarriageBann | Efam_MarriageLicense |
@@ -2440,7 +2456,7 @@ let add_fam_norm gen r adop_list =
         match find_all_fields "PLAC" r.rsons with
           r :: rl ->
           if String.uncapitalize_ascii r.rval = "unmarried" then
-            NotMarried, ""
+            NotMarried, Compat.String.empty
           else
             let p = strip_spaces r.rval in
             let rec loop =
@@ -2452,7 +2468,7 @@ let add_fam_norm gen r adop_list =
               | [] -> relation, p
             in
             loop rl
-        | [] -> relation, ""
+        | [] -> relation, Compat.String.empty
       in
       let u =
         match find_field "TYPE" r.rsons with
@@ -2485,11 +2501,11 @@ let add_fam_norm gen r adop_list =
       in
       let note =
         match find_all_fields "NOTE" r.rsons with
-          [] -> ""
+          [] -> Compat.String.empty
         | rl -> treat_notes gen rl
       in
       u, d, p, (note, []), source gen r, witnesses
-    | None -> relation, None, "", ("", []), ("", []), []
+    | None -> relation, None, Compat.String.empty, (Compat.String.empty, []), (Compat.String.empty, []), []
   in
   let witnesses = Array.of_list witnesses in
   let div =
@@ -2508,18 +2524,18 @@ let add_fam_norm gen r adop_list =
   let fevents = treat_fam_fevent gen fath r in
   let comment =
     match find_all_fields "NOTE" r.rsons with
-      [] -> ""
+      [] -> Compat.String.empty
     | rl -> treat_notes gen rl
   in
   let (fsources, fsources_nt) =
     let (s, s_nt) = source gen r in
-    if s = "" then !default_source, s_nt else s, s_nt
+    if Compat.String.is_empty s then !default_source, s_nt else s, s_nt
   in
   let concat_text s1 s2 s_sep =
-    let s = if s1 = "" then "" else s_sep in s1 ^ s ^ s2
+    let s = if Compat.String.is_empty s1 then Compat.String.empty else s_sep in s1 ^ s ^ s2
   in
   let ext_sources =
-    let text = concat_text "" (notes_from_source_record marr_nt) "<br>\n" in
+    let text = concat_text Compat.String.empty (notes_from_source_record marr_nt) "<br>\n" in
     concat_text text (notes_from_source_record fsources_nt) "<br>\n"
   in
   let ext_notes =
@@ -2529,11 +2545,11 @@ let add_fam_norm gen r adop_list =
         if rtl = [] then init
         else concat_text init (html_text_of_tags text rtl) "\n"
       in
-      let nt = remain_tags_in_notes "FAM" "" r.rsons in
+      let nt = remain_tags_in_notes "FAM" Compat.String.empty r.rsons in
       let nt = remain_tags_in_notes "MARR SOUR" nt marr_nt in
       let nt = remain_tags_in_notes "SOUR SOUR" nt fsources_nt in
-      if nt = "" then "" else "<pre>\n" ^ nt ^ "\n</pre>"
-    else ""
+      if Compat.String.is_empty nt then Compat.String.empty else "<pre>\n" ^ nt ^ "\n</pre>"
+    else Compat.String.empty
   in
   let add_in_person_notes iper =
     match gen.g_per.arr.(iper) with
@@ -2541,8 +2557,8 @@ let add_fam_norm gen r adop_list =
     | Right3 (p, a, u) ->
       let notes = gen.g_str.arr.(p.notes) in
       let notes =
-        if notes = "" then ext_sources ^ ext_notes
-        else if ext_sources = "" then notes ^ "\n" ^ ext_notes
+        if Compat.String.is_empty notes then ext_sources ^ ext_notes
+        else if Compat.String.is_empty ext_sources then notes ^ "\n" ^ ext_notes
         else notes ^ "<br>\n" ^ ext_sources ^ ext_notes
       in
       let new_notes = add_string gen notes in
@@ -2550,7 +2566,7 @@ let add_fam_norm gen r adop_list =
       gen.g_per.arr.(iper) <- Right3 (p, a, u)
   in
   let _ =
-    if ext_notes = "" then ()
+    if ext_notes = Compat.String.empty then ()
     else begin add_in_person_notes fath; add_in_person_notes moth end
   in
   (* Mise à jour des évènements principaux. *)
@@ -2613,7 +2629,7 @@ let treat_header2 r =
   match find_field "PLAC" r.rsons with
     Some rr ->
       begin match find_field "FORM" rr.rsons with
-        Some rrr -> if rrr.rval <> "" then ()
+        Some rrr -> if not @@ Compat.String.is_empty rrr.rval then ()
       | None -> ()
       end
   | None -> ()
@@ -2663,16 +2679,16 @@ let find_lev0 (strm__ : _ Stream.t) =
   let bp = Stream.count strm__ in
   let _ = line_start '0' strm__ in
   let _ =
-    try skip_space strm__ with Stream.Failure -> raise (Stream.Error "")
+    try skip_space strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let r1 =
-    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error "")
+    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let r2 =
-    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error "")
+    try get_ident 0 strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   let _ =
-    try skip_to_eoln strm__ with Stream.Failure -> raise (Stream.Error "")
+    try skip_to_eoln strm__ with Stream.Failure -> raise (Stream.Error Compat.String.empty)
   in
   bp, r1, r2
 
@@ -2872,14 +2888,14 @@ let add_parents_to_isolated gen =
 let make_arrays fname =
   let gen =
     {g_per = {arr = [| |]; tlen = 0}; g_fam = {arr = [| |]; tlen = 0};
-     g_str = {arr = [| |]; tlen = 0}; g_bnot = ""; g_ic = open_in_bin_with_bom_check fname;
+     g_str = {arr = [| |]; tlen = 0}; g_bnot = Compat.String.empty; g_ic = open_in_bin_with_bom_check fname;
      g_not = Hashtbl.create 3001; g_src = Hashtbl.create 3001;
      g_hper = Hashtbl.create 3001; g_hfam = Hashtbl.create 3001;
      g_hstr = Hashtbl.create 3001; g_hnam = Hashtbl.create 3001;
      g_adop = Hashtbl.create 3001; g_godp = []; g_prelated = [];
      g_frelated = []; g_witn = []}
   in
-  assert (add_string gen "" = string_empty);
+  assert (add_string gen Compat.String.empty = string_empty);
   assert (add_string gen "?" = string_quest);
   assert (add_string gen "x" = string_x);
   Printf.eprintf "*** pass 1 (note)\n";
@@ -2921,7 +2937,8 @@ let make_subarrays (g_per, g_fam, g_str, g_bnot) =
   in
   let strings = Array.sub g_str.arr 0 g_str.tlen in
   let bnotes =
-    {nread = (fun s _ -> if s = "" then g_bnot else ""); norigin_file = "";
+    {nread = (fun s _ -> if Compat.String.is_empty s then
+      g_bnot else Compat.String.empty); norigin_file = Compat.String.empty;
      efiles = fun _ -> []}
   in
   persons, families, strings, bnotes
@@ -3240,8 +3257,8 @@ let speclist =
         | Some i ->
           let a = String.sub s 0 i in
           let b = String.sub s (i + 1) (String.length s - i - 1) in
-          let a = if a = "" then !alive_years else int_of_string a in
-          let b = max a (if b = "" then !dead_years else int_of_string b) in
+          let a = if Compat.String.is_empty a then !alive_years else int_of_string a in
+          let b = max a (if Compat.String.is_empty b then !dead_years else int_of_string b) in
           alive_years := a ;
           dead_years := b ;
         | None -> raise (Arg.Bad "bad parameter for -udi")
@@ -3282,7 +3299,7 @@ let speclist =
   ] |> List.sort compare |> Arg.align
 
 let anonfun s =
-  if !in_file = "" then in_file := s
+  if Compat.String.is_empty !in_file then in_file := s
   else raise (Arg.Bad "Cannot treat several GEDCOM files")
 
 let errmsg = "Usage: ged2gwb [<ged>] [options] where options are:"
@@ -3290,15 +3307,15 @@ let errmsg = "Usage: ged2gwb [<ged>] [options] where options are:"
 let main () =
   Arg.parse speclist anonfun errmsg;
   if not (Array.mem "-bd" Sys.argv) then Secure.set_base_dir ".";
-  if !in_file <> "" then
+  if not @@ Compat.String.is_empty !in_file then
     close_in (open_in_bin_with_bom_check !in_file);
   let input_file =
-    if !in_file <> "" then
+    if not @@ Compat.String.is_empty !in_file then
       Filename.remove_extension !in_file
     else
       !in_file
   in
-  if input_file <> "" && (not (Array.mem "-o" Sys.argv)) then out_file := input_file;
+  if not @@ Compat.String.is_empty input_file && (not (Array.mem "-o" Sys.argv)) then out_file := input_file;
   out_file := Filename.basename !out_file |> Filename.remove_extension;
   if not (Mutil.good_name !out_file) then (
     (* Util.transl conf not available !*)

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -4,12 +4,13 @@ open Geneweb
 open Gwcomp
 open Def
 module Driver = Geneweb_db.Driver
+module Compat = Geneweb_compat
 
 (* From OCaml manual, integer in binary format is 4 bytes long. *)
 let sizeof_long = 4
 
 (** Default source field for persons and families without source data *)
-let default_source = ref ""
+let default_source = ref Compat.String.empty
 
 (** Base consistency check *)
 let do_check = ref true
@@ -145,7 +146,7 @@ let check_error ?(critical = false) gen msg =
 let set_error base gen x =
   Printf.printf "\nError: ";
   Check.print_base_error stdout base x;
-  check_error gen ""
+  check_error gen Compat.String.empty
 
 (** Function that will be called if base's checker will find a warning *)
 let set_warning base no_warn x =
@@ -189,7 +190,7 @@ let output_item_value oc v = Marshal.to_channel oc v [ Marshal.No_sharing ]
 let input_item_value ic = input_value ic
 
 (** Empty string *)
-let no_string = ""
+let no_string = Compat.String.empty
 
 (** Stores unique string (if not already present) inside the base's string array
     and associate this string to its index in mentioned array. Extens array if
@@ -213,7 +214,7 @@ let unique_string gen x =
 
 (** Dummy [family] with its empty [couple] and [descendants]. *)
 let no_family gen =
-  let empty_string = unique_string gen "" in
+  let empty_string = unique_string gen Compat.String.empty in
   let fam =
     {
       marriage = Date.cdate_None;
@@ -239,7 +240,7 @@ let no_family gen =
     with default value. Returns also empty [ascend] and [union] attached to the
     considered person. *)
 let make_person gen p n occ : min_person * ascend * union =
-  let empty_string = unique_string gen "" in
+  let empty_string = unique_string gen Compat.String.empty in
   let p =
     {
       m_first_name = unique_string gen p;
@@ -256,7 +257,7 @@ let make_person gen p n occ : min_person * ascend * union =
   (p, a, u)
 
 (** Dummy [min_person] with its empty [ascend] and [union]. *)
-let no_person gen = make_person gen "" "" 0
+let no_person gen = make_person gen Compat.String.empty Compat.String.empty 0
 
 (** Extends person's acendant's and union's arrays inside [gen.g_base] if
     needed. *)
@@ -481,14 +482,16 @@ let insert_undefined gen key =
     then (
       Printf.printf "\nError: Person defined with two spellings:\n";
       Printf.printf "  \"%s%s %s\"\n" key.pk_first_name
-        (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
+        (match x.m_occ with
+        | 0 -> Compat.String.empty
+        | n -> "." ^ string_of_int n)
         key.pk_surname;
       Printf.printf "  \"%s%s %s\"\n"
         (p_first_name gen.g_base x)
-        (match occ with 0 -> "" | n -> "." ^ string_of_int n)
+        (match occ with 0 -> Compat.String.empty | n -> "." ^ string_of_int n)
         (p_surname gen.g_base x);
       gen.g_def.(ip) <- true;
-      check_error gen "");
+      check_error gen Compat.String.empty);
   (x, ip)
 
 (** Insert person's definition in the base and modifies all coresponding fields
@@ -563,7 +566,9 @@ let insert_person gen so =
   if gen.g_def.(ip) then (
     let person_str =
       Printf.sprintf "%s%s %s" so.first_name
-        (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
+        (match x.m_occ with
+        | 0 -> Compat.String.empty
+        | n -> "." ^ string_of_int n)
         so.surname
     in
     Printf.printf "\nError: Person already defined: \"%s\"\n" person_str;
@@ -573,10 +578,10 @@ let insert_person gen so =
     then
       Printf.printf "as name: \"%s%s %s\"\n"
         (p_first_name gen.g_base x)
-        (match occ with 0 -> "" | n -> "." ^ string_of_int n)
+        (match occ with 0 -> Compat.String.empty | n -> "." ^ string_of_int n)
         (p_surname gen.g_base x);
     flush stdout;
-    check_error gen "")
+    check_error gen Compat.String.empty)
   else (* else set it as defined *)
     gen.g_def.(ip) <- true;
   if not gen.g_errored then
@@ -587,24 +592,30 @@ let insert_person gen so =
       (* print error about person defined with two spellings *)
       let msg =
         Printf.sprintf "Two spellings: \"%s%s %s\" vs \"%s%s %s\"" so.first_name
-          (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
+          (match x.m_occ with
+          | 0 -> Compat.String.empty
+          | n -> "." ^ string_of_int n)
           so.surname
           (p_first_name gen.g_base x)
-          (match occ with 0 -> "" | n -> "." ^ string_of_int n)
+          (match occ with
+          | 0 -> Compat.String.empty
+          | n -> "." ^ string_of_int n)
           (p_surname gen.g_base x)
       in
       Printf.printf "\nError: Person defined with two spellings:\n";
       Printf.printf "  \"%s%s %s\"\n" so.first_name
-        (match x.m_occ with 0 -> "" | n -> "." ^ string_of_int n)
+        (match x.m_occ with
+        | 0 -> Compat.String.empty
+        | n -> "." ^ string_of_int n)
         so.surname;
       Printf.printf "  \"%s%s %s\"\n"
         (p_first_name gen.g_base x)
-        (match occ with 0 -> "" | n -> "." ^ string_of_int n)
+        (match occ with 0 -> Compat.String.empty | n -> "." ^ string_of_int n)
         (p_surname gen.g_base x);
       gen.g_def.(ip) <- true;
       check_error ~critical:true gen msg);
   if not gen.g_errored then (
-    let empty_string = unique_string gen "" in
+    let empty_string = unique_string gen Compat.String.empty in
     (* Convert [(_,_,string) gen_person] to [person]. Save all strings in base *)
     let x =
       {
@@ -644,7 +655,8 @@ let insert_person gen so =
         notes = empty_string;
         psources =
           unique_string gen
-            (if so.psources = "" then !default_source else so.psources);
+            (if Compat.String.is_empty so.psources then !default_source
+             else so.psources);
         key_index = ip;
       }
     in
@@ -828,10 +840,10 @@ let update_fevents_with_family gen fam =
           {
             efam_name = Efam_Divorce;
             efam_date = cd;
-            efam_place = unique_string gen "";
-            efam_reason = unique_string gen "";
-            efam_note = unique_string gen "";
-            efam_src = unique_string gen "";
+            efam_place = unique_string gen Compat.String.empty;
+            efam_reason = unique_string gen Compat.String.empty;
+            efam_note = unique_string gen Compat.String.empty;
+            efam_src = unique_string gen Compat.String.empty;
             efam_witnesses = [||];
           }
         in
@@ -842,10 +854,10 @@ let update_fevents_with_family gen fam =
           {
             efam_name = Efam_Separated;
             efam_date = Date.cdate_None;
-            efam_place = unique_string gen "";
-            efam_reason = unique_string gen "";
-            efam_note = unique_string gen "";
-            efam_src = unique_string gen "";
+            efam_place = unique_string gen Compat.String.empty;
+            efam_reason = unique_string gen Compat.String.empty;
+            efam_note = unique_string gen Compat.String.empty;
+            efam_src = unique_string gen Compat.String.empty;
             efam_witnesses = [||];
           }
         in
@@ -855,10 +867,10 @@ let update_fevents_with_family gen fam =
           {
             efam_name = Efam_Separated;
             efam_date = cd;
-            efam_place = unique_string gen "";
-            efam_reason = unique_string gen "";
-            efam_note = unique_string gen "";
-            efam_src = unique_string gen "";
+            efam_place = unique_string gen Compat.String.empty;
+            efam_reason = unique_string gen Compat.String.empty;
+            efam_note = unique_string gen Compat.String.empty;
+            efam_src = unique_string gen Compat.String.empty;
             efam_witnesses = [||];
           }
         in
@@ -958,7 +970,8 @@ let insert_family gen co fath_sex moth_sex witl fevtl fo deo =
   (* insert sources comment *)
   let fsources =
     unique_string gen
-      (if fo.fsources = "" then !default_source else fo.fsources)
+      (if Compat.String.is_empty fo.fsources then !default_source
+       else fo.fsources)
   in
   (* extend arrays if needed *)
   new_ifam gen;
@@ -1052,9 +1065,9 @@ let insert_pevents fname gen sb pevtl =
     Printf.printf "\nFile \"%s\"" fname;
     Printf.printf "\nError: Individual events already defined for \"%s%s %s\"\n"
       (sou gen.g_base p.m_first_name)
-      (if p.m_occ = 0 then "" else "." ^ string_of_int p.m_occ)
+      (if p.m_occ = 0 then Compat.String.empty else "." ^ string_of_int p.m_occ)
       (sou gen.g_base p.m_surname);
-    check_error gen "")
+    check_error gen Compat.String.empty)
   else
     (* sort evenets *)
     let pevents =
@@ -1102,19 +1115,19 @@ let insert_notes fname gen key str =
   with
   | Some ip ->
       let p = poi gen.g_base ip in
-      if sou gen.g_base p.m_notes <> "" then (
+      if not @@ Compat.String.is_empty @@ sou gen.g_base p.m_notes then (
         Printf.printf "\nFile \"%s\"" fname;
         Printf.printf "\nError: Notes already defined for \"%s%s %s\"\n"
           key.pk_first_name
-          (if occ = 0 then "" else "." ^ string_of_int occ)
+          (if occ = 0 then Compat.String.empty else "." ^ string_of_int occ)
           key.pk_surname;
-        check_error gen "")
+        check_error gen Compat.String.empty)
       else p.m_notes <- unique_string gen str
   | None ->
       Printf.printf "File \"%s\"\n" fname;
       Printf.printf "*** warning: undefined person: \"%s%s %s\"\n"
         key.pk_first_name
-        (if occ = 0 then "" else "." ^ string_of_int occ)
+        (if occ = 0 then Compat.String.empty else "." ^ string_of_int occ)
         key.pk_surname;
       flush stdout
 
@@ -1127,7 +1140,7 @@ let insert_bnotes fname gen nfname str =
     (* Convert path notation from 'dir1:dir2:file' to 'dir1/dir2/file'
        (if a valid path) *)
     let nfname =
-      if nfname = "" then ""
+      if Compat.String.is_empty nfname then Compat.String.empty
       else
         match NotesLinks.check_file_name nfname with
         | Some (dl, f) -> List.fold_right Filename.concat dl f
@@ -1139,13 +1152,15 @@ let insert_bnotes fname gen nfname str =
         | Drop -> assert false
         | Erase -> str
         | Merge -> old_nread nfname RnAll ^ str
-        | First -> ( match old_nread nfname RnAll with "" -> str | str -> str)
+        | First ->
+            let s = old_nread nfname RnAll in
+            if Compat.String.is_empty s then str else s
       in
       {
         nread = (fun f n -> if f = nfname then str else old_nread f n);
         norigin_file = fname;
         efiles =
-          (if nfname <> "" then
+          (if not @@ Compat.String.is_empty nfname then
              let efiles = gen.g_base.c_bnotes.efiles () in
              fun () -> nfname :: efiles
            else gen.g_base.c_bnotes.efiles);
@@ -1189,9 +1204,10 @@ let insert_relations fname gen sb sex rl =
       Printf.printf "\nFile \"%s\"" fname;
       Printf.printf "\nError: Relations already defined for \"%s%s %s\"\n"
         (sou gen.g_base p.m_first_name)
-        (if p.m_occ = 0 then "" else "." ^ string_of_int p.m_occ)
+        (if p.m_occ = 0 then Compat.String.empty
+         else "." ^ string_of_int p.m_occ)
         (sou gen.g_base p.m_surname);
-      check_error gen "")
+      check_error gen Compat.String.empty)
   else (
     notice_sex gen p sex;
     let rl = List.map (insert_relation gen ip) rl in
@@ -1548,13 +1564,13 @@ let convert_persons per_index_ic per_ic persons =
     persons
 
 (** File containing the particles to use *)
-let particules_file = ref ""
+let particules_file = ref Compat.String.empty
 
 (** Returns list of particles from the file. If filename is empty string then
     returns default particles list *)
-let input_particles = function
-  | "" -> Mutil.default_particles
-  | file -> Mutil.input_particles file
+let input_particles file =
+  if Compat.String.is_empty file then Mutil.default_particles
+  else Mutil.input_particles file
 
 (** Empty base *)
 let empty_base : cbase =
@@ -1567,7 +1583,11 @@ let empty_base : cbase =
     c_descends = [||];
     c_strings = [||];
     c_bnotes =
-      { nread = (fun _ _ -> ""); norigin_file = ""; efiles = (fun _ -> []) };
+      {
+        nread = (fun _ _ -> Compat.String.empty);
+        norigin_file = Compat.String.empty;
+        efiles = (fun _ -> []);
+      };
   }
 
 (** Extract information from the [gen.g_base] and create database *)
@@ -1671,8 +1691,8 @@ let link ?(no_warn = false) next_family_fun bdir =
   let fi =
     {
       f_local_names = Hashtbl.create 20011;
-      f_curr_src_file = "";
-      f_curr_gwo_file = "";
+      f_curr_src_file = Compat.String.empty;
+      f_curr_gwo_file = Compat.String.empty;
       f_separate = false;
       f_shift = 0;
       f_bnotes = Merge;
@@ -1700,7 +1720,7 @@ let link ?(no_warn = false) next_family_fun bdir =
   in
   let per_index_ic = open_in_bin tmp_per_index in
   let per_ic = open_in_bin tmp_per in
-  let istr_empty = unique_string gen "" in
+  let istr_empty = unique_string gen Compat.String.empty in
   let istr_quest = unique_string gen "?" in
   assert (istr_empty = 0);
   assert (istr_quest = 1);

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -289,7 +289,7 @@ let () =
   Secure.set_base_dir base_dir;
   GWPARAM.init ();
   let dist_etc_d = Filename.concat (Filename.dirname Sys.argv.(0)) "etc" in
-  if !Db1link.particules_file = "" then
+  if Compat.String.is_empty !Db1link.particules_file then
     Db1link.particules_file := Filename.concat dist_etc_d "particles.txt";
   if !Gwcomp.verbose then
     if !Gwcomp.rgpd then

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -13,6 +13,7 @@ module Dirs = Geneweb_dirs
 module Plugin = Geneweb_plugin
 module Server = Geneweb_http.Server
 module Code = Geneweb_http.Code
+module Compat = Geneweb_compat
 
 type opened_file = { path : string; mutable oc : out_channel }
 type log = Stdout | Stderr | File of opened_file | Syslog
@@ -99,7 +100,8 @@ let client_accepts_encoding request encoding =
       in
       let p = String.trim part in
       Mutil.contains p encoding
-      && dominated (String.concat "" (String.split_on_char ' ' p))
+      && dominated
+           (String.concat Compat.String.empty (String.split_on_char ' ' p))
     in
     not (List.exists dominated_by_zero (String.split_on_char ',' accept))
 
@@ -226,16 +228,16 @@ type plugin = {
 }
 
 let printer_conf = { Config.empty with output_conf }
-let auth_file = ref ""
+let auth_file = ref Compat.String.empty
 let cache_langs = ref []
 let cache_databases = ref []
 let choose_browser_lang = ref false
 let conn_timeout = ref 120
 let daemon = ref false
 let default_lang = ref "fr"
-let friend_passwd = ref ""
+let friend_passwd = ref Compat.String.empty
 let green_color = "#2f6400"
-let images_dir = ref ""
+let images_dir = ref Compat.String.empty
 let lexicon_list = ref [ Filename.concat "lang" "lexicon.txt" ]
 let login_timeout = ref 1800
 let default_n_workers = 20
@@ -255,7 +257,7 @@ let debug = ref false
 let check = ref false
 let use_auth_digest_scheme = ref false
 let wizard_just_friend = ref false
-let wizard_passwd = ref ""
+let wizard_passwd = ref Compat.String.empty
 let predictable_mode = ref false
 let log_file : log ref = ref Stderr
 let verbosity_level = ref 6
@@ -306,11 +308,11 @@ type auth_report = {
 let split_username username =
   let l1 = String.split_on_char '|' username in
   match List.length l1 with
-  | 1 -> (username, "")
+  | 1 -> (username, Compat.String.empty)
   | 2 -> (List.nth l1 0, List.nth l1 1)
   | _ ->
       Logs.err (fun k -> k "Bad .auth key or sosa encoding");
-      (username, "")
+      (username, Compat.String.empty)
 
 let log_passwd_failed ar tm from request base_file =
   let referer = Mutil.extract_param "referer: " '\n' request in
@@ -323,7 +325,8 @@ let log_passwd_failed ar tm from request base_file =
   if !trace_failed_passwd then
     Logs.info (fun k -> k ~tags:timestamp " (%s)" (String.escaped ar.ar_uauth));
   Logs.info (fun k -> k "\n  From: %s\n  Agent: %s" from user_agent);
-  if referer <> "" then Logs.info (fun k -> k "  Referer: %s" referer)
+  if not @@ Compat.String.is_empty referer then
+    Logs.info (fun k -> k "  Referer: %s" referer)
 
 let copy_file conf fname =
   match Util.open_etc_file conf fname with
@@ -380,7 +383,7 @@ let index_from s o c =
 let index s c = index_from s 0 c
 
 let rec extract_assoc key = function
-  | [] -> ("", [])
+  | [] -> (Compat.String.empty, [])
   | ((k, v) as kv) :: kvl ->
       if k = key then (Mutil.decode v, kvl)
       else
@@ -474,8 +477,8 @@ let load_plugin ~unsafe ~forced path =
   let lex_dir = path // "assets" // "lex" in
   if Sys.file_exists lex_dir then add_lex_dir lex_dir;
   Plugin.assets := path // "assets";
-  Fun.protect ~finally:(fun () -> Plugin.assets := "") @@ fun () ->
-  load_cmxs cmxs
+  Fun.protect ~finally:(fun () -> Plugin.assets := Compat.String.empty)
+  @@ fun () -> load_cmxs cmxs
 
 let load_plugins { path; unsafe; forced; collection } =
   if not collection then load_plugin ~unsafe ~forced path
@@ -523,7 +526,7 @@ let print_renamed conf new_n =
     let new_req =
       let len = String.length conf.bname in
       let rec loop i =
-        if i > String.length req then ""
+        if i > String.length req then Compat.String.empty
         else if i >= len && String.sub req (i - len) len = conf.bname then
           String.sub req 0 (i - len)
           ^ new_n
@@ -580,17 +583,17 @@ let nonce_private_key =
           let s =
             let rec loop () =
               match input_line ic with
-              | s when s = "" || s.[0] = '#' -> loop ()
+              | s when s = Compat.String.empty || s.[0] = '#' -> loop ()
               | s -> s
-              | exception End_of_file -> ""
+              | exception End_of_file -> Compat.String.empty
             in
             loop ()
           in
           close_in ic;
           s
-        with Sys_error _ -> ""
+        with Sys_error _ -> Compat.String.empty
       in
-      if k = "" then (
+      if Compat.String.is_empty k then (
         Random.self_init ();
         let k = Random.bits () in
         let oc = open_out fname in
@@ -638,14 +641,18 @@ let unauth_server conf ar =
     in
     Output.header conf
       "WWW-Authenticate: Digest realm=\"%s %s\"%s%s,qop=\"auth\"" typ conf.bname
-      (if nonce = "" then "" else Printf.sprintf ",nonce=\"%s\"" nonce)
-      (if ar.ar_can_stale then ",stale=true" else "")
+      (if Compat.String.is_empty nonce then Compat.String.empty
+       else Printf.sprintf ",nonce=\"%s\"" nonce)
+      (if ar.ar_can_stale then ",stale=true" else Compat.String.empty)
   else
     Output.header conf "WWW-Authenticate: Basic realm=\"%s %s\"" typ conf.bname;
   let env =
     List.fold_left
       (fun l (k, v) ->
-        if k = "" || (k = "oc" && int_of_string (Mutil.decode v) = 0) then l
+        if
+          Compat.String.is_empty k
+          || (k = "oc" && int_of_string (Mutil.decode v) = 0)
+        then l
         else (k ^ "=" ^ Mutil.decode v) :: l)
       []
       (conf.henv @ conf.senv @ conf.env)
@@ -671,7 +678,7 @@ let unauth_server conf ar =
    Output.print_sstring conf "<li>\n";
    Output.printf conf {|%s : <a href="%s?%s%s%s">%s</a>|} (transl conf "access")
      conf.bname env
-     (if env = "" then "" else "&")
+     (if Compat.String.is_empty env then Compat.String.empty else "&")
      alt_bind alt_access;
    Output.print_sstring conf "</li>\n";
    Output.print_sstring conf "<li>\n";
@@ -684,7 +691,7 @@ let unauth_server conf ar =
   Hutil.trailer conf
 
 let gen_match_auth_file test_user_and_password auth_file base_file =
-  if auth_file = "" then None
+  if Compat.String.is_empty auth_file then None
   else
     let aul = read_gen_auth_file auth_file base_file in
     let rec loop = function
@@ -729,7 +736,8 @@ let match_simple_passwd sauth uauth =
       | None -> sauth = uauth)
 
 let basic_match_auth passwd auth_file uauth base_file =
-  if passwd <> "" && match_simple_passwd passwd uauth then Some ""
+  if (not @@ Compat.String.is_empty passwd) && match_simple_passwd passwd uauth
+  then Some Compat.String.empty
   else basic_match_auth_file uauth auth_file base_file
 
 type access_type =
@@ -762,7 +770,7 @@ let get_actlog check_from utm from_addr base_password =
           let c = line.[ispace + 1] in
           let user =
             let k = ispace + 3 in
-            if k >= String.length line then ""
+            if k >= String.length line then Compat.String.empty
             else String.sub line k (String.length line - k)
           in
           let len = String.length user in
@@ -770,7 +778,7 @@ let get_actlog check_from utm from_addr base_password =
             match String.index_opt user ' ' with
             | Some i ->
                 (String.sub user 0 i, String.sub user (i + 1) (len - i - 1))
-            | None -> (user, "")
+            | None -> (user, Compat.String.empty)
           in
           let list, r, changed =
             if utm -. tm >= tmout then (list, r, true)
@@ -807,8 +815,8 @@ let set_actlog list =
     List.iter
       (fun ((from, base_pw), (a, c, d, e)) ->
         Printf.fprintf oc "%.0f %s/%s %c%s%s\n" a from base_pw c
-          (if d = "" then "" else " " ^ d)
-          (if e = "" then "" else " " ^ e))
+          (if Compat.String.is_empty d then Compat.String.empty else " " ^ d)
+          (if Compat.String.is_empty e then Compat.String.empty else " " ^ e))
       list;
     close_out oc
   with Sys_error e -> Logs.warn (fun k -> k "Error opening actlog: %s" e)
@@ -838,10 +846,12 @@ let random_self_init () =
 let set_token utm from_addr base_file acc user username =
   let lock_file = !GWPARAM.adm_file "gwd.lck" in
   (* FIXME: we silently ignore errors if we cannot lock the database. *)
-  let on_exn _exn _bt = "" in
+  let on_exn _exn _bt = Compat.String.empty in
   Lock.control ~on_exn ~wait:true ~lock_file @@ fun () ->
   random_self_init ();
-  let list, _, _ = get_actlog false utm "" "" in
+  let list, _, _ =
+    get_actlog false utm Compat.String.empty Compat.String.empty
+  in
   let x, xx =
     let base = base_file ^ "_" in
     let rec loop ntimes =
@@ -899,7 +909,7 @@ let refresh_url conf bname =
 
 let http_preferred_language request =
   let v = Mutil.extract_param "accept-language: " '\n' request in
-  if v = "" then ""
+  if Compat.String.is_empty v then Compat.String.empty
   else
     let s = String.lowercase_ascii v in
     let list =
@@ -919,7 +929,7 @@ let http_preferred_language request =
             if List.mem blang Version.available_languages then blang
             else loop list
           else loop list
-      | [] -> ""
+      | [] -> Compat.String.empty
     in
     loop list
 
@@ -928,16 +938,18 @@ let allowed_denied_titles key extra_line env base_env () =
   else
     try
       let fname = List.assoc key base_env in
-      if fname = "" then []
+      if fname = Compat.String.empty then []
       else
         let ic = Secure.open_in (Filename.concat (Secure.base_dir ()) fname) in
         let rec loop set =
           let line, eof =
-            try (input_line ic, false) with End_of_file -> ("", true)
+            try (input_line ic, false)
+            with End_of_file -> (Compat.String.empty, true)
           in
           let set =
             let line = if eof then extra_line |> Mutil.decode else line in
-            if line = "" || line.[0] = ' ' || line.[0] = '#' then set
+            if Compat.String.is_empty line || line.[0] = ' ' || line.[0] = '#'
+            then set
             else
               let line =
                 match String.index_opt line '/' with
@@ -962,22 +974,25 @@ let allowed_denied_titles key extra_line env base_env () =
 
 let allowed_titles env =
   let extra_line =
-    try List.assoc "extra_title" env with Not_found -> Adef.encoded ""
+    try List.assoc "extra_title" env
+    with Not_found -> Adef.encoded Compat.String.empty
   in
   allowed_denied_titles "allowed_titles_file" extra_line env
 
-let denied_titles = allowed_denied_titles "denied_titles_file" (Adef.encoded "")
+let denied_titles =
+  allowed_denied_titles "denied_titles_file" (Adef.encoded Compat.String.empty)
 
 let parse_digest s =
   let rec parse_main (strm__ : _ Stream.t) =
     match try Some (ident strm__) with Stream.Failure -> None with
     | Some s ->
         let _ =
-          try spaces strm__ with Stream.Failure -> raise (Stream.Error "")
+          try spaces strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         let kvl =
           try key_eq_val_list strm__
-          with Stream.Failure -> raise (Stream.Error "")
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         if s = "Digest" then kvl else []
     | _ -> []
@@ -987,7 +1002,7 @@ let parse_digest s =
         Stream.junk strm__;
         let len =
           try ident_kont (Buff.store 0 c) strm__
-          with Stream.Failure -> raise (Stream.Error "")
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         Buff.get len
     | _ -> raise Stream.Failure
@@ -1001,14 +1016,15 @@ let parse_digest s =
     match Stream.peek strm__ with
     | Some ' ' -> (
         Stream.junk strm__;
-        try spaces strm__ with Stream.Failure -> raise (Stream.Error ""))
+        try spaces strm__
+        with Stream.Failure -> raise (Stream.Error Compat.String.empty))
     | _ -> ()
   and key_eq_val_list (strm__ : _ Stream.t) =
     match try Some (key_eq_val strm__) with Stream.Failure -> None with
     | Some kv ->
         let kvl =
           try key_eq_val_list_kont strm__
-          with Stream.Failure -> raise (Stream.Error "")
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         kv :: kvl
     | _ -> []
@@ -1017,14 +1033,16 @@ let parse_digest s =
     | Some ',' ->
         Stream.junk strm__;
         let _ =
-          try spaces strm__ with Stream.Failure -> raise (Stream.Error "")
+          try spaces strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         let kv =
-          try key_eq_val strm__ with Stream.Failure -> raise (Stream.Error "")
+          try key_eq_val strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         let kvl =
           try key_eq_val_list_kont strm__
-          with Stream.Failure -> raise (Stream.Error "")
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         kv :: kvl
     | _ -> []
@@ -1034,25 +1052,29 @@ let parse_digest s =
     | Some '=' ->
         Stream.junk strm__;
         let v =
-          try val_or_str strm__ with Stream.Failure -> raise (Stream.Error "")
+          try val_or_str strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         (k, v)
-    | _ -> raise (Stream.Error "")
+    | _ -> raise (Stream.Error Compat.String.empty)
   and val_or_str (strm__ : _ Stream.t) =
     match Stream.peek strm__ with
     | Some '"' ->
         Stream.junk strm__;
         let v =
-          try string 0 strm__ with Stream.Failure -> raise (Stream.Error "")
+          try string 0 strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         let _ =
-          try spaces strm__ with Stream.Failure -> raise (Stream.Error "")
+          try spaces strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         v
     | _ ->
         let v = any_val 0 strm__ in
         let _ =
-          try spaces strm__ with Stream.Failure -> raise (Stream.Error "")
+          try spaces strm__
+          with Stream.Failure -> raise (Stream.Error Compat.String.empty)
         in
         v
   and string len (strm__ : _ Stream.t) =
@@ -1079,23 +1101,25 @@ let basic_authorization from_addr request base_env passwd access_type utm
     try List.assoc "wizard_passwd" base_env with Not_found -> !wizard_passwd
   in
   let wizard_passwd_file =
-    try List.assoc "wizard_passwd_file" base_env with Not_found -> ""
+    try List.assoc "wizard_passwd_file" base_env
+    with Not_found -> Compat.String.empty
   in
   let friend_passwd =
     try List.assoc "friend_passwd" base_env with Not_found -> !friend_passwd
   in
   let friend_passwd_file =
-    try List.assoc "friend_passwd_file" base_env with Not_found -> ""
+    try List.assoc "friend_passwd_file" base_env
+    with Not_found -> Compat.String.empty
   in
   let passwd1 =
     let auth = Mutil.extract_param "authorization: " '\r' request in
-    if auth = "" then ""
+    if Compat.String.is_empty auth then Compat.String.empty
     else
       let s = "Basic " in
       if Mutil.start_with s 0 auth then
         let i = String.length s in
         Base64.decode (String.sub auth i (String.length auth - i))
-      else ""
+      else Compat.String.empty
   in
   let uauth = if passwd = "w" || passwd = "f" then passwd1 else passwd in
   let auto = Mutil.extract_param "gw-connection-type: " '\r' request in
@@ -1103,64 +1127,78 @@ let basic_authorization from_addr request base_env passwd access_type utm
   let ok, wizard, friend, username =
     if (not !Server.cgi) && (passwd = "w" || passwd = "f") then
       if passwd = "w" then
-        if wizard_passwd = "" && wizard_passwd_file = "" then
-          (true, true, friend_passwd = "", "")
+        if
+          Compat.String.is_empty wizard_passwd
+          && Compat.String.is_empty wizard_passwd_file
+        then
+          (true, true, Compat.String.is_empty friend_passwd, Compat.String.empty)
         else
           match
             basic_match_auth wizard_passwd wizard_passwd_file uauth base_file
           with
           | Some username -> (true, true, false, username)
-          | None -> (false, false, false, "")
+          | None -> (false, false, false, Compat.String.empty)
       else if passwd = "f" then
-        if friend_passwd = "" && friend_passwd_file = "" then
-          (true, false, true, "")
+        if
+          Compat.String.is_empty friend_passwd
+          && Compat.String.is_empty friend_passwd_file
+        then (true, false, true, Compat.String.empty)
         else
           match
             basic_match_auth friend_passwd friend_passwd_file uauth base_file
           with
           | Some username -> (true, false, true, username)
-          | None -> (false, false, false, "")
+          | None -> (false, false, false, Compat.String.empty)
       else assert false
-    else if wizard_passwd = "" && wizard_passwd_file = "" then
-      (true, true, friend_passwd = "", "")
+    else if
+      Compat.String.is_empty wizard_passwd
+      && Compat.String.is_empty wizard_passwd_file
+    then (true, true, friend_passwd = Compat.String.empty, Compat.String.empty)
     else
       match
         basic_match_auth wizard_passwd wizard_passwd_file uauth base_file
       with
       | Some username -> (true, true, false, username)
       | _ -> (
-          if friend_passwd = "" && friend_passwd_file = "" then
-            (true, false, true, "")
+          if
+            Compat.String.is_empty friend_passwd
+            && Compat.String.is_empty friend_passwd_file
+          then (true, false, true, Compat.String.empty)
           else
             match
               basic_match_auth friend_passwd friend_passwd_file uauth base_file
             with
             | Some username -> (true, false, true, username)
-            | None -> (true, false, false, ""))
+            | None -> (true, false, false, Compat.String.empty))
   in
   let user =
     match String.index_opt uauth ':' with
     | Some i ->
         let s = String.sub uauth 0 i in
-        if s = wizard_passwd || s = friend_passwd then "" else s
-    | None -> ""
+        if s = wizard_passwd || s = friend_passwd then Compat.String.empty
+        else s
+    | None -> Compat.String.empty
   in
   let command, passwd =
     if access_type = ATset then
       if wizard then
         let pwd_id = set_token utm from_addr base_file 'w' user username in
-        if !Server.cgi then (command, pwd_id) else (base_file ^ "_" ^ pwd_id, "")
+        if !Server.cgi then (command, pwd_id)
+        else (base_file ^ "_" ^ pwd_id, Compat.String.empty)
       else if friend then
         let pwd_id = set_token utm from_addr base_file 'f' user username in
-        if !Server.cgi then (command, pwd_id) else (base_file ^ "_" ^ pwd_id, "")
-      else if !Server.cgi then (command, "")
-      else (base_file, "")
+        if !Server.cgi then (command, pwd_id)
+        else (base_file ^ "_" ^ pwd_id, Compat.String.empty)
+      else if !Server.cgi then (command, Compat.String.empty)
+      else (base_file, Compat.String.empty)
     else if !Server.cgi then (command, passwd)
-    else if passwd = "" then
+    else if Compat.String.is_empty passwd then
       if auto = "auto" then
-        let suffix = if wizard then "_w" else if friend then "_f" else "" in
+        let suffix =
+          if wizard then "_w" else if friend then "_f" else Compat.String.empty
+        in
         (base_file ^ suffix, passwd)
-      else (base_file, "")
+      else (base_file, Compat.String.empty)
     else (base_file ^ "_" ^ passwd, passwd)
   in
   let auth_scheme =
@@ -1177,7 +1215,7 @@ let basic_authorization from_addr request base_env passwd access_type utm
               String.sub passwd1 (i + 1) (String.length passwd1 - i - 1)
             in
             (u, p)
-        | None -> ("", passwd)
+        | None -> (Compat.String.empty, passwd)
       in
       HttpAuth (Basic { bs_realm = realm; bs_user = u; bs_pass = p })
   in
@@ -1200,11 +1238,11 @@ let bad_nonce_report command passwd_char =
     ar_command = command;
     ar_passwd = passwd_char;
     ar_scheme = NoAuth;
-    ar_user = "";
-    ar_name = "";
+    ar_user = Compat.String.empty;
+    ar_name = Compat.String.empty;
     ar_wizard = false;
     ar_friend = false;
-    ar_uauth = "";
+    ar_uauth = Compat.String.empty;
     ar_can_stale = true;
   }
 
@@ -1212,16 +1250,16 @@ let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz
     base_file =
   let asch = HttpAuth (Digest ds) in
   let digest_match_simple_passwd () =
-    if wf_passwd = "" then false
+    if Compat.String.is_empty wf_passwd then false
     else
       let user, pass =
         match String.index_opt wf_passwd ':' with
         | Some i ->
             ( String.sub wf_passwd 0 i,
               String.sub wf_passwd (i + 1) (String.length wf_passwd - i - 1) )
-        | None -> ("", wf_passwd)
+        | None -> (Compat.String.empty, wf_passwd)
       in
-      (user = "" || user = ds.ds_username)
+      (Compat.String.is_empty user || user = ds.ds_username)
       && is_that_user_and_password asch ds.ds_username pass
   in
   if digest_match_simple_passwd () then
@@ -1233,10 +1271,10 @@ let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz
         ar_passwd = passwd_char;
         ar_scheme = asch;
         ar_user = ds.ds_username;
-        ar_name = "";
+        ar_name = Compat.String.empty;
         ar_wizard = wiz;
         ar_friend = not wiz;
-        ar_uauth = "";
+        ar_uauth = Compat.String.empty;
         ar_can_stale = false;
       }
   else
@@ -1253,7 +1291,7 @@ let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz
             ar_name = username;
             ar_wizard = wiz;
             ar_friend = not wiz;
-            ar_uauth = "";
+            ar_uauth = Compat.String.empty;
             ar_can_stale = false;
           }
     | None ->
@@ -1263,10 +1301,10 @@ let test_passwd ds nonce command wf_passwd wf_passwd_file passwd_char wiz
           ar_passwd = passwd_char;
           ar_scheme = asch;
           ar_user = ds.ds_username;
-          ar_name = "";
+          ar_name = Compat.String.empty;
           ar_wizard = false;
           ar_friend = false;
-          ar_uauth = "";
+          ar_uauth = Compat.String.empty;
           ar_can_stale = false;
         }
 
@@ -1275,42 +1313,49 @@ let digest_authorization request base_env passwd utm base_file command =
     try List.assoc "wizard_passwd" base_env with Not_found -> !wizard_passwd
   in
   let wizard_passwd_file =
-    try List.assoc "wizard_passwd_file" base_env with Not_found -> ""
+    try List.assoc "wizard_passwd_file" base_env
+    with Not_found -> Compat.String.empty
   in
   let friend_passwd =
     try List.assoc "friend_passwd" base_env with Not_found -> !friend_passwd
   in
   let friend_passwd_file =
-    try List.assoc "friend_passwd_file" base_env with Not_found -> ""
+    try List.assoc "friend_passwd_file" base_env
+    with Not_found -> Compat.String.empty
   in
   let command = if !Server.cgi then command else base_file in
-  if wizard_passwd = "" && wizard_passwd_file = "" then
+  if
+    Compat.String.is_empty wizard_passwd
+    && Compat.String.is_empty wizard_passwd_file
+  then
     {
       ar_ok = true;
       ar_command = command;
-      ar_passwd = "";
+      ar_passwd = Compat.String.empty;
       ar_scheme = NoAuth;
-      ar_user = "";
-      ar_name = "";
+      ar_user = Compat.String.empty;
+      ar_name = Compat.String.empty;
       ar_wizard = true;
-      ar_friend = friend_passwd = "";
-      ar_uauth = "";
+      ar_friend = friend_passwd = Compat.String.empty;
+      ar_uauth = Compat.String.empty;
       ar_can_stale = false;
     }
   else if passwd = "w" || passwd = "f" then
     let auth = Mutil.extract_param "authorization: " '\r' request in
     if Mutil.start_with "Digest " 0 auth then
       let meth =
-        match Mutil.extract_param "GET " ' ' request with
-        | "" -> "POST"
-        | _ -> "GET"
+        if Compat.String.is_empty @@ Mutil.extract_param "GET " ' ' request then
+          "POST"
+        else "GET"
       in
       let _ =
         trace_auth base_env (fun oc ->
             Printf.fprintf oc "\nauth = \"%s\"\n" auth)
       in
       let digenv = parse_digest auth in
-      let get_digenv s = try List.assoc s digenv with Not_found -> "" in
+      let get_digenv s =
+        try List.assoc s digenv with Not_found -> Compat.String.empty
+      in
       let ds =
         {
           ds_username = get_digenv "username";
@@ -1354,25 +1399,28 @@ let digest_authorization request base_env passwd utm base_file command =
         ar_command = command;
         ar_passwd = passwd;
         ar_scheme = NoAuth;
-        ar_user = "";
-        ar_name = "";
+        ar_user = Compat.String.empty;
+        ar_name = Compat.String.empty;
         ar_wizard = false;
         ar_friend = false;
-        ar_uauth = "";
+        ar_uauth = Compat.String.empty;
         ar_can_stale = false;
       }
   else
-    let friend = friend_passwd = "" && friend_passwd_file = "" in
+    let friend =
+      Compat.String.is_empty friend_passwd
+      && Compat.String.is_empty friend_passwd_file
+    in
     {
       ar_ok = true;
       ar_command = command;
-      ar_passwd = "";
+      ar_passwd = Compat.String.empty;
       ar_scheme = NoAuth;
-      ar_user = "";
-      ar_name = "";
+      ar_user = Compat.String.empty;
+      ar_name = Compat.String.empty;
       ar_wizard = false;
       ar_friend = friend;
-      ar_uauth = "";
+      ar_uauth = Compat.String.empty;
       ar_can_stale = false;
     }
 
@@ -1382,7 +1430,8 @@ let authorization from_addr request base_env passwd access_type utm base_file
   | ATwizard (user, username) ->
       let command, passwd =
         if !Server.cgi then (command, passwd)
-        else if passwd = "" then (base_file, "")
+        else if Compat.String.is_empty passwd then
+          (base_file, Compat.String.empty)
         else (base_file ^ "_" ^ passwd, passwd)
       in
       let auth_scheme = TokenAuth { ts_user = user; ts_pass = passwd } in
@@ -1395,13 +1444,14 @@ let authorization from_addr request base_env passwd access_type utm base_file
         ar_name = username;
         ar_wizard = true;
         ar_friend = false;
-        ar_uauth = "";
+        ar_uauth = Compat.String.empty;
         ar_can_stale = false;
       }
   | ATfriend (user, username) ->
       let command, passwd =
         if !Server.cgi then (command, passwd)
-        else if passwd = "" then (base_file, "")
+        else if Compat.String.is_empty passwd then
+          (base_file, Compat.String.empty)
         else (base_file ^ "_" ^ passwd, passwd)
       in
       let auth_scheme = TokenAuth { ts_user = user; ts_pass = passwd } in
@@ -1414,23 +1464,24 @@ let authorization from_addr request base_env passwd access_type utm base_file
         ar_name = username;
         ar_wizard = false;
         ar_friend = true;
-        ar_uauth = "";
+        ar_uauth = Compat.String.empty;
         ar_can_stale = false;
       }
   | ATnormal ->
       let command, passwd =
-        if !Server.cgi then (command, "") else (base_file, "")
+        if !Server.cgi then (command, Compat.String.empty)
+        else (base_file, Compat.String.empty)
       in
       {
         ar_ok = true;
         ar_command = command;
         ar_passwd = passwd;
         ar_scheme = NoAuth;
-        ar_user = "";
-        ar_name = "";
+        ar_user = Compat.String.empty;
+        ar_name = Compat.String.empty;
         ar_wizard = false;
         ar_friend = false;
-        ar_uauth = "";
+        ar_uauth = Compat.String.empty;
         ar_can_stale = false;
       }
   | ATnone | ATset ->
@@ -1445,7 +1496,10 @@ let string_to_char_list s =
   exp (String.length s - 1) []
 
 let make_conf ~secret_salt from_addr request script_name env =
-  if !allowed_tags_file <> "" && not (Sys.file_exists !allowed_tags_file) then (
+  if
+    (not @@ Compat.String.is_empty !allowed_tags_file)
+    && not (Sys.file_exists !allowed_tags_file)
+  then (
     let str =
       Printf.sprintf "Requested allowed_tags file (%s) absent"
         !allowed_tags_file
@@ -1458,11 +1512,12 @@ let make_conf ~secret_salt from_addr request script_name env =
   let command, base_file, passwd, env, access_type =
     let base_access, env =
       let x, env = extract_assoc "b" env in
-      if x <> "" || cgi then (x, env) else (script_name, env)
+      if (not @@ Compat.String.is_empty x) || cgi then (x, env)
+      else (script_name, env)
     in
     let bname, access =
       match String.split_on_char '_' base_access with
-      | [ bname ] -> (bname, "")
+      | [ bname ] -> (bname, Compat.String.empty)
       | [ bname; access ] -> (bname, access)
       | _ ->
           Logs.err (fun k -> k "bad bname: (%s)" base_access);
@@ -1488,7 +1543,8 @@ let make_conf ~secret_salt from_addr request script_name env =
   in
   let lang, env = extract_assoc "lang" env in
   let lang =
-    if lang = "" && !choose_browser_lang then http_preferred_language request
+    if Compat.String.is_empty lang && !choose_browser_lang then
+      http_preferred_language request
     else lang
   in
   let lang = alias_lang lang in
@@ -1496,27 +1552,30 @@ let make_conf ~secret_salt from_addr request script_name env =
     let x, env = extract_assoc "opt" env in
     match x with
     | "from" -> ("from", env)
-    | "" -> ("", env)
-    | _ -> ("", ("opt", Mutil.encode x) :: env)
+    | "" -> (Compat.String.empty, env)
+    | _ -> (Compat.String.empty, ("opt", Mutil.encode x) :: env)
   in
   let threshold_test, env = extract_assoc "threshold" env in
-  if threshold_test <> "" then
+  if not @@ Compat.String.is_empty threshold_test then
     RelationLink.threshold := int_of_string threshold_test;
   GWPARAM.test_reorg base_file;
   let base_env =
-    if base_file = "" then []
+    if Compat.String.is_empty base_file then []
     else Util.read_base_env base_file (Option.get !gw_prefix) !debug
   in
   let default_lang =
     try
       let x = List.assoc "default_lang" base_env in
-      if x = "" then !default_lang else x
+      if Compat.String.is_empty x then !default_lang else x
     with Not_found -> !default_lang
   in
   let browser_lang =
-    if !choose_browser_lang then http_preferred_language request else ""
+    if !choose_browser_lang then http_preferred_language request
+    else Compat.String.empty
   in
-  let default_lang = if browser_lang = "" then default_lang else browser_lang in
+  let default_lang =
+    if Compat.String.is_empty browser_lang then default_lang else browser_lang
+  in
   let vowels =
     match List.assoc_opt "vowels" base_env with
     | Some l ->
@@ -1529,7 +1588,9 @@ let make_conf ~secret_salt from_addr request script_name env =
         loop [] 0
     | _ -> [ "a"; "e"; "i"; "o"; "u"; "y" ]
   in
-  let lexicon_lang = if lang = "" then default_lang else lang in
+  let lexicon_lang =
+    if Compat.String.is_empty lang then default_lang else lang
+  in
   let lexicon = load_lexicon lexicon_lang in
   (* A l'initialisation de la config, il n'y a pas de sosa_ref. *)
   (* Il sera mis à jour par effet de bord dans request.ml       *)
@@ -1549,14 +1610,16 @@ let make_conf ~secret_salt from_addr request script_name env =
   in
   let manitou =
     try
-      ar.ar_wizard && ar.ar_user <> ""
+      ar.ar_wizard
+      && (not @@ Compat.String.is_empty ar.ar_user)
       && p_getenv env "manitou" <> Some "off"
       && List.assoc "manitou" base_env = ar.ar_user
     with Not_found -> false
   in
   let supervisor =
     try
-      ar.ar_wizard && ar.ar_user <> ""
+      ar.ar_wizard
+      && Compat.String.is_empty ar.ar_user
       && List.assoc "supervisor" base_env = ar.ar_user
     with Not_found -> false
   in
@@ -1600,7 +1663,7 @@ let make_conf ~secret_salt from_addr request script_name env =
       highlight =
         (try List.assoc "highlight_color" base_env
          with Not_found -> green_color);
-      lang = (if lang = "" then default_lang else lang);
+      lang = (if Compat.String.is_empty lang then default_lang else lang);
       vowels;
       default_lang;
       browser_lang;
@@ -1656,10 +1719,14 @@ let make_conf ~secret_salt from_addr request script_name env =
       cgi_passwd = ar.ar_passwd;
       henv =
         ((if not !Server.cgi then []
-          else if ar.ar_passwd = "" then [ ("b", Mutil.encode base_file) ]
+          else if Compat.String.is_empty ar.ar_passwd then
+            [ ("b", Mutil.encode base_file) ]
           else [ ("b", Mutil.encode @@ base_file ^ "_" ^ ar.ar_passwd) ])
-        @ (if lang = "" then [] else [ ("lang", Mutil.encode lang) ])
-        @ if from = "" then [] else [ ("opt", Mutil.encode from) ]);
+        @ (if Compat.String.is_empty lang then []
+           else [ ("lang", Mutil.encode lang) ])
+        @
+        if Compat.String.is_empty from then []
+        else [ ("opt", Mutil.encode from) ]);
       base_env;
       allowed_titles = Lazy.from_fun (allowed_titles env base_env);
       denied_titles = Lazy.from_fun (denied_titles env base_env);
@@ -1672,7 +1739,7 @@ let make_conf ~secret_salt from_addr request script_name env =
       auth_file =
         (try
            let x = List.assoc "auth_file" base_env in
-           if x = "" then !auth_file
+           if Compat.String.is_empty x then !auth_file
            else Filename.concat (!GWPARAM.bpath base_file) x
          with Not_found -> !auth_file);
       border = (match Util.p_getint env "border" with Some i -> i | None -> 0);
@@ -1722,18 +1789,24 @@ let log tm conf from gauth request script_name contents =
              Printf.sprintf "%s..." (String.sub contents 0 200)
            else contents)
           (Printf.sprintf "  From: %s" from)
-          (if gauth <> "" then Printf.sprintf "\n  User: %s" gauth else "")
+          (if not @@ Compat.String.is_empty gauth then
+             Printf.sprintf "\n  User: %s" gauth
+           else Compat.String.empty)
           (if conf.wizard && not conf.friend then
              Printf.sprintf "\n  User: %s%s(wizard)" conf.user
-               (if conf.user = "" then "" else " ")
+               (if Compat.String.is_empty conf.user then Compat.String.empty
+                else " ")
            else if conf.friend && not conf.wizard then
              Printf.sprintf "\n  User: %s%s(friend)" conf.user
-               (if conf.user = "" then "" else " ")
-           else "")
-          (if user_agent <> "" then Printf.sprintf "\n  Agent: %s" user_agent
-           else "")
-          (if referer <> "" then Printf.sprintf "\n  Referer: %s" referer
-           else ""))
+               (if Compat.String.is_empty conf.user then Compat.String.empty
+                else " ")
+           else Compat.String.empty)
+          (if not @@ Compat.String.is_empty user_agent then
+             Printf.sprintf "\n  Agent: %s" user_agent
+           else Compat.String.empty)
+          (if not @@ Compat.String.is_empty referer then
+             Printf.sprintf "\n  Referer: %s" referer
+           else Compat.String.empty))
 
 let is_robot from =
   let lock_file = !GWPARAM.adm_file "gwd.lck" in
@@ -1744,10 +1817,10 @@ let is_robot from =
   List.mem_assoc from robxcl.Robot.excl
 
 let auth_err request auth_file =
-  if auth_file = "" then (false, "")
+  if Compat.String.is_empty auth_file then (false, Compat.String.empty)
   else
     let auth = Mutil.extract_param "authorization: " '\r' request in
-    if auth <> "" then
+    if not @@ Compat.String.is_empty auth then
       match try Some (Secure.open_in auth_file) with Sys_error _ -> None with
       | Some ic -> (
           let auth =
@@ -1844,8 +1917,9 @@ let conf_and_connection =
         Output.flush conf
     | None -> (
         let auth_err, auth =
-          if conf.auth_file = "" then (false, "")
-          else if !Server.cgi then (true, "")
+          if Compat.String.is_empty conf.auth_file then
+            (false, Compat.String.empty)
+          else if !Server.cgi then (true, Compat.String.empty)
           else auth_err request conf.auth_file
         in
         let mode = Util.p_getenv conf.env "m" in
@@ -1865,9 +1939,10 @@ let conf_and_connection =
               let auth_type =
                 let x =
                   try List.assoc "auth_file" conf.base_env
-                  with Not_found -> ""
+                  with Not_found -> Compat.String.empty
                 in
-                if x = "" then "GeneWeb service" else "database " ^ conf.bname
+                if Compat.String.is_empty x then "GeneWeb service"
+                else "database " ^ conf.bname
               in
               refuse_auth conf from auth auth_type
         | _, _, ({ ar_ok = false } as ar) ->
@@ -2036,7 +2111,7 @@ let find_misc_file conf name =
     if Sys.file_exists name' then name'
     else
       let name' = Util.search_in_assets @@ Filename.concat "etc" name in
-      if Sys.file_exists name' then name' else ""
+      if Sys.file_exists name' then name' else Compat.String.empty
 
 let print_misc_file conf misc_fname encoding =
   match misc_fname with
@@ -2099,12 +2174,13 @@ let misc_request conf request fname =
         | [] -> (find_misc_file conf fname, No_encoding)
         | (ext, enc) :: rest ->
             let path = find_misc_file conf (fname ^ ext) in
-            if path <> "" then (path, enc) else try_candidates rest
+            if not @@ Compat.String.is_empty path then (path, enc)
+            else try_candidates rest
       in
       try_candidates candidates
     else (find_misc_file conf fname, No_encoding)
   in
-  if actual_fname <> "" then
+  if not @@ Compat.String.is_empty actual_fname then
     let misc_fname =
       if Filename.check_suffix fname ".css" then Css actual_fname
       else if Filename.check_suffix fname ".js" then Js actual_fname
@@ -2143,7 +2219,7 @@ let extract_multipart boundary str =
       if i = String.length str || str.[i] = '\n' || str.[i] = '\r' then (s, i)
       else loop (s ^ String.make 1 str.[i]) (i + 1)
     in
-    loop "" i
+    loop Compat.String.empty i
   in
   let boundary = "--" ^ boundary in
   let rec loop i =
@@ -2207,7 +2283,7 @@ let extract_multipart boundary str =
     List.fold_left
       (fun (str, sep) (v, x) ->
         if v = "file" then (str, sep) else (str ^^^ sep ^<^ v ^<^ "=" ^<^ x, "&"))
-      (Adef.encoded "", "")
+      (Adef.encoded Compat.String.empty, Compat.String.empty)
       env
   in
   (str, env)
@@ -2265,7 +2341,7 @@ let generate_secret_salt ?(random = true) () =
   if random then (
     Random.self_init ();
     string_of_int @@ Random.bits ())
-  else ""
+  else Compat.String.empty
 
 let retrieve_secret_salt () =
   match Unix.getenv "SECRET_SALT" with
@@ -2378,7 +2454,8 @@ let geneweb_cgi ~secret_salt addr script_name contents =
   let add k x request =
     try
       let v = Sys.getenv x in
-      if v = "" then raise Not_found else (k ^ ": " ^ v) :: request
+      if Compat.String.is_empty v then raise Not_found
+      else (k ^ ": " ^ v) :: request
     with Not_found -> request
   in
   let request = [] in
@@ -2408,7 +2485,9 @@ let arg_parse_in_file fname speclist anonfun errmsg =
     let list =
       let rec loop acc =
         match input_line ic with
-        | line -> loop (if line <> "" then line :: acc else acc)
+        | line ->
+            loop
+              (if not @@ Compat.String.is_empty line then line :: acc else acc)
         | exception End_of_file ->
             close_in ic;
             List.rev acc
@@ -2456,11 +2535,13 @@ let arg_plugin_aux () =
     | "-unsafe" -> (true, force, p)
     | "-force" -> (unsafe, true, p)
     | p' ->
-        assert (p = "");
+        assert (Compat.String.is_empty p);
         (unsafe, force, p')
   in
-  let rec loop ((_, _, p) as acc) = if p = "" then loop (aux acc) else acc in
-  loop (false, false, "")
+  let rec loop ((_, _, p) as acc) =
+    if Compat.String.is_empty p then loop (aux acc) else acc
+  in
+  loop (false, false, Compat.String.empty)
 
 let arg_plugin opt doc =
   ( opt,
@@ -2704,10 +2785,12 @@ let parse_cmd () =
   let anonfun s = raise (Arg.Bad ("don't know what to do with " ^ s)) in
   (if Sys.unix then
      default_lang :=
-       let s = try Sys.getenv "LANG" with Not_found -> "" in
+       let s = try Sys.getenv "LANG" with Not_found -> Compat.String.empty in
        if List.mem s Version.available_languages then s
        else
-         let s = try Sys.getenv "LC_CTYPE" with Not_found -> "" in
+         let s =
+           try Sys.getenv "LC_CTYPE" with Not_found -> Compat.String.empty
+         in
          if String.length s >= 2 then
            let s = String.sub s 0 2 in
            if List.mem s Version.available_languages then s else "en"
@@ -2732,7 +2815,7 @@ let main () =
             process (acc ^ "<br><b>" ^ arg ^ "</b> ") false rest
           else process (acc ^ arg) false rest
     in
-    process "" false (Array.to_list Sys.argv)
+    process Compat.String.empty false (Array.to_list Sys.argv)
   in
   Geneweb.GWPARAM.gwd_cmd := gwd_cmd;
   List.iter load_plugins !plugins;
@@ -2746,7 +2829,7 @@ let main () =
       let dbn = !GWPARAM.bpath dbn in
       Driver.load_database dbn)
     !cache_databases;
-  if !auth_file <> "" && !force_cgi then
+  if (not @@ Compat.String.is_empty !auth_file) && !force_cgi then
     Logs.warn (fun k ->
         k
           "-auth option is not compatible with CGI mode.\n\
@@ -2754,7 +2837,7 @@ let main () =
            file");
   if !use_auth_digest_scheme && !force_cgi then
     Logs.warn (fun k -> k "-digest option is not compatible with CGI mode.");
-  (if !images_dir <> "" then
+  (if not @@ Compat.String.is_empty !images_dir then
      let abs_dir =
        let f =
          Util.search_in_assets (Filename.concat !images_dir "gwback.jpg")
@@ -2763,15 +2846,15 @@ let main () =
        if Filename.is_relative d then Filename.concat (Sys.getcwd ()) d else d
      in
      images_prefix := Some ("file://" ^ slashify abs_dir));
-  GWPARAM.cnt_dir := !GWPARAM.cnt_d "";
+  GWPARAM.cnt_dir := !GWPARAM.cnt_d Compat.String.empty;
   let dist_etc_d = Filename.concat (Filename.dirname Sys.argv.(0)) "etc" in
-  if !Mutil.particles_file = "" then
+  if Compat.String.is_empty !Mutil.particles_file then
     Mutil.particles_file := Filename.concat dist_etc_d "particles.txt";
   Server.stop_server :=
     List.fold_left Filename.concat !GWPARAM.cnt_dir [ "STOP_SERVER" ];
   let query, cgi =
     try (Sys.getenv "QUERY_STRING" |> Adef.encoded, true)
-    with Not_found -> ("" |> Adef.encoded, !force_cgi)
+    with Not_found -> (Compat.String.empty |> Adef.encoded, !force_cgi)
   in
   Util.is_welcome := false;
   if !check then exit 0;
@@ -2789,12 +2872,15 @@ let main () =
     in
     let addr =
       try Sys.getenv "REMOTE_HOST"
-      with Not_found -> ( try Sys.getenv "REMOTE_ADDR" with Not_found -> "")
+      with Not_found -> (
+        try Sys.getenv "REMOTE_ADDR" with Not_found -> Compat.String.empty)
     in
     let script =
       try Sys.getenv "SCRIPT_NAME" with Not_found -> Sys.argv.(0)
     in
-    let secret_salt = match !cgi_secret_salt with None -> "" | Some s -> s in
+    let secret_salt =
+      match !cgi_secret_salt with None -> Compat.String.empty | Some s -> s
+    in
     geneweb_cgi ~secret_salt addr (Filename.basename script) query)
   else geneweb_server ~predictable_mode:!predictable_mode ()
 

--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -10,6 +10,7 @@ module Gutil = Geneweb_db.Gutil
 module Plugin = Geneweb_plugin
 module Server = Geneweb_http.Server
 module Code = Geneweb_http.Code
+module Compat = Geneweb_compat
 
 let person_is_std_key conf base p k =
   let k = Name.strip_lower k in
@@ -100,7 +101,8 @@ let process_titles conf base n p =
     (fun t ->
       match (t.t_name, Driver.get_public_name p) with
       | Tname s, _ -> compare_and_add t s
-      | _, pn when Driver.sou base pn <> "" -> compare_and_add t pn
+      | _, pn when not @@ Compat.String.is_empty @@ Driver.sou base pn ->
+          compare_and_add t pn
       | _ -> ())
     (nobtit conf base p);
   !tl
@@ -330,12 +332,12 @@ let make_henv conf base =
     else conf
   in
   let conf =
-    if conf.userkey = "" then conf
+    if Compat.String.is_empty conf.userkey then conf
     else
       let fn, oc, sn = GWPARAM.split_key conf.userkey in
       match
         Geneweb_db.Driver.person_of_key base fn sn
-          (if oc = "" then 0 else int_of_string oc)
+          (if Compat.String.is_empty oc then 0 else int_of_string oc)
       with
       | Some ip ->
           {
@@ -501,7 +503,7 @@ let w_base ~none fn conf (bfile : string option) =
           fn conf base)
 
 let w_person ~none fn conf base =
-  match find_person_in_env conf base "" with
+  match find_person_in_env conf base Compat.String.empty with
   | Some p -> fn conf base p
   | _ -> none conf base
 
@@ -516,7 +518,8 @@ let treat_request =
   let w_lock = w_lock ~onerror:(fun conf _ -> Update.error_locked conf) in
   let w_base =
     let none conf =
-      if conf.bname = "" then GWPARAM.output_error conf Code.Bad_Request
+      if Compat.String.is_empty conf.bname then
+        GWPARAM.output_error conf Code.Bad_Request
       else (
         Notif.error
           ~title:(Util.transl conf "NOTIF_TT unknown base")
@@ -542,14 +545,14 @@ let treat_request =
       conf l
   in
   let handle_no_bfile conf l =
-    if conf.bname = "" then
+    if Compat.String.is_empty conf.bname then
       try Templ.output_simple conf Templ.Env.empty "index"
       with _ -> propose_base conf
     else print_page conf l
   in
   fun conf ->
     let bfile =
-      if conf.bname = "" then None
+      if Compat.String.is_empty conf.bname then None
       else
         let bfile =
           Filename.concat (Secure.base_dir ()) (conf.bname ^ ".gwb")
@@ -581,7 +584,9 @@ let treat_request =
             List.iter
               (fun (ns, fn) -> if List.mem ns plugins then fn conf bfile)
               !Plugin.se;
-          let m = Option.value ~default:"" (p_getenv conf.env "m") in
+          let m =
+            Option.value ~default:Compat.String.empty (p_getenv conf.env "m")
+          in
           if not @@ try_plugin plugins conf bfile m then
             ((if
                 List.assoc_opt "counter" conf.base_env <> Some "no"
@@ -753,7 +758,8 @@ let treat_request =
                      match p_getenv conf.env "ajax" with
                      | Some "on" ->
                          let charset =
-                           if conf.charset = "" then "utf-8" else conf.charset
+                           if Compat.String.is_empty conf.charset then "utf-8"
+                           else conf.charset
                          in
                          Output.header conf
                            "Content-type: application/json; charset=%s" charset;
@@ -810,7 +816,8 @@ let treat_request =
                      (* Récupère le contenu non vide de la recherche. *)
                      let real_input label =
                        match p_getenv conf.env label with
-                       | Some s -> if s = "" then None else Some s
+                       | Some s ->
+                           if Compat.String.is_empty s then None else Some s
                        | None -> None
                      in
                      (* Recherche par clé, sosa, alias ... *)
@@ -865,13 +872,14 @@ let treat_request =
                            match p_getenv conf.env "f" with
                            | Some f ->
                                if NotesLinks.check_file_name f <> None then f
-                               else ""
-                           | None -> ""
+                               else Compat.String.empty
+                           | None -> Compat.String.empty
                          in
                          NotesDisplay.print_what_links conf base fnotes
                      | _, Some "on" ->
                          let charset =
-                           if conf.charset = "" then "utf-8" else conf.charset
+                           if Compat.String.is_empty conf.charset then "utf-8"
+                           else conf.charset
                          in
                          Output.header conf
                            "Content-type: application/json; charset=%s" charset;
@@ -889,7 +897,7 @@ let treat_request =
                      let t_param =
                        match p_getenv conf.env "t" with
                        | Some t -> ("t", Mutil.encode t)
-                       | None -> ("t", Mutil.encode "")
+                       | None -> ("t", Mutil.encode Compat.String.empty)
                      in
                      let conf =
                        {
@@ -955,7 +963,9 @@ let treat_request =
                          RelationDisplay.print conf base p1 (Some p2)
                      | _ -> (
                          (* Fallback sur l'ancien format *)
-                         let p1_old = find_person_in_env conf base "" in
+                         let p1_old =
+                           find_person_in_env conf base Compat.String.empty
+                         in
                          let p2_old = find_person_in_env conf base "1" in
                          match (p1_old, p2_old) with
                          | Some p1, Some p2 ->
@@ -1001,7 +1011,9 @@ let treat_request =
                  w_base @@ fun conf base ->
                  match Util.p_getenv conf.env "v" with
                  | Some f -> (
-                     match Util.find_person_in_env conf base "" with
+                     match
+                       Util.find_person_in_env conf base Compat.String.empty
+                     with
                      | Some p -> Perso.interp_templ ("tp_" ^ f) conf base p
                      | _ ->
                          Perso.interp_templ ("tp0_" ^ f) conf base
@@ -1037,15 +1049,16 @@ let treat_request =
         in
         Hutil.rheader conf title;
         let base_name =
-          if conf.cgi then Printf.sprintf "b=%s&" conf.bname else ""
+          if conf.cgi then Printf.sprintf "b=%s&" conf.bname
+          else Compat.String.empty
         in
         let user = transl_nth conf "user/password/cancel" 0 in
         let passwd = transl_nth conf "user/password/cancel" 1 in
         let referer =
           match Util.extract_value '?' (get_referer conf :> string) with
-          | exception Not_found -> ""
-          | referer when referer <> "" -> "&" ^ referer
-          | _ -> ""
+          | exception Not_found -> Compat.String.empty
+          | referer when not @@ Compat.String.is_empty referer -> "&" ^ referer
+          | _ -> Compat.String.empty
         in
         let body =
           if conf.cgi then

--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -2,6 +2,7 @@ open Geneweb
 module Collection = Geneweb_db.Collection
 module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
+module Compat = Geneweb_compat
 
 type gwexport_charset = Ansel | Ansi | Ascii | Utf8
 
@@ -33,13 +34,13 @@ let default_opts =
     censor = 0;
     charset = Utf8;
     desc = None;
-    img_base_path = "";
+    img_base_path = Compat.String.empty;
     keys = [];
     aws = false;
     mem = false;
     no_notes = `none;
     no_picture = false;
-    oc = ("", prerr_string, fun () -> close_out stderr);
+    oc = (Compat.String.empty, prerr_string, fun () -> close_out stderr);
     parentship = false;
     picture_path = false;
     source = None;

--- a/bin/gwgc/gwgc.ml
+++ b/bin/gwgc/gwgc.ml
@@ -1,8 +1,9 @@
 module Database = Geneweb_db.Database
 module Gwdb_gc = Geneweb_db.Db_gc
+module Compat = Geneweb_compat
 
 let dry_run = ref false
-let bname = ref ""
+let bname = ref Compat.String.empty
 
 let speclist =
   [ ("--dry-run", Arg.Set dry_run, " do not commit changes (only print)") ]
@@ -13,11 +14,10 @@ let usage = "Usage: " ^ Sys.argv.(0) ^ " [OPTION] base"
 let () =
   Arg.parse speclist anonfun usage;
   let bname =
-    match !bname with
-    | "" ->
-        Arg.usage speclist usage;
-        exit 1
-    | s -> s
+    if Compat.String.is_empty !bname then (
+      Arg.usage speclist usage;
+      exit 1)
+    else !bname
   in
   let dry_run = !dry_run in
   Secure.set_base_dir (Filename.dirname bname);

--- a/bin/robot/robot.ml
+++ b/bin/robot/robot.ml
@@ -1,6 +1,6 @@
 (* Robot blacklist manager for Geneweb *)
 (* Usage: robot <command> [options] *)
-
+module Compat = Geneweb_compat
 open Printf
 
 let magic_robot = "GWRB0008"
@@ -165,7 +165,7 @@ let import_blacklist input_file =
   let xcl =
     match read_robot_file fname with
     | Some x -> x
-    | None -> { excl = []; who = W.empty; max_conn = (0, "") }
+    | None -> { excl = []; who = W.empty; max_conn = (0, Compat.String.empty) }
   in
 
   let ic = Secure.open_in input_file in
@@ -176,7 +176,7 @@ let import_blacklist input_file =
        incr line_num;
        let line = input_line ic in
        let line = String.trim line in
-       if line <> "" && line.[0] <> '#' then
+       if (not (Compat.String.is_empty line)) && line.[0] <> '#' then
          try
            let ip, cnt =
              match String.split_on_char '\t' line with
@@ -214,7 +214,7 @@ let add_ip patterns_str =
     if String.contains patterns_str ',' then
       String.split_on_char ',' patterns_str
       |> List.map String.trim
-      |> List.filter (fun s -> s <> "")
+      |> List.filter (fun s -> not @@ Compat.String.is_empty s)
     else [ patterns_str ]
   in
 
@@ -229,7 +229,7 @@ let add_ip patterns_str =
   let xcl =
     match read_robot_file fname with
     | Some x -> x
-    | None -> { excl = []; who = W.empty; max_conn = (0, "") }
+    | None -> { excl = []; who = W.empty; max_conn = (0, Compat.String.empty) }
   in
 
   List.iter
@@ -275,7 +275,7 @@ let remove_ip ip =
   let xcl =
     match read_robot_file fname with
     | Some x -> x
-    | None -> { excl = []; who = W.empty; max_conn = (0, "") }
+    | None -> { excl = []; who = W.empty; max_conn = (0, Compat.String.empty) }
   in
   if List.mem_assoc ip xcl.excl then (
     xcl.excl <- List.remove_assoc ip xcl.excl;
@@ -285,7 +285,7 @@ let remove_ip ip =
 
 let clear_all () =
   let fname = get_robot_file () in
-  let xcl = { excl = []; who = W.empty; max_conn = (0, "") } in
+  let xcl = { excl = []; who = W.empty; max_conn = (0, Compat.String.empty) } in
   write_robot_file fname xcl;
   printf "Cleared all robot data\n"
 
@@ -293,8 +293,8 @@ let clear_monitoring () =
   let fname = get_robot_file () in
   let xcl =
     match read_robot_file fname with
-    | Some x -> { x with who = W.empty; max_conn = (0, "") }
-    | None -> { excl = []; who = W.empty; max_conn = (0, "") }
+    | Some x -> { x with who = W.empty; max_conn = (0, Compat.String.empty) }
+    | None -> { excl = []; who = W.empty; max_conn = (0, Compat.String.empty) }
   in
   write_robot_file fname xcl;
   printf "Cleared monitoring data (kept blacklist)\n"

--- a/bin/update_nldb/update_nldb.ml
+++ b/bin/update_nldb/update_nldb.ml
@@ -4,9 +4,10 @@ module Driver = Geneweb_db.Driver
 module Gutil = Geneweb_db.Gutil
 module Collection = Geneweb_db.Collection
 module Dirs = Geneweb_dirs
+module Compat = Geneweb_compat
 
 let debug = ref false
-let fname = ref ""
+let fname = ref Compat.String.empty
 let errmsg = Format.sprintf "usage: %s [options] <file_name>" Sys.argv.(0)
 
 let speclist =
@@ -21,7 +22,7 @@ let speclist =
   ]
 
 let anonfun s =
-  if !fname = "" then fname := s
+  if Compat.String.is_empty !fname then fname := s
   else raise (Arg.Bad "Cannot treat several databases")
 
 let notes_links s =
@@ -75,7 +76,7 @@ let compute base bdir =
 
   Printf.eprintf "--- database notes\n";
   flush stderr;
-  let list = notes_links (Driver.base_notes_read base "") in
+  let list = notes_links (Driver.base_notes_read base Compat.String.empty) in
   (if list = ([], []) then ()
    else
      let pg = NLDB.PgNotes in
@@ -169,7 +170,7 @@ let compute base bdir =
     with Sys_error _ ->
       Printf.eprintf "Warning: error while reading misc notes %s\n" name
   in
-  loop Filename.current_dir_name "";
+  loop Filename.current_dir_name Compat.String.empty;
 
   let buffer = Buffer.create 1024 in
   let add_string istr =
@@ -261,7 +262,7 @@ let main () =
   Secure.set_base_dir ".";
   Arg.parse speclist anonfun errmsg;
   let bname = Filename.concat (Secure.base_dir ()) !fname in
-  if !fname = "" then (
+  if Compat.String.is_empty !fname then (
     Printf.eprintf "Missing database name\n";
     Printf.eprintf "Use option -help for usage\n";
     flush stderr;

--- a/lib/compat/geneweb_compat.ml
+++ b/lib/compat/geneweb_compat.ml
@@ -100,3 +100,12 @@ module Seq = struct
 
   include Seq
 end
+
+module String = struct
+  open String
+
+  let empty = ""
+  let is_empty s = Int.equal (length s) 0
+
+  include String
+end

--- a/lib/compat/geneweb_compat.mli
+++ b/lib/compat/geneweb_compat.mli
@@ -142,3 +142,15 @@ module Seq : sig
 
       @since 4.14 *)
 end
+
+module String : sig
+  val empty : string
+  (** The empty string.
+
+      @since 4.13 *)
+
+  val is_empty : string -> bool
+  (** [is_empty s] is [true] if and only if [s] is an empty string.
+
+      @since 5.5 *)
+end

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -6,6 +6,7 @@ module Parser = Geneweb_templ.Parser
 module Ast = Geneweb_templ.Ast
 module Loc = Geneweb_templ.Loc
 module Driver = Geneweb_db.Driver
+module Compat = Geneweb_compat
 
 exception UnboundVar
 exception BadApplyArity
@@ -125,7 +126,7 @@ let setup_link (conf : Config.config) =
     let i = String.rindex s ':' in
     let s = "http://" ^ String.sub s 0 i ^ ":2316/" in
     "<a href=\"" ^ s ^ "gwsetup?v=main.htm\">gwsetup</a>"
-  with Not_found -> ""
+  with Not_found -> Compat.String.empty
 
 let esc s = (Util.escape_html s :> string)
 
@@ -134,7 +135,8 @@ let url_aux ?(pwd = true) (conf : Config.config) =
     List.filter_map
       (fun (k, v) ->
         let v = Adef.as_string v in
-        if ((k = "oc" || k = "ocz") && v = "0") || k = "" then None
+        if ((k = "oc" || k = "ocz") && v = "0") || Compat.String.is_empty k then
+          None
         else Some (Format.sprintf "%s=%s" k v))
       (conf.henv @ conf.senv @ conf.env)
   in
@@ -148,7 +150,9 @@ let url_aux ?(pwd = true) (conf : Config.config) =
 let find_sosa_ref (conf : Config.config) =
   let env = conf.henv @ conf.senv @ conf.env in
   let get_env evar env =
-    match List.assoc_opt evar env with Some s -> Adef.as_string s | None -> ""
+    match List.assoc_opt evar env with
+    | Some s -> Adef.as_string s
+    | None -> Compat.String.empty
   in
   let pz = get_env "pz" env in
   let nz = get_env "nz" env in
@@ -210,40 +214,45 @@ let rec eval_variable (conf : Config.config) = function
       List.fold_left
         (fun acc (k, v) ->
           let duplicate =
-            if is_duplicate k l then {| style="color:red"|} else ""
+            if is_duplicate k l then {| style="color:red"|}
+            else Compat.String.empty
           in
           acc
           ^ Format.sprintf "<b%s>%s</b>=%s<br>\n" duplicate k
               (if conf.wizard || not (List.mem k wizard_only) then
                  (Util.escape_html v :> string)
-               else if (Util.escape_html v :> string) = "" then ""
+               else if Compat.String.is_empty (Util.escape_html v :> string)
+               then Compat.String.empty
                else "####"))
-        "" l
+        Compat.String.empty l
   | [ "gwd"; "arglist" ] -> !GWPARAM.gwd_cmd
   | [ "bvar"; v ] | [ "b"; v ] -> (
-      try List.assoc v conf.base_env with Not_found -> "")
+      try List.assoc v conf.base_env with Not_found -> Compat.String.empty)
   | [ "connections"; "wizards" ] -> (
       match conf.n_connect with
-      | Some (_c, cw, _cf, _) -> if cw > 0 then Printf.sprintf "%d" cw else ""
-      | None -> "")
+      | Some (_c, cw, _cf, _) ->
+          if cw > 0 then Printf.sprintf "%d" cw else Compat.String.empty
+      | None -> Compat.String.empty)
   | [ "connections"; "friends" ] -> (
       match conf.n_connect with
-      | Some (_c, _cw, cf, _) -> if cf > 0 then Printf.sprintf "%d" cf else ""
-      | None -> "")
+      | Some (_c, _cw, cf, _) ->
+          if cf > 0 then Printf.sprintf "%d" cf else Compat.String.empty
+      | None -> Compat.String.empty)
   | [ "connections"; "total" ] -> (
       match conf.n_connect with
-      | Some (c, _cw, _cf, _) -> if c > 0 then Printf.sprintf "%d" c else ""
-      | None -> "")
+      | Some (c, _cw, _cf, _) ->
+          if c > 0 then Printf.sprintf "%d" c else Compat.String.empty
+      | None -> Compat.String.empty)
   | [ "evar"; v; "ns" ] | [ "e"; v; "ns" ] -> (
       try
         let vv = List.assoc v (conf.env @ conf.henv) in
         Mutil.gen_decode false vv |> esc
-      with Not_found -> "")
+      with Not_found -> Compat.String.empty)
   | [ "evar"; v ] | [ "e"; v ] -> (
       (* TODO verify if senv must be treated as well *)
       match Util.p_getenv (conf.env @ conf.henv) v with
       | Some vv -> esc vv
-      | None -> "")
+      | None -> Compat.String.empty)
   (* look for evar.vi scanning i down to 0 *)
   | [ "evar_cur"; v; i ] ->
       (* TODO same as evar *)
@@ -251,10 +260,10 @@ let rec eval_variable (conf : Config.config) = function
       let rec loop n =
         match Util.p_getenv (conf.env @ conf.henv) (v ^ string_of_int n) with
         | Some vv -> vv
-        | None -> if n > 0 then loop (n - 1) else ""
+        | None -> if n > 0 then loop (n - 1) else Compat.String.empty
       in
       loop n
-  | [ "link_next" ] -> ""
+  | [ "link_next" ] -> Compat.String.empty
   | [ "prefix_set"; pl ] ->
       let pl_l =
         match pl with
@@ -268,12 +277,15 @@ let rec eval_variable (conf : Config.config) = function
       (Util.commd ~excl:pl_l conf :> string)
   | [ "prefix_set"; evar; str ] ->
       let prefix = (Util.commd ~excl:[ evar ] conf :> string) in
-      let amp = if prefix.[String.length prefix - 1] = '?' then "" else "&" in
-      if str = "" then prefix
+      let amp =
+        if prefix.[String.length prefix - 1] = '?' then Compat.String.empty
+        else "&"
+      in
+      if Compat.String.is_empty str then prefix
       else prefix ^ Printf.sprintf "%s%s=%s" amp evar str
   | [ "random"; "init" ] ->
       Random.self_init ();
-      ""
+      Compat.String.empty
   | [ "random"; "bits" ] -> (
       try string_of_int (Random.bits ())
       with Failure _ | Invalid_argument _ -> raise Not_found)
@@ -293,7 +305,7 @@ let rec eval_variable (conf : Config.config) = function
       match int_of_string_opt n with
       | Some n ->
           let v =
-            Option.value ~default:""
+            Option.value ~default:Compat.String.empty
               (Util.p_getenv (conf.env @ conf.henv @ conf.senv) v)
           in
           substr_start_aux n v
@@ -312,7 +324,7 @@ let rec eval_variable (conf : Config.config) = function
   | [ "user"; "index" ] -> (
       match conf.user_iper with
       | Some ip -> Driver.Iper.to_string ip
-      | None -> "")
+      | None -> Compat.String.empty)
   | [ "user"; "name" ] -> conf.username
   | [ "user"; "key" ] -> conf.userkey
   | [ s ] -> eval_simple_variable conf s
@@ -326,12 +338,15 @@ and eval_sosa_ref conf sl =
   | [ "occ" ] -> occ
   | [ "index" ] -> i
   | [ "access" ] ->
-      if i <> "" then "i=" ^ i
-      else if fn <> "" || sn <> "" then
-        Format.sprintf "p=%s&n=%s&oc=%s" fn sn occ
-      else ""
+      if not @@ Compat.String.is_empty i then "i=" ^ i
+      else if
+        (not @@ Compat.String.is_empty fn) || (not @@ Compat.String.is_empty sn)
+      then Format.sprintf "p=%s&n=%s&oc=%s" fn sn occ
+      else Compat.String.empty
   | [] ->
-      let occ = if occ = "" then "" else "." ^ occ in
+      let occ =
+        if Compat.String.is_empty occ then Compat.String.empty else "." ^ occ
+      in
       Format.sprintf "%s%s %s" fn occ sn
   | _ -> "???1"
 
@@ -376,34 +391,35 @@ and eval_simple_variable conf = function
                         (Util.commd conf :> string)
                         cw
                     else string_of_int cw)
-               else "")
+               else Compat.String.empty)
             ^
             if cf > 0 then
               Printf.sprintf ", %s %d"
                 (Util.transl_nth conf "wizard/wizards/friend/friends/exterior" 3)
                 cf
-            else ""
-          else ""
-      | None -> "")
+            else Compat.String.empty
+          else Compat.String.empty
+      | None -> Compat.String.empty)
   | "doctype" -> (Util.doctype :> string)
   | "highlight" -> conf.highlight
   | "gw_prefix" ->
       let s =
-        if conf.cgi then Adef.escaped conf.gw_prefix else Adef.escaped ""
+        if conf.cgi then Adef.escaped conf.gw_prefix
+        else Adef.escaped Compat.String.empty
       in
       let s = (s :> string) in
-      if s = "" then s else s ^ Filename.dir_sep
+      if Compat.String.is_empty s then s else s ^ Filename.dir_sep
   | "images_prefix" | "image_prefix" -> Util.images_prefix conf ^ "/"
   | "lang" -> conf.lang
   | "lang_fallback" -> (
       match List.assoc_opt conf.lang !Mutil.fallback with
       | Some l -> l
-      | None -> "")
+      | None -> Compat.String.empty)
   | "default_lang" -> conf.default_lang
   | "browser_lang" -> conf.browser_lang
   | "left" -> conf.left
   | "nl" -> "\n"
-  | "nn" -> ""
+  | "nn" -> Compat.String.empty
   | "plugins" ->
       let l = List.map Filename.basename conf.plugins in
       String.concat ", " l
@@ -426,19 +442,26 @@ and eval_simple_variable conf = function
   | "right" -> conf.right
   | "sosa_ref" -> (
       match find_sosa_ref conf with
-      | iz, _, _, _ when iz <> "" -> iz
-      | _, fn, sn, occ when fn <> "" || sn <> "" ->
-          let occ = if occ = "" then "" else "." ^ occ in
+      | iz, _, _, _ when not @@ Compat.String.is_empty iz -> iz
+      | _, fn, sn, occ
+        when (not @@ Compat.String.is_empty fn)
+             || (not @@ Compat.String.is_empty sn) ->
+          let occ =
+            if Compat.String.is_empty occ then Compat.String.empty
+            else "." ^ occ
+          in
           Format.sprintf "%s%s %s" fn occ sn
       | _ -> "???2")
-  | "setup_link" -> if conf.setup_link then " - " ^ setup_link conf else ""
+  | "setup_link" ->
+      if conf.setup_link then " - " ^ setup_link conf else Compat.String.empty
   | "sp" -> " "
   | "static_path" | "etc_prefix" ->
       let s =
-        if conf.cgi then Adef.escaped conf.etc_prefix else Adef.escaped ""
+        if conf.cgi then Adef.escaped conf.etc_prefix
+        else Adef.escaped Compat.String.empty
       in
       let s = (s :> string) in
-      if s = "" then s else s ^ "/"
+      if Compat.String.is_empty s then s else s ^ "/"
   | "suffix" ->
       Log.warn (fun k -> k "%%suffix; is deprecated, use %%url_set instead");
       let l =
@@ -450,7 +473,8 @@ and eval_simple_variable conf = function
         List.filter_map
           (fun (k, v) ->
             let v = Adef.as_string v in
-            if ((k = "oc" || k = "ocz") && v = "0") || k = "" then None
+            if ((k = "oc" || k = "ocz") && v = "0") || Compat.String.is_empty k
+            then None
             else Some (Format.sprintf "%s=%s" k v))
           l
       in
@@ -464,7 +488,7 @@ and eval_simple_variable conf = function
   | "compil_date" -> Version.compil_date
   | "branch" -> Version.branch
   | "source" -> Version.src
-  | "/" -> ""
+  | "/" -> Compat.String.empty
   | _ -> raise Not_found
 
 let rec string_of_expr_val = function
@@ -513,7 +537,7 @@ let apply_format conf nth s1 s2 =
                       let i = String.index s2 ':' in
                       ( String.sub s2 0 i,
                         String.sub s2 (i + 1) (String.length s2 - i - 1) )
-                    with _ -> ("", "")
+                    with _ -> (Compat.String.empty, Compat.String.empty)
                   in
                   match Util.check_format "%s%s" s1 with
                   | Some s3 -> Printf.sprintf s3 s21 s22
@@ -572,7 +596,7 @@ let rec eval_ast conf Ast.{ desc; _ } =
   | ast -> not_impl "eval_ast" ast
 
 and eval_transl conf upp s c =
-  if c = "" && String.length s > 0 && s.[0] = '\n' then
+  if Compat.String.is_empty c && String.length s > 0 && s.[0] = '\n' then
     eval_transl_inline conf s
   else eval_transl_lexicon conf upp s c
 
@@ -607,7 +631,8 @@ and eval_transl_lexicon conf upp s c =
         String.sub s 0 (k + 1)
         ^ c
         ^
-        if String.length s = k + 1 || String.length s = k + 2 then ""
+        if String.length s = k + 1 || String.length s = k + 2 then
+          Compat.String.empty
         else if existing_choice then
           String.sub s (k + 2) (String.length s - k - 2)
         else String.sub s (k + 1) (String.length s - k - 1) )
@@ -616,7 +641,7 @@ and eval_transl_lexicon conf upp s c =
     let nth = try Some (int_of_string c) with Failure _ -> None in
     match split_at_coloncolon s with
     | None -> (
-        try apply_format conf nth s ""
+        try apply_format conf nth s Compat.String.empty
         with Failure _ ->
           raise Not_found
           (* TODO check the use of if c = "n" then s else Mutil.nominative s
@@ -649,7 +674,9 @@ and eval_transl_lexicon conf upp s c =
                 in
                 (* parse_templ handles only text, evars and translations *)
                 (* more complex parsing (%surname;, %if; ...) not available *)
-                List.fold_left (fun s a -> s ^ eval_ast conf a) "" astl
+                List.fold_left
+                  (fun s a -> s ^ eval_ast conf a)
+                  Compat.String.empty astl
               in
               let s4 = String.sub s2 (j + 1) (String.length s2 - j - 1) in
               let s2 = s3 ^ s4 in
@@ -664,7 +691,9 @@ and eval_transl_lexicon conf upp s c =
           let s3 =
             match nth with
             | Some n -> Util.transl_nth conf s2 n
-            | None -> if s2 = "" then "" else Util.transl conf s2
+            | None ->
+                if Compat.String.is_empty s2 then Compat.String.empty
+                else Util.transl conf s2
           in
           Util.transl_decline conf s1 s3)
   in
@@ -683,7 +712,9 @@ let templ_eval_var (conf : Config.config) = function
   | [ "false" ] -> VVbool false
   | [ "has_referer" ] ->
       (* deprecated since version 5.00 *)
-      VVbool (Mutil.extract_param "referer: " '\n' conf.request <> "")
+      VVbool
+        (not @@ Compat.String.is_empty
+        @@ Mutil.extract_param "referer: " '\n' conf.request)
   | [ "is_welcome" ] -> VVbool !Util.is_welcome
   | [ "just_friend_wizard" ] -> VVbool conf.just_friend_wizard
   | [ "friend" ] -> VVbool conf.friend
@@ -753,7 +784,7 @@ let rec eval_expr ((conf, eval_var, eval_apply) as ceva) Ast.{ desc; loc } =
               | [ e ] -> e
               | el ->
                   let sl = List.map string_of_expr_val el in
-                  VVstring (String.concat "" sl) ))
+                  VVstring (String.concat Compat.String.empty sl) ))
           ell
       in
       VVstring (eval_apply loc s vl)
@@ -795,7 +826,7 @@ let rec eval_expr ((conf, eval_var, eval_apply) as ceva) Ast.{ desc; loc } =
   | Apack al ->
       let vl = List.map (eval_expr ceva) al in
       let sl = List.map string_of_expr_val vl in
-      VVstring (String.concat "" sl)
+      VVstring (String.concat Compat.String.empty sl)
   | e -> raise_with_loc loc (Failure (not_impl "eval_expr" e))
 
 let eval_bool_expr conf (eval_var, eval_apply) e =
@@ -818,12 +849,12 @@ let eval_string_expr conf (eval_var, eval_apply) e =
   with Exc_located _ as exn ->
     let bt = Printexc.get_raw_backtrace () in
     Log.debug (fun k -> k "%a" pp_exception (exn, bt));
-    ""
+    Compat.String.empty
 
 let print_body_prop (conf : Config.config) =
   let s =
     try " dir=\"" ^ Hashtbl.find conf.lexicon "!dir" ^ "\""
-    with Not_found -> ""
+    with Not_found -> Compat.String.empty
   in
   Output.print_sstring conf (s ^ Util.body_prop conf)
 
@@ -889,7 +920,7 @@ let eval_subst loc f set_vother env xl vl a =
 
 let squeeze_spaces s =
   let rec loop i =
-    if i = String.length s then ""
+    if i = String.length s then Compat.String.empty
     else
       match s.[i] with
       | ' ' | '\n' | '\r' | '\t' -> loop (i + 1)
@@ -1000,12 +1031,12 @@ let rec eval_date_var conf jd = function
       try
         let _, md = Calendar.moon_phase_of_sdn jd in
         VVstring (string_of_int md)
-      with Failure _ -> VVstring "")
+      with Failure _ -> VVstring Compat.String.empty)
   | "moon_phase" :: sl -> (
       try
         let mp, _ = Calendar.moon_phase_of_sdn jd in
         eval_moon_phase_var mp sl
-      with Failure _ -> VVstring "")
+      with Failure _ -> VVstring Compat.String.empty)
   | [ "week_day" ] ->
       let wday =
         let jd_today = Calendar.sdn_of_gregorian conf.today in
@@ -1018,7 +1049,9 @@ let rec eval_date_var conf jd = function
 and eval_moon_phase_var mp = function
   | [ "hour" ] ->
       let s =
-        match mp with None -> "" | Some (_, hh, _) -> Printf.sprintf "%02d" hh
+        match mp with
+        | None -> Compat.String.empty
+        | Some (_, hh, _) -> Printf.sprintf "%02d" hh
       in
       VVstring s
   | [ "index" ] ->
@@ -1033,7 +1066,9 @@ and eval_moon_phase_var mp = function
       VVstring (string_of_int i)
   | [ "minute" ] ->
       let s =
-        match mp with None -> "" | Some (_, _, mm) -> Printf.sprintf "%02d" mm
+        match mp with
+        | None -> Compat.String.empty
+        | Some (_, _, mm) -> Printf.sprintf "%02d" mm
       in
       VVstring s
   | _ -> raise Not_found
@@ -1071,11 +1106,11 @@ let eval_var conf ifun env ep loc sl =
     | [ "trace"; s ] ->
         Printf.eprintf "***** %s; " s;
         flush stderr;
-        VVstring ""
+        VVstring Compat.String.empty
     | [ "tracenl"; s ] ->
         Printf.eprintf "***** %s\n" s;
         flush stderr;
-        VVstring ""
+        VVstring Compat.String.empty
     | s :: sl -> (
         match (get_val ifun.get_vother s env, sl) with
         | Some (VVother f), sl -> f sl
@@ -1130,7 +1165,7 @@ let rec eval conf ifun env =
     | [ e ] -> e
     | el ->
         let sl = List.map string_of_expr_val el in
-        VVstring (String.concat "" sl)
+        VVstring (String.concat Compat.String.empty sl)
   and eval_expr env ep (e : Ast.t) =
     let eval_apply = eval_apply env ep in
     let eval_var = eval_var conf ifun env ep in
@@ -1152,7 +1187,7 @@ let rec eval conf ifun env =
             al (env, [])
         in
         let sl = List.map (eval_ast env ep) al in
-        String.concat "" sl
+        String.concat Compat.String.empty sl
     | None -> (
         match (f, vl) with
         | "capitalize", [ (None, VVstring s) ] -> Utf8.capitalize_fst s
@@ -1168,13 +1203,13 @@ let rec eval conf ifun env =
             in
             match Util.hash_file_cached fpath with
             | Some hash -> hash
-            | None -> "")
+            | None -> Compat.String.empty)
         | "interp", [ (None, VVstring s) ] ->
             let astl =
               Parser.parse ~on_exn ~resolve_include:(resolve_include conf)
                 (`Raw s)
             in
-            String.concat "" (eval_ast_list env ep astl)
+            String.concat Compat.String.empty (eval_ast_list env ep astl)
         | "language_name", [ (None, VVstring s) ] ->
             Translate.language_name s (Util.transl conf "!languages")
         | "url_encode", [ (None, VVstring s) ]
@@ -1192,10 +1227,12 @@ let rec eval conf ifun env =
             Util.translate_eval (Util.nth_field s1 n)
         | "nth_0", [ (None, VVstring s1); (None, VVstring s2) ] ->
             let n = try int_of_string s2 with Failure _ -> 0 in
-            if Util.nth_field s1 n = "" then "0" else Util.nth_field s1 n
+            if Compat.String.is_empty @@ Util.nth_field s1 n then "0"
+            else Util.nth_field s1 n
         | "nth_c", [ (None, VVstring s1); (None, VVstring s2) ] -> (
             let n = try int_of_string s2 with Failure _ -> 0 in
-            try Char.escaped (String.get s1 n) with Invalid_argument _ -> "")
+            try Char.escaped (String.get s1 n)
+            with Invalid_argument _ -> Compat.String.empty)
         | "1000sep", [ (None, VVstring s) ] ->
             let n = try int_of_string s with Failure _ -> 0 in
             let sep = Util.transl conf "(thousand separator)" in
@@ -1231,7 +1268,7 @@ let rec eval conf ifun env =
     let al =
       if eval_bool_expr conf (eval_var, eval_apply) e then alt else ale
     in
-    String.concat "" (List.map eval_ast al)
+    String.concat Compat.String.empty (List.map eval_ast al)
   and eval_for env ep iterator min max al =
     let rec loop env min max accu =
       let new_env = env in
@@ -1247,13 +1284,13 @@ let rec eval conf ifun env =
         int_of_string (eval_string_expr conf (eval_var, eval_apply) max)
       in
       if int_min < int_max then
-        let instr = String.concat "" (List.map eval_ast al) in
+        let instr = String.concat Compat.String.empty (List.map eval_ast al) in
         let accu = accu ^ instr in
         let a = Ast.mk_op2 "+" min (Ast.mk_int "1") in
         loop new_env a max accu
       else accu
     in
-    loop env min max ""
+    loop env min max Compat.String.empty
   in
   let rec print_ast env ep (Ast.{ desc; loc } as a) =
     match desc with
@@ -1373,8 +1410,8 @@ and print_simple_variable conf = function
   | "bases_list_links" ->
       let format_link bname =
         Format.sprintf {|<a href="%s%s">%s</a>|}
-          ((if conf.cgi then "?b=" else "") ^ bname)
-          (if conf.lang = conf.default_lang then ""
+          ((if conf.cgi then "?b=" else Compat.String.empty) ^ bname)
+          (if conf.lang = conf.default_lang then Compat.String.empty
            else (if conf.cgi then "&" else "?") ^ "lang=" ^ conf.lang)
           bname
       in
@@ -1405,7 +1442,7 @@ and print_simple_variable conf = function
               && f.[0] <> '~'
             then acc ^ Format.sprintf "<option>%s\n" f
             else acc)
-          "" f_list
+          Compat.String.empty f_list
       in
       Output.print_sstring conf res
   | _ -> raise Not_found

--- a/lib/update_util.ml
+++ b/lib/update_util.ml
@@ -1,3 +1,4 @@
+module Compat = Geneweb_compat
 open Config
 open Def
 open Util
@@ -15,11 +16,11 @@ type create_info = Update.create_info = {
 let ci_empty =
   {
     ci_birth_date = None;
-    ci_birth_place = "";
+    ci_birth_place = Compat.String.empty;
     ci_death = DontKnowIfDead;
     ci_death_date = None;
-    ci_death_place = "";
-    ci_occupation = "";
+    ci_death_place = Compat.String.empty;
+    ci_occupation = Compat.String.empty;
     ci_public = false;
   }
 
@@ -88,7 +89,9 @@ let update_ci conf create key =
     | _ -> DontKnowIfDead
   in
   let occupation =
-    match p_getenv conf.env (key ^ "_occu") with Some s -> s | _ -> ""
+    match p_getenv conf.env (key ^ "_occu") with
+    | Some s -> s
+    | _ -> Compat.String.empty
   in
   let x =
     match create with
@@ -128,19 +131,20 @@ let eval_default_var conf s =
     let len = String.length sini in
     if String.length s > len && String.sub s 0 (String.length sini) = sini then
       String.sub s len (String.length s - len)
-    else ""
+    else Compat.String.empty
   in
 
   let v = extract_var "evar_" s in
-  if v <> "" then
+  if not @@ Compat.String.is_empty v then
     match p_getenv (conf.env @ conf.henv) v with
     | Some vv -> safe_val (Util.escape_html vv :> Adef.safe_string)
-    | None -> str_val ""
+    | None -> str_val Compat.String.empty
   else
     let v = extract_var "bvar_" s in
-    let v = if v = "" then extract_var "cvar_" s else v in
-    if v <> "" then
-      str_val (try List.assoc v conf.base_env with Not_found -> "")
+    let v = if Compat.String.is_empty v then extract_var "cvar_" s else v in
+    if not @@ Compat.String.is_empty v then
+      str_val
+        (try List.assoc v conf.base_env with Not_found -> Compat.String.empty)
     else raise Not_found
 
 let eval_date_field = function
@@ -154,12 +158,13 @@ let eval_date_field = function
       | Dtext _ -> None)
 
 let eval_is_cal cal = function
-  | Some (Adef.Dgreg (_, x)) -> if x = cal then "1" else ""
-  | Some (Dtext _) | None -> ""
+  | Some (Adef.Dgreg (_, x)) -> if x = cal then "1" else Compat.String.empty
+  | Some (Dtext _) | None -> Compat.String.empty
 
 let eval_is_prec cond = function
-  | Some (Adef.Dgreg ({ prec = x; _ }, _)) -> if cond x then "1" else ""
-  | Some (Dtext _) | None -> ""
+  | Some (Adef.Dgreg ({ prec = x; _ }, _)) ->
+      if cond x then "1" else Compat.String.empty
+  | Some (Dtext _) | None -> Compat.String.empty
 
 let add_precision s p =
   match p with
@@ -180,47 +185,49 @@ let eval_date_var od s =
       | Some (Dgreg (_, Djulian)) -> "julian"
       | Some (Dgreg (_, Dfrench)) -> "french"
       | Some (Dgreg (_, Dhebrew)) -> "hebrew"
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | "day" -> (
       match eval_date_field od with
-      | Some d -> if d.Adef.day = 0 then "" else string_of_int d.Adef.day
-      | None -> "")
+      | Some d ->
+          if d.Adef.day = 0 then Compat.String.empty
+          else string_of_int d.Adef.day
+      | None -> Compat.String.empty)
   | "month" -> (
       match eval_date_field od with
       | Some d -> (
-          if d.Adef.month = 0 then ""
+          if d.Adef.month = 0 then Compat.String.empty
           else
             match od with
             | Some (Adef.Dgreg (_, Dfrench)) -> short_f_month d.Adef.month
             | _ -> string_of_int d.Adef.month)
-      | None -> "")
+      | None -> Compat.String.empty)
   | "orday" -> (
       match eval_date_field od with
       | Some d -> (
           match d.Adef.prec with
           | Adef.OrYear d2 | YearInt d2 ->
-              if d2.day2 = 0 then "" else string_of_int d2.day2
-          | _ -> "")
-      | None -> "")
+              if d2.day2 = 0 then Compat.String.empty else string_of_int d2.day2
+          | _ -> Compat.String.empty)
+      | None -> Compat.String.empty)
   | "ormonth" -> (
       match eval_date_field od with
       | Some d -> (
           match d.Adef.prec with
           | OrYear d2 | YearInt d2 -> (
-              if d2.month2 = 0 then ""
+              if d2.month2 = 0 then Compat.String.empty
               else
                 match od with
                 | Some (Adef.Dgreg (_, Dfrench)) -> short_f_month d2.month2
                 | _ -> string_of_int d2.month2)
-          | _ -> "")
-      | None -> "")
+          | _ -> Compat.String.empty)
+      | None -> Compat.String.empty)
   | "oryear" -> (
       match eval_date_field od with
       | Some d -> (
           match d.Adef.prec with
           | OrYear d2 | YearInt d2 -> string_of_int d2.year2
-          | _ -> "")
-      | None -> "")
+          | _ -> Compat.String.empty)
+      | None -> Compat.String.empty)
   | "prec" -> (
       match od with
       | Some (Adef.Dgreg ({ prec = Sure; _ }, _)) -> "sure"
@@ -230,20 +237,20 @@ let eval_date_var od s =
       | Some (Dgreg ({ prec = After; _ }, _)) -> "after"
       | Some (Dgreg ({ prec = OrYear _; _ }, _)) -> "oryear"
       | Some (Dgreg ({ prec = YearInt _; _ }, _)) -> "yearint"
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | "text" -> (
       match od with
       | Some (Dtext s) -> Util.safe_html s |> Adef.as_string
-      | Some (Dgreg _) | None -> "")
+      | Some (Dgreg _) | None -> Compat.String.empty)
   | "year" -> (
       match eval_date_field od with
       | Some d -> string_of_int d.Adef.year
-      | None -> "")
+      | None -> Compat.String.empty)
   | "cal_french" -> eval_is_cal Adef.Dfrench od
   | "cal_gregorian" -> eval_is_cal Adef.Dgregorian od
   | "cal_hebrew" -> eval_is_cal Adef.Dhebrew od
   | "cal_julian" -> eval_is_cal Adef.Djulian od
-  | "prec_no" -> if od = None then "1" else ""
+  | "prec_no" -> if od = None then "1" else Compat.String.empty
   | "prec_sure" -> eval_is_prec (function Adef.Sure -> true | _ -> false) od
   | "prec_about" -> eval_is_prec (function Adef.About -> true | _ -> false) od
   | "prec_maybe" -> eval_is_prec (function Adef.Maybe -> true | _ -> false) od
@@ -265,12 +272,12 @@ let eval_create c = function
       | Update.Create
           (_, Some { ci_birth_date = Some (Dgreg (dmy, Dfrench)); _ }) ->
           let dmy = Calendar.french_of_gregorian dmy in
-          if dmy.day <> 0 then string_of_int dmy.day else ""
+          if dmy.day <> 0 then string_of_int dmy.day else Compat.String.empty
       | Update.Create
           (_, Some { ci_birth_date = Some (Dgreg ({ day = d; _ }, _)); _ })
         when d <> 0 ->
           string_of_int d
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | "birth_month" -> (
       str_val
       @@
@@ -278,17 +285,18 @@ let eval_create c = function
       | Update.Create
           (_, Some { ci_birth_date = Some (Dgreg (dmy, Dfrench)); _ }) ->
           let dmy = Calendar.french_of_gregorian dmy in
-          if dmy.month <> 0 then short_f_month dmy.month else ""
+          if dmy.month <> 0 then short_f_month dmy.month
+          else Compat.String.empty
       | Update.Create
           (_, Some { ci_birth_date = Some (Dgreg ({ month = m; _ }, _)); _ })
         when m <> 0 ->
           string_of_int m
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | "birth_place" -> (
       match c with
       | Update.Create (_, Some { ci_birth_place = pl; _ }) ->
           safe_val (Util.escape_html pl :> Adef.safe_string)
-      | _ -> str_val "")
+      | _ -> str_val Compat.String.empty)
   | "birth_year" -> (
       str_val
       @@
@@ -300,9 +308,9 @@ let eval_create c = function
               add_precision (string_of_int dmy.year) dmy.prec
           | Some (Dgreg ({ year = y; prec = p; _ }, _)) ->
               add_precision (string_of_int y) p
-          | Some _ -> ""
-          | None -> if ci.ci_public then "p" else "")
-      | _ -> "")
+          | Some _ -> Compat.String.empty
+          | None -> if ci.ci_public then "p" else Compat.String.empty)
+      | _ -> Compat.String.empty)
   | "death_day" -> (
       str_val
       @@
@@ -310,12 +318,12 @@ let eval_create c = function
       | Update.Create
           (_, Some { ci_death_date = Some (Dgreg (dmy, Dfrench)); _ }) ->
           let dmy = Calendar.french_of_gregorian dmy in
-          if dmy.day <> 0 then string_of_int dmy.day else ""
+          if dmy.day <> 0 then string_of_int dmy.day else Compat.String.empty
       | Update.Create
           (_, Some { ci_death_date = Some (Dgreg ({ day = d; _ }, _)); _ })
         when d <> 0 ->
           string_of_int d
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | "death_month" -> (
       str_val
       @@
@@ -328,12 +336,12 @@ let eval_create c = function
           (_, Some { ci_death_date = Some (Dgreg ({ month = m; _ }, _)); _ })
         when m <> 0 ->
           string_of_int m
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | "death_place" -> (
       match c with
       | Update.Create (_, Some { ci_death_place = pl; _ }) ->
           safe_val (Util.escape_html pl :> Adef.safe_string)
-      | _ -> str_val "")
+      | _ -> str_val Compat.String.empty)
   | "death_year" -> (
       str_val
       @@
@@ -350,13 +358,16 @@ let eval_create c = function
           add_precision (string_of_int y) p
       | Update.Create (_, Some { ci_death = death; ci_death_date = None; _ })
         -> (
-          match death with DeadDontKnowWhen -> "+" | NotDead -> "-" | _ -> "")
-      | _ -> "")
+          match death with
+          | DeadDontKnowWhen -> "+"
+          | NotDead -> "-"
+          | _ -> Compat.String.empty)
+      | _ -> Compat.String.empty)
   | "occupation" -> (
       match c with
       | Update.Create (_, Some { ci_occupation = occupation; _ }) ->
           safe_val (Util.escape_html occupation :> Adef.safe_string)
-      | _ -> str_val "")
+      | _ -> str_val Compat.String.empty)
   | "sex" -> (
       str_val
       @@
@@ -364,7 +375,7 @@ let eval_create c = function
       | Update.Create (Male, _) -> "male"
       | Update.Create (Female, _) -> "female"
       | Update.Create (Neuter, _) -> "neuter"
-      | _ -> "")
+      | _ -> Compat.String.empty)
   | _ -> raise Not_found
 
 let map_nosexcheck = function

--- a/plugins/gwxjg/gwxjg_data.ml
+++ b/plugins/gwxjg/gwxjg_data.ml
@@ -2,6 +2,7 @@ module Ezgw = Gwxjg_ezgw
 module Lexicon_parser = Gwxjg_lexicon_parser
 module Sosa = Geneweb_sosa
 module Db = Geneweb_db
+module Compat = Geneweb_compat
 open Geneweb
 open Jingoo
 open Jg_types
@@ -493,7 +494,7 @@ and mk_title conf base t =
   let ident = Tstr (Driver.sou base t.Def.t_ident) in
   let name =
     match t.t_name with
-    | Tmain -> Tstr ""
+    | Tmain -> Tstr Compat.String.empty
     | Tname s -> Tstr (Driver.sou base s)
     | Tnone -> Tnull
   in
@@ -695,7 +696,7 @@ and unsafe_mk_person conf base (p : Driver.person) =
   let image =
     Tstr
       (Image.get_portrait conf base p
-      |> Option.fold ~none:"" ~some:Image.src_to_string)
+      |> Option.fold ~none:Compat.String.empty ~some:Image.src_to_string)
   in
   let iper = Tstr (Driver.Iper.to_string iper') in
   let linked_page =
@@ -728,7 +729,8 @@ and unsafe_mk_person conf base (p : Driver.person) =
                safe
                  (List.fold_left
                     (Perso.linked_page_text conf base p s key)
-                    (Adef.safe "") db))
+                    (Adef.safe Compat.String.empty)
+                    db))
          else Tnull))
   in
   let titles = lazy_list (mk_title conf base) (Driver.get_titles p) in
@@ -1076,21 +1078,19 @@ let module_NAME base =
   in
   let particle =
     func_arg1_no_kw (function
-      | (Tstr s | Tsafe s) as x -> (
-          match get_particle s with
-          | "" -> Tnull
-          | s -> str_or_safe (String.trim s) x)
+      | (Tstr s | Tsafe s) as x ->
+          if Compat.String.is_empty @@ get_particle s then Tnull
+          else str_or_safe (String.trim s) x
       | _ -> assert false)
   in
   let without_particle =
     func_arg1_no_kw (function
-      | (Tstr s | Tsafe s) as x -> (
-          match get_particle s with
-          | "" -> Tstr s
-          | part ->
-              let l = String.length part in
-              let s = String.sub s l (String.length s - l) in
-              str_or_safe s x)
+      | (Tstr s | Tsafe s) as x ->
+          if Compat.String.is_empty @@ get_particle s then Tstr s
+          else
+            let l = String.length s in
+            let s = String.sub s l (String.length s - l) in
+            str_or_safe s x
       | _ -> assert false)
   in
   let lower =
@@ -1156,7 +1156,7 @@ let mk_env conf base =
              match Util.p_getenv conf.env "pz" with
              | None -> (
                  match List.assoc_opt "default_sosa_ref" conf.base_env with
-                 | Some n when n <> "" -> (
+                 | Some n when not (Compat.String.is_empty n) -> (
                      match Gutil.person_ht_find_all base n with
                      | [ ip ] -> get_n_mk_person conf base ip
                      | _ -> Tnull)
@@ -1236,7 +1236,7 @@ let trans ?(autoescape = true) (conf : Config.config) =
                  try unbox_string @@ arg "elision" with Not_found -> acc
                in
                if
-                 x <> ""
+                 (not (Compat.String.is_empty x))
                  && Unidecode.decode
                       (fun _ _ -> false)
                       (fun _ -> function
@@ -1253,7 +1253,9 @@ let trans ?(autoescape = true) (conf : Config.config) =
            if i < 0 then s else loop (conv s (Array.unsafe_get t i) ^ s) (i - 1)
          in
          let len = Array.length t in
-         loop (conv "" @@ Array.unsafe_get t @@ (len - 1)) (len - 2)
+         loop
+           (conv Compat.String.empty @@ Array.unsafe_get t @@ (len - 1))
+           (len - 2)
          |> Util.translate_eval)
     with Not_found -> Tstr (Printf.sprintf "{{%s|trans}}" @@ stringify @@ s)
   in
@@ -1277,7 +1279,7 @@ let alphabetic =
   func_arg2_no_kw @@ fun a b ->
   let str = function
     | Tsafe b | Tstr b -> b
-    | Tnull -> ""
+    | Tnull -> Compat.String.empty
     | _ -> failwith_type_error_2 "alphabetic" a b
   in
   Tint (Utf8.compare (str a) (str b))
@@ -1287,7 +1289,7 @@ let module_CAST =
     func_arg1_no_kw @@ function
     | Tstr _ as s -> s
     | Tsafe s -> Tstr s
-    | Tnull -> Tstr ""
+    | Tnull -> Tstr Compat.String.empty
     | Tint i -> Tstr (string_of_int i)
     | Tfloat f -> Tstr (string_of_float f)
     | Tbool b -> Tstr (string_of_bool b)


### PR DESCRIPTION
Strings in OCaml used to be mutable and the string literal "" produced a fresh string (so an allocation for it). ~~Even if empty strings are not immutable, it seems that `caml_alloc_string` still allocates them.~~

This PR removes all the memory duplicates of \"\". If you need to create the empty string, please use `Compat.String.empty` and to check if the string is empty, use `Compat.String.is_empty`.

This PR shouldn't have a significative impact on performances even if we do less allocations.