### PR TITLE
Don't print unescaped dollars in man pages

### DIFF
--- a/bin/gwd/cmd.ml
+++ b/bin/gwd/cmd.ml
@@ -187,7 +187,7 @@ let default_images_dir = ""
 
 let base_dir =
   let doc = "$(docv) is the directory where GeneWeb databases are stored." in
-  let absent = Dirs.name default_base_dir in
+  let absent = Dirs.name ~escaped:true default_base_dir in
   C.Arg.(
     value
     & opt dirpath (Dirs.path default_base_dir)

--- a/lib/dirs/geneweb_dirs.mli
+++ b/lib/dirs/geneweb_dirs.mli
@@ -2,8 +2,9 @@ type one
 type many
 type 'a var
 
-val name : 'a var -> string
-(** [name v] returns the standard name of the variable. *)
+val name : ?escaped:bool -> 'a var -> string
+(** [name ?escaped v] returns the standard name of the variable. The flag
+    [escaped] escapes dollars to be printable in man pages. *)
 
 val path : one var -> string
 (** [path v] returns the path contained in the variable. *)

--- a/lib/dirs/var.ml
+++ b/lib/dirs/var.ml
@@ -8,7 +8,9 @@ type _ content =
 type 'a t = { name : string; content : 'a content }
 
 let ( // ) = Filename.concat
-let name { name; _ } = Fmt.str "$%s" name
+
+let name ?(escaped = false) { name; _ } =
+  if escaped then Fmt.str "\\$%s" name else Fmt.str "$%s" name
 
 let concat { name; content = One s } suffix =
   let name = name ^ "/" ^ suffix in

--- a/test/gwd/help.t
+++ b/test/gwd/help.t
@@ -1,0 +1,4 @@
+Ensures that we don't use unescaped dollars in man pages. See issue
+https://github.com/geneweb/geneweb/issues/2771 for more details.
+
+  $ gwd --help > /dev/null


### PR DESCRIPTION
Cmdliner uses $ to recognize some variables in man pages. We must escape dollars in CLI documentation.

Fix issue https://github.com/geneweb/geneweb/issues/2771