### PR TITLE
Bump the minimal version of OCaml to 4.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-26, windows-2022]
-        ocaml-compiler: [4.10.2, 4.14.3, 5.4.1]
-        exclude:
-          - os: windows-2022
-            ocaml-compiler: 4.10.2
+        ocaml-compiler: [4.14.3, 5.4.1]
+        include:
+          - os: ubuntu-22.04-arm
+            ocaml-compiler: 4.11.2
+          - os: macos-15-intel
+            ocaml-compiler: 4.11.2
     outputs:
       total_matrix_jobs: ${{ strategy.job-total || 0 }}
       metric: ${{ steps.collect-metrics.outputs.metric }}

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
   (tags (genealogy))
   (sites (share hd))
   (depends
-    (ocaml (>= 4.10))
+    ocaml
     geneweb-compat
     geneweb-http
     (alcotest :with-test)
@@ -62,14 +62,13 @@
   (name geneweb-compat)
   (synopsis "Geneweb library for legacy support")
   (tags (geneweb legacy))
-  (depends
-    (ocaml (>= 4.10))))
+  (depends ocaml))
 
 (package
   (name geneweb-http)
   (synopsis "Geneweb library for HTTP support")
   (depends
-    (ocaml (>= 4.10))
+    ocaml
     camlp-streams
     geneweb-compat
     logs
@@ -80,7 +79,7 @@
   (synopsis "Geneweb library for RPC support")
   (tags (geneweb rpc json))
   (depends
-    (ocaml (>= 4.10))
+    ocaml
     (geneweb (= :version))
     (qcheck :with-test)
     (qcheck-alcotest :with-test)

--- a/geneweb-compat.opam
+++ b/geneweb-compat.opam
@@ -10,7 +10,7 @@ doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.10"}
+  "ocaml"
   "odoc" {with-doc}
 ]
 build: [

--- a/geneweb-http.opam
+++ b/geneweb-http.opam
@@ -9,7 +9,7 @@ doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.10"}
+  "ocaml"
   "camlp-streams"
   "geneweb-compat"
   "logs"

--- a/geneweb-rpc.opam
+++ b/geneweb-rpc.opam
@@ -10,7 +10,7 @@ doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.10"}
+  "ocaml"
   "geneweb" {= version}
   "qcheck" {with-test}
   "qcheck-alcotest" {with-test}

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -12,7 +12,7 @@ doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
   "dune" {>= "3.6"}
-  "ocaml" {>= "4.10"}
+  "ocaml"
   "geneweb-compat"
   "geneweb-http"
   "alcotest" {with-test}


### PR DESCRIPTION
The old versions of OCaml have been archived last week. The minimal version of OCaml is 4.11 on opam repository.

See https://discuss.ocaml.org/t/archival-ann-raising-the-ocaml-lower-bound-to-4-11-0-for-opam-repository/17965 for more information.

This PR bumps the minimal version to 4.11 in the CI and remove constraints in our opam files as we support all the current OCaml compilers of the official repository.