### PR TITLE
pin ocamlformat to 0.29.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -44,7 +44,7 @@ jobs:
           dune-cache: true
 
       - name: Install ocamlformat
-        run: opam install dune ocamlformat.0.28.1
+        run: opam install dune ocamlformat.0.29.0
 
       - name: Check formatting with dune
         id: format-check

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile = default
-version = 0.28.1
+version = 0.29.0

--- a/dune-project
+++ b/dune-project
@@ -49,7 +49,7 @@
     pp_loc
     dune-site
     (utop :with-dev-setup)
-    (ocamlformat (and :with-dev-setup (= "0.28.1")))
+    (ocamlformat (and :with-dev-setup (= "0.29.0")))
   )
   (depopts
     (ancient (>= 0.10.0))

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -43,7 +43,7 @@ depends: [
   "pp_loc"
   "dune-site"
   "utop" {with-dev-setup}
-  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "ocamlformat" {with-dev-setup & = "0.29.0"}
   "odoc" {with-doc}
 ]
 depopts: [

--- a/lib/search/index.ml
+++ b/lib/search/index.ml
@@ -166,8 +166,7 @@ module Make (W : Word.S) (E : Entry) = struct
 
                 let pattern = p
                 let max_dist = max_dist
-              end)
-          in
+              end) in
           A ((module A), A.init))
         ps
     in

--- a/lib/statistics.ml
+++ b/lib/statistics.ml
@@ -234,8 +234,8 @@ let person_pass conf base a by_cache auth_cache =
               then age - 1
               else age
             in
-            if age >= 0 && age < age_max then begin
-              match Driver.get_sex p with
+            if age >= 0 && age < age_max then
+              begin match Driver.get_sex p with
               | Male ->
                   a.age_death_men.(age) <- a.age_death_men.(age) + 1;
                   a.sum_life_men <- a.sum_life_men + age;
@@ -256,7 +256,7 @@ let person_pass conf base a by_cache auth_cache =
                     a.life_cent_cnt_women.(ci) <- a.life_cent_cnt_women.(ci) + 1
                   end
               | Neuter -> ()
-            end
+              end
         | _ -> ()
       end)
     (Driver.persons base)


### PR DESCRIPTION
Nearly no changes for our sources: it's a +4-5 diff on two files.