### PR TITLE
convert pn to p, n and poc to p oc in LINKED url

### DIFF
--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -503,8 +503,9 @@
           %end;
           %( Linked notes bouton with count %)
           %if;has_linked_pages;
+            %let;poc;%apply;p_to_poc(e.p)%in;
             <li class="nav-item">
-              <a class="nav-link text-secondary" href="%url_set.m.LINKED;"
+              <a class="nav-link text-secondary" href="%apply;url_set%with;m/p%and;LINKED/%poc;%end;"
                 title="[*linked pages help]">%nn;
                 <i class="fa fa-file-lines fa-fw" aria-hidden="true"></i>%nn;
                 <sup class="small">%linked_pages_nbr;</sup>%nn;
@@ -512,7 +513,7 @@
             </li>
             %if;(nb_linked_pages_type.gallery>0)
               <li class="nav-item">
-                <a class="nav-link text-secondary" href="%url_set.m_type.LINKED_gallery"
+                <a class="nav-link text-secondary" href="%apply;url_set%with;m/p/type%and;LINKED/%poc;/gallery%end;"
                   title="[*linked albums help]">%nn;
                   <i class="fa fa-images fa-fw me-1" aria-hidden="true"></i>%nn;
                   %let;nbalb;%nb_linked_pages_type.album;%in;

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -146,7 +146,7 @@
         or (friend and (b.friend_passwd_file!="" or b.friend_passwd!="")))
         <a class="border border-%if;friend;primary%elseif;wizard;success%end; text-%if;friend;primary%elseif;wizard;success%end; rounded text-center mt-1 w-100 rounded-bottom"
           %let;userk;%if;(user.key!="")%user.key;%elseif;(user.name!="")%user.name;%else;%user.ident;%end;%in;
-          href="%prefix;m=S&pn=%apply;uri_encode(userk)"%sp;
+          href="%prefix;m=S&%apply;key_to_pocn(userk)"%sp;
           %if;(user.key="")title="[*no user key]" data-bs-toggle="tooltip"%end;>%nn;
           %if;wizard;[*wizard/wizards/friend/friends/exterior]0%elseif;friend;[*wizard/wizards/friend/friends/exterior]2%end; %username;</a>
         <a class="btn btn-sm btn-outline-danger mt-1 w-100" href="%prefix;w=" role="button"><i class="fas fa-right-from-bracket me-1" aria-hidden="true"></i>[*disconnect]</a>

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -333,43 +333,20 @@ let is_semi_public p = Driver.get_access p = Def.SemiPublic
 
 (* assumes fn+sn, fn sn, fn.occ+sn, fn.occ sn *)
 let split_key key =
-  let dot = String.index_opt key '.' in
-  let plus = String.index_opt key '+' in
-
-  match (dot, plus) with
-  | Some d, _ ->
-      (* Has dot: firstname.occ separator *)
-      let space_after_dot =
-        try Some (String.index_from key (d + 1) ' ') with Not_found -> None
+  let key = String.map (fun c -> if c = '+' then ' ' else c) key in
+  match String.index_opt key ' ' with
+  | None -> ("?", "", "?") (* FIXME could be (key, "", "?") or ("?", "", key) *)
+  | Some sep ->
+      let fn_oc = String.sub key 0 sep in
+      let sn = String.sub key (sep + 1) (String.length key - sep - 1) in
+      let fn, oc =
+        match String.rindex_opt fn_oc '.' with
+        | None -> (fn_oc, "")
+        | Some d ->
+            ( String.sub fn_oc 0 d,
+              String.sub fn_oc (d + 1) (String.length fn_oc - d - 1) )
       in
-      let plus_after_dot =
-        match plus with Some p when p > d -> Some p | _ -> None
-      in
-      let sn_sep =
-        match (space_after_dot, plus_after_dot) with
-        | Some s, Some p -> min s p (* Use whichever comes first *)
-        | Some s, None -> s
-        | None, Some p -> p
-        | None, None -> -1
-      in
-      if sn_sep <> -1 then
-        ( String.sub key 0 d,
-          String.sub key (d + 1) (sn_sep - d - 1),
-          String.sub key (sn_sep + 1) (String.length key - sn_sep - 1) )
-      else ("?", "", "?")
-  | None, Some p ->
-      (* No dot but has plus: firstname+surname *)
-      ( String.sub key 0 p,
-        "",
-        String.sub key (p + 1) (String.length key - p - 1) )
-  | None, None -> (
-      (* No dot or plus: use first space *)
-      match String.index_opt key ' ' with
-      | Some s ->
-          ( String.sub key 0 s,
-            "",
-            String.sub key (s + 1) (String.length key - s - 1) )
-      | None -> ("?", "", "?"))
+      (fn, oc, sn)
 
 (* Determine if person is related to the current user *)
 let ancestors _conf base max_generations family ip =

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1177,6 +1177,9 @@ let rec eval conf ifun env =
             String.concat "" (eval_ast_list env ep astl)
         | "language_name", [ (None, VVstring s) ] ->
             Translate.language_name s (Util.transl conf "!languages")
+        | "key_to_pnoc", [ (None, VVstring s) ] -> Util.key_to_pnoc true s
+        | "p_to_poc", [ (None, VVstring s) ] -> Util.p_to_poc s
+        | "key_to_pocn", [ (None, VVstring s) ] -> Util.key_to_pnoc false s
         | "url_encode", [ (None, VVstring s) ]
         | "uri_encode", [ (None, VVstring s) ] ->
             Util.uri_encode s

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -774,6 +774,37 @@ let clean_comment_tags s = Str.global_replace (Str.regexp "<!--.*-->") "" s
 let uri_encode s = Uri.pct_encode ~component:`Query s
 let uri_decode s = try Uri.pct_decode s with _ -> s
 
+let key_to_pnoc pnoc key =
+  let key = String.map (fun c -> if c = '+' then ' ' else c) key in
+  let spaceIdx =
+    match String.rindex_opt key ' ' with
+    | None -> String.length key
+    | Some i -> i
+  in
+  let fn_oc = String.sub key 0 spaceIdx in
+  let sn = String.sub key (spaceIdx + 1) (String.length key - spaceIdx - 1) in
+  let fn, oc =
+    match String.rindex_opt fn_oc '.' with
+    | None -> (fn_oc, "0")
+    | Some i ->
+        ( String.sub fn_oc 0 i,
+          String.sub fn_oc (i + 1) (String.length fn_oc - i - 1) )
+  in
+  let oc_part = if oc = "0" then "" else Printf.sprintf "&oc=%s" oc in
+  if pnoc then Printf.sprintf "p=%s&n=%s%s" fn sn oc_part
+  else Printf.sprintf "p=%s.%s&n=%s" fn oc sn
+
+let p_to_poc fn_oc =
+  let fn, oc =
+    match String.rindex_opt fn_oc '.' with
+    | None -> (fn_oc, "0")
+    | Some i ->
+        ( String.sub fn_oc 0 i,
+          String.sub fn_oc (i + 1) (String.length fn_oc - i - 1) )
+  in
+  let oc_part = if oc = "0" then "" else Printf.sprintf "&oc=%s" oc in
+  Printf.sprintf "%s%s" fn oc_part
+
 let hidden_textarea conf k v =
   Output.print_sstring conf {|<textarea style="display:none;" name="|};
   Output.print_string conf (escape_html k);

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -79,6 +79,8 @@ val clean_html_tags : string -> string
 val clean_comment_tags : string -> string
 val uri_encode : string -> string
 val uri_decode : string -> string
+val key_to_pnoc : bool -> string -> string
+val p_to_poc : string -> string
 
 val html : ?content_type:string -> config -> unit
 (** Prints HTTP response headers with giving content type (default :


### PR DESCRIPTION
When a person was found with pn=fn.oc sn, it was not possible to obtain LINKED pages.
This PR reconstructs proper p n oc for these URL

improve GWPARAM.split_key to handle H..0 Gouraud
Dots in fn are possible, but not in sn!