### PR TITLE
Deprecate multi-parents feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,2 @@
+## unreleased
+- Deprecate the multi-parents feature (#2726)

--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -10,7 +10,7 @@ type person = (int, int, int) Def.gen_person
 type ascend = int Def.gen_ascend
 type union = int Def.gen_union
 type family = (int, int, int) Def.gen_family
-type couple = int Def.gen_couple
+type couple = int Adef.gen_couple
 type descend = int Def.gen_descend
 
 let log_oc = ref stdout

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -32,7 +32,7 @@ type union = int Def.gen_union
 type family = (int, int, int) Def.gen_family
 (** Family's entry in the base *)
 
-type couple = int Def.gen_couple
+type couple = int Adef.gen_couple
 (** Family's couple entry in the base *)
 
 type descend = int Def.gen_descend

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -27,7 +27,7 @@ type somebody =
 
 type gw_syntax =
   | Family of
-      somebody gen_couple
+      somebody Adef.gen_couple
       * sex
       * sex
       * (somebody * sex) list

--- a/bin/gwc/gwcomp.mli
+++ b/bin/gwc/gwcomp.mli
@@ -27,7 +27,7 @@ type somebody =
 (** Blocks that could appear in .gw file. *)
 type gw_syntax =
   | Family of
-      somebody gen_couple
+      somebody Adef.gen_couple
       * sex
       * sex
       * (somebody * sex) list

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1444,6 +1444,12 @@ let string_to_char_list s =
   let rec exp i l = if i < 0 then l else exp (i - 1) (s.[i] :: l) in
   exp (String.length s - 1) []
 
+let warning_multi_parents () =
+  Logs.warn (fun k ->
+      k
+        "The multi-parents feature is deprecated. Setting it up will no longer \
+         have any effect.")
+
 let make_conf ~secret_salt from_addr request script_name env =
   if !allowed_tags_file <> "" && not (Sys.file_exists !allowed_tags_file) then (
     let str =
@@ -1576,6 +1582,8 @@ let make_conf ~secret_salt from_addr request script_name env =
   let plugins =
     List.fold_left (fun acc { path; _ } -> path :: acc) [] !plugins |> List.rev
   in
+  if List.assoc_opt "multi_parents" base_env = Some "yes" then
+    warning_multi_parents ();
   let conf =
     {
       from = from_addr;
@@ -1605,9 +1613,6 @@ let make_conf ~secret_salt from_addr request script_name env =
       default_lang;
       browser_lang;
       default_sosa_ref;
-      multi_parents =
-        (try List.assoc "multi_parents" base_env = "yes"
-         with Not_found -> false);
       authorized_wizards_notes =
         (try List.assoc "authorized_wizards_notes" base_env = "yes"
          with Not_found -> false);

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -596,10 +596,8 @@
       <div class="row">
           %foreach;parent;
             %let;os;%parent.sexes;%in;
-            %if;(cnt!=1 and bvar.multi_parents="yes")<hr class="w-100">%end;
             <div class="col-12">
               %apply;parent(cnt,"parent",parent.sex)
-              %if;(bvar.multi_parents="yes")%apply;insert_parent(cnt)%end;
             </div>
             %if;(cnt=2)
               <div class="custom-control custom-checkbox mt-3 ml-3">

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -63,7 +63,6 @@ type config = {
   default_lang : string;
   browser_lang : string;
   default_sosa_ref : Geneweb_db.Driver.iper * Geneweb_db.Driver.person option;
-  multi_parents : bool;
   authorized_wizards_notes : bool;
   public_if_titles : bool;
   public_if_no_date : bool;
@@ -148,7 +147,6 @@ let empty =
     default_lang = "";
     browser_lang = "";
     default_sosa_ref = (Geneweb_db.Driver.Iper.dummy, None);
-    multi_parents = false;
     authorized_wizards_notes = false;
     public_if_titles = false;
     public_if_no_date = false;

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -68,7 +68,6 @@ type config = {
   default_lang : string;
   browser_lang : string;
   default_sosa_ref : Geneweb_db.Driver.iper * Geneweb_db.Driver.person option;
-  multi_parents : bool;
   authorized_wizards_notes : bool;
   public_if_titles : bool;
   public_if_no_date : bool;

--- a/lib/db/database.mli
+++ b/lib/db/database.mli
@@ -19,7 +19,7 @@ val make :
   * int Def.gen_ascend array
   * int Def.gen_union array)
   * ((int, int, int) Def.gen_family array
-    * int Def.gen_couple array
+    * int Adef.gen_couple array
     * int Def.gen_descend array)
   * string array
   * Def.base_notes ->

--- a/lib/db/db_gc.ml
+++ b/lib/db/db_gc.ml
@@ -65,7 +65,7 @@ let gc ?(dry_run = true) base =
       (* if family wasn't deleted *)
       if f.fam_index <> dummy_ifam then
         let _ = Futil.map_family_ps markp markf marks f in
-        let _ = Futil.map_couple_p false markp @@ base.data.couples.get i in
+        let _ = Adef.map_couple_p markp @@ base.data.couples.get i in
         let _ = Futil.map_descend_p markp @@ base.data.descends.get i in
         ()
   done;
@@ -143,7 +143,7 @@ let gc ?(dry_run = true) base =
     in
     let couples =
       Array.init lenf @@ fun i ->
-      Futil.map_couple_p false dst_iper @@ base.data.couples.get @@ src_ifam i
+      Adef.map_couple_p dst_iper @@ base.data.couples.get @@ src_ifam i
     in
     let descends =
       Array.init lenf @@ fun i ->

--- a/lib/db/dbdisk.ml
+++ b/lib/db/dbdisk.ml
@@ -2,7 +2,7 @@ type dsk_person = (int, int, int) Def.gen_person
 type dsk_ascend = int Def.gen_ascend
 type dsk_union = int Def.gen_union
 type dsk_family = (int, int, int) Def.gen_family
-type dsk_couple = int Def.gen_couple
+type dsk_couple = int Adef.gen_couple
 type dsk_descend = int Def.gen_descend
 type dsk_title = int Def.gen_title
 

--- a/lib/db/dbdisk.mli
+++ b/lib/db/dbdisk.mli
@@ -10,7 +10,7 @@ type dsk_union = int Def.gen_union
 type dsk_family = (int, int, int) Def.gen_family
 (** Family's entry in the base *)
 
-type dsk_couple = int Def.gen_couple
+type dsk_couple = int Adef.gen_couple
 (** Family's couple entry in the base *)
 
 type dsk_descend = int Def.gen_descend

--- a/lib/db/driver.ml
+++ b/lib/db/driver.ml
@@ -441,7 +441,7 @@ type family = {
   base : base;
   ifam : ifam;
   mutable f : (iper, ifam, istr) Def.gen_family option;
-  mutable c : iper Def.gen_couple option;
+  mutable c : iper Adef.gen_couple option;
   mutable d : iper Def.gen_descend option;
 }
 

--- a/lib/db/driver.mli
+++ b/lib/db/driver.mli
@@ -62,7 +62,7 @@ val make :
   * int Def.gen_ascend array
   * int Def.gen_union array)
   * ((int, int, int) Def.gen_family array
-    * int Def.gen_couple array
+    * int Adef.gen_couple array
     * int Def.gen_descend array)
   * string array
   * Def.base_notes ->
@@ -315,7 +315,7 @@ val get_titles : person -> title list
 val get_witnesses : family -> iper array
 (** Get array of family's witnesses ids *)
 
-val gen_couple_of_family : family -> iper Def.gen_couple
+val gen_couple_of_family : family -> iper Adef.gen_couple
 (** Extract [gen_couple] from [family]. *)
 
 val gen_descend_of_family : family -> iper Def.gen_descend
@@ -335,7 +335,9 @@ val gen_union_of_person : person -> ifam Def.gen_union
 
 val family_of_gen_family :
   base ->
-  (iper, ifam, istr) Def.gen_family * iper Def.gen_couple * iper Def.gen_descend ->
+  (iper, ifam, istr) Def.gen_family
+  * iper Adef.gen_couple
+  * iper Def.gen_descend ->
   family
 (** Create [family] from associated values. *)
 
@@ -369,7 +371,7 @@ val no_family : ifam -> (iper, ifam, istr) Def.gen_family
 val no_descend : iper Def.gen_descend
 (** Returns unitialised [gen_descend] *)
 
-val no_couple : iper Def.gen_couple
+val no_couple : iper Adef.gen_couple
 (** Returns unitialised [gen_couple] *)
 
 val nb_of_persons : base -> int
@@ -407,7 +409,7 @@ val patch_descend : base -> ifam -> iper Def.gen_descend -> unit
 (** Modify/add descendants of a family with a giving id. Modification stay
     blocked until call of [commit_patches]. *)
 
-val patch_couple : base -> ifam -> iper Def.gen_couple -> unit
+val patch_couple : base -> ifam -> iper Adef.gen_couple -> unit
 (** Modify/add couple of a family with a giving id. Modification stay blocked
     until call of [commit_patches]. *)
 
@@ -452,7 +454,7 @@ val insert_family : base -> ifam -> (iper, ifam, istr) Def.gen_family -> unit
 val insert_family_with_couple_and_descendants :
   base ->
   (iper, ifam, istr) Def.gen_family ->
-  iper Def.gen_couple ->
+  iper Adef.gen_couple ->
   iper Def.gen_descend ->
   ifam
 (** [insert_family base f c d] Add a new family with its couple and descendants
@@ -472,7 +474,7 @@ val insert_person_with_union_and_ascendants :
     the [base]. Allocate and returns the fresh new id for this person. [p]
     SHOULD be defined using [dummy_iper]. *)
 
-val insert_couple : base -> ifam -> iper Def.gen_couple -> unit
+val insert_couple : base -> ifam -> iper Adef.gen_couple -> unit
 (** Same as [patch_descend] *)
 
 val delete_person : base -> iper -> unit

--- a/lib/db/gutil.ml
+++ b/lib/db/gutil.ml
@@ -36,10 +36,6 @@ let designation base p =
 
 let father = Adef.father
 let mother = Adef.mother
-
-let couple multi fath moth =
-  if not multi then Adef.couple fath moth else Adef.multi_couple fath moth
-
 let parent_array = Adef.parent_array
 
 let spouse ip cpl =

--- a/lib/db/gutil.ml
+++ b/lib/db/gutil.ml
@@ -34,10 +34,6 @@ let designation base p =
   let nom = Driver.p_surname base p in
   first_name ^ "." ^ string_of_int (Driver.get_occ p) ^ " " ^ nom
 
-let father = Adef.father
-let mother = Adef.mother
-let parent_array = Adef.parent_array
-
 let spouse ip cpl =
   if ip = Driver.get_father cpl then Driver.get_mother cpl
   else Driver.get_father cpl

--- a/lib/db/gutil.mli
+++ b/lib/db/gutil.mli
@@ -1,7 +1,5 @@
 (* Copyright (c) 1998-2007 INRIA *)
 
-open Def
-
 exception Same_person
 
 val is_ancestor :
@@ -67,15 +65,6 @@ val sort_person_list : Driver.base -> Driver.person list -> Driver.person list
 val sort_uniq_person_list :
   Driver.base -> Driver.person list -> Driver.person list
 (** Same as [sort_person_list] but also remove duplicates *)
-
-val father : 'a gen_couple -> 'a
-(** Same as [Adef.father] *)
-
-val mother : 'a gen_couple -> 'a
-(** Same as [Adef.mother] *)
-
-val parent_array : 'a gen_couple -> 'a array
-(** Same as [Adef.parent_array] *)
 
 val find_free_occ : Driver.base -> string -> string -> int
 (** Find first free occurence number for the person with specified first name

--- a/lib/db/gutil.mli
+++ b/lib/db/gutil.mli
@@ -74,10 +74,6 @@ val father : 'a gen_couple -> 'a
 val mother : 'a gen_couple -> 'a
 (** Same as [Adef.mother] *)
 
-val couple : bool -> 'a -> 'a -> 'a gen_couple
-(** [couple multi f m] creates a couple from father [f] and mother [m]. If
-    [multi] true uses multiparent functionality *)
-
 val parent_array : 'a gen_couple -> 'a array
 (** Same as [Adef.parent_array] *)
 

--- a/lib/def/adef.ml
+++ b/lib/def/adef.ml
@@ -41,8 +41,6 @@ let[@inline] mother cpl = cpl.mother
 let couple father mother = { father; mother }
 let parent parent = { father = parent.(0); mother = parent.(1) }
 let parent_array cpl = [| cpl.father; cpl.mother |]
-let multi_couple father mother : 'person gen_couple = { father; mother }
-let multi_parent = parent
 
 let map_couple_p fp { father; mother } =
   { father = fp father; mother = fp mother }

--- a/lib/def/adef.ml
+++ b/lib/def/adef.ml
@@ -35,25 +35,17 @@ type cdate =
   | Cnone
 
 type 'person gen_couple = { father : 'person; mother : 'person }
-and 'person gen_parents = { parent : 'person array }
 
-let father cpl =
-  if Obj.size (Obj.repr cpl) = 2 then cpl.father else (Obj.magic cpl).parent.(0)
-
-let mother cpl =
-  if Obj.size (Obj.repr cpl) = 2 then cpl.mother else (Obj.magic cpl).parent.(1)
-
+let[@inline] father cpl = cpl.father
+let[@inline] mother cpl = cpl.mother
 let couple father mother = { father; mother }
 let parent parent = { father = parent.(0); mother = parent.(1) }
+let parent_array cpl = [| cpl.father; cpl.mother |]
+let multi_couple father mother : 'person gen_couple = { father; mother }
+let multi_parent = parent
 
-let parent_array cpl =
-  if Obj.size (Obj.repr cpl) = 2 then [| cpl.father; cpl.mother |]
-  else (Obj.magic cpl).parent
-
-let multi_couple father mother : 'person gen_couple =
-  Obj.magic { parent = [| father; mother |] }
-
-let multi_parent parent : 'person gen_couple = Obj.magic { parent }
+let map_couple_p fp { father; mother } =
+  { father = fp father; mother = fp mother }
 
 type 'a astring = string
 type safe_string = [ `encoded | `escaped | `safe ] astring

--- a/lib/def/adef.mli
+++ b/lib/def/adef.mli
@@ -73,12 +73,6 @@ val parent_array : 'a gen_couple -> 'a array
 (** Returns array from [gen_couple]. First element of array is father, second -
     mother *)
 
-val multi_couple : 'a -> 'a -> 'a gen_couple
-(** @deprecated Use [couple] instead *)
-
-val multi_parent : 'a array -> 'a gen_couple
-(** @deprecated Use [parent] instead *)
-
 val map_couple_p : ('a -> 'b) -> 'a gen_couple -> 'b gen_couple
 (** Convert generic type used to represent father and mother inside
     [Def.gen_couple] into another one. *)

--- a/lib/def/adef.mli
+++ b/lib/def/adef.mli
@@ -79,6 +79,10 @@ val multi_couple : 'a -> 'a -> 'a gen_couple
 val multi_parent : 'a array -> 'a gen_couple
 (** @deprecated Use [parent] instead *)
 
+val map_couple_p : ('a -> 'b) -> 'a gen_couple -> 'b gen_couple
+(** Convert generic type used to represent father and mother inside
+    [Def.gen_couple] into another one. *)
+
 type +'a astring = private string
 type safe_string = [ `encoded | `escaped | `safe ] astring
 type escaped_string = [ `encoded | `escaped ] astring

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -262,9 +262,6 @@ type ('person, 'ifam, 'string) gen_family = {
 }
 (** Polymorphic type describing information about family. *)
 
-type 'person gen_couple = 'person Adef.gen_couple
-(** Alias to [Adef.gen_couple] *)
-
 (** Database errors describing bad specification of the person *)
 type 'person error =
   | AlreadyDefined of 'person

--- a/lib/mergeFamOk.ml
+++ b/lib/mergeFamOk.ml
@@ -221,11 +221,11 @@ let print_merge conf base =
       let fam2 = Driver.foi base (Driver.Ifam.of_string f2) in
       let sfam, sdes = reconstitute conf base ifam1 fam1 fam2 in
       let digest =
-        let ini_sfam = UpdateFam.string_family_of conf base ifam1 in
+        let ini_sfam = UpdateFam.string_family_of base ifam1 in
         Update.digest_family ini_sfam
       in
       let scpl =
-        Futil.map_couple_p conf.multi_parents
+        Adef.map_couple_p
           (UpdateFam.person_key base)
           (Driver.gen_couple_of_family (Driver.foi base sfam.fam_index))
       in

--- a/lib/mergeInd.ml
+++ b/lib/mergeInd.ml
@@ -133,9 +133,9 @@ let effective_merge_ind conf base (warning : CheckItem.base_warning -> unit) p1
       let cpl = Driver.foi base ifam in
       let cpl =
         if Driver.get_iper p2 = Driver.get_father cpl then
-          Gutil.couple false (Driver.get_iper p1) (Driver.get_mother cpl)
+          Adef.couple (Driver.get_iper p1) (Driver.get_mother cpl)
         else if Driver.get_iper p2 = Driver.get_mother cpl then
-          Gutil.couple false (Driver.get_father cpl) (Driver.get_iper p1)
+          Adef.couple (Driver.get_father cpl) (Driver.get_iper p1)
         else assert false
       in
       Driver.patch_couple base ifam cpl

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -472,9 +472,9 @@ let redirect_added_families base p ip2 p2_family =
                   Driver.patch_person base ip w)
               evt.efam_witnesses)
           (Driver.get_fevents fam);
-        Gutil.couple false p.key_index (Driver.get_mother fam))
+        Adef.couple p.key_index (Driver.get_mother fam))
       else if ip2 = Driver.get_mother fam then
-        Gutil.couple false (Driver.get_father fam) p.key_index
+        Adef.couple (Driver.get_father fam) p.key_index
       else assert false
     in
     Driver.patch_couple base ifam cpl

--- a/lib/update.mli
+++ b/lib/update.mli
@@ -138,7 +138,7 @@ val digest_person :
 val digest_family :
   ?salt:string ->
   (key, Geneweb_db.Driver.ifam, string) gen_family
-  * key gen_couple
+  * key Adef.gen_couple
   * key gen_descend ->
   string
 (** [digest_family ?salt fam] generates a digest of the family [fam]. The

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -21,7 +21,7 @@ let person_key base ip =
   in
   (first_name, surname, occ, Update.Link, "")
 
-let string_family_of conf base ifam =
+let string_family_of base ifam =
   let fam = Driver.foi base ifam in
   let sfam =
     Futil.map_family_ps (person_key base)
@@ -30,8 +30,7 @@ let string_family_of conf base ifam =
       (Driver.gen_family_of_family fam)
   in
   let scpl =
-    Futil.map_couple_p conf.multi_parents (person_key base)
-      (Driver.gen_couple_of_family fam)
+    Adef.map_couple_p (person_key base) (Driver.gen_couple_of_family fam)
   in
   let sdes =
     Futil.map_descend_p (person_key base) (Driver.gen_descend_of_family fam)
@@ -644,7 +643,7 @@ let print_add conf base =
       fsources = default_source conf;
       fam_index = Driver.Ifam.dummy;
     }
-  and cpl = Gutil.couple conf.multi_parents fath moth
+  and cpl = Adef.couple fath moth
   and des = { children = [||] } in
   print_update_fam conf base (fam, cpl, des) digest
 
@@ -668,7 +667,7 @@ let print_add_parents conf base =
           fam_index = Driver.Ifam.dummy;
         }
       and cpl =
-        Gutil.couple conf.multi_parents
+        Adef.couple
           ( "",
             Driver.sou base (Driver.get_surname p),
             0,
@@ -692,7 +691,7 @@ let print_add_parents conf base =
 let print_mod conf base =
   match p_getenv conf.env "i" with
   | Some i ->
-      let sfam = string_family_of conf base (Driver.Ifam.of_string i) in
+      let sfam = string_family_of base (Driver.Ifam.of_string i) in
       let salt = Option.get conf.secret_salt in
       let digest = Update.digest_family ~salt sfam in
       print_update_fam conf base sfam digest
@@ -813,7 +812,7 @@ let print_change_event_order conf base =
   | None -> Hutil.incorrect_request conf
   | Some i ->
       let i = Driver.Ifam.of_string i in
-      let sfam = string_family_of conf base i in
+      let sfam = string_family_of base i in
       let ifun =
         Templ.
           {

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -172,7 +172,7 @@ and eval_is_last env =
 and eval_parent conf base env cpl sl =
   match get_env "cnt" env with
   | Vint i ->
-      let arr = Gutil.parent_array cpl in
+      let arr = Adef.parent_array cpl in
       let i = i - 1 in
       let k =
         if i >= 0 && i < Array.length arr then arr.(i)
@@ -281,7 +281,7 @@ and eval_simple_var conf base env (fam, cpl, des) = function
   | [ "digest" ] -> eval_string_env "digest" env
   | [ "divorce" ] -> eval_divorce fam
   | [ "divorce"; s ] -> eval_divorce' fam s
-  | "father" :: sl -> eval_key conf base (Gutil.father cpl) sl
+  | "father" :: sl -> eval_key conf base (Adef.father cpl) sl
   | [ "fsources" ] ->
       safe_val (Util.escape_html fam.fsources :> Adef.safe_string)
   | [ "is_first" ] -> eval_is_first env
@@ -293,7 +293,7 @@ and eval_simple_var conf base env (fam, cpl, des) = function
       safe_val (Util.escape_html fam.marriage_note :> Adef.safe_string)
   | [ "marriage_src" ] ->
       safe_val (Util.escape_html fam.marriage_src :> Adef.safe_string)
-  | "mother" :: sl -> eval_key conf base (Gutil.mother cpl) sl
+  | "mother" :: sl -> eval_key conf base (Adef.mother cpl) sl
   | [ "mrel" ] -> str_val (eval_relation_kind fam.relation)
   | [ "nb_fevents" ] -> str_val (string_of_int (List.length fam.fevents))
   | [ "origin_file" ] ->
@@ -447,7 +447,7 @@ let print_foreach print_ast _eval_expr =
     | [ "fevent" ] -> print_foreach_fevent env fcd al fam.fevents
     | [ "fwitness" ] -> print_foreach_fwitness env fcd al fam.fevents
     | [ "witness" ] -> print_foreach_witness env fcd al fam.witnesses
-    | [ "parent" ] -> print_foreach_parent env fcd al (Gutil.parent_array cpl)
+    | [ "parent" ] -> print_foreach_parent env fcd al (Adef.parent_array cpl)
     | _ -> raise Not_found
   and print_foreach_child env fcd al arr =
     for i = 0 to max 1 (Array.length arr) - 1 do

--- a/lib/updateFam.mli
+++ b/lib/updateFam.mli
@@ -11,7 +11,7 @@ val print_update_fam :
   config ->
   Geneweb_db.Driver.base ->
   (Update.key, Geneweb_db.Driver.ifam, string) gen_family
-  * Update.key gen_couple
+  * Update.key Adef.gen_couple
   * Update.key gen_descend ->
   string ->
   unit
@@ -50,5 +50,5 @@ val string_family_of :
   Geneweb_db.Driver.base ->
   Geneweb_db.Driver.ifam ->
   (Update.key, Geneweb_db.Driver.ifam, string) gen_family
-  * Update.key gen_couple
+  * Update.key Adef.gen_couple
   * Update.key gen_descend

--- a/lib/updateFam.mli
+++ b/lib/updateFam.mli
@@ -47,7 +47,6 @@ val print_change_event_order : config -> Geneweb_db.Driver.base -> unit
 (** Displays the form for changing the order of events for a family *)
 
 val string_family_of :
-  config ->
   Geneweb_db.Driver.base ->
   Geneweb_db.Driver.ifam ->
   (Update.key, Geneweb_db.Driver.ifam, string) gen_family

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -549,9 +549,9 @@ let check_parents conf cpl =
            (transl_nth conf "father/mother" i |> Adef.safe))
     else None
   in
-  match check Gutil.father 0 with
+  match check Adef.father 0 with
   | Some _ as err -> err
-  | None -> check Gutil.mother 1
+  | None -> check Adef.mother 1
 
 let check_family conf fam cpl :
     Update.update_error option * Update.update_error option =
@@ -1055,7 +1055,7 @@ let is_created_or_already_there ochil_arr nchil schil =
 
 let need_check_noloop (scpl, sdes, onfs) =
   if
-    Array.exists is_a_link (Gutil.parent_array scpl)
+    Array.exists is_a_link (Adef.parent_array scpl)
     || Array.exists is_a_link sdes.children
   then
     match onfs with
@@ -1063,7 +1063,7 @@ let need_check_noloop (scpl, sdes, onfs) =
         (not
            (Mutil.array_forall2
               (is_created_or_already_there opar)
-              npar (Gutil.parent_array scpl)))
+              npar (Adef.parent_array scpl)))
         || not
              (Mutil.array_forall2
                 (is_created_or_already_there ochil)
@@ -1218,8 +1218,8 @@ let forbidden_disconnected conf scpl sdes =
   in
   if no_dec then
     if
-      get_create (Gutil.father scpl) = Update.Link
-      || get_create (Gutil.mother scpl) = Update.Link
+      get_create (Adef.father scpl) = Update.Link
+      || get_create (Adef.mother scpl) = Update.Link
     then false
     else Array.for_all (fun p -> get_create p <> Update.Link) sdes.children
   else false

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -499,7 +499,7 @@ let reconstitute_family conf base nsck =
       fsources;
       fam_index;
     }
-  and cpl = Futil.parent conf.multi_parents (Array.of_list parents)
+  and cpl = Adef.parent (Array.of_list parents)
   and des = { children = Array.of_list children } in
   (fam, cpl, des, ext)
 
@@ -808,9 +808,7 @@ let aux_effective_mod conf base nsck sfam scpl sdes fi origin_file =
     match p_getenv conf.env "psrc" with Some s -> String.trim s | None -> ""
   in
   let ncpl =
-    Futil.map_couple_p conf.multi_parents
-      (Update.insert_person conf base psrc created_p)
-      scpl
+    Adef.map_couple_p (Update.insert_person conf base psrc created_p) scpl
   in
   let nfam =
     Futil.map_family_ps
@@ -1386,7 +1384,7 @@ let print_mod_aux conf base callback =
   let sfam, scpl, sdes, ext = reconstitute_family conf base nsck in
   let redisp = Option.is_some (p_getenv conf.env "return") in
   let digest =
-    let ini_sfam = UpdateFam.string_family_of conf base sfam.fam_index in
+    let ini_sfam = UpdateFam.string_family_of base sfam.fam_index in
     let salt = Option.get conf.secret_salt in
     Update.digest_family ~salt ini_sfam
   in
@@ -1525,7 +1523,7 @@ let print_change_event_order conf base =
       let fam = update_family_with_fevents conf base fam in
       Driver.patch_family base fam.fam_index fam;
       let a = Driver.foi base fam.fam_index in
-      let cpl = Futil.parent conf.multi_parents (Driver.get_parent_array a) in
+      let cpl = Adef.parent (Driver.get_parent_array a) in
       let des = { children = Driver.get_children a } in
       let wl =
         let wl = ref [] in

--- a/lib/updateFamOk.mli
+++ b/lib/updateFamOk.mli
@@ -20,14 +20,14 @@ val effective_mod :
   Geneweb_db.Driver.base ->
   bool ->
   (Update.key, Geneweb_db.Driver.ifam, string) Def.gen_family ->
-  Update.key Def.gen_couple ->
+  Update.key Adef.gen_couple ->
   Update.key Def.gen_descend ->
   Geneweb_db.Driver.ifam
   * ( Geneweb_db.Driver.iper,
       Geneweb_db.Driver.ifam,
       Geneweb_db.Driver.istr )
     Def.gen_family
-  * Geneweb_db.Driver.iper Def.gen_couple
+  * Geneweb_db.Driver.iper Adef.gen_couple
   * Geneweb_db.Driver.iper Def.gen_descend
 
 val effective_del :
@@ -46,9 +46,9 @@ val all_checks_family :
     Geneweb_db.Driver.ifam,
     Geneweb_db.Driver.istr )
   Def.gen_family ->
-  Geneweb_db.Driver.iper Def.gen_couple ->
+  Geneweb_db.Driver.iper Adef.gen_couple ->
   Geneweb_db.Driver.iper Def.gen_descend ->
-  Update.key Def.gen_couple
+  Update.key Adef.gen_couple
   * Update.key Def.gen_descend
   * (('i array * 'j array) * ('i array * 'j array)) option ->
   CheckItem.base_warning list * CheckItem.base_misc list
@@ -77,7 +77,7 @@ val print_mod_aux :
      Geneweb_db.Driver.ifam,
      string )
    Def.gen_family ->
-  (string * string * int * Update.create * string) Def.gen_couple ->
+  (string * string * int * Update.create * string) Adef.gen_couple ->
   (string * string * int * Update.create * string) Def.gen_descend ->
   unit) ->
   unit
@@ -96,7 +96,7 @@ val print_change_event_order : Config.config -> Geneweb_db.Driver.base -> unit
 val check_family :
   Config.config ->
   (string * string * _ * _ * _, _, _) Def.gen_family ->
-  (string * string * _ * _ * _) Def.gen_couple ->
+  (string * string * _ * _ * _) Adef.gen_couple ->
   Update.update_error option * Update.update_error option
 (** [check_family conf fam cpl] Checks that no name is missing. *)
 
@@ -113,14 +113,14 @@ val effective_add :
   Geneweb_db.Driver.base ->
   bool ->
   (Update.key, 'a, string) Def.gen_family ->
-  Update.key Def.gen_couple ->
+  Update.key Adef.gen_couple ->
   Update.key Def.gen_descend ->
   Geneweb_db.Driver.ifam
   * ( Geneweb_db.Driver.iper,
       Geneweb_db.Driver.ifam,
       Geneweb_db.Driver.istr )
     Def.gen_family
-  * Geneweb_db.Driver.iper Def.gen_couple
+  * Geneweb_db.Driver.iper Adef.gen_couple
   * Geneweb_db.Driver.iper Def.gen_descend
 (** [effective_add conf base nsck sfam scpl sdes] Patch base without commiting
     changes. *)

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -1,6 +1,5 @@
 (* Copyright (c) 2006-2007 INRIA *)
 
-open Adef
 open Def
 
 external identity : 'a -> 'a = "%identity"
@@ -180,12 +179,7 @@ let map_family_ps ?(fd = identity) fp ff fs fam =
     fam_index = ff fam.fam_index;
   }
 
-let parent multi parent =
-  if not multi then Adef.parent parent else Adef.multi_parent parent
-
-let map_couple_p multi_parents fp cpl =
-  parent multi_parents (Array.map fp (parent_array cpl))
-
+let parent _multi_parent = Adef.parent
 let map_descend_p fp des = { children = Array.map fp des.children }
 
 let gen_person_misc_names sou empty_string quest_string first_name surname

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -179,7 +179,6 @@ let map_family_ps ?(fd = identity) fp ff fs fam =
     fam_index = ff fam.fam_index;
   }
 
-let parent _multi_parent = Adef.parent
 let map_descend_p fp des = { children = Array.map fp des.children }
 
 let gen_person_misc_names sou empty_string quest_string first_name surname

--- a/lib/util/futil.mli
+++ b/lib/util/futil.mli
@@ -84,9 +84,6 @@ val map_family_ps :
       [Def.gen_family] into another one. If [fd] is present, apply it on it on
       every date (marriage, divorce, famillial events, etc.).*)
 
-val parent : bool -> 'a array -> 'a gen_couple
-(** @deprecated Use [Adef.parent] instead. *)
-
 val map_descend_p : ('a -> 'b) -> 'a gen_descend -> 'b gen_descend
 (** Convert generic type used to represent children inside [Def.gen_descend]
     into another one.*)

--- a/lib/util/futil.mli
+++ b/lib/util/futil.mli
@@ -84,11 +84,6 @@ val map_family_ps :
       [Def.gen_family] into another one. If [fd] is present, apply it on it on
       every date (marriage, divorce, famillial events, etc.).*)
 
-val map_couple_p : bool -> ('a -> 'b) -> 'a gen_couple -> 'b gen_couple
-(** Convert generic type used to represent father and mother inside
-    [Def.gen_couple] into another one. If first argument is true then use
-    multi-parent functionality. *)
-
 val parent : bool -> 'a array -> 'a gen_couple
 (** @deprecated Use [Adef.parent] instead. *)
 

--- a/plugins/fixbase/plugin_fixbase.ml
+++ b/plugins/fixbase/plugin_fixbase.ml
@@ -270,8 +270,7 @@ let fixbase_ok conf base =
           (Driver.gen_family_of_family f)
       in
       let mkc f =
-        Futil.map_couple_p false Driver.Iper.to_string
-          (Driver.gen_couple_of_family f)
+        Adef.map_couple_p Driver.Iper.to_string (Driver.gen_couple_of_family f)
       in
       let mkd f =
         Futil.map_descend_p Driver.Iper.to_string


### PR DESCRIPTION
The multi-parents feature is no longer used. This PR removes it. `gwd` emits a warning message if the user set `conf.multi_parents` to `true`.