### PR TITLE
improve error reporting in imageCarrousel

### DIFF
--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -317,7 +317,7 @@ let output_error =
     Output.header conf "Connection: close";
     List.iter (Output.header conf "%s") headers;
     Output.print_string conf (Adef.encoded "<h1>Incorrect request</h1>");
-    match content with
+    (match content with
     | Some content -> Output.print_string conf content
     | None -> (
         let code =
@@ -340,7 +340,8 @@ let output_error =
         | None -> (
             match fname "en" with
             | Some fn -> output_file conf fn
-            | None -> Output.print_sstring conf ""))
+            | None -> Output.print_sstring conf "")));
+    Output.flush conf
 
 let is_semi_public p = Driver.get_access p = Def.SemiPublic
 

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -2,7 +2,7 @@ open Config
 open Def
 open Util
 
-let src = Logs.Src.create ~doc:"ImageCarrousel" "CARR"
+let src = Logs.Src.create ~doc:"ImageCarrousel" __MODULE__
 
 module Log = (val Logs.src_log src : Logs.LOG)
 module Driver = Geneweb_db.Driver
@@ -27,11 +27,18 @@ let extension_of_type = function
 let image_types = [ JPEG; GIF; PNG ]
 let raise_modErr s = raise @@ Update.ModErr (Update.UERR s)
 
+(* Raised after a complete HTTP response has been sent, to cleanly unwind the
+   call stack without triggering the server's generic exception handler (which
+   would produce a blank "no content sent" page). *)
+exception Done
+
 let incorrect conf str =
+  Log.err (fun k -> k "incorrect request: %s" str);
   Hutil.incorrect_request conf ~comment:str;
-  failwith (__FILE__ ^ " (" ^ str ^ ")" :> string)
+  raise Done
 
 let incorrect_content_type conf base p s =
+  Log.err (fun k -> k "incorrect image content type: %s" s);
   let title _ =
     Output.print_sstring conf (Utf8.capitalize (Util.transl conf "error"))
   in
@@ -41,9 +48,11 @@ let incorrect_content_type conf base p s =
   Output.printf conf "</em>\n</p>\n<ul>\n<li>\n%s</li>\n</ul>\n"
     (Util.referenced_person_title_text conf base p :> string);
   Hutil.trailer conf;
-  failwith (__FILE__ ^ " " ^ string_of_int __LINE__ :> string)
+  Output.flush conf;
+  raise Done
 
 let error_too_big_image conf base p len max_len =
+  Log.err (fun k -> k "image too big: %d bytes (max %d)" len max_len);
   let title _ =
     Output.print_sstring conf (Utf8.capitalize (Util.transl conf "error"))
   in
@@ -55,7 +64,8 @@ let error_too_big_image conf base p len max_len =
   Output.printf conf "</em></p>\n<ul>\n<li>\n%s</li>\n</ul>\n"
     (Util.referenced_person_title_text conf base p :> string);
   Hutil.trailer conf;
-  failwith (__FILE__ ^ " " ^ string_of_int __LINE__ :> string)
+  Output.flush conf;
+  raise Done
 
 let raw_get conf key =
   try List.assoc key conf.env
@@ -388,12 +398,14 @@ let effective_send_ok conf base p file =
   print_sent conf base p
 
 let print_send_ok conf base =
-  let ip =
-    try raw_get conf "i" |> Mutil.decode |> Driver.Iper.of_string
-    with Failure _ -> incorrect conf "print send ok"
-  in
-  let p = Driver.poi base ip in
-  raw_get conf "file" |> Adef.as_string |> effective_send_ok conf base p
+  try
+    let ip =
+      try raw_get conf "i" |> Mutil.decode |> Driver.Iper.of_string
+      with Failure _ -> incorrect conf "print send ok"
+    in
+    let p = Driver.poi base ip in
+    raw_get conf "file" |> Adef.as_string |> effective_send_ok conf base p
+  with Done -> ()
 
 (* carrousel *)
 let effective_send_c_ok conf base p file file_name =
@@ -605,11 +617,13 @@ let effective_delete_ok conf base p =
   print_deleted conf base p
 
 let print_del_ok conf base =
-  match p_getenv conf.env "i" with
-  | Some ip ->
-      let p = Driver.poi base (Driver.Iper.of_string ip) in
-      effective_delete_ok conf base p
-  | None -> incorrect conf "print del ok"
+  try
+    match p_getenv conf.env "i" with
+    | Some ip ->
+        let p = Driver.poi base (Driver.Iper.of_string ip) in
+        effective_delete_ok conf base p
+    | None -> incorrect conf "print del ok"
+  with Done -> ()
 
 let print_del conf base =
   match p_getenv conf.env "i" with
@@ -820,137 +834,147 @@ let effective_reset_c_ok conf base p =
    - Single, clean request cycle *)
 
 let print_main_c conf base =
-  match Util.p_getenv conf.env "em" with
-  | None -> (
-      (* Process action and redirect with success message *)
-      match Util.p_getenv conf.env "m" with
-      | Some m -> (
-          match Util.p_getenv conf.env "i" with
-          | Some ip -> (
-              let p = Driver.poi base (Driver.Iper.of_string ip) in
-              let processed_filename =
-                match m with
-                | "SND_IMAGE_C_OK" ->
+  try
+    match Util.p_getenv conf.env "em" with
+    | None -> (
+        (* Process action and redirect with success message *)
+        match Util.p_getenv conf.env "m" with
+        | Some m -> (
+            match Util.p_getenv conf.env "i" with
+            | Some ip -> (
+                let p = Driver.poi base (Driver.Iper.of_string ip) in
+                let processed_filename =
+                  match m with
+                  | "SND_IMAGE_C_OK" ->
+                      let mode =
+                        try (List.assoc "mode" conf.env :> string)
+                        with Not_found -> "portraits"
+                      in
+                      let file_name =
+                        try List.assoc "file_name" conf.env |> Mutil.decode
+                        with Not_found -> ""
+                      in
+                      let file_name =
+                        if file_name = "" then
+                          try List.assoc "file_name_2" conf.env |> Mutil.decode
+                          with Not_found -> ""
+                        else file_name
+                      in
+                      let file_name =
+                        (Mutil.decode (Adef.encoded file_name) :> string)
+                      in
+                      let file =
+                        if mode = "note" || mode = "source" then "file_name"
+                        else
+                          match Util.p_getenv conf.env "image_url" with
+                          | Some url when url <> "" -> ""
+                          | _ -> (
+                              try (raw_get conf "file" :> string) with _ -> "")
+                      in
+                      effective_send_c_ok conf base p file file_name
+                  | "DEL_IMAGE_C_OK" -> effective_delete_c_ok conf base p
+                  | "RESET_IMAGE_C_OK" -> effective_reset_c_ok conf base p
+                  | "BLASON_MOVE_TO_ANC" ->
+                      if Image.has_blason conf base p true then
+                        match Util.p_getenv conf.env "ia" with
+                        | Some ia ->
+                            let fa =
+                              Driver.poi base (Driver.Iper.of_string ia)
+                            in
+                            Filename.basename (move_blason_file conf base p fa)
+                        | None -> ""
+                      else ""
+                  | "PORTRAIT_TO_BLASON" ->
+                      Filename.basename
+                        (effective_copy_portrait_to_blason conf base p)
+                  | "IMAGE_TO_BLASON" ->
+                      Filename.basename
+                        (effective_copy_image_to_blason conf base p)
+                  | "BLASON_STOP" ->
+                      let has_blason_self = Image.has_blason conf base p true in
+                      let has_blason = Image.has_blason conf base p false in
+                      if has_blason && not has_blason_self then
+                        Filename.basename (create_blason_stop conf base p)
+                      else "error"
+                  | _ -> "incorrect request"
+                in
+
+                (* HTTP redirect to main page with success message *)
+                match processed_filename with
+                | "error" -> Hutil.incorrect_request conf
+                | "incorrect request" ->
+                    Hutil.incorrect_request conf ~comment:"incorrect request"
+                | _ ->
                     let mode =
                       try (List.assoc "mode" conf.env :> string)
                       with Not_found -> "portraits"
                     in
-                    let file_name =
-                      try List.assoc "file_name" conf.env |> Mutil.decode
-                      with Not_found -> ""
-                    in
-                    let file_name =
-                      if file_name = "" then
-                        try List.assoc "file_name_2" conf.env |> Mutil.decode
-                        with Not_found -> ""
-                      else file_name
-                    in
-                    let file_name =
-                      (Mutil.decode (Adef.encoded file_name) :> string)
-                    in
-                    let file =
-                      if mode = "note" || mode = "source" then "file_name"
-                      else
-                        match Util.p_getenv conf.env "image_url" with
-                        | Some url when url <> "" -> ""
-                        | _ -> (
-                            try (raw_get conf "file" :> string) with _ -> "")
-                    in
-                    effective_send_c_ok conf base p file file_name
-                | "DEL_IMAGE_C_OK" -> effective_delete_c_ok conf base p
-                | "RESET_IMAGE_C_OK" -> effective_reset_c_ok conf base p
-                | "BLASON_MOVE_TO_ANC" ->
-                    if Image.has_blason conf base p true then
-                      match Util.p_getenv conf.env "ia" with
-                      | Some ia ->
-                          let fa = Driver.poi base (Driver.Iper.of_string ia) in
-                          Filename.basename (move_blason_file conf base p fa)
-                      | None -> ""
-                    else ""
-                | "PORTRAIT_TO_BLASON" ->
-                    Filename.basename
-                      (effective_copy_portrait_to_blason conf base p)
-                | "IMAGE_TO_BLASON" ->
-                    Filename.basename
-                      (effective_copy_image_to_blason conf base p)
-                | "BLASON_STOP" ->
-                    let has_blason_self = Image.has_blason conf base p true in
-                    let has_blason = Image.has_blason conf base p false in
-                    if has_blason && not has_blason_self then
-                      Filename.basename (create_blason_stop conf base p)
-                    else "error"
-                | _ -> "incorrect request"
-              in
-
-              (* HTTP redirect to main page with success message *)
-              match processed_filename with
-              | "error" -> Hutil.incorrect_request conf
-              | "incorrect request" ->
-                  Hutil.incorrect_request conf ~comment:"incorrect request"
-              | _ ->
-                  let mode =
-                    try (List.assoc "mode" conf.env :> string)
-                    with Not_found -> "portraits"
-                  in
-                  let display_filename =
-                    if Filename.extension processed_filename = "" then
-                      (* Pas d'extension, essayer de la récupérer *)
-                      let keydir =
-                        Image.default_image_filename "portraits" base p
-                      in
-                      let ext =
-                        get_extension conf keydir mode false processed_filename
-                      in
-                      if ext <> "." then processed_filename ^ ext
+                    let display_filename =
+                      if Filename.extension processed_filename = "" then
+                        (* Pas d'extension, essayer de la récupérer *)
+                        let keydir =
+                          Image.default_image_filename "portraits" base p
+                        in
+                        let ext =
+                          get_extension conf keydir mode false
+                            processed_filename
+                        in
+                        if ext <> "." then processed_filename ^ ext
+                        else processed_filename
                       else processed_filename
-                    else processed_filename
-                  in
-                  let base_url =
-                    Printf.sprintf
-                      "%sm=SND_IMAGE_C&i=%s&em=%s&file_name=%s&mode=%s"
-                      (commd conf :> string)
-                      ip
-                      (Mutil.encode m :> string)
-                      (Mutil.encode display_filename :> string)
-                      (Mutil.encode mode :> string)
-                  in
-                  let url_params = ref [] in
-                  (try
-                     if List.assoc "delete" conf.env = Adef.encoded "on" then
-                       url_params := ("delete", "on") :: !url_params
-                   with Not_found -> ());
-                  (try
-                     let fn2 =
-                       List.assoc "file_name_2" conf.env |> Mutil.decode
-                     in
-                     if fn2 <> "" then
-                       url_params := ("file_name_2", fn2) :: !url_params
-                   with Not_found -> ());
-                  (if m = "IMAGE_TO_BLASON" then
-                     let ext = Filename.extension processed_filename in
-                     if ext <> "" then url_params := ("ext", ext) :: !url_params);
-                  let params_string =
-                    List.fold_left
-                      (fun acc (key, value) ->
-                        acc ^ "&" ^ key ^ "=" ^ (Mutil.encode value :> string))
-                      "" !url_params
-                  in
-                  let redirect_url = base_url ^ params_string in
-                  Output.status conf Code.Moved_Temporarily;
-                  Output.header conf "Location: %s" redirect_url;
-                  Output.header conf "Connection: close";
-                  Output.flush conf)
-          | None -> Hutil.incorrect_request conf ~comment:"missing person index"
-          )
-      | None -> Hutil.incorrect_request conf ~comment:"missing action")
-  (* Display main page with success message from URL params *)
-  | Some _ ->
-      let p =
-        match Util.p_getint conf.env "i" with
-        | Some ip -> Driver.poi base (Driver.Iper.of_string (string_of_int ip))
-        | None -> failwith "No person index in success display"
-      in
-      Perso.interp_templ "carrousel" conf base p
+                    in
+                    let base_url =
+                      Printf.sprintf
+                        "%sm=SND_IMAGE_C&i=%s&em=%s&file_name=%s&mode=%s"
+                        (commd conf :> string)
+                        ip
+                        (Mutil.encode m :> string)
+                        (Mutil.encode display_filename :> string)
+                        (Mutil.encode mode :> string)
+                    in
+                    let url_params = ref [] in
+                    (try
+                       if List.assoc "delete" conf.env = Adef.encoded "on" then
+                         url_params := ("delete", "on") :: !url_params
+                     with Not_found -> ());
+                    (try
+                       let fn2 =
+                         List.assoc "file_name_2" conf.env |> Mutil.decode
+                       in
+                       if fn2 <> "" then
+                         url_params := ("file_name_2", fn2) :: !url_params
+                     with Not_found -> ());
+                    (if m = "IMAGE_TO_BLASON" then
+                       let ext = Filename.extension processed_filename in
+                       if ext <> "" then
+                         url_params := ("ext", ext) :: !url_params);
+                    let params_string =
+                      List.fold_left
+                        (fun acc (key, value) ->
+                          acc ^ "&" ^ key ^ "=" ^ (Mutil.encode value :> string))
+                        "" !url_params
+                    in
+                    let redirect_url = base_url ^ params_string in
+                    Output.status conf Code.Moved_Temporarily;
+                    Output.header conf "Location: %s" redirect_url;
+                    Output.header conf "Connection: close";
+                    Output.flush conf)
+            | None ->
+                Hutil.incorrect_request conf ~comment:"missing person index")
+        | None -> Hutil.incorrect_request conf ~comment:"missing action")
+    (* Display main page with success message from URL params *)
+    | Some _ ->
+        let p =
+          match Util.p_getint conf.env "i" with
+          | Some ip ->
+              Driver.poi base (Driver.Iper.of_string (string_of_int ip))
+          | None ->
+              Hutil.incorrect_request conf
+                ~comment:"missing person index in display";
+              raise Done
+        in
+        Perso.interp_templ "carrousel" conf base p
+  with Done -> ()
 
 let print conf base =
   match p_getenv conf.env "i" with


### PR DESCRIPTION
## Replace `failwith` with `Done` exception for clean error responses

### Problem

Error paths in `imageCarrousel.ml` used `failwith` to abort after sending an HTTP error page. This unwound the call stack through the server's generic exception handler, which would attempt to write another response — producing a blank or garbled page for the client.

Additionally, `output_error` in `GWPARAM.ml` was not flushing the connection after writing the error body, and multipart upload bytes could leak into the response body when image validation failed.

### Solution

Introduce a local `exception Done` that signals "a complete HTTP response has already been sent — just unwind quietly." Every public entry point catches it with `with Done -> ()`.

### Changes

**`lib/imageCarrousel.ml`**
- Add `exception Done` with an explanatory comment
- `incorrect`: log the error via `Log.err`, then raise `Done` instead of `failwith`
- `incorrect_content_type`, `error_too_big_image`: call `Output.flush conf` before raising `Done` to seal the response
- `print_send_ok`, `print_del_ok`, `print_main_c`, `print`, `print_family`: wrap bodies in `try … with Done -> ()`
- `effective_send_c_ok`: drain remaining multipart stream bytes with `Stream.junk` before calling error handlers, preventing upload data from leaking into the response; strip `"file"` from `conf.env` immediately after reading it
- `print_main_c` (`em` display branch): replace `failwith` with `Hutil.incorrect_request` + `raise Done` when the person index is missing

**`lib/GWPARAM.ml`**
- `output_error`: add `Output.flush conf` at the end so the error page is always flushed to the client

### Why `Done` and not a boolean / option?

The error functions already write a full HTTP response (status, headers, body, trailer) before returning. A boolean return value would require every caller to check it and short-circuit manually. `Done` lets the control flow express "we're finished" directly, with a single catch at each top-level entry point.