### PR TITLE
Add a dev shell for OCaml 4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,17 @@
         };
         overlays.default = import ./nix/overlay.nix { inherit system inputs; };
         formatter = pkgs.nixfmt;
-        devShells.default = import ./nix/devshell.nix { inherit system inputs; };
+        devShells = {
+          default = import ./nix/devshell.nix { inherit system inputs; };
+          ocaml4 = import ./nix/devshell.nix {
+            inherit system inputs;
+            overlays = [
+              (super: self: {
+                ocamlPackages = self.ocaml-ng.ocamlPackages_4_14;
+              })
+            ];
+          };
+        };
       }
     );
 }

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,7 +1,12 @@
-{ system, inputs, ... }:
+{
+  system,
+  inputs,
+  overlays ? [ ],
+  ...
+}:
 let
   pkgs = import ./packages.nix {
-    inherit system inputs;
+    inherit system inputs overlays;
     framePointerSupport = true;
   };
   ocamlPackages = pkgs.ocamlPackages;

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -2,6 +2,7 @@
   system,
   inputs,
   framePointerSupport ? false,
+  overlays ? [ ],
   ...
 }:
 let
@@ -9,5 +10,5 @@ let
 in
 import inputs.nixpkgs {
   inherit system;
-  overlays = [ genewebOverlay ];
+  overlays = overlays ++ [ genewebOverlay ];
 }


### PR DESCRIPTION
It is helpful to switch between OCaml 4 and 5 quickly. Run
```console
nix develop .#ocaml4
```
to open a dev shell with all the dependencies in OCaml 4.14.