### PR TITLE
Fix template AST number detection for large Sosa values

### DIFF
--- a/lib/templ/ast.ml
+++ b/lib/templ/ast.ml
@@ -142,22 +142,22 @@ let[@inline] mk_int ?loc x = mk ?loc (Aint x)
 let[@inline] mk_include ?loc x = mk ?loc (Ainclude x)
 let[@inline] mk_pack ?loc l = mk ?loc (Apack l)
 
+let is_number s =
+  let len = String.length s in
+  if len = 0 then false
+  else
+    let start = if s.[0] = '-' then 1 else 0 in
+    start < len
+    && (let rec loop i =
+          i >= len || (s.[i] >= '0' && s.[i] <= '9' && loop (i + 1))
+        in
+        loop start)
+
 let rec subst_desc sf desc =
   match desc with
   | Atext s -> Atext (sf s)
   | Avar (s, sl) -> (
       let s1 = sf s in
-      let is_number s =
-        let len = String.length s in
-        if len = 0 then false
-        else
-          let start = if s.[0] = '-' then 1 else 0 in
-          start < len
-          && (let rec loop i =
-                i >= len || (s.[i] >= '0' && s.[i] <= '9' && loop (i + 1))
-              in
-              loop start)
-      in
       if sl = [] && is_number s1 then Aint s1
       else
         let sl1 = List.map sf sl in

--- a/lib/templ/ast.ml
+++ b/lib/templ/ast.ml
@@ -147,14 +147,18 @@ let rec subst_desc sf desc =
   | Atext s -> Atext (sf s)
   | Avar (s, sl) -> (
       let s1 = sf s in
-      if
-        sl = []
-        &&
-          try
-            let _ = int_of_string s1 in
-            true
-          with Failure _ -> false
-      then Aint s1
+      let is_number s =
+        let len = String.length s in
+        if len = 0 then false
+        else
+          let start = if s.[0] = '-' then 1 else 0 in
+          start < len
+          && (let rec loop i =
+                i >= len || (s.[i] >= '0' && s.[i] <= '9' && loop (i + 1))
+              in
+              loop start)
+      in
+      if sl = [] && is_number s1 then Aint s1
       else
         let sl1 = List.map sf sl in
         match String.split_on_char '.' s1 with


### PR DESCRIPTION
## Summary

- In `lib/templ/ast.ml`, `subst_desc` uses `int_of_string` to detect whether a substituted template parameter is a numeric literal. This overflows OCaml's 63-bit native int for values > 2^62 − 1 (~4.6 × 10¹⁸), causing the value to be misclassified as a variable reference (`Avar`) instead of a number literal (`Aint`). The variable lookup silently fails, producing no output.
- This breaks any template that passes large Sosa numbers as function parameters — for example, a recursive `sosapath` function that builds a gender chain by repeated division. Databases with 60+ generations of ancestry (e.g., Roglo) are affected.
- Fix: replace `int_of_string` with a simple digit-check. The `Aint` constructor only stores the string, so no actual integer parsing is needed. The fix is backward-compatible — behavior is identical for numbers that fit in native int.

## Test plan

- [ ] Verify `make build` succeeds
- [ ] Verify `make test` passes
- [ ] Test with a database containing 60+ generations of ancestry — template functions receiving Sosa numbers > 2^62 should now produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)