### PR TITLE
Ignore `distrib` and `result` directories

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(data_only_dirs distribution result)


### PR DESCRIPTION
Dune shouldn't read dune files located in these directories as there are duplicates of dune files in the source three.