### PR TITLE
handle correctly non gregorian calendars in birth/death lists

### DIFF
--- a/lib/birthDeath.ml
+++ b/lib/birthDeath.ml
@@ -31,14 +31,15 @@ let select (type a)
         let x = get base i in
         match get_date x with
         | Some (Adef.Dgreg (d, cal)) ->
+            let d_greg = Date.approx_gregorian ~from:cal d in
             let aft =
               match ref_date with
-              | Some ref_date -> Date.compare_dmy ref_date d <= 0
+              | Some ref_date -> Date.compare_dmy ref_date d_greg <= 0
               | None -> false
             in
             if aft then (q, len)
             else
-              let e = (x, d, cal) in
+              let e = (x, d_greg, cal) in
               if len < n then (Q.add e q, len + 1)
               else (snd (Q.take (Q.add e q)), len)
         | _ -> (q, len))


### PR DESCRIPTION
Use Date.approx_gregorian to position them in the list! 
If day =0 and/or month=0, propose a mid point

Previously, some person dead on marhechvan 5503 (entre le 29 octobre et le 27 novembre 1742) would show up iat the top of the list of 20 latest death!