### PR TITLE
Allow to create a fresh database with `gwc`

### DIFF
--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -56,28 +56,30 @@ let iterator_gwo_file file_info input =
    operating system at the end of the current process. *)
 let iterator_gwo_files bar inputs file_info =
   let queue = Queue.of_seq @@ List.to_seq inputs in
-  let curr = ref (iterator_gwo_file file_info @@ Queue.pop queue) in
-  let len = Queue.length queue in
-  let cnt = ref 0 in
-  let rec next () =
-    let ic, it = !curr in
-    match it () with
-    | exception exn ->
-        let bt = Printexc.get_raw_backtrace () in
-        close_in_noerr ic;
-        Printexc.raise_with_backtrace exn bt
-    | Some _ as v -> v
-    | None -> (
-        close_in ic;
-        match Queue.pop queue with
-        | exception Queue.Empty -> None
-        | gwo ->
-            incr cnt;
-            ProgrBar.progress bar !cnt len;
-            curr := iterator_gwo_file file_info gwo;
-            next ())
-  in
-  next
+  if Queue.is_empty queue then fun _ -> None
+  else
+    let curr = ref (iterator_gwo_file file_info @@ Queue.pop queue) in
+    let len = Queue.length queue in
+    let cnt = ref 0 in
+    let rec next () =
+      let ic, it = !curr in
+      match it () with
+      | exception exn ->
+          let bt = Printexc.get_raw_backtrace () in
+          close_in_noerr ic;
+          Printexc.raise_with_backtrace exn bt
+      | Some _ as v -> v
+      | None -> (
+          close_in ic;
+          match Queue.pop queue with
+          | exception Queue.Empty -> None
+          | gwo ->
+              incr cnt;
+              ProgrBar.progress bar !cnt len;
+              curr := iterator_gwo_file file_info gwo;
+              next ())
+    in
+    next
 
 let generate_database ~no_warn ~bdir bar gwo_files =
   let iterator = iterator_gwo_files bar gwo_files in
@@ -247,7 +249,10 @@ let anonfun fname =
 
 let parse_output inputs output =
   match (inputs, output) with
-  | [], _ -> raise_bad "You must specify at least one input file."
+  | [], None ->
+      raise_bad
+        "You must specify at least one input file or a base name for a fresh \
+         database."
   | _ :: _ :: _, None ->
       raise_bad
         "In presence of several input files, we cannot infer the output \

--- a/test/gwc/run.t
+++ b/test/gwc/run.t
@@ -39,8 +39,34 @@
   [2]
 
   $ gwc -bd .
-  Fatal error: exception Stdlib.Arg.Bad("You must specify at least one input file.")
+  Fatal error: exception Stdlib.Arg.Bad("You must specify at least one input file or a base name for a fresh database.")
   [2]
+
+  $ gwc -bd . -o bar
+  Compilation: 0 min 0 sec
+  Migration check for bar:
+    Classic .gwf exists: false
+    Reorg .gwf exists: false
+  Creating default configuration: bar.gwf
+  
+  pcnt 0 persons 0
+  fcnt 0 families 0
+  scnt 2 strings 3
+  *** saving persons array
+  *** saving ascends array
+  *** saving unions array
+  *** saving families array
+  *** saving couples array
+  *** saving descends array
+  *** saving strings array
+  *** create name index
+  *** create strings of sname
+  *** create strings of fname
+  *** create string index
+  *** create surname index
+  *** create first name index
+  *** ok
+  Database generation: 0 min 0 sec
 
   $ gwc -gwo -bd . ../galichet.gw
   Compilation: 0 min 0 sec
@@ -178,4 +204,3 @@
   Database generation: 0 min 0 sec
   ../galichet.gwo galichet.gwo differ: char 16, line 1
   [1]
-


### PR DESCRIPTION
The commit https://github.com/geneweb/geneweb/commit/d7507e39 introduced a bug in `gwc`. The command
```
dune exec -- bin/gwc/gwc.exe -o foo
```
should create an empty database from scratch. Instead, the command emits an error because we don't provide a gwo or gw files.

This commit restores the previous behavior and a cram test to prevent from breaking it again in the future.