### PR TITLE
Fix version.ml regeneration with Dune 3.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,7 @@ ifneq ($(COMMIT_COMMENT),)
 endif
 	@printf '\n\033[1;1mGenerating configuration files\033[0m\n'
 
-refresh-version:
-	@rm -f _build/default/lib/version.ml
-
-fmt build build-geneweb gwd distrib install uninstall: info refresh-version
+fmt build build-geneweb gwd distrib install uninstall: info
 
 fmt: ## Format Ocaml code
 	@printf "\n\033[1;1mOcamlformat\033[0m\n"

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,7 @@
 (rule
  (target version.ml)
  (deps
+  (universe)
   (:script ./generate_version.sh)
   (:input ./version.txt))
  (action


### PR DESCRIPTION
`version.ml` depends on external Git state through `generate_version.sh`, but the rule only depended on tracked files.

The previous workaround removed
`_build/default/lib/version.ml` from the Makefile to force regeneration. Since Dune 3.23 this now causes inconsistent incremental build state and may fail with:

Error: I/O error: lib/version.ml: No such file or directory

Dune 3.23 introduced stricter sandboxing and explicitly forbids user rules from touching paths inside `_build`.

Use `(universe)` instead so Dune properly invalidates the rule when external state changes, and remove the Makefile hack touching `_build`.

Refs:
* Dune 3.23 changelog
* "Dune will no longer stat paths in the _build directory"