### PR TITLE
test/run_gw_test.sh to use new --load-all-plugins

### DIFF
--- a/test/run_gw_test.sh
+++ b/test/run_gw_test.sh
@@ -153,7 +153,7 @@ OCAMLRUNPARAM=b $SUDOPRFX $BIN_DIR/gwd \
   --connection-timeout=3600 \
   --default-lang=en \
   --log='<stderr>' \
-  --plugins=uf:$BIN_DIR/plugins \
+  --load-all-plugins \
   2>> $GWDLOG &
 fi
 set +x


### PR DESCRIPTION
test/run_gw_test.sh to use new --load-all-plugins

Required change as per new commit id 35ee62606
"Use dune to install plugins"
that removed --plugins and use --load-all-plugins