### PR TITLE
Fix stack overflow in iter_path_entries on Windows drive roots

### DIFF
--- a/lib/util/filesystem.ml
+++ b/lib/util/filesystem.ml
@@ -39,11 +39,12 @@ let ( // ) = Filename.concat
 
 let iter_path_entries f path =
   let rec loop path =
-    match (Filename.dirname path, Filename.basename path) with
-    | ("." | "/"), _ -> f path
-    | path, base ->
-        loop path;
-        f (path // base)
+    let dir = Filename.dirname path in
+    if dir = path then f path
+    else begin
+      loop dir;
+      f (dir // Filename.basename path)
+    end
   in
   loop path
 


### PR DESCRIPTION
On Windows, Filename.dirname "C:\\" returns "C:\\" (fixed point). The previous termination condition ("." | "/") never matched, causing infinite recursion and a stack overflow at startup when paths rooted at a drive letter were traversed by create_dir ~parent:true.

Replace the pattern match with a dir = path fixed-point check, which correctly terminates on all platforms (Unix "/", relative ".", Windows "C:\").
<hr>

``` bash
[ERROR]: Stack overflow
         Raised by primitive operation at Stdlib__Bytes.sub in file "bytes.ml", line 68, characters 12-22
         Called from Stdlib__String.sub in file "string.ml" (inlined), line 50, characters 2-23
         Called from Stdlib__Filename.Win32.drive_and_path in file "filename.ml", line 253, characters 28-64
         Called from Stdlib__Filename.Win32.dirname in file "filename.ml", line 256, characters 24-40
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 42, characters 11-32
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 45, characters 8-17
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 45, characters 8-17
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 45, characters 8-17
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 45, characters 8-17
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 45, characters 8-17
         Called from Filesystem.iter_path_entries.loop in file "lib/util/filesystem.ml", line 45, characters 8-17

```
(+ about 1000 times this last lines)

I'm launching `gw/gwd.exe -p 2318 -allowed_tags bases/tags.txt -log '<stderr>' -blang -log_level 7 -debug`

Same with `gw/gwd.exe --port 2318 --allowed-tags-file bases/tags.txt --log '<stderr>' --browser-lang --verbosity 6 --debug`