### PR TITLE
Use `Dirs.path` to get the default bd directory

### DIFF
--- a/bin/gwd/cmd.ml
+++ b/bin/gwd/cmd.ml
@@ -187,10 +187,11 @@ let default_images_dir = ""
 
 let base_dir =
   let doc = "$(docv) is the directory where GeneWeb databases are stored." in
+  let absent = Dirs.name default_base_dir in
   C.Arg.(
     value
-    & opt dirpath (Dirs.name default_base_dir)
-    & info [ "bd"; "base-dir" ] ~docs:dirs_section ~doc)
+    & opt dirpath (Dirs.path default_base_dir)
+    & info [ "bd"; "base-dir" ] ~absent ~docs:dirs_section ~doc)
 
 let socket_dir =
   let doc =


### PR DESCRIPTION
`Dirs.name` prints the abstract path and you got a awful $XDG_DATA_DIR in your current directory...