### PR TITLE
fix(ci/win): use curl-based cpanm for Perl dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,16 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
-      - name: Install Perl dependencies (Windows @v3)
+      - name: Install Perl dependencies (Windows)
         if: runner.os == 'Windows'
         shell: bash
-        run: cpanm --notest String::ShellQuote IPC::System::Simple
+        run: |
+          curl -fsSL https://cpanmin.us | perl - --notest IPC::System::Simple String::ShellQuote
+          for pkg in conf-perl-ipc-system-simple conf-perl-string-shellquote; do
+            d=".pins/$pkg"; mkdir -p "$d"
+            printf 'opam-version: "2.0"\nsynopsis: "Pin bypass"\nmaintainer: "ci"\nbuild: ["true"]\ninstall: ["true"]\n' > "$d/opam"
+            opam pin add "$pkg" "$d" --yes --no-action
+          done
 
       - name: Remove locked mingw gcc shim if present
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,12 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          cpanm --notest String::ShellQuote IPC::System::Simple
+          curl -fsSL https://cpanmin.us | perl - --notest IPC::System::Simple String::ShellQuote
+          for pkg in conf-perl-ipc-system-simple conf-perl-string-shellquote; do
+            d=".pins/$pkg"; mkdir -p "$d"
+            printf 'opam-version: "2.0"\nsynopsis: "Pin bypass"\nmaintainer: "ci"\nbuild: ["true"]\ninstall: ["true"]\n' > "$d/opam"
+            opam pin add "$pkg" "$d" --yes --no-action
+          done
           rm -f _opam/bin/x86_64-w64-mingw32-gcc.exe || true
           rm -f _opam/bin/i686-w64-mingw32-gcc.exe || true
 


### PR DESCRIPTION
setup-ocaml v3.5.0 introduced two breaking changes for Windows CI:

1. --cygwin-internal-install (# 1067) bootstraps a minimal Cygwin that no longer includes cpanm. Fix: fetch cpanm via cpanmin.us.

2. The minimal Cygwin has its own perl (`C:\.opam\.cygwin\root\bin\perl.exe`) distinct from the runner's Strawberry Perl. cpanm installs modules into Strawberry's `@INC`, but opam verifies conf-perl-* packages using its internal Cygwin perl which cannot see them. Fix: pin conf-perl-ipc-system-simple and conf-perl-string-shellquote to no-op packages so opam skips the unreliable check.

Previous CI runs passed by accident: the opam cache restored a pre-v3.5.0 Cygwin state that still had cpanm and satisfied conf-perl.

Ref: ocaml/setup-ocaml # 1067, # 1069, # 1085