### PR TITLE
Use the executable path of gwsetup as default value for `bin_dir`

### DIFF
--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -2,12 +2,22 @@ open Geneweb
 module Server = Geneweb_http.Server
 module Code = Geneweb_http.Code
 
+let ( // ) = Filename.concat
+
+let default_bin_dir =
+  match Unix.getenv "INSIDE_DUNE" with
+  | exception Not_found -> Filename.dirname Sys.executable_name
+  | default ->
+      (* As dune uses symbolic links to populate the binary directory in
+         `_build/install` directory, we cannot use `executable_path` here. *)
+      default // Filename.parent_dir_name // "install" // "default" // "bin"
+
 let interface = ref "localhost"
 let port = ref 2316
 let gwd_port = ref 2317
 let default_lang = ref "en"
 let setup_dir = ref "."
-let bin_dir = ref ""
+let bin_dir = ref default_bin_dir
 let base_dir = ref (Secure.base_dir ())
 let lang_param = ref ""
 let bname = ref ""


### PR DESCRIPTION
The gwsetup binary used the current working process as default value for the binary directory distribution. It worked for the previous distribution process but failed with both opam installtion and `dune exec` commands.

Fortunately, the OCaml runtime defined a convenient function to retrieve the absolute path of the binary of the current processus. On Linux, it relies on the value of the symbolic link `/proc/self/exe`. Contrary to `argv.(0)` value, this approach don't return a wrong path if the parent process rename the process.

This approach doesn't work for `dune exec` as dune uses symbolic links to populate its binary directory. The `INSIDE_DUNE` environment variable is used to recognize this situation and infer the appropriate path for the binary directory.

This commit works with the legacy release distribution.