### PR TITLE
Active tests in flake

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.6)
+(lang dune 3.8)
 (using dune_site 0.1)
 (generate_opam_files true)
 

--- a/geneweb-compat.opam
+++ b/geneweb-compat.opam
@@ -9,7 +9,7 @@ homepage: "https://geneweb.org"
 doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.8"}
   "ocaml"
   "odoc" {with-doc}
 ]

--- a/geneweb-http.opam
+++ b/geneweb-http.opam
@@ -8,7 +8,7 @@ homepage: "https://geneweb.org"
 doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.8"}
   "ocaml"
   "camlp-streams"
   "geneweb-compat"

--- a/geneweb-rpc.opam
+++ b/geneweb-rpc.opam
@@ -9,7 +9,7 @@ homepage: "https://geneweb.org"
 doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.8"}
   "ocaml"
   "geneweb" {= version}
   "qcheck" {with-test}

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -11,7 +11,7 @@ homepage: "https://geneweb.org"
 doc: "https://geneweb.tuxfamily.org/wiki/GeneWeb"
 bug-reports: "https://github.com/geneweb/geneweb/issues"
 depends: [
-  "dune" {>= "3.6"}
+  "dune" {>= "3.8"}
   "ocaml"
   "geneweb-compat"
   "geneweb-http"

--- a/nix/geneweb-compat.nix
+++ b/nix/geneweb-compat.nix
@@ -7,4 +7,5 @@ buildDunePackage {
   pname = "geneweb-compat";
   src = lib.cleanSource ../.;
   version = "dev";
+  doCheck = true;
 }

--- a/nix/geneweb-rpc.nix
+++ b/nix/geneweb-rpc.nix
@@ -22,6 +22,7 @@
 buildDunePackage {
   pname = "geneweb-rpc";
   inherit (geneweb) version src;
+  doCheck = true;
 
   buildInputs = [
     geneweb-compat

--- a/nix/geneweb.nix
+++ b/nix/geneweb.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildDunePackage,
+  alcotest,
   ancient,
   brotli,
   pcre2,
@@ -20,6 +21,8 @@
   ppx_blob,
   ppx_deriving,
   ppx_import,
+  qcheck,
+  qcheck-alcotest,
   stdlib-shims,
   unidecode,
   uutf,
@@ -41,12 +44,19 @@ buildDunePackage {
   pname = "geneweb";
   version = "dev";
   src = lib.cleanSource ../.;
+  doCheck = true;
 
   nativeBuildInputs = [
     brotli
     not-ocamlfind
     cppo
     camlp5
+  ];
+
+  buildInputs = [
+    alcotest
+    qcheck
+    qcheck-alcotest
   ];
 
   propagatedBuildInputs = [

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (test
+ (package geneweb)
  (name test)
  (modules
   test
@@ -11,10 +12,10 @@
  (libraries alcotest geneweb fmt))
 
 (test
+ (package geneweb)
  (deps
   (:dict ./dict.txt))
  (name search_test)
- (package geneweb)
  (libraries
   fmt
   qcheck
@@ -26,5 +27,6 @@
   (run %{test} %{dict})))
 
 (test
+ (package geneweb)
  (name heap_test)
  (libraries qcheck qcheck-alcotest geneweb_compat geneweb_search))

--- a/test/templ/dune
+++ b/test/templ/dune
@@ -12,6 +12,7 @@
    (run ./templ_test.exe %{template}))))
 
 (rule
+ (package geneweb)
  (alias runtest)
  (action
   (diff template.expected template.out)))


### PR DESCRIPTION
The derivations for GeneWeb packages didn't run tests. This PR actives them and ensure that
tests have the right package stanza.

This PR is rebased on #2832 