### PR TITLE
Add opam CI

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -1,0 +1,38 @@
+name: Opam installation
+on:
+  push:
+    paths:
+      - '*.opam'
+  pull_request:
+    paths:
+      - '*.opam'
+
+env:
+  OPAMYES: true
+
+jobs:
+  opam:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Ocaml with v3
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5
+
+      - name: Install geneweb-compat
+        run: opam install ./geneweb-compat.opam
+
+      - name: Install geneweb-http
+        run: opam install ./geneweb-http.opam
+
+      - name: Install geneweb
+        run: opam install ./geneweb.opam
+
+      - name: Install geneweb-rpc
+        run: opam install ./geneweb-rpc.opam
+
+      - name: Check binaries
+        run: opam exec -- gwd --check

--- a/dune-project
+++ b/dune-project
@@ -70,7 +70,10 @@
   (synopsis "Geneweb library for HTTP support")
   (depends
     (ocaml (>= 4.10))
-    geneweb-compat))
+    camlp-streams
+    geneweb-compat
+    logs
+    fmt))
 
 (package
   (name geneweb-rpc)

--- a/geneweb-http.opam
+++ b/geneweb-http.opam
@@ -10,7 +10,10 @@ bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "4.10"}
+  "camlp-streams"
   "geneweb-compat"
+  "logs"
+  "fmt"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This PR adds a CI to check that opam files contains all the
dependencies for each packages of GeneWeb. The CI only runs if we modify
opam files.