### PR TITLE
Roglo: move welcome language selector with JS instead of duplicating template code

### DIFF
--- a/hd/etc/copyr.txt
+++ b/hd/etc/copyr.txt
@@ -77,8 +77,7 @@
 
       <!-- Language selector and connections info -->
       <div class="d-flex flex-row align-items-lg-end mt-0 ms-3 border-0">
-        %if;(e.templ="" and not (roglo and is_welcome)
-          and not (e.m="MOD_IND_OK" or e.m="MOD_FAM_OK" or e.m="ADD_PAR_OK"))
+        %if;(e.templ="" and not (e.m="MOD_IND_OK" or e.m="MOD_FAM_OK" or e.m="ADD_PAR_OK"))
           <div class="btn-group dropup" data-bs-toggle="tooltip" data-bs-placement="left"
             title="%apply;language_name(lang) – [*select lang]">
             <button class="btn btn-link dropdown-toggle" type="button" id="dropdownMenu1"

--- a/hd/etc/js.txt
+++ b/hd/etc/js.txt
@@ -493,6 +493,17 @@ function initializeLazyModules() {
   loadScriptOnce('load_once_rlm_builder', '%etc_prefix;js/rlm_builder.js?hash=%apply;hash%with;%etc_prefix;js/rlm_builder.js%end;');
 }
 %end;
+%if;(roglo and is_welcome)
+function moveWelcomeLangSelect() {
+  const sel = document.getElementById('dropdownMenu1');
+  const group = sel ? sel.closest('.btn-group') : null;
+  const loginBox = document.getElementById('gw-login');
+  if (!group || !loginBox) return;
+  grp.classList.remove('dropup');
+  grp.classList.add('dropdown');
+  loginBox.appendChild(group);
+}
+%end;
 %if;(e.templ="" and not is_welcome)
 // Focus on found autofocus input in opening BS modal
 function setupModalAutofocus() {
@@ -846,6 +857,9 @@ document.addEventListener('DOMContentLoaded', () => {
   %end;
   %if;wizard;
     inputToBook.addNavigation();
+  %end;
+  %if;roglo;
+    moveWelcomeLangSelect();
   %end;
 %end;
 %if;("IND" in e.m or "FAM" in e.m)

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -51,26 +51,6 @@
       ([wizard/wizards/friend/friends/exterior]0)"><i class="fa fa-zzz me-1"></i>[*yyy]1
   </a>
 %end;
-%define;language(x)
-  %apply;nth%with;
-    af/ar/bg/br/ca/co/cs/da/de/en/eo/es/et/fi/fr/he/is/%nn;
-    it/lt/lv/nl/no/oc/pl/pt/pt-br/ro/ru/sk/sl/sv/tr/zh/
-    %and;x%end;
-%end;
-%define;set_lang(l1) %( see same condition in Util.commd and Templ.reorder %)
-  %if;(default_lang!="l1")%url_set.lang_file.l1;%else;%url_set.lang_file;%end;
-%end;
-%define;language_link()
-  %for;i;0;33;
-    %let;l1;%apply;language(i)%in;
-    %if;(lang!=l1)
-      <a class="dropdown-item%if;(l1=b.default_lang) bg-warning%end;" id="lang_%l1;"%sp;
-        href="%apply;set_lang(l1)">%nn;
-       <code>%if;(l1!="pt-br")%l1;&nbsp;&nbsp;&nbsp;%else;%l1;%end;%sp;</code>%nn;
-       %apply;capitalize%with;%apply;language_name(l1)%end;</a>
-    %end;
-  %end;
-%end;
 %if;(e.i!="" or e.p!="" or e.n!="" or e.pn!="")
   <div class="d-flex justify-content-center">
     <div class="alert alert-danger alert-dismissible fade show text-center w-75 m-2" role="alert">
@@ -98,7 +78,7 @@
     </div>
   </div>
   <div class="col-12 col-md-3 order-1 order-md-3 ms-md-2 px-0 mt-xs-2 mt-lg-0 align-self-center">
-    <div class="d-flex flex-column col-md-10 ps-1 pe-0">
+    <div id="gw-login" class="d-flex flex-column col-md-10 ps-1 pe-0">
       %if;(cgi and (not wizard or not friend))
         <form class="d-flex" method="post" action="%action;">
           %hidden;
@@ -152,21 +132,6 @@
           %if;wizard;[*wizard/wizards/friend/friends/exterior]0%elseif;friend;[*wizard/wizards/friend/friends/exterior]2%end; %username;</a>
         <a class="btn btn-sm btn-outline-danger mt-1 w-100" href="%prefix;w=" role="button"><i class="fas fa-right-from-bracket mr-1" aria-hidden="true"></i>[*disconnect]</a>
       %end;
-      %if;roglo;
-        <div class="btn-group" data-toggle="tooltip" data-placement="left"
-          title="%apply;language_name(lang) – [*select lang]">
-          <button class="btn btn-link dropdown-toggle" type="button" id="dropdownMenu1"
-            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">%nn;
-            <span class="sr-only">lang</span>%nn;
-            <span class="text-uppercase">%lang;</span>%nn;
-            <span class="sr-only">, [select lang]</span>%nn;
-          </button>
-          <div class="dropdown-menu scrollable-lang" aria-labelledby="dropdownMenu1">
-            %apply;language_link()
-          </div>
-        </div>
-      %end;
-
     </div>
   </div>
   <div class="my-0 order-3 order-md-2 flex-fill text-lg-center align-self-md-center">


### PR DESCRIPTION
Remove the duplicated Roglo-specific language selector from welcome.txt and reuse the existing selector defined in copyr.txt by relocating its .btn-group into #gw-login on DOMContentLoaded.

Also switch the Bootstrap wrapper from dropup to dropdown after moving the element so the menu opens downward in the login area.

This keeps the language selector logic centralized in a single template, reduces maintenance burden, and avoids duplicated language list markup.