### PR TITLE
Do not print empty header for app messages

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -23,13 +23,22 @@ let timestamp_tag : unit Logs.Tag.def =
 let timestamp = Logs.Tag.(empty |> add timestamp_tag ())
 let pp_brackets ~style pp = Fmt.(brackets @@ styled style @@ pp)
 
-let pp_level ppf l =
-  match l with
+let pp_level ppf level =
+  match level with
   | Logs.App -> ()
   | Logs.Error -> pp_brackets ~style:`Red Fmt.string ppf "ERROR"
   | Logs.Warning -> pp_brackets ~style:`Yellow Fmt.string ppf "WARN"
   | Logs.Info -> pp_brackets ~style:`Blue Fmt.string ppf "INFO"
   | Logs.Debug -> pp_brackets ~style:`Green Fmt.string ppf "DEBUG"
+
+let pp_header ppf timestamp level =
+  match level with
+  | Logs.App -> ()
+  | _ ->
+    Format.fprintf ppf "%a%a: "
+      Fmt.(
+        option ~none:nop @@ pp_brackets ~style:`Magenta (Ptime.pp_rfc3339 ()))
+      timestamp pp_level level
 
 let reporter ~predictable_mode ppf =
   let report src level ~over k msgf =
@@ -47,10 +56,7 @@ let reporter ~predictable_mode ppf =
       else
       Some (Ptime_clock.now ())
     in
-    Format.fprintf ppf "%a%a: "
-      Fmt.(
-        option ~none:nop @@ pp_brackets ~style:`Magenta (Ptime.pp_rfc3339 ()))
-      timestamp pp_level level;
+    pp_header ppf timestamp level;
     Format.pp_open_box ppf 0;
     Format.kfprintf k ppf fmt
   in

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -42,10 +42,10 @@ let reporter ~predictable_mode ppf =
     msgf @@ fun ?header ?tags fmt ->
     let timestamp =
       Option.bind tags @@ fun tags ->
+      Option.bind (Logs.Tag.find timestamp_tag tags) @@ fun () ->
       if predictable_mode then Some Ptime.epoch
       else
-        Option.bind (Logs.Tag.find timestamp_tag tags) @@ fun () ->
-        Some (Ptime_clock.now ())
+      Some (Ptime_clock.now ())
     in
     Format.fprintf ppf "%a%a: "
       Fmt.(

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -35,10 +35,10 @@ let pp_header ppf timestamp level =
   match level with
   | Logs.App -> ()
   | _ ->
-    Format.fprintf ppf "%a%a: "
-      Fmt.(
-        option ~none:nop @@ pp_brackets ~style:`Magenta (Ptime.pp_rfc3339 ()))
-      timestamp pp_level level
+      Format.fprintf ppf "%a%a: "
+        Fmt.(
+          option ~none:nop @@ pp_brackets ~style:`Magenta (Ptime.pp_rfc3339 ()))
+        timestamp pp_level level
 
 let reporter ~predictable_mode ppf =
   let report src level ~over k msgf =
@@ -52,9 +52,7 @@ let reporter ~predictable_mode ppf =
     let timestamp =
       Option.bind tags @@ fun tags ->
       Option.bind (Logs.Tag.find timestamp_tag tags) @@ fun () ->
-      if predictable_mode then Some Ptime.epoch
-      else
-      Some (Ptime_clock.now ())
+      if predictable_mode then Some Ptime.epoch else Some (Ptime_clock.now ())
     in
     pp_header ppf timestamp level;
     Format.pp_open_box ppf 0;


### PR DESCRIPTION
The app level is not used a lot but we don't print header or timestamp
for it.