### PR TITLE
Local abstract types are no longer distinct for the type checker

### DIFF
--- a/lib/dirs/var.ml
+++ b/lib/dirs/var.ml
@@ -1,5 +1,5 @@
-type one
-type many
+type one = private One
+type many = private Many
 
 type _ content =
   | One : string -> one content


### PR DESCRIPTION
Before OCaml 5.4, abstract types locally defined in the same module where considered distinct. For instance, in this snippet
```ocaml
type a
type b

type _ t = A : a t | B : b t
```
the type `a` and `b` are considered distinct and the pattern matching
```ocaml
let foo (A : a t) = ...
```
was exhaustive.

After OCaml 5.5, the type checker changed and these inequalities are not added in its environment. The new extern type feature is the best solution:
```ocaml
type a = extern "a"
type b = extern "b"
...
```
but it's not available for OCaml < 5.5. We must use the previous approach with `type a = private A...`.

Solved #2772 