### PR TITLE
Fix family merge digest mismatch ("base has changed" error)

### DIFF
--- a/lib/mergeFamOk.ml
+++ b/lib/mergeFamOk.ml
@@ -1,4 +1,4 @@
-(* $Id: mergeFamOk.ml,v 5.19 2007-09-12 09:58:44 ddr Exp $ *)
+(* $Id: mergeFamOk.ml v 7.1 16/06/2026 18:10:10 ddr Exp $ *)
 (* Copyright (c) 1998-2007 INRIA *)
 
 open Config
@@ -222,7 +222,8 @@ let print_merge conf base =
       let sfam, sdes = reconstitute conf base ifam1 fam1 fam2 in
       let digest =
         let ini_sfam = UpdateFam.string_family_of base ifam1 in
-        Update.digest_family ini_sfam
+        let salt = Option.get conf.secret_salt in
+        Update.digest_family ~salt ini_sfam
       in
       let scpl =
         Adef.map_couple_p

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -1062,18 +1062,18 @@ let feed_key (s1, s2, i, c, s3) =
   Hasher.SHA256.(
     string s1 <+> string s2 <+> int i <+> feed_create c <+> string s3)
 
-let digest_person =
+let digest_person ~salt =
   let feeder p = Hasher.SHA256.((gen_person iper feed_key string) p) in
-  Hasher.SHA256.feeder_to_hasher feeder
+  Hasher.SHA256.feeder_to_hasher ~salt feeder
 
-let digest_family =
+let digest_family ~salt =
   let feeder (f, c, d) =
     Hasher.SHA256.(
       (gen_family feed_key ifam string) f
       <+> (gen_couple feed_key) c
       <+> (gen_descend feed_key) d)
   in
-  Hasher.SHA256.feeder_to_hasher feeder
+  Hasher.SHA256.feeder_to_hasher ~salt feeder
 
 let get var key env =
   match p_getenv env (var ^ "_" ^ key) with

--- a/lib/update.mli
+++ b/lib/update.mli
@@ -126,28 +126,26 @@ val error_digest : config -> 'exn
 val error_same_file : config -> 'exn
 
 val digest_person :
-  ?salt:string -> (Geneweb_db.Driver.iper, key, string) gen_person -> string
-(** [digest_person ?salt per] generates a digest of the person [pers]. The
+  salt:string -> (Geneweb_db.Driver.iper, key, string) gen_person -> string
+(** [digest_person ~salt per] generates a digest of the person [per]. The
     function is intended for use in form to help prevent:
     - Concurrent edits of the same person.
-    - Cross-site Request Forgery (CSRF) attacks.
-
-    The optional [salt] parameter should be set to a secret value generated at
-    server startup to strengthen security. *)
+    - Cross-site Request Forgery (CSRF) attacks. [salt] is a secret value
+      generated at server startup; it is mandatory so that the compiler rejects
+      any call site that would omit it. *)
 
 val digest_family :
-  ?salt:string ->
+  salt:string ->
   (key, Geneweb_db.Driver.ifam, string) gen_family
   * key Adef.gen_couple
   * key gen_descend ->
   string
-(** [digest_family ?salt fam] generates a digest of the family [fam]. The
+(** [digest_family ~salt fam] generates a digest of the family [fam]. The
     function is intended for use in form to help prevent:
     - Concurrent edits of the same family.
-    - Cross-site Request Forgery (CSRF) attacks.
-
-    The optional [salt] parameter should be set to a secret value generated at
-    server startup to strengthen security. *)
+    - Cross-site Request Forgery (CSRF) attacks. [salt] is a secret value
+      generated at server startup; it is mandatory so that the compiler rejects
+      any call site that would omit it. *)
 
 val reconstitute_date : config -> string -> Adef.date option
 


### PR DESCRIPTION
mergeFamOk.ml computed the initial digest without the secret salt, while updateFamOk.ml's `print_mod_aux` verifies it with `~salt`. The mismatch always triggered `UERR_digest` on `MRG_MOD_FAM_OK`, blocking every family merge.
Add `~salt` to the `Update.digest_family` call in `print_merge`, aligning it with the salted digest used by person merge (`mergeIndOkDisplay.ml`) and standard family update (`updateFam.ml`).

Closes issue #2853