### PR TITLE
CI Windows: remove manual Perl dependency workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,17 +89,6 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
-      - name: Install Perl dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          curl -fsSL https://cpanmin.us | perl - --notest IPC::System::Simple String::ShellQuote
-          for pkg in conf-perl-ipc-system-simple conf-perl-string-shellquote; do
-            d=".pins/$pkg"; mkdir -p "$d"
-            printf 'opam-version: "2.0"\nsynopsis: "Pin bypass"\nmaintainer: "ci"\nbuild: ["true"]\ninstall: ["true"]\n' > "$d/opam"
-            opam pin add "$pkg" "$d" --yes --no-action
-          done
-
       - name: Remove locked mingw gcc shim if present
         if: runner.os == 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,10 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
-      - name: Install Perl dependencies and remove locked mingw gcc shim (Windows)
+      - name: Remove locked mingw gcc shim (Windows)
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          curl -fsSL https://cpanmin.us | perl - --notest IPC::System::Simple String::ShellQuote
-          for pkg in conf-perl-ipc-system-simple conf-perl-string-shellquote; do
-            d=".pins/$pkg"; mkdir -p "$d"
-            printf 'opam-version: "2.0"\nsynopsis: "Pin bypass"\nmaintainer: "ci"\nbuild: ["true"]\ninstall: ["true"]\n' > "$d/opam"
-            opam pin add "$pkg" "$d" --yes --no-action
-          done
           rm -f _opam/bin/x86_64-w64-mingw32-gcc.exe || true
           rm -f _opam/bin/i686-w64-mingw32-gcc.exe || true
 


### PR DESCRIPTION
conf-perl-ipc-system-simple.4 and conf-perl-string-shellquote.4 (ocaml/opam-repository#29613) add native Cygwin/MSYS2 support, installing Perl modules via cpan automatically during opam dependency resolution — no manual step needed anymore.

This removes the curl+cpanm and opam pin workaround introduced after setup-ocaml v3.5.0 broke conf-perl resolution on Windows by switching to --cygwin-internal-install (ocaml/setup-ocaml#1067).