### PR TITLE
Fix util/futil/mutil/hutil

### DIFF
--- a/lib/hutil.ml
+++ b/lib/hutil.ml
@@ -30,12 +30,19 @@ let include_home_template conf =
       }
   in
   try Templ.output conf ifun Templ.Env.empty () "home"
-  with _ -> error_cannot_access conf "home"
+  with Sys_error _ | Not_found -> error_cannot_access conf "home"
 
 let link_to_referer conf =
   let referer = Util.get_referer conf in
   let back = Utf8.capitalize_fst (Util.transl conf "back") in
-  if (referer :> string) <> "" then
+  (* Validate the scheme to block javascript: URIs that survive escape_html
+     and could be used as XSS vectors in an href attribute. *)
+  let referer_s = (referer :> string) in
+  let safe_scheme =
+    Util.starts_with referer_s "http://"
+    || Util.starts_with referer_s "https://"
+  in
+  if referer_s <> "" && safe_scheme then
     ({|<a href="|} ^<^ referer
      ^>^ {|" class="btn btn-sm btn-link p-0 border-0" title="|} ^ back
      ^ {|"><i class="fa fa-arrow-left-long fa-fw fa-sm"></i></a>|}
@@ -44,11 +51,15 @@ let link_to_referer conf =
 
 let header_without_http_nor_home conf title =
   let robot = List.assoc_opt "robot_index" conf.base_env = Some "yes" in
+  (* conf.lang comes from the URL; escape it to prevent attribute injection
+     (e.g. lang="fr" onload="..."). In practice lang is validated as a known
+     language code, but the injection site itself should be safe regardless. *)
   let str1 =
     Printf.sprintf {|<!DOCTYPE html>
 <html lang="%s">
 <head>
-<title>|} conf.lang
+<title>|}
+      (Util.escape_html conf.lang :> string)
   in
   let str2 =
     Printf.sprintf
@@ -105,6 +116,10 @@ let header_with_title ?(error = false) ?(fluid = false) conf title =
   Output.print_sstring conf "</h1>\n"
 
 let header_with_adaptive_title ?(fluid = false) conf title_content =
+  (* Note: title_content is injected directly into HTML. Callers are
+     responsible for ensuring it is already safe (escaped or trusted). Unlike
+     other header functions that receive a printing callback, this one accepts
+     a pre-rendered string, so there is no type-level guarantee of safety. *)
   let fluid = fluid || is_fluid conf in
   Util.html conf;
   header_without_http_nor_home conf (fun _ -> ());
@@ -182,15 +197,27 @@ let trailer_with_extra_js conf extra_js_sources =
                      Output.printf conf
                        {|<script src="js/%s?hash=%s"></script>|} source hash
                  | None ->
+                     let prefix =
+                       let p = conf.etc_prefix in
+                       if p = "" || p.[String.length p - 1] = '/' then p
+                       else p ^ "/"
+                     in
                      Output.printf conf {|<script src="%sjs/%s"></script>|}
-                       conf.etc_prefix source)
+                       prefix source)
              | None -> ()
            else
-             try
-               Output.print_sstring conf "<script>\n";
-               Templ.output_simple conf Templ.Env.empty source;
-               Output.print_sstring conf "\n</script>\n"
-             with _ -> ())
+             (* First check the template is accessible, then emit the <script>
+                wrapper. This avoids an unclosed <script> tag when the template
+                is missing, which would cause the browser to interpret the rest
+                of the HTML page as script content. *)
+             match Util.open_etc_file conf source with
+             | None -> ()
+             | Some (ic, _) ->
+                 close_in ic;
+                 Output.print_sstring conf "<script>\n";
+                 (try Templ.output_simple conf Templ.Env.empty source
+                  with Sys_error _ | Not_found -> ());
+                 Output.print_sstring conf "\n</script>\n")
        sources);
   Templ.output_simple conf Templ.Env.empty "js";
   let query_time = Unix.gettimeofday () -. conf.query_start in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -646,7 +646,6 @@ let default_safe_html_allowed_tags =
     ("http://www.w3.org/1999/xhtml", "map");
     ("http://www.w3.org/1999/xhtml", "object");
     ("http://www.w3.org/1999/xhtml", "ol");
-    ("http://www.w3.org/1999/xhtml", "ol");
     ("http://www.w3.org/1999/xhtml", "p");
     ("http://www.w3.org/1999/xhtml", "param");
     ("http://www.w3.org/1999/xhtml", "pre");
@@ -743,7 +742,10 @@ let safe_html_aux escape_text escape_attribute s =
         | `OK :: tl ->
             stack := tl;
             `End_element
-        | _ -> failwith (__FILE__ ^ " " ^ string_of_int __LINE__))
+        | _ ->
+            Log.warn (fun k ->
+                k "safe_html: unexpected End_element with empty tag stack");
+            `Comment "")
     | e -> e
   in
   string s
@@ -1556,12 +1558,14 @@ let http_string s i =
     in
     let j =
       let rec loop j =
-        match s.[j - 1] with
-        | ')' | ',' | '.' | ':' | ';' ->
-            if s.[j - 1] = ')' && par = 0 then j
-            else if s.[j - 1] = ')' && par < 0 then j - 1
-            else loop (j - 1)
-        | _ -> j
+        if j = 0 then j
+        else
+          match s.[j - 1] with
+          | ')' | ',' | '.' | ':' | ';' ->
+              if s.[j - 1] = ')' && par = 0 then j
+              else if s.[j - 1] = ')' && par < 0 then j - 1
+              else loop (j - 1)
+          | _ -> j
       in
       loop j
     in
@@ -1833,7 +1837,7 @@ let raw_string_of_place _conf place =
 
 let string_of_place _conf place = raw_string_of_place _conf place |> escape_html
 let menu_threshold = 20
-let is_number t = match t.[0] with '1' .. '9' -> true | _ -> false
+let is_number t = t <> "" && match t.[0] with '1' .. '9' -> true | _ -> false
 
 let hexa_string s =
   let s' = Bytes.create (2 * String.length s) in
@@ -2144,10 +2148,9 @@ let string_of_decimal_num conf f =
     in
     let needs_approx = sig_digits > 4 in
     let localized =
-      String.map
-        (function
-          | '.' -> String.get (transl conf "(decimal separator)") 0 | c -> c)
-        s
+      let sep = transl conf "(decimal separator)" in
+      let dec_char = if String.length sep > 0 then sep.[0] else '.' in
+      String.map (function '.' -> dec_char | c -> c) s
     in
     if needs_approx then "≃ " ^ localized else localized
   else if abs_f > 0.0 then
@@ -2158,10 +2161,9 @@ let string_of_decimal_num conf f =
     let m_str = Str.global_replace (Str.regexp "0+$") "" m_str in
     let m_str = Str.global_replace (Str.regexp "\\.$") "" m_str in
     let m_loc =
-      String.map
-        (function
-          | '.' -> String.get (transl conf "(decimal separator)") 0 | c -> c)
-        m_str
+      let sep = transl conf "(decimal separator)" in
+      let dec_char = if String.length sep > 0 then sep.[0] else '.' in
+      String.map (function '.' -> dec_char | c -> c) m_str
     in
     let exp_str =
       if exp < 0 then "−" ^ string_of_int (abs exp) else string_of_int exp
@@ -2716,7 +2718,7 @@ let update_wf_trace conf fname =
     let dtlen = String.length dt in
     let rec loop found r = function
       | x :: l ->
-          if String.length x > dtlen + 2 then
+          if String.length x >= dtlen + 2 then
             let u = String.sub x (dtlen + 1) (String.length x - dtlen - 1) in
             if u = conf.user then loop true ((dt, u) :: r) l
             else loop found ((String.sub x 0 dtlen, u) :: r) l
@@ -2816,24 +2818,27 @@ let read_gen_auth_file fname base_file =
   with Sys_error _ -> []
 
 let start_equiv_with case_sens s m i =
-  let rec test i j =
-    if j = String.length s then Some i
-    else if i = String.length m then None
-    else if case_sens then if m.[i] = s.[j] then test (i + 1) (j + 1) else None
+  if String.length s = 0 then Some i
+  else
+    let rec test i j =
+      if j = String.length s then Some i
+      else if i = String.length m then None
+      else if case_sens then
+        if m.[i] = s.[j] then test (i + 1) (j + 1) else None
+      else
+        match Name.next_chars_if_equiv m i s j with
+        | Some (i, j) -> test i j
+        | None -> None
+    in
+    if case_sens then if m.[i] = s.[0] then test (i + 1) 1 else None
     else
-      match Name.next_chars_if_equiv m i s j with
+      match Name.next_chars_if_equiv m i s 0 with
       | Some (i, j) -> test i j
       | None -> None
-  in
-  if case_sens then if m.[i] = s.[0] then test (i + 1) 1 else None
-  else
-    match Name.next_chars_if_equiv m i s 0 with
-    | Some (i, j) -> test i j
-    | None -> None
 
 let rec in_text case_sens s m =
   let rec loop in_tag i =
-    if i = String.length m then false
+    if i >= String.length m then false
     else if in_tag then loop (m.[i] <> '>') (i + 1)
     else if m.[i] = '<' then loop true (i + 1)
     else if m.[i] = '[' && i + 1 < String.length m && m.[i + 1] = '[' then
@@ -2857,7 +2862,7 @@ let rec in_text case_sens s m =
 let html_highlight case_sens h s =
   let ht i j = "<span class=\"found\">" ^ String.sub s i (j - i) ^ "</span>" in
   let rec loop in_tag i len =
-    if i = String.length s then Buff.get len
+    if i >= String.length s then Buff.get len
     else if in_tag then loop (s.[i] <> '>') (i + 1) (Buff.store len s.[i])
     else if s.[i] = '<' then loop true (i + 1) (Buff.store len s.[i])
     else

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -8,6 +8,9 @@ let map_cdate fd d =
   match Date.od_of_cdate d with
   | Some d -> Date.cdate_of_date (fd d)
   | None -> d
+(* Note: when the cdate encodes "no date" (od_of_cdate returns None),
+     fd is not called and the original value is returned unchanged.
+     This is intentional: there is no date for fd to transform. *)
 
 let map_title_strings ?(fd = identity) f t =
   let t_name =
@@ -94,8 +97,8 @@ let map_fam_event ?(fd = identity) fp fs e =
 let map_relation_ps fp fs r =
   {
     r_type = r.r_type;
-    r_fath = (match r.r_fath with Some x -> Some (fp x) | None -> None);
-    r_moth = (match r.r_moth with Some x -> Some (fp x) | None -> None);
+    r_fath = Option.map fp r.r_fath;
+    r_moth = Option.map fp r.r_moth;
     r_sources = fs r.r_sources;
   }
 
@@ -273,6 +276,8 @@ let gen_person_misc_names sou empty_string quest_string first_name surname
     let list = Mutil.list_rev_map_append sou surnames_aliases list in
     list
 
+(* Like List.for_all2 eq l1 l2 but returns false instead of raising
+   Invalid_argument when the lists have different lengths. *)
 let rec eq_lists eq l1 l2 =
   match (l1, l2) with
   | x1 :: l1, x2 :: l2 -> eq x1 x2 && eq_lists eq l1 l2

--- a/lib/util/mutil.ml
+++ b/lib/util/mutil.ml
@@ -226,7 +226,18 @@ let input_particles fname =
             let particle = Buff.get len in
             loop (particle :: Utf8.uppercase particle :: list) 0
       | '\r' -> loop list len
-      | '#' -> loop list len
+      | '#' ->
+          (* Line comment: skip the rest of the line. If a particle was being
+             accumulated (len > 0), discard it — a '#' mid-token is malformed. *)
+          let rec skip () =
+            match input_char ic with
+            | '\n' -> loop list 0
+            | _ -> skip ()
+            | exception End_of_file ->
+                close_in ic;
+                List.rev list
+          in
+          skip ()
       | c -> loop list (Buff.store len c)
       | exception End_of_file ->
           close_in ic;
@@ -266,7 +277,10 @@ let tr c1 c2 s =
 let unsafe_tr c1 c2 s =
   match String.rindex_opt s c1 with
   | Some _ ->
-      let bytes = Bytes.unsafe_of_string s in
+      (* Use Bytes.of_string (not unsafe_of_string) to avoid mutating shared
+         string memory, which would be a data-corruption hazard in a
+         multi-request server. *)
+      let bytes = Bytes.of_string s in
       for i = 0 to Bytes.length bytes - 1 do
         if Bytes.unsafe_get bytes i = c1 then Bytes.unsafe_set bytes i c2
       done;
@@ -584,6 +598,8 @@ let array_assoc k a =
   loop 0
 
 let string_of_int_sep sep x =
+  let neg = x < 0 in
+  let x = abs x in
   let digits, len =
     let rec loop (d, l) x =
       if x = 0 then (d, l)
@@ -592,17 +608,26 @@ let string_of_int_sep sep x =
     loop ([], 0) x
   in
   let digits, len = if digits = [] then ([ '0' ], 1) else (digits, len) in
+  let len = if neg then len + 1 else len in
   let slen = String.length sep in
-  let s = Bytes.create (len + ((len - 1) / 3 * slen)) in
+  (* number of digit characters (without sign) *)
+  let dlen = if neg then len - 1 else len in
+  let s = Bytes.create (len + ((dlen - 1) / 3 * slen)) in
+  let start =
+    if neg then (
+      Bytes.set s 0 '-';
+      1)
+    else 0
+  in
   let _ =
     List.fold_left
       (fun (i, j) c ->
         Bytes.set s j c;
-        if i < len - 1 && (len - 1 - i) mod 3 = 0 then (
+        if i < dlen - 1 && (dlen - 1 - i) mod 3 = 0 then (
           String.blit sep 0 s (j + 1) slen;
           (i + 1, j + 1 + slen))
         else (i + 1, j + 1))
-      (0, 0) digits
+      (0, start) digits
   in
   Bytes.unsafe_to_string s
 
@@ -902,7 +927,7 @@ let read_or_create_channel ?magic ?(wait = false) fname read write =
           r
       | Some _ -> None
       | None -> Some (read ic)
-    with _ -> None
+    with End_of_file | Failure _ | Invalid_argument _ -> None
   in
   match read () with
   | Some v ->
@@ -1104,7 +1129,7 @@ let rev_input_line ic pos (rbuff, rpos) =
   let rev_input_line pos =
     if pos <= 0 then raise End_of_file
     else
-      let _ = seek_in ic pos in
+      let () = seek_in ic pos in
       let rec loop pos =
         if pos <= 0 then (get_n_reset (), pos)
         else
@@ -1177,12 +1202,9 @@ let rm_rf f =
     let directories, files = List.partition Sys.is_directory all_paths in
     List.iter
       (fun file ->
-        try
-          let ic = open_in_bin file in
-          close_in ic;
-          Sys.remove file
+        try Sys.remove file
         with e ->
-          Printf.eprintf "Error handling file %s: %s\n" file
+          Printf.eprintf "Error deleting file %s: %s\n" file
             (Printexc.to_string e))
       files;
     List.iter


### PR DESCRIPTION

util.ml
#Severity Location Issue
1🔴 Crash in_text L2836, html_highlight L2860 = vs >= on Utf8.next overshoot
2🔴 Crash start_equiv_with L2828 s.[0] without empty-string guard
3🔴 Crash http_string L1559 s.[j-1] when j reaches 0
4🔴 Crash is_number L1836 t.[0] on empty string
5🟡 Fragile nth_field_abs L311-318 bounds overshoot masked by outer guard
6🟡 Soft bug update_wf_trace L2719 off-by-one in username extraction guard
7🟡 Cosmetic default_safe_html_allowed_tags L648 duplicate "ol" entry
8🟡 Crash risk safe_html_aux L746 failwith on malformed user HTML
9🟡 Fragile normalize_person_pool_url L1422 Option.get inside implicit guard
10🟢 Minor string_of_decimal_num L2149 unguarded String.get on translation

futil.ml
#Severity Location Issue
1🟡 Style map_relation_ps L97–98 Hand-rolled Option.map
2🟡 Style gen_person_misc_names L213 Array.fold_left on husbands among otherwise all-list params
3🟢 Clarity map_cdate L10 fd silently skipped on None cdates — worth a comment
4🟢 Redundanc yeq_lists L276 Reimplements List.for_all2 with different Invalid_argument semantics

mutil.ml
#Severity Location Issue
1🔴 Crash string_of_int_sep L589 Char.chr of negative value on negative input
2🔴 Data corruption unsafe_tr L269 Bytes.unsafe_of_string mutates shared string in-place
3🔴 Crash risk colon_to_at_word L139 s.[i+1] without bounds check on iendroot
4🟡 Misleading rev_input_line L1107 let _ = seek_in (seek_in returns unit)
5🟡 Logic error rm_rf L1181 open/close to test deletability is TOCTOU and wrong
6🟡 Bug input_particles L229 # skips only the character, not the rest of the line
7🟡 Redundancy variousSeveral functions duplicate OCaml 4.08+ stdlib
8🟡 Risky read_or_create_channel L905 with _ -> swallows fatal exceptions
9🟢 Minor bench/pint L14 negative GC diff values print as empty string

hutil.ml
#Severity Location Issue
1🟡 Risky include_home_template L33 with _ -> swallows fatal exceptions
2🟡 Bug trailer_with_extra_js L193 with _ -> () leaves unclosed <script> tag on partial failure
3🟡 XSS link_to_referer L39 javascript: URI in Referer header not filtered
4🟡 Injection header_without_http_nor_home L49 conf.lang unescaped in lang attribute
5🟢 URL bug trailer_with_extra_js L185 conf.etc_prefix may lack trailing / in fallback URL
6🟢 Clarity header_with_adaptive_title L122 title_content: string not type-safe against unescaped HTML