### PR TITLE
ci: pin conf-brotli fix and add apt-get update for Linux

### DIFF
--- a/.github/opam-pins/conf-brotli/opam
+++ b/.github/opam-pins/conf-brotli/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "fxfactorial"
+authors: "The Brotli Authors"
+homepage: "https://github.com/google/brotli"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "MIT"
+build: [
+  ["pkgconf" "libbrotlidec" "libbrotlienc"]
+    {os = "win32" & os-distribution != "cygwinports"}
+  ["pkg-config" "libbrotlidec" "libbrotlienc"]
+    {os != "win32"}
+]
+depexts: [
+  ["brotli-dev"] {os-distribution = "alpine"}
+  ["brotli"] {os-distribution = "arch"}
+  ["libbrotli-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["brotli-devel"] {os-family = "fedora"}
+  ["libbrotli-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["brotli"] {os = "freebsd"}
+  ["brotli"] {os-distribution = "homebrew" & os = "macos"}
+  ["libbrotli-devel"] {os-distribution = "cygwin"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-8" "oraclelinux-9" # not available
+]
+synopsis: "Virtual package relying on a brotli system installation"
+description:
+  "This package can only install if libbrotli is installed on the system."
+depends: ["conf-pkg-config" {build}]
+flags: conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,13 @@ jobs:
           rm -f _opam/bin/x86_64-w64-mingw32-gcc.exe || true
           rm -f _opam/bin/i686-w64-mingw32-gcc.exe || true
 
+      - name: Update apt cache
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -qq
+
+      - name: Pin conf-brotli fix
+        run: opam pin conf-brotli .github/opam-pins/conf-brotli/ --no-action
+
       # The uucp library seems to push old OCaml compiler to their limits,
       # see https://github.com/ocaml/ocaml/issues/14166. This is a workaround
       # to avoid this error by increasing the stack limit of the current shell.


### PR DESCRIPTION
Pin a local corrected conf-brotli.0.0.1 opam file fixing the build field syntax broken in ocaml/opam-repository@2a45163 (arguments must be part of each command list, not free-standing strings).

Add `apt-get update` before dependency installation on Linux runners to work around stale mirror failures on Ubuntu (missing gdk-pixbuf, an xdot dependency).

Both fixes are temporary: the pin will be removed once the correction is merged in ocaml/opam-repository, and the apt-get update can be revisited once GitHub fixes the mirror issue.