### PR TITLE
Overwrite gwo files

### DIFF
--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -1436,7 +1436,7 @@ let compile ~bname oc input =
 let compile ~bname ~output input =
   line_cnt := 0;
   Compat.Out_channel.with_open_gen
-    [ Open_wronly; Open_creat; Open_excl; Open_binary ]
+    [ Open_wronly; Open_creat; Open_binary ]
     0o644 output
   @@ fun oc ->
   try compile ~bname oc input


### PR DESCRIPTION
This commit restores the previous behavior. If gwo files are already present in the current directory, there are replaced by the new ones silently.