### PR TITLE
Prevent from leaking file descriptors with `Secure.open_*` and `open_*`

### DIFF
--- a/bin/cache_files/cache_files.ml
+++ b/bin/cache_files/cache_files.ml
@@ -47,17 +47,13 @@ let write_cache_file bname fname data =
 let write_checkdata_cache bname fname entries =
   let filename = bname ^ "_" ^ fname ^ "_checkdata.cache" in
   let file = !cache_dir // filename in
-  let oc = Secure.open_out_bin file in
-  let finally () = try close_out oc with Sys_error _ -> () in
-  Fun.protect ~finally @@ fun () -> Marshal.to_channel oc entries []
+  Secure.with_open_out_bin file @@ fun oc -> Marshal.to_channel oc entries []
 
 let read_checkdata_cache bname fname =
   let filename = bname ^ "_" ^ fname ^ "_checkdata.cache" in
   let file = !cache_dir // filename in
   if Sys.file_exists file then
-    let ic = Secure.open_in_bin file in
-    let finally () = try close_in ic with Sys_error _ -> () in
-    Fun.protect ~finally @@ fun () ->
+    Secure.with_open_in_bin file @@ fun ic ->
     try
       let entries = (Marshal.from_channel ic : checkdata_entry list) in
       Some (List.map snd entries)

--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -349,23 +349,19 @@ let alias_lang lang =
   else
     let fname = Util.search_in_assets (Filename.concat "lang" "alias_lg.txt") in
     try
-      let ic = Secure.open_in fname in
-      let lang =
-        let rec loop () =
-          match input_line ic with
-          | line -> (
-              match String.index_opt line '=' with
-              | Some i ->
-                  if lang = String.sub line 0 i then
-                    String.sub line (i + 1) (String.length line - i - 1)
-                  else loop ()
-              | None -> loop ())
-          | exception End_of_file -> lang
-        in
-        loop ()
+      Secure.with_open_in_text fname @@ fun ic ->
+      let rec loop () =
+        match input_line ic with
+        | line -> (
+            match String.index_opt line '=' with
+            | Some i ->
+                if lang = String.sub line 0 i then
+                  String.sub line (i + 1) (String.length line - i - 1)
+                else loop ()
+            | None -> loop ())
+        | exception End_of_file -> lang
       in
-      close_in ic;
-      lang
+      loop ()
     with Sys_error _ -> lang
 
 let log_redirect from request req =
@@ -1837,7 +1833,7 @@ let print_misc_file conf misc_fname encoding =
   | Woff2 fname
   | CacheGz fname -> (
       try
-        let ic = Secure.open_in_bin fname in
+        Secure.with_open_in_bin fname @@ fun ic ->
         let buf = Bytes.create 1024 in
         let len = in_channel_length ic in
         content_misc conf len misc_fname encoding;
@@ -1850,12 +1846,11 @@ let print_misc_file conf misc_fname encoding =
             loop (len - olen)
         in
         loop len;
-        close_in ic;
         true
       with Sys_error _ -> false)
   | Other _ -> false
   | Map fname | Png fname ->
-      let ic = Secure.open_in_bin fname in
+      Secure.with_open_in_bin fname @@ fun ic ->
       let buf = Bytes.create 1024 in
       let len = in_channel_length ic in
       content_misc conf len misc_fname No_encoding;
@@ -1868,7 +1863,6 @@ let print_misc_file conf misc_fname encoding =
           loop (len - olen)
       in
       loop len;
-      close_in ic;
       true
 
 let misc_request conf request fname =

--- a/bin/robot/robot.ml
+++ b/bin/robot/robot.ml
@@ -28,26 +28,21 @@ let output_excl oc xcl =
 
 let read_robot_file fname =
   try
-    let ic = Secure.open_in_bin fname in
+    Secure.with_open_in_bin fname @@ fun ic ->
     let b = really_input_string ic (String.length magic_robot) in
-    if b <> magic_robot then (
-      close_in ic;
+    if b <> magic_robot then
       if b = "GWRB0007" then (
         printf "Error: Old format detected.\n";
         printf "Please start gwd once to migrate.\n";
         exit 1)
       else (
         printf "Error: Invalid robot file format.\n";
-        exit 1));
-    let v = (input_value ic : excl) in
-    close_in ic;
-    Some v
+        exit 1);
+    Some (input_value ic : excl)
   with _ -> None
 
 let write_robot_file fname xcl =
-  let oc = Secure.open_out_bin fname in
-  output_excl oc xcl;
-  close_out oc
+  Secure.with_open_out_bin fname @@ fun oc -> output_excl oc xcl
 
 let is_valid_ip ip =
   if String.contains ip '*' then
@@ -145,7 +140,7 @@ let export_blacklist output_file =
   match read_robot_file fname with
   | None -> printf "No robot file found\n"
   | Some xcl ->
-      let oc = Secure.open_out output_file in
+      Secure.with_open_out_text output_file @@ fun oc ->
       fprintf oc "# Robot blacklist export\n";
       fprintf oc "# Format: IP<TAB>attempts\n";
       let tm = Unix.localtime (Unix.time ()) in
@@ -153,7 +148,6 @@ let export_blacklist output_file =
         (1900 + tm.Unix.tm_year) (succ tm.Unix.tm_mon) tm.Unix.tm_mday
         tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec;
       List.iter (fun (ip, cnt) -> fprintf oc "%s\t%d\n" ip !cnt) xcl.excl;
-      close_out oc;
       printf "Exported %d entries to %s\n" (List.length xcl.excl) output_file
 
 let import_blacklist input_file =

--- a/lib/compat/geneweb_compat.ml
+++ b/lib/compat/geneweb_compat.ml
@@ -34,6 +34,79 @@ module In_channel = struct
     match Stdlib.input_line ic with
     | s -> Some s
     | exception End_of_file -> None
+
+  let read_upto ic buf ofs len =
+    let rec loop ofs len =
+      if len = 0 then ofs
+      else begin
+        let r = Stdlib.input ic buf ofs len in
+        if r = 0 then ofs else loop (ofs + r) (len - r)
+      end
+    in
+    loop ofs len - ofs
+
+  let ensure buf ofs n =
+    let len = Bytes.length buf in
+    if len >= ofs + n then buf
+    else begin
+      let new_len = ref len in
+      while !new_len < ofs + n do
+        new_len := (2 * !new_len) + 1
+      done;
+      let new_len = !new_len in
+      let new_len =
+        if new_len <= Sys.max_string_length then new_len
+        else if ofs < Sys.max_string_length then Sys.max_string_length
+        else
+          failwith
+            "In_channel.input_all: channel content is larger than maximum \
+             string length"
+      in
+      let new_buf = Bytes.create new_len in
+      Bytes.blit buf 0 new_buf 0 ofs;
+      new_buf
+    end
+
+  let io_buffer_size = 65536
+
+  let input_all ic =
+    let chunk_size = io_buffer_size in
+    let initial_size =
+      try Stdlib.in_channel_length ic - Stdlib.pos_in ic
+      with Sys_error _ -> -1
+    in
+    let initial_size = if initial_size < 0 then chunk_size else initial_size in
+    let initial_size =
+      if initial_size <= Sys.max_string_length then initial_size
+      else Sys.max_string_length
+    in
+    let buf = Bytes.create initial_size in
+    let nread = read_upto ic buf 0 initial_size in
+    if nread < initial_size then (* EOF reached, buffer partially filled *)
+      Bytes.sub_string buf 0 nread
+    else
+      (* nread = initial_size, maybe EOF reached *)
+      begin match Stdlib.input_char ic with
+      | exception End_of_file ->
+          (* EOF reached, buffer is completely filled *)
+          Bytes.unsafe_to_string buf
+      | c ->
+          (* EOF not reached *)
+          let rec loop buf ofs =
+            let buf = ensure buf ofs chunk_size in
+            let rem = Bytes.length buf - ofs in
+            (* [rem] can be < [chunk_size] if buffer size close to
+               [Sys.max_string_length] *)
+            let r = read_upto ic buf ofs rem in
+            if r < rem then (* EOF reached *)
+              Bytes.sub_string buf 0 (ofs + r)
+            else (* r = rem *)
+              loop buf (ofs + rem)
+          in
+          let buf = ensure buf nread (chunk_size + 1) in
+          Bytes.set buf nread c;
+          loop buf (nread + 1)
+      end
 end
 
 module Out_channel = struct

--- a/lib/compat/geneweb_compat.mli
+++ b/lib/compat/geneweb_compat.mli
@@ -57,6 +57,13 @@ module In_channel : sig
       A newline is the character [\n] unless the file is open in text mode and
       {!Sys.win32} is [true] in which case it is the sequence of characters
       [\r\n]. *)
+
+  val input_all : t -> string
+  (** [input_all ic] reads all remaining data from [ic].
+
+      If the same channel is read concurrently by multiple threads, the returned
+      string is not guaranteed to contain contiguous characters from the input.
+  *)
 end
 
 module Out_channel : sig

--- a/lib/db/database.ml
+++ b/lib/db/database.ml
@@ -14,6 +14,8 @@ type family = dsk_family
 type couple = dsk_couple
 type descend = dsk_descend
 
+let ( // ) = Filename.concat
+
 let move_with_backup src dst =
   Mutil.rm (dst ^ "~");
   Mutil.mv dst (dst ^ "~");
@@ -130,15 +132,15 @@ let old_persons_of_first_name_or_surname base_data params =
 
     let compare = Dutil.compare_snames_i base_data
   end) in
-  let fname_dat = Filename.concat bname names_dat in
+  let fname_dat = bname // names_dat in
   let bt =
     let btr = ref None in
     fun () ->
       match !btr with
       | Some bt -> bt
       | None ->
-          let fname_inx = Filename.concat bname names_inx in
-          let ic_inx = Secure.open_in_bin fname_inx in
+          let fname_inx = bname // names_inx in
+          Secure.with_open_in_bin fname_inx @@ fun ic_inx ->
           (*
           let ab1 = Gc.allocated_bytes () in
           *)
@@ -150,7 +152,6 @@ let old_persons_of_first_name_or_surname base_data params =
             names_inx (ab2 -. ab1);
           flush stderr;
           *)
-          close_in ic_inx;
           btr := Some bt;
           bt
   in
@@ -158,7 +159,7 @@ let old_persons_of_first_name_or_surname base_data params =
     let ipera =
       try
         let pos = IstrTree.find istr (bt ()) in
-        let ic_dat = Secure.open_in_bin fname_dat in
+        Secure.with_open_in_bin fname_dat @@ fun ic_dat ->
         seek_in ic_dat pos;
         let len = input_binary_int ic_dat in
         let rec read_loop ipera len =
@@ -168,7 +169,6 @@ let old_persons_of_first_name_or_surname base_data params =
             read_loop (iper :: ipera) (len - 1)
         in
         let ipera = read_loop [] len in
-        close_in ic_dat;
         ipera
       with Not_found -> []
     in
@@ -248,14 +248,13 @@ let binary_search_next arr cmp =
 
 let new_persons_of_first_name_or_surname cmp_str cmp_istr base_data params =
   let proj, person_patches, names_inx, names_dat, bname = params in
-  let fname_dat = Filename.concat bname names_dat in
+  let fname_dat = bname // names_dat in
   (* content of "snames.inx" *)
   let bt =
     lazy
-      (let fname_inx = Filename.concat bname names_inx in
-       let ic_inx = Secure.open_in_bin fname_inx in
+      (let fname_inx = bname // names_inx in
+       Secure.with_open_in_bin fname_inx @@ fun ic_inx ->
        let bt : (int * int) array = input_value ic_inx in
-       close_in ic_inx;
        bt)
   in
   (* ordered by string name's ids attached to the patched persons *)
@@ -288,7 +287,7 @@ let new_persons_of_first_name_or_surname cmp_str cmp_istr base_data params =
           if k = istr then 0 else cmp_str base_data s (base_data.strings.get k)
         in
         let pos = snd @@ bt.(binary_search bt cmp) in
-        let ic_dat = Secure.open_in_bin fname_dat in
+        Secure.with_open_in_bin fname_dat @@ fun ic_dat ->
         seek_in ic_dat pos;
         let len = input_binary_int ic_dat in
         let rec read_loop ipera len =
@@ -298,7 +297,6 @@ let new_persons_of_first_name_or_surname cmp_str cmp_istr base_data params =
             read_loop (iper :: ipera) (len - 1)
         in
         let ipera = read_loop [] len in
-        close_in ic_dat;
         ipera
       with Not_found -> []
     in
@@ -379,29 +377,25 @@ let persons_of_name bname patches =
   fun s ->
     let i = Dutil.name_index s in
     let ai =
-      let ic_inx = Secure.open_in_bin (Filename.concat bname "names.inx") in
-      let ai =
-        let fname_inx_acc = Filename.concat bname "names.acc" in
-        if Sys.file_exists fname_inx_acc then (
-          Secure.with_open_in_bin fname_inx_acc @@ fun ic_inx_acc ->
-          seek_in ic_inx_acc (Iovalue.sizeof_long * i);
-          let pos = Position.input ic_inx_acc in
-          Position.seek_in ic_inx pos;
-          (Iovalue.input ic_inx : int array))
-        else
-          let a =
-            match !t with
-            | Some a -> a
-            | None ->
-                seek_in ic_inx Dutil.int_size;
-                let a : Dutil.name_index_data = input_value ic_inx in
-                t := Some a;
-                a
-          in
-          a.(i)
-      in
-      close_in ic_inx;
-      ai
+      Secure.with_open_in_bin (bname // "names.inx") @@ fun ic_inx ->
+      let fname_inx_acc = bname // "names.acc" in
+      if Sys.file_exists fname_inx_acc then (
+        Secure.with_open_in_bin fname_inx_acc @@ fun ic_inx_acc ->
+        seek_in ic_inx_acc (Iovalue.sizeof_long * i);
+        let pos = Position.input ic_inx_acc in
+        Position.seek_in ic_inx pos;
+        (Iovalue.input ic_inx : int array))
+      else
+        let a =
+          match !t with
+          | Some a -> a
+          | None ->
+              seek_in ic_inx Dutil.int_size;
+              let a : Dutil.name_index_data = input_value ic_inx in
+              t := Some a;
+              a
+        in
+        a.(i)
     in
     match Hashtbl.find patches i with
     | patches ->
@@ -415,30 +409,26 @@ let old_strings_of_fsname bname strings (_, person_patches) =
   fun s ->
     let i = Dutil.name_index s in
     let r =
-      let ic_inx = Secure.open_in_bin (Filename.concat bname "names.inx") in
-      let ai =
-        let fname_inx_acc = Filename.concat bname "names.acc" in
-        if Sys.file_exists fname_inx_acc then (
-          Secure.with_open_in_bin fname_inx_acc @@ fun ic_inx_acc ->
-          seek_in ic_inx_acc (Iovalue.sizeof_long * (Dutil.table_size + i));
-          let pos = Position.input ic_inx_acc in
-          Position.seek_in ic_inx pos;
-          (Iovalue.input ic_inx : int array))
-        else
-          let a =
-            match !t with
-            | Some a -> a
-            | None ->
-                let pos = Position.input ic_inx in
-                Position.seek_in ic_inx pos;
-                let a : Dutil.strings_of_fsname = input_value ic_inx in
-                t := Some a;
-                a
-          in
-          a.(i)
-      in
-      close_in ic_inx;
-      ai
+      Secure.with_open_in_bin (bname // "names.inx") @@ fun ic_inx ->
+      let fname_inx_acc = bname // "names.acc" in
+      if Sys.file_exists fname_inx_acc then (
+        Secure.with_open_in_bin fname_inx_acc @@ fun ic_inx_acc ->
+        seek_in ic_inx_acc (Iovalue.sizeof_long * (Dutil.table_size + i));
+        let pos = Position.input ic_inx_acc in
+        Position.seek_in ic_inx pos;
+        (Iovalue.input ic_inx : int array))
+      else
+        let a =
+          match !t with
+          | Some a -> a
+          | None ->
+              let pos = Position.input ic_inx in
+              Position.seek_in ic_inx pos;
+              let a : Dutil.strings_of_fsname = input_value ic_inx in
+              t := Some a;
+              a
+        in
+        a.(i)
     in
     Hashtbl.fold
       (fun _ p acc ->
@@ -466,32 +456,28 @@ let new_strings_of_fsname_aux offset_acc offset_inx split get bname strings
   fun s ->
     let i = Dutil.name_index s in
     let r =
-      let ic_inx = Secure.open_in_bin (Filename.concat bname "names.inx") in
-      let ai =
-        let fname_inx_acc = Filename.concat bname "names.acc" in
-        if Sys.file_exists fname_inx_acc then (
-          Secure.with_open_in_bin fname_inx_acc @@ fun ic_inx_acc ->
-          seek_in ic_inx_acc
-            (Iovalue.sizeof_long * ((offset_acc * Dutil.table_size) + i));
-          let pos = input_binary_int ic_inx_acc in
-          seek_in ic_inx pos;
-          (Iovalue.input ic_inx : int array))
-        else
-          let a =
-            match !t with
-            | Some a -> a
-            | None ->
-                seek_in ic_inx offset_inx;
-                let pos = Position.input ic_inx in
-                Position.seek_in ic_inx pos;
-                let a : Dutil.strings_of_fsname = input_value ic_inx in
-                t := Some a;
-                a
-          in
-          a.(i)
-      in
-      close_in ic_inx;
-      ai
+      Secure.with_open_in_bin (bname // "names.inx") @@ fun ic_inx ->
+      let fname_inx_acc = bname // "names.acc" in
+      if Sys.file_exists fname_inx_acc then (
+        Secure.with_open_in_bin fname_inx_acc @@ fun ic_inx_acc ->
+        seek_in ic_inx_acc
+          (Iovalue.sizeof_long * ((offset_acc * Dutil.table_size) + i));
+        let pos = input_binary_int ic_inx_acc in
+        seek_in ic_inx pos;
+        (Iovalue.input ic_inx : int array))
+      else
+        let a =
+          match !t with
+          | Some a -> a
+          | None ->
+              seek_in ic_inx offset_inx;
+              let pos = Position.input ic_inx in
+              Position.seek_in ic_inx pos;
+              let a : Dutil.strings_of_fsname = input_value ic_inx in
+              t := Some a;
+              a
+        in
+        a.(i)
     in
     Hashtbl.fold
       (fun _ p acc ->
@@ -529,17 +515,15 @@ let verbose = Mutil.verbose
 
 let make_visible_record_access perm bname persons =
   let visible_ref = ref None in
-  let fname = Filename.concat bname "restrict" in
+  let fname = bname // "restrict" in
   let read_or_create_visible () =
     let visible =
       try
-        let ic = Secure.open_in fname in
+        Secure.with_open_in_text fname @@ fun ic ->
         if Sys.unix && !verbose then (
           Printf.eprintf "*** read restrict file\n";
           flush stderr);
-        let visible = input_value ic in
-        close_in ic;
-        visible
+        input_value ic
       with Sys_error _ -> Array.make persons.len VsNone
     in
     visible_ref := Some visible;
@@ -550,12 +534,11 @@ let make_visible_record_access perm bname persons =
     | Some visible ->
         if perm = RDONLY then raise (HttpExn (Forbidden, __LOC__))
         else
-          let oc = Secure.open_out fname in
+          Secure.with_open_out_text fname @@ fun oc ->
           if Sys.unix && !verbose then (
             Printf.eprintf "*** write restrict file\n";
             flush stderr);
-          output_value oc visible;
-          close_out oc
+          output_value oc visible
     | None -> ()
   in
   let v_get fct i =
@@ -871,7 +854,7 @@ let input_patches bname =
   let fname = Filename.concat bname "patches" in
   if Sys.file_exists fname then
     try
-      let ic = Secure.open_in_bin fname in
+      Secure.with_open_in_bin fname @@ fun ic ->
       let r =
         if check_patch_magic ic then (input_value ic : patches_ht)
         else (
@@ -893,16 +876,15 @@ let input_patches bname =
           List.iter (add (ref 0, ht.h_name)) !(patches.Old.p_name);
           ht)
       in
-      close_in ic;
       Ok r
     with _ -> Error (Printf.sprintf "%s: corrupted file" fname)
   else Ok (empty_patch_ht ())
 
 let input_synchro bname =
   try
-    let ic = Secure.open_in_bin (Filename.concat bname "synchro_patches") in
+    Secure.with_open_in_bin (Filename.concat bname "synchro_patches")
+    @@ fun ic ->
     let r : synchro_patch = input_value ic in
-    close_in ic;
     r
   with _ -> { synch_list = [] }
 
@@ -1153,9 +1135,7 @@ let with_database ?(read_only = false) bname k =
           (snd pending.h_person) (nbp_read ())
       in
       let tmp_nbp_fname = nbp_fname ^ "_tmp" in
-      let oc = Secure.open_out_bin tmp_nbp_fname in
-      output_value oc nbp;
-      close_out oc;
+      Secure.with_open_out_bin tmp_nbp_fname (fun oc -> output_value oc nbp);
       let aux (n, ht) (n', ht') =
         n := !n';
         Hashtbl.iter (Hashtbl.replace ht) ht';
@@ -1170,15 +1150,13 @@ let with_database ?(read_only = false) bname k =
       aux patches.h_descend pending.h_descend;
       aux patches.h_string pending.h_string;
       (* update "patches" file *)
-      let tmp_fname = Filename.concat bname "1patches" in
-      let fname = Filename.concat bname "patches" in
-      let tm_oc = Secure.open_out_bin tm_fname in
-      output_string tm_oc (tm : Adef.safe_string :> string);
-      close_out tm_oc;
-      let oc_tmp = Secure.open_out_bin tmp_fname in
-      output_string oc_tmp magic_patch;
-      Dutil.output_value_no_sharing oc_tmp (patches : patches_ht);
-      close_out oc_tmp;
+      let tmp_fname = bname // "1patches" in
+      let fname = bname // "patches" in
+      Secure.with_open_out_bin tm_fname (fun oc ->
+          output_string oc (tm : Adef.safe_string :> string));
+      Secure.with_open_out_bin tmp_fname (fun oc ->
+          output_string oc magic_patch;
+          Dutil.output_value_no_sharing oc (patches : patches_ht));
       move_with_backup tmp_nbp_fname nbp_fname;
       move_with_backup tmp_fname fname;
       commit_synchro ();
@@ -1269,21 +1247,17 @@ let with_database ?(read_only = false) bname k =
       else Filename.concat "notes_d" (fnotes ^ ".txt")
     in
     try
-      let ic = Secure.open_in (Filename.concat bname fname) in
-      let str =
-        match rn_mode with
-        | RnDeg -> if in_channel_length ic = 0 then "" else " "
-        | Rn1Ln -> ( try input_line ic with End_of_file -> "")
-        | RnAll ->
-            let rec loop len =
-              match input_char ic with
-              | exception End_of_file -> Buff.get len
-              | c -> loop (Buff.store len c)
-            in
-            loop 0
-      in
-      close_in ic;
-      str
+      Secure.with_open_in_text (bname // fname) @@ fun ic ->
+      match rn_mode with
+      | RnDeg -> if in_channel_length ic = 0 then "" else " "
+      | Rn1Ln -> ( try input_line ic with End_of_file -> "")
+      | RnAll ->
+          let rec loop len =
+            match input_char ic with
+            | exception End_of_file -> Buff.get len
+            | c -> loop (Buff.store len c)
+          in
+          loop 0
     with Sys_error _ -> ""
   in
   let commit_notes =
@@ -1298,10 +1272,8 @@ let with_database ?(read_only = false) bname k =
       let fname = Filename.concat bname fname in
       (try Sys.remove (fname ^ "~") with Sys_error _ -> ());
       (try Sys.rename fname (fname ^ "~") with _ -> ());
-      if s <> "" then (
-        let oc = Secure.open_out fname in
-        output_string oc s;
-        close_out oc)
+      if s <> "" then
+        Secure.with_open_out_text fname (fun oc -> output_string oc s)
   in
   let commit_wiznotes =
     if perm = RDONLY then fun _ _ -> raise (HttpExn (Forbidden, __LOC__))
@@ -1317,10 +1289,8 @@ let with_database ?(read_only = false) bname k =
         in
         (try Sys.remove (fname ^ "~") with Sys_error _ -> ());
         (try Sys.rename fname (fname ^ "~") with _ -> ());
-        if s <> "" then (
-          let oc = Secure.open_out fname in
-          output_string oc s;
-          close_out oc))
+        if s <> "" then
+          Secure.with_open_out_text fname (fun oc -> output_string oc s))
   in
   let ext_files () =
     Filesystem.walk_folder ~recursive:true

--- a/lib/db/driver.ml
+++ b/lib/db/driver.ml
@@ -78,6 +78,7 @@ let spi_next (spi : string_person_index) istr = spi.next istr
 
 type base = dsk_base
 
+let ( // ) = Filename.concat
 let sou base i = base.data.strings.get i
 let bname base = Filename.(remove_extension @@ basename base.data.bdir)
 let nb_of_persons base = base.data.persons.len
@@ -286,29 +287,25 @@ module NLDB = struct
 
   let check_format base =
     let fname = bfname base "notes_links" in
-    match try Some (open_in_bin fname) with Sys_error _ -> None with
-    | Some ic ->
-        let ok = Mutil.check_magic magic ic in
-        close_in ic;
-        if ok then `Ok else `BadFormat
-    | None -> `NoFile
+    match open_in_bin fname with
+    | ic ->
+        Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
+        if Mutil.check_magic magic ic then `Ok else `BadFormat
+    | exception Sys_error _ -> `NoFile
 
   let read base =
     let fname = bfname base "notes_links" in
-    match try Some (open_in_bin fname) with Sys_error _ -> None with
-    | Some ic ->
-        let r =
-          if Mutil.check_magic magic ic then
-            (input_value ic : (iper, iper) Def.NLDB.t)
-          else (
-            if not !warned then (
-              warned := true;
-              Log.warn (fun m -> m "Unsupported nldb format in %s" fname));
-            [])
-        in
-        close_in_noerr ic;
-        r
-    | None -> []
+    match open_in_bin fname with
+    | ic ->
+        Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
+        if Mutil.check_magic magic ic then
+          (input_value ic : (iper, iper) Def.NLDB.t)
+        else (
+          if not !warned then (
+            warned := true;
+            Log.warn (fun m -> m "Unsupported nldb format in %s" fname));
+          [])
+    | exception Sys_error _ -> []
 
   let write base db =
     if base.data.perm = RDONLY then raise Def.(HttpExn (Forbidden, __LOC__))
@@ -334,14 +331,13 @@ let base_wiznotes_dir _base = "wiznotes"
 
 let base_notes_read_file base fname mode =
   try
-    let ic = Secure.open_in @@ Filename.concat base.data.bdir fname in
+    Secure.with_open_in_text (base.data.bdir // fname) @@ fun ic ->
     let str =
       match mode with
       | Def.RnDeg -> if in_channel_length ic = 0 then "" else " "
       | Def.Rn1Ln -> ( try input_line ic with End_of_file -> "")
       | Def.RnAll -> Mutil.input_file_ic ic
     in
-    close_in ic;
     str
   with Sys_error _ -> ""
 
@@ -548,14 +544,13 @@ let visible_ref : (iper, bool) Hashtbl.t option ref = ref None
 let read_or_create_visible base =
   let fname = Filename.concat base.data.bdir "restrict" in
   let visible =
-    if Sys.file_exists fname then (
-      let ic = Secure.open_in_bin fname in
+    if Sys.file_exists fname then
+      Secure.with_open_in_bin fname @@ fun ic ->
       let visible =
         if Mutil.check_magic Mutil.executable_magic ic then input_value ic
         else Hashtbl.create (nb_of_persons base)
       in
-      close_in ic;
-      visible)
+      visible
     else Hashtbl.create (nb_of_persons base)
   in
   visible_ref := Some visible;
@@ -567,10 +562,9 @@ let base_visible_write base =
     let fname = Filename.concat base.data.bdir "restrict" in
     match !visible_ref with
     | Some visible ->
-        let oc = Secure.open_out_bin fname in
+        Secure.with_open_out_bin fname @@ fun oc ->
         output_string oc Mutil.executable_magic;
-        output_value oc visible;
-        close_out oc
+        output_value oc visible
     | None -> ()
 
 let base_visible_get base fct i =

--- a/lib/image.ml
+++ b/lib/image.ml
@@ -4,6 +4,7 @@ let src = Logs.Src.create ~doc:"Image" "IMG "
 
 module Log = (val Logs.src_log src : Logs.LOG)
 module Driver = Geneweb_db.Driver
+module Compat = Geneweb_compat
 
 let path_str path =
   match path with Some (`Path pa) -> pa | Some (`Url u) -> u | None -> ""
@@ -161,7 +162,7 @@ let size_from_path fname =
     if fname = "" then Error ()
     else
       try
-        let ic = Secure.open_in_bin fname in
+        Secure.with_open_in_bin fname @@ fun ic ->
         let r =
           try
             (* TODO: should match on mime type here *)
@@ -172,7 +173,6 @@ let size_from_path fname =
             | _s -> Error ()
           with End_of_file -> Error ()
         in
-        close_in ic;
         r
       with Sys_error _e -> Error ()
   in
@@ -489,11 +489,9 @@ let get_carrousel_file_content conf base p fname kind old =
   let fname =
     Filename.chop_extension (carrousel_file_path conf base p fname old) ^ kind
   in
-  if Sys.file_exists fname then (
-    let ic = Secure.open_in fname in
-    let s = really_input_string ic (in_channel_length ic) in
-    close_in ic;
-    if s = "" then None else Some s)
+  if Sys.file_exists fname then
+    let s = Secure.with_open_in_text fname Compat.In_channel.input_all in
+    if s = "" then None else Some s
   else None
 
 (* get list of files in carrousel *)

--- a/lib/imageDisplay.ml
+++ b/lib/imageDisplay.ml
@@ -69,7 +69,7 @@ let print_image_file conf fname =
            fname)
   | Some (_suff, ctype) -> (
       try
-        let ic = Secure.open_in_bin fname in
+        Secure.with_open_in_bin fname @@ fun ic ->
         let buf = Bytes.create 1024 in
         let len = in_channel_length ic in
         content conf ctype len fname;
@@ -82,7 +82,6 @@ let print_image_file conf fname =
             loop (len - olen)
         in
         loop len;
-        close_in ic;
         Ok ()
       with Sys_error e ->
         Log.err (fun k ->

--- a/lib/srcfileDisplay.ml
+++ b/lib/srcfileDisplay.ml
@@ -23,7 +23,7 @@ let count conf =
   let _ = Util.test_cnt_d conf in
   let fname = !GWPARAM.adm_file (conf.bname ^ ".txt") in
   try
-    let ic = Secure.open_in fname in
+    Secure.with_open_in_text fname @@ fun ic ->
     let rd =
       try
         let wc = int_of_string (input_line ic) in
@@ -50,7 +50,6 @@ let count conf =
           normal_cnt = 0;
         }
     in
-    close_in ic;
     rd
   with _ ->
     {
@@ -66,7 +65,7 @@ let write_counter conf r =
   let cnt_d = Util.test_cnt_d conf in
   let fname = Filename.concat cnt_d (conf.bname ^ ".txt") in
   try
-    let oc = Secure.open_out_bin fname in
+    Secure.with_open_out_bin fname @@ fun oc ->
     output_string oc (string_of_int r.welcome_cnt);
     output_string oc "\n";
     output_string oc (string_of_int r.request_cnt);
@@ -78,8 +77,7 @@ let write_counter conf r =
     output_string oc (string_of_int r.friend_cnt);
     output_string oc "\n";
     output_string oc (string_of_int r.normal_cnt);
-    output_string oc "\n";
-    close_out oc
+    output_string oc "\n"
   with _ -> ()
 
 let set_wizard_and_friend_traces conf =
@@ -433,9 +431,9 @@ and copy_from_file conf base name mode =
     | Lang -> any_lang_file_name conf name
     | Source -> source_file_name conf name
   in
-  match try Some (Secure.open_in fname) with Sys_error _ -> None with
-  | Some ic -> copy_from_channel conf base ic mode
-  | None ->
+  match Secure.open_in fname with
+  | ic -> copy_from_channel conf base ic mode
+  | exception Sys_error _ ->
       Output.printf conf "<em>... file not found: \"%s.txt\"</em><br>" name
 
 and copy_from_channel conf base ic mode =
@@ -449,13 +447,16 @@ let gen_print mode conf base fname =
   let channel =
     match mode with
     | Lang -> (
-        try Some (Secure.open_in (lang_file_name conf fname))
-        with Sys_error _ -> (
-          try Some (Secure.open_in (any_lang_file_name conf fname))
-          with Sys_error _ -> None))
+        match Secure.open_in @@ lang_file_name conf fname with
+        | ic -> Some ic
+        | exception Sys_error _ -> (
+            match Secure.open_in @@ any_lang_file_name conf fname with
+            | ic -> Some ic
+            | exception Sys_error _ -> None))
     | Source -> (
-        try Some (Secure.open_in (source_file_name conf fname))
-        with Sys_error _ -> None)
+        match Secure.open_in (source_file_name conf fname) with
+        | ic -> Some ic
+        | exception Sys_error _ -> None)
   in
   match channel with
   | Some ic ->

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -39,8 +39,9 @@ let read_auth_file fname bname =
     data
 
 let read_wizard_notes fname =
-  match try Some (Secure.open_in fname) with Sys_error _ -> None with
-  | Some ic ->
+  match Secure.open_in fname with
+  | ic ->
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
       let date, len =
         try
           let line = input_line ic in
@@ -61,22 +62,23 @@ let read_wizard_notes fname =
       in
       let len = loop len in
       (Buff.get len, date)
-  | None -> ("", 0.)
+  | exception Sys_error _ -> ("", 0.)
 
 let write_wizard_notes fname nn =
   if nn = "" then Mutil.rm fname
   else
-    match try Some (Secure.open_out fname) with Sys_error _ -> None with
-    | Some oc ->
+    match Secure.open_out fname with
+    | oc ->
+        Fun.protect ~finally:(fun () -> close_out_noerr oc) @@ fun () ->
         Printf.fprintf oc "WIZNOTES\n%.0f\n" (Unix.time ());
         output_string oc nn;
-        output_string oc "\n";
-        close_out oc
-    | None -> ()
+        output_string oc "\n"
+    | exception Sys_error _ -> ()
 
 let wiznote_date wfile =
-  match try Some (Secure.open_in wfile) with Sys_error _ -> None with
-  | Some ic ->
+  match Secure.open_in wfile with
+  | ic ->
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
       let date =
         try
           let line = input_line ic in
@@ -86,9 +88,8 @@ let wiznote_date wfile =
           let s = Unix.stat wfile in
           s.Unix.st_mtime
       in
-      close_in ic;
       (wfile, date)
-  | None -> ("", 0.)
+  | exception Sys_error _ -> ("", 0.)
 
 let print_wizards_by_alphabetic_order conf list =
   let wprint_elem (wz, (wname, (_, islash)), wfile, stm) =
@@ -528,8 +529,9 @@ let print_mod_ok conf base =
 
 let wizard_denying wddir =
   let fname = Filename.concat wddir "connected.deny" in
-  match try Some (Secure.open_in fname) with Sys_error _ -> None with
-  | Some ic ->
+  match Secure.open_in fname with
+  | ic ->
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
       let rec loop list =
         match try Some (input_line ic) with End_of_file -> None with
         | Some wname -> loop (wname :: list)
@@ -538,7 +540,7 @@ let wizard_denying wddir =
             List.rev list
       in
       loop []
-  | None -> []
+  | exception Sys_error _ -> []
 
 let print_connected_wizard conf first wddir wz tm_user =
   let wfile, stm = wiznote_date (wzfile wddir wz) in
@@ -636,7 +638,7 @@ let do_change_wizard_visibility conf base x set_vis =
   (if ((not set_vis) && not is_visible) || (set_vis && is_visible) then ()
    else
      let tmp_file = Filename.concat wiznotes_dir "1connected.deny" in
-     let oc = Secure.open_out tmp_file in
+     Secure.with_open_out_text tmp_file @@ fun oc ->
      let found =
        List.fold_left
          (fun found wz ->
@@ -647,7 +649,6 @@ let do_change_wizard_visibility conf base x set_vis =
          false denying
      in
      if (not found) && not set_vis then Printf.fprintf oc "%s\n" conf.user;
-     close_out oc;
      let file = Filename.concat wiznotes_dir "connected.deny" in
      Mutil.rm file;
      Sys.rename tmp_file file);


### PR DESCRIPTION
The functions `Secure.open_*` and `open_*` don't close automatically the file descriptor if an exception is raised before calling the close function. I found few file descriptor leaks while debugging GeneWeb.

This commit replaces several of these calls by `with_open_*` patterns.