### PR TITLE
fix issue 2731 (returns spouse in visitor mode)

### DIFF
--- a/lib/searchName.ml
+++ b/lib/searchName.ml
@@ -974,7 +974,6 @@ let search_fullname conf base fn sn =
       k "      search_fullname: %d results" (List.length persons));
   match persons with
   | [] -> { exact = []; partial = []; spouse = [] }
-  | [ p ] -> { exact = [ Driver.get_iper p ]; partial = []; spouse = [] }
   | pl ->
       let opts =
         { order = false; exact1 = true; incl_aliases = false; absolute = false }


### PR DESCRIPTION
Bug : dans search_fullname, le pattern | [ p ] -> court-circuitait la vérification du prénom quand advanced_search ne retournait qu'un seul porteur du surname. En mode visitor, les personnes masquées étant filtrées par advanced_search, il ne restait souvent qu'un seul résultat — qui était retourné directement en exact sans vérifier que son prénom correspondait à la recherche.
Fix : supprimer le cas | [ p ] -> et laisser le cas général | pl -> gérer tous les cas, y compris un seul résultat, en passant toujours par search_for_multiple_fn pour valider le prénom.

Le comportement différent entre magicien et visiteur est lié à la famille concernée! Le papa est décédé et a eu plusieurs enfants (seuls porteurs du patronyme). En mode magicien, search_fullname renvoie la liste du papa+enfants, en mode visiteur seul la papa est renvoyé!