### PR TITLE
Check if a path is a valid plugin directory before loading it

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -293,23 +293,26 @@ let check_plugin =
 
 let load_plugin ~unsafe ~forced path =
   let pname = Filename.basename path in
-  Logs.debug (fun k ->
-      k "Loading plugin (unsafe = %b, forced = %b) %s..." unsafe forced pname);
-  if not (unsafe || check_plugin path) then (
-    Logs.err (fun k ->
-        k "Refuse to load plugin %s for cause of wrong checksum." pname);
-    exit 1);
-  let pname = Filename.basename path in
-  let cmxs =
-    let s = Fmt.str "plugin_%s.cmxs" pname in
-    path // s
-  in
-  lexicon_fname := !lexicon_fname ^ pname ^ ".";
-  let lex_dir = path // "assets" // "lex" in
-  if Sys.file_exists lex_dir then add_lex_dir lex_dir;
-  Plugin.assets := path // "assets";
-  Fun.protect ~finally:(fun () -> Plugin.assets := "") @@ fun () ->
-  load_cmxs cmxs
+  if not @@ Plugin.is_plugin_dir path then
+    Logs.err (fun k -> k "%S is not a plugin directory." path)
+  else (
+    Logs.debug (fun k ->
+        k "Loading plugin (unsafe = %b, forced = %b) %s..." unsafe forced pname);
+    if not (unsafe || check_plugin path) then (
+      Logs.err (fun k ->
+          k "Refuse to load plugin %s for cause of wrong checksum." pname);
+      exit 1);
+    let pname = Filename.basename path in
+    let cmxs =
+      let s = Fmt.str "plugin_%s.cmxs" pname in
+      path // s
+    in
+    lexicon_fname := !lexicon_fname ^ pname ^ ".";
+    let lex_dir = path // "assets" // "lex" in
+    if Sys.file_exists lex_dir then add_lex_dir lex_dir;
+    Plugin.assets := path // "assets";
+    Fun.protect ~finally:(fun () -> Plugin.assets := "") @@ fun () ->
+    load_cmxs cmxs)
 
 let load_plugins Cmd.{ path; unsafe; forced; collection } =
   if not collection then load_plugin ~unsafe ~forced path

--- a/lib/plugin/geneweb_plugin.ml
+++ b/lib/plugin/geneweb_plugin.ml
@@ -76,22 +76,30 @@ let topological_sort (type a) (t : (a * a list) list) : (a list, a list) result
   | l -> Ok (List.rev l)
   | exception Cycle l -> Error (List.rev l)
 
+let is_plugin_dir path =
+  let pname = Filename.basename path in
+  let file = Fmt.str "plugin_%s.cmxs" pname in
+  Sys.file_exists (path // file)
+
 let compute_dependencies path =
   let deps =
     Filesystem.walk_folder
       (fun e acc ->
         match e with
         | Dir d ->
-            let meta_file = d // "META" in
-            MS.update (Filename.basename d)
-              (fun o ->
-                match o with
-                | Some _ -> o
-                | None ->
-                    if Sys.file_exists meta_file then
-                      Some Meta.(parse meta_file).depends
-                    else Some [])
-              acc
+            if is_plugin_dir d then
+              let meta_file = d // "META" in
+              let pname = Filename.basename d in
+              MS.update pname
+                (fun o ->
+                  match o with
+                  | Some _ -> o
+                  | None ->
+                      if Sys.file_exists meta_file then
+                        Some Meta.(parse meta_file).depends
+                      else Some [])
+                acc
+            else acc
         | Exn { path = _; exn; bt } -> Printexc.raise_with_backtrace exn bt
         | _ -> acc)
       path MS.empty

--- a/lib/plugin/geneweb_plugin.mli
+++ b/lib/plugin/geneweb_plugin.mli
@@ -47,6 +47,10 @@ val checksum : string -> string
 (** [checksum path] computes the SHA-256 sum of the cmxs files containes in the
     directory [path]. *)
 
+val is_plugin_dir : string -> bool
+(** [is_plugin_dir path] checks if [path] is the directory of a GeneWeb plugin.
+*)
+
 val compute_dependencies : string -> (string list, string list) result
 (** [compute_dependencies path] returns a topologically sorted list of all
     plugins found in [path] for safe loading.

--- a/test/gwd/plugin.t
+++ b/test/gwd/plugin.t
@@ -57,3 +57,10 @@
   [DEBUG]: Loading plugin (unsafe = true, forced = true) no_index...
   [DEBUG]: Loading plugin (unsafe = true, forced = true) xhtml...
   [DEBUG]: End of check mode.
+
+  $ gwd --check --plugin ../../plugins/foo
+  [ERROR]: "../../plugins/foo" is not a plugin directory.
+  [DEBUG]: End of check mode.
+
+  $ mkdir -p ./foo/bar && gwd --check --plugins ./foo; rm -Rf foo
+  [DEBUG]: End of check mode.


### PR DESCRIPTION
A valid plugin directory is of the form `dir/pname` and
there exists a file `plugin_pname.cmxs` in the directory.