### PR TITLE
Use the default bases directory in gwsetup

### DIFF
--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -8,7 +8,7 @@ let gwd_port = ref 2317
 let default_lang = ref "en"
 let setup_dir = ref "."
 let bin_dir = ref ""
-let base_dir = ref (Filename.concat Filename.current_dir_name "bases")
+let base_dir = ref (Secure.base_dir ())
 let lang_param = ref ""
 let bname = ref ""
 let no_o = ref true
@@ -512,7 +512,7 @@ let rec copy_from_stream conf print strm =
                 if c = ')' then () else loop ()
               in
               loop ()
-          | 'b' -> for_all conf print (all_db ".") strm
+          | 'b' -> for_all conf print (all_db !base_dir) strm
           | 'e' ->
               print "lang=";
               print conf.lang;
@@ -1353,7 +1353,7 @@ let rename conf =
       files
   in
   try
-    check_new_names conf rename_list (all_db ".");
+    check_new_names conf rename_list (all_db !base_dir);
     check_rename_conflict conf (snd (List.split rename_list));
     List.iter
       (fun (k, v) ->
@@ -1844,7 +1844,6 @@ let intro () =
         else !default_lang
     else !default_lang
   in
-  Secure.set_base_dir ".";
   Arg.parse speclist anonfun usage;
   if !bin_dir = "" then bin_dir := !setup_dir;
   Printf.eprintf "Start gwsetup\n%!";

--- a/etc/gwsetup.sh
+++ b/etc/gwsetup.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd `dirname "$0"`
 cd bases
-exec ../gw/gwsetup -gd ../gw "$@"
+exec ../gw/gwsetup -bd ../bases -gd ../gw "$@"

--- a/lib/util/secure.ml
+++ b/lib/util/secure.ml
@@ -14,7 +14,7 @@ let default_base_dir =
   let t = Dirs.make () in
   Dirs.(data_home t // "geneweb" // "bases")
 
-let bd_r = ref (Dirs.path default_base_dir)
+let bd_r = ref None
 
 (* [decompose: string -> string list] decompose a path into a list of
    directory and a basename. "a/b/c" -> [ "a" ; "b"; "c" ] *)
@@ -40,12 +40,14 @@ let add_assets d =
 (* set base dir to which acces could be allowed *)
 let set_base_dir d =
   let ok = decompose d in
-  bd_r := d;
+  bd_r := Some d;
   ok_r := ok :: (List.filter (( <> ) ok)) !ok_r
+
+let () = set_base_dir @@ Dirs.path default_base_dir
 
 (* get all assets *)
 let assets () = !assets_r
-let base_dir () = !bd_r
+let base_dir () = Option.get !bd_r
 
 (* [list_check_prefix d df] returns either [None] if [d] is not a prefix of
    [df], or [Some suffix], where [df = d @ suffix] *)


### PR DESCRIPTION
The gwsetup binary doesn't follow the conventions of GeneWeb. In
particular, the current directory was hardcoded as bases directory in
few locations.

This PR changes gwsetup as follows:
- The `-bd` argument is no longer ignored and it's default value is the
  same as the one used by `gwd`, that is `Secure.default_base_dir`.
- This directory is used everywhere in the script.
- The `gwsetup.sh` script is updated to change the default bases
  directory. After introducing dotenv file, we can use a common dotenv
  to set this directory for both gwd and gwsetup in a directory
  installation.

To test this PR, you can run:
```console
make distrib
cd distrib
./gwd.sh &
./gwsetup.sh
```

This PR is rebased on #2856 