### PR TITLE
Fix 'portraist' typo in image carrousel send-portrait flow

### DIFF
--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -957,7 +957,7 @@ let print conf base =
       let fn = Driver.p_first_name base p in
       let sn = Driver.p_surname base p in
       if fn = "?" || sn = "?" then Hutil.incorrect_request conf
-      else print_send_image conf base "portraist" p
+      else print_send_image conf base "portraits" p
 
 let print_family conf base =
   match p_getenv conf.env "i" with


### PR DESCRIPTION
Closes #2755.

`lib/imageCarrousel.ml:960` calls `print_send_image` with mode `"portraist"` for the portrait upload flow. The matching call in the family/blason branch on line 969 uses `"blasons"` (plural), and the downstream consumers in the same file (`effective_send_ok` line 333, mode comparisons around line 369) treat `"portraits"` (plural) as the canonical value. The typo causes the `SND_IMAGE_C_OK` form to submit a hidden `mode=portraist` that no downstream branch recognises, surfacing as `bad command: SND_IMAGE_C_OK (portraist)` when a wizard tries to upload a portrait via the carrousel.

Replace `"portraist"` with `"portraits"` so it matches the sibling pattern and the downstream comparisons.

Verified against current `master` before commit.