### PR TITLE
Deprecate `--browser-lang` and `--setup-link` CLI options

### DIFF
--- a/bin/gwd/cmd.ml
+++ b/bin/gwd/cmd.ml
@@ -49,7 +49,6 @@ type t = {
   daemon : bool;
   (* Web interface *)
   default_lang : string;
-  browser_lang : bool;
   setup_link : bool;
   (* Plugins *)
   plugins : plugin list;
@@ -502,8 +501,8 @@ let default_default_lang = "fr"
 
 let default_lang =
   let doc =
-    "Set the fallback language for the user interface if no \n\
-    \  language is specified."
+    "Set the fallback language for the user interface if no language is \
+     specified."
   in
   C.Arg.(
     value
@@ -512,10 +511,12 @@ let default_lang =
 
 let browser_lang =
   let doc =
-    "Select the user interface language based on the client\n  configuration."
+    "Select the user interface language based on the client configuration."
   in
+  let deprecated = "This option is noop" in
   C.Arg.(
-    value & flag & info [ "browser-lang" ] ~docs:web_interface_section ~doc)
+    value & flag
+    & info [ "browser-lang" ] ~deprecated ~docs:web_interface_section ~doc)
 
 let setup_link =
   let doc =
@@ -664,7 +665,7 @@ let t =
   and+ cgi = cgi
   and+ daemon = daemon
   and+ default_lang = default_lang
-  and+ browser_lang = browser_lang
+  and+ _ : bool = browser_lang
   and+ setup_link = setup_link
   and+ plugins = plugins
   and+ debug, check, verbosity = debug_flags
@@ -706,7 +707,6 @@ let t =
     cgi;
     daemon;
     default_lang;
-    browser_lang;
     setup_link;
     plugins;
     debug;

--- a/bin/gwd/cmd.ml
+++ b/bin/gwd/cmd.ml
@@ -49,7 +49,6 @@ type t = {
   daemon : bool;
   (* Web interface *)
   default_lang : string;
-  setup_link : bool;
   (* Plugins *)
   plugins : plugin list;
   (* Tracing & debugging *)
@@ -522,9 +521,13 @@ let setup_link =
   let doc =
     "Display a shortcut link at the bottom of the pages to gwsetup tool."
   in
+  let deprecated =
+    "This option is noop. The setup link is displayed by default. Use the gwf \
+     option to turn it off."
+  in
   C.Arg.(
     value & flag
-    & info [ "setup-link" ] ~docs:web_interface_section ~docv:"URL" ~doc)
+    & info [ "setup-link" ] ~deprecated ~docs:web_interface_section ~doc)
 
 (* Plugin commands *)
 
@@ -666,7 +669,7 @@ let t =
   and+ daemon = daemon
   and+ default_lang = default_lang
   and+ _ : bool = browser_lang
-  and+ setup_link = setup_link
+  and+ _ : bool = setup_link
   and+ plugins = plugins
   and+ debug, check, verbosity = debug_flags
   and+ log = log
@@ -707,7 +710,6 @@ let t =
     cgi;
     daemon;
     default_lang;
-    setup_link;
     plugins;
     debug;
     check;

--- a/bin/gwd/cmd.mli
+++ b/bin/gwd/cmd.mli
@@ -51,7 +51,6 @@ type t = {
   daemon : bool;
   (* Web interface *)
   default_lang : string;
-  setup_link : bool;
   (* Plugin *)
   plugins : plugin list;
   (* Tracing & debugging *)

--- a/bin/gwd/cmd.mli
+++ b/bin/gwd/cmd.mli
@@ -51,7 +51,6 @@ type t = {
   daemon : bool;
   (* Web interface *)
   default_lang : string;
-  browser_lang : bool;
   setup_link : bool;
   (* Plugin *)
   plugins : plugin list;

--- a/bin/gwd/cmd_legacy.ml
+++ b/bin/gwd/cmd_legacy.ml
@@ -50,7 +50,6 @@ let redirected_addr : string option ref = ref None
 let robot_xcl : (int * int) option ref = ref None
 let selected_addr : string option ref = ref None
 let selected_port = ref Cmd.default_port
-let setup_link = ref false
 let trace_failed_passwd = ref false
 let debug = ref false
 let check = ref false

--- a/bin/gwd/cmd_legacy.ml
+++ b/bin/gwd/cmd_legacy.ml
@@ -34,7 +34,6 @@ let set_socket_dir s = socket_dir := Some s
 let auth_file : string option ref = ref None
 let cache_langs : string list ref = ref []
 let cache_databases : string list ref = ref []
-let choose_browser_lang = ref false
 let conn_timeout = ref Cmd.default_connection_timeout
 let daemon = ref false
 let friend_passwd : string option ref = ref None

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1331,10 +1331,7 @@ let make_conf ~secret_salt from_addr request script_name env =
     (command, bname, passwd, env, access_type)
   in
   let lang, env = extract_assoc "lang" env in
-  let lang =
-    if lang = "" && !choose_browser_lang then http_preferred_language request
-    else lang
-  in
+  let lang = if lang = "" then http_preferred_language request else lang in
   let lang = alias_lang lang in
   let from, env =
     let x, env = extract_assoc "opt" env in
@@ -1357,9 +1354,7 @@ let make_conf ~secret_salt from_addr request script_name env =
       if x = "" then !default_lang else x
     with Not_found -> !default_lang
   in
-  let browser_lang =
-    if !choose_browser_lang then http_preferred_language request else ""
-  in
+  let browser_lang = http_preferred_language request in
   let default_lang = if browser_lang = "" then default_lang else browser_lang in
   let vowels =
     match List.assoc_opt "vowels" base_env with
@@ -2365,7 +2360,6 @@ let parse_cmd () =
       auth_file := o.authorization_file;
       cache_langs := o.cache_langs;
       cache_databases := o.cache_databases;
-      choose_browser_lang := o.browser_lang;
       conn_timeout := o.connection_timeout;
       daemon := o.daemon;
       friend_passwd := o.friend_password;

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1456,7 +1456,8 @@ let make_conf ~secret_salt from_addr request script_name env =
       public_if_no_date =
         (try List.assoc "public_if_no_date" base_env = "yes"
          with Not_found -> false);
-      setup_link = !setup_link;
+      setup_link =
+        (try List.assoc "setup_link" base_env <> "no" with Not_found -> true);
       access_by_key =
         (try List.assoc "access_by_key" base_env = "yes"
          with Not_found -> ar.ar_wizard && ar.ar_friend);
@@ -2384,7 +2385,6 @@ let parse_cmd () =
       verbosity_level := o.verbosity;
       force_cgi := o.cgi;
       cgi_secret_salt := o.secret_salt;
-      setup_link := o.setup_link;
       plugins := o.plugins;
       Lock.no_lock_flag := o.no_lock;
       Mutil.particles_file := Option.value ~default:"" o.particles_file;

--- a/etc/Windows/gwd.bat
+++ b/etc/Windows/gwd.bat
@@ -1,1 +1,1 @@
-start "GeneWeb server" /min gw\gwd --bd .\bases --setup-link --browser-lang --log log.txt
+start "GeneWeb server" /min gw\gwd --bd .\bases --setup-link --log log.txt

--- a/etc/Windows/gwd.bat
+++ b/etc/Windows/gwd.bat
@@ -1,1 +1,1 @@
-start "GeneWeb server" /min gw\gwd --bd .\bases --setup-link --log log.txt
+start "GeneWeb server" /min gw\gwd --bd .\bases --log log.txt

--- a/etc/gwd.sh
+++ b/etc/gwd.sh
@@ -3,6 +3,5 @@ cd `dirname "$0"`
 exec gw/gwd \
   --bd ./bases \
   --setup-link \
-  --browser-lang \
   --log gw/gwd.log \
   "$@"

--- a/etc/gwd.sh
+++ b/etc/gwd.sh
@@ -2,6 +2,5 @@
 cd `dirname "$0"`
 exec gw/gwd \
   --bd ./bases \
-  --setup-link \
   --log gw/gwd.log \
   "$@"

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -66,7 +66,7 @@ type config = {
   authorized_wizards_notes : bool;
   public_if_titles : bool;
   public_if_no_date : bool;
-  mutable setup_link : bool;
+  setup_link : bool;
   access_by_key : bool;
   private_years : int;
   private_years_death : int;
@@ -87,7 +87,7 @@ type config = {
   denied_titles : string list Lazy.t;
   request : string list;
   lexicon : (string, string) Hashtbl.t;
-  mutable charset : string;
+  charset : string;
   is_rtl : bool;
   left : string;
   right : string;

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -71,7 +71,7 @@ type config = {
   authorized_wizards_notes : bool;
   public_if_titles : bool;
   public_if_no_date : bool;
-  mutable setup_link : bool;
+  setup_link : bool;
   access_by_key : bool;
   private_years : int;
   private_years_death : int;
@@ -92,7 +92,7 @@ type config = {
   denied_titles : string list Lazy.t;
   request : string list;
   lexicon : (string, string) Hashtbl.t;
-  mutable charset : string;
+  charset : string;
   is_rtl : bool;
   left : string;
   right : string;

--- a/test/install-cgi/gwd.cgi
+++ b/test/install-cgi/gwd.cgi
@@ -19,6 +19,5 @@ LOGS_DIR="../tmp"
   --bd "$BASES_DIR" \
   --gw-prefix "$BIN_DIR" \
   --etc-prefix "../distribution/gw/etc" \
-  --browser-lang \
   --plugins u:"$BIN_DIR"/plugins \
   --verbosity 7 --log "<stderr>" 2>> "$LOGS_DIR"/gwd.log

--- a/test/run_gw_test.sh
+++ b/test/run_gw_test.sh
@@ -145,7 +145,6 @@ pgrep gwd >/dev/null && \
 
 test -n "$debug" && set -x
 OCAMLRUNPARAM=b $SUDOPRFX $BIN_DIR/gwd \
-  --setup-link \
   --bd=$BASES_DIR \
   --hd=$BIN_DIR \
   $gwdopt \


### PR DESCRIPTION
These options are enabled by default. See commit messages for more details.