### PR TITLE
add permalink button on copyright line for pages without menubar

### DIFF
--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -45,8 +45,34 @@
 
 %if;(not cancel_links)
   <div class="d-flex flex-row justify-content-center justify-content-lg-end my-2" id="copyr">
-    <div class="d-flex flex-wrap justify-content-md-end align-items-center">
-      <!-- legal notices -->
+      <div class="d-flex justify-content-between w-100 px-5">
+      %( permalink %)
+      <div class="btn-group mx-3 mt-3">
+        <a id="permalink_url" href="%url_set.opt.noindex;"></a>&nbsp;
+        [*permalink]%sp;
+        <button type="button" class="btn btn-sm btn-outline-secondary ms-2"
+          title="[*copy permalink]"
+          onclick="fetch(document.getElementById('permalink_url').href)
+            .then(r => r.text())
+            .then(text => {
+              const tmp = document.createElement('div');
+              tmp.innerHTML = text;
+              const href = tmp.querySelector('a')?.href || text.trim();
+              console.log('href:', href);
+              return href.replace(/&opt=noindex/g, '').replace(/\?opt=noindex&?/g, '?');
+            })
+            .then(url => {
+              console.log('copying:', url);
+              return navigator.clipboard.writeText(url.trim());
+            })
+            .then(() => { this.innerHTML='<i class=\'fa fa-copy\'></i> ✓'; 
+                          setTimeout(() => this.innerHTML='<i class=\'fa fa-copy\'></i>', 1500); })
+            .catch(() => { this.innerHTML='<i class=\'fa fa-times\'></i>'; 
+                           setTimeout(() => this.innerHTML='<i class=\'fa fa-copy\'></i>', 1500); })">
+          <i class="fa fa-copy"></i>
+        </button>
+      </div>
+      %( legal notices %)
       %if;is_printed_by_template;
         %if;(notice1=1)
             %apply;notice("notice1", lang)

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -5487,10 +5487,16 @@ sv: kopiera länken
 tr: bağlantıyı panoya kopyala
 
     copy permalink
-co: cupià u permaliame
-de: Permalink kopieren
-en: copy the permalink
-fr: copier le permalien
+co: cupià u permaliame in u preme’papei
+de: Permalink kopieren in die Zwischenablage
+en: copy the permalink to the clipboard. Add _f (friends) or _w (wizards) to the base name if you wish that the link to carry this privilege.
+fr: copier le permalien dans le presse-papier. Ajoutez _f (amis) ou _w (magicien) au nom de la base si vous souhaitez que le lien porte ce privilège.
+
+    permalink
+co: permaliame
+de: Permalink
+en: permalink
+fr: permalien 
 
     country
 co: statu

--- a/plugins/no_index/plugin_no_index.ml
+++ b/plugins/no_index/plugin_no_index.ml
@@ -118,8 +118,14 @@ let w_base =
   Gwd_lib.Request.w_base ~none
 
 let no_index conf base =
-  let opt1 = Util.p_getenv conf.env "opt" = Some "no_index" in
-  let opt2 = Util.p_getenv conf.env "opt" = Some "no_index_pwd" in
+  let opt1 =
+    Util.p_getenv conf.env "opt" = Some "no_index"
+    || Util.p_getenv conf.env "opt" = Some "noindex"
+  in
+  let opt2 =
+    Util.p_getenv conf.env "opt" = Some "no_index_pwd"
+    || Util.p_getenv conf.env "opt" = Some "noindexpwd"
+  in
   if opt1 || opt2 then (
     let link = url_no_index conf base opt2 in
     Output.print_sstring conf {|<a href="|};


### PR DESCRIPTION
add permalink button on copyright line (for pages without menubar).
The permalink is "visitors". Add _f or _w to the base name for friends or wizard privileges.
