### PR TITLE
Fix generate dune inc

### DIFF
--- a/hd/etc/css/dune
+++ b/hd/etc/css/dune
@@ -9,6 +9,6 @@
    (run ../generate_dune_inc.exe .))))
 
 (rule
- (alias default)
+ (alias all)
  (action
   (diff dune.inc dune.inc.gen)))

--- a/hd/etc/css/dune.inc
+++ b/hd/etc/css/dune.inc
@@ -1,61 +1,54 @@
 
 (rule
-  (target datatables.min.css.gz)
-  (deps (:input datatables.min.css))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target datatables.min.css.br)
-  (deps (:input datatables.min.css))
-  (action
-    (run brotli -f -q 11 %{input})))
-(rule
-  (target bootstrap.min.css.gz)
-  (deps (:input bootstrap.min.css))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target bootstrap.min.css.br)
-  (deps (:input bootstrap.min.css))
-  (action
-    (run brotli -f -q 11 %{input})))
-(rule
-  (target tom-select.bootstrap5.min.css.gz)
-  (deps (:input tom-select.bootstrap5.min.css))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target tom-select.bootstrap5.min.css.br)
-  (deps (:input tom-select.bootstrap5.min.css))
-  (action
-    (run brotli -f -q 11 %{input})))
-(rule
-  (target all.min.css.gz)
+  (package geneweb)
+  (targets all.min.css.gz all.min.css.br)
   (deps (:input all.min.css))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target all.min.css.br)
-  (deps (:input all.min.css))
+  (package geneweb)
+  (targets bootstrap.min.css.gz bootstrap.min.css.br)
+  (deps (:input bootstrap.min.css))
   (action
-    (run brotli -f -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target css.css.gz)
+  (package geneweb)
+  (targets css.css.gz css.css.br)
   (deps (:input css.css))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target css.css.br)
-  (deps (:input css.css))
+  (package geneweb)
+  (targets datatables.min.css.gz datatables.min.css.br)
+  (deps (:input datatables.min.css))
   (action
-    (run brotli -f -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target fanchart.css.gz)
+  (package geneweb)
+  (targets fanchart.css.gz fanchart.css.br)
   (deps (:input fanchart.css))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target fanchart.css.br)
-  (deps (:input fanchart.css))
+  (package geneweb)
+  (targets tom-select.bootstrap5.min.css.gz tom-select.bootstrap5.min.css.br)
+  (deps (:input tom-select.bootstrap5.min.css))
   (action
-    (run brotli -f -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))

--- a/hd/etc/generate_dune_inc.ml
+++ b/hd/etc/generate_dune_inc.ml
@@ -6,7 +6,6 @@ let pp_rule ppf path =
   Format.fprintf ppf
     {|
 (rule
-  (alias install)
   (package geneweb)
   (targets %s %s)
   (deps (:input %s))

--- a/hd/etc/generate_dune_inc.ml
+++ b/hd/etc/generate_dune_inc.ml
@@ -1,33 +1,28 @@
 let add_extension path ext = Format.sprintf "%s%s" path ext
 
-let pp_rule path =
+let pp_rule ppf path =
   let target_gzip = add_extension path ".gz" in
   let target_brotli = add_extension path ".br" in
-  Format.printf
+  Format.fprintf ppf
     {|
 (rule
-  (target %s)
+  (alias install)
+  (package geneweb)
+  (targets %s %s)
   (deps (:input %s))
   (action
-    (run gzip -9 -k -f %%{input})))
-(rule
-  (target %s)
-  (deps (:input %s))
-  (action
-    (run brotli -q 11 %%{input})))@?|}
-    target_gzip path target_brotli path
+    (concurrent
+      (run gzip -9 -k -f %%{input})
+      (run brotli -q 11 %%{input}))))@?|}
+    target_gzip target_brotli path
+
+let pp_newline ppf () = Format.fprintf ppf "\n"
 
 let () =
-  let handle = Unix.opendir Sys.argv.(1) in
-  Fun.protect ~finally:(fun () -> Unix.closedir handle) @@ fun () ->
-  let rec loop () =
-    match Unix.readdir handle with
-    | exception End_of_file -> ()
-    | s -> (
-        match Filename.extension s with
-        | ".css" | ".js" ->
-            pp_rule s;
-            loop ()
-        | _ -> loop ())
+  let files =
+    Array.to_list @@ Sys.readdir Sys.argv.(1)
+    |> List.filter (fun f ->
+        match Filename.extension f with ".css" | ".js" -> true | _ -> false)
+    |> List.sort String.compare
   in
-  loop ()
+  Format.printf "%a@." (Format.pp_print_list ~pp_sep:pp_newline pp_rule) files

--- a/hd/etc/js/dune
+++ b/hd/etc/js/dune
@@ -9,6 +9,6 @@
    (run ../generate_dune_inc.exe .))))
 
 (rule
- (alias install)
+ (alias all)
  (action
   (diff dune.inc dune.inc.gen)))

--- a/hd/etc/js/dune.inc
+++ b/hd/etc/js/dune.inc
@@ -1,301 +1,320 @@
 
 (rule
-  (target person_picker.min.js.gz)
-  (deps (:input person_picker.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target person_picker.min.js.br)
-  (deps (:input person_picker.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target chart.umd.min.js.gz)
-  (deps (:input chart.umd.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target chart.umd.min.js.br)
-  (deps (:input chart.umd.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target cousins.js.gz)
-  (deps (:input cousins.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target cousins.js.br)
-  (deps (:input cousins.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target bootstrap.bundle.min.js.gz)
-  (deps (:input bootstrap.bundle.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target bootstrap.bundle.min.js.br)
-  (deps (:input bootstrap.bundle.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target html5sortable.min.js.gz)
-  (deps (:input html5sortable.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target html5sortable.min.js.br)
-  (deps (:input html5sortable.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target datatables.min.js.gz)
-  (deps (:input datatables.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target datatables.min.js.br)
-  (deps (:input datatables.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target regex.min.js.gz)
-  (deps (:input regex.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target regex.min.js.br)
-  (deps (:input regex.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target dagSvg.js.gz)
-  (deps (:input dagSvg.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target dagSvg.js.br)
-  (deps (:input dagSvg.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target notes_upd_gallery.min.js.gz)
-  (deps (:input notes_upd_gallery.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target notes_upd_gallery.min.js.br)
-  (deps (:input notes_upd_gallery.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target permalink.min.js.gz)
-  (deps (:input permalink.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target permalink.min.js.br)
-  (deps (:input permalink.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target checkdata.min.js.gz)
-  (deps (:input checkdata.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target checkdata.min.js.br)
-  (deps (:input checkdata.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target fanchart.min.js.gz)
-  (deps (:input fanchart.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target fanchart.min.js.br)
-  (deps (:input fanchart.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target checkdata.js.gz)
-  (deps (:input checkdata.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target checkdata.js.br)
-  (deps (:input checkdata.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target p_mod.min.js.gz)
-  (deps (:input p_mod.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target p_mod.min.js.br)
-  (deps (:input p_mod.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target rlm_builder.js.gz)
-  (deps (:input rlm_builder.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target rlm_builder.js.br)
-  (deps (:input rlm_builder.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target fanchart.js.gz)
-  (deps (:input fanchart.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target fanchart.js.br)
-  (deps (:input fanchart.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target p_mod.js.gz)
-  (deps (:input p_mod.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target p_mod.js.br)
-  (deps (:input p_mod.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target jquery.min.js.gz)
-  (deps (:input jquery.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target jquery.min.js.br)
-  (deps (:input jquery.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target relationmatrix.js.gz)
-  (deps (:input relationmatrix.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target relationmatrix.js.br)
-  (deps (:input relationmatrix.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target clearinput.js.gz)
-  (deps (:input clearinput.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target clearinput.js.br)
-  (deps (:input clearinput.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target notes_upd_gallery.js.gz)
-  (deps (:input notes_upd_gallery.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target notes_upd_gallery.js.br)
-  (deps (:input notes_upd_gallery.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target line.js.gz)
-  (deps (:input line.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target line.js.br)
-  (deps (:input line.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target relationmatrix.min.js.gz)
-  (deps (:input relationmatrix.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target relationmatrix.min.js.br)
-  (deps (:input relationmatrix.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target permalink.js.gz)
-  (deps (:input permalink.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target permalink.js.br)
-  (deps (:input permalink.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target tom-select.complete.min.js.gz)
-  (deps (:input tom-select.complete.min.js))
-  (action
-    (run gzip -9 -k -f %{input})))
-(rule
-  (target tom-select.complete.min.js.br)
-  (deps (:input tom-select.complete.min.js))
-  (action
-    (run brotli -q 11 %{input})))
-(rule
-  (target autosize.min.js.gz)
+  (alias install)
+  (package geneweb)
+  (targets autosize.min.js.gz autosize.min.js.br)
   (deps (:input autosize.min.js))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target autosize.min.js.br)
-  (deps (:input autosize.min.js))
+  (alias install)
+  (package geneweb)
+  (targets bootstrap.bundle.min.js.gz bootstrap.bundle.min.js.br)
+  (deps (:input bootstrap.bundle.min.js))
   (action
-    (run brotli -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target maphilight.min.js.gz)
-  (deps (:input maphilight.min.js))
+  (alias install)
+  (package geneweb)
+  (targets chart.umd.min.js.gz chart.umd.min.js.br)
+  (deps (:input chart.umd.min.js))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target maphilight.min.js.br)
-  (deps (:input maphilight.min.js))
+  (alias install)
+  (package geneweb)
+  (targets checkdata.js.gz checkdata.js.br)
+  (deps (:input checkdata.js))
   (action
-    (run brotli -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target cousins.min.js.gz)
+  (alias install)
+  (package geneweb)
+  (targets checkdata.min.js.gz checkdata.min.js.br)
+  (deps (:input checkdata.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets clearinput.js.gz clearinput.js.br)
+  (deps (:input clearinput.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets cousins.js.gz cousins.js.br)
+  (deps (:input cousins.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets cousins.min.js.gz cousins.min.js.br)
   (deps (:input cousins.min.js))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target cousins.min.js.br)
-  (deps (:input cousins.min.js))
+  (alias install)
+  (package geneweb)
+  (targets dagSvg.js.gz dagSvg.js.br)
+  (deps (:input dagSvg.js))
   (action
-    (run brotli -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target person_picker.js.gz)
-  (deps (:input person_picker.js))
+  (alias install)
+  (package geneweb)
+  (targets datatables.min.js.gz datatables.min.js.br)
+  (deps (:input datatables.min.js))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target person_picker.js.br)
-  (deps (:input person_picker.js))
+  (alias install)
+  (package geneweb)
+  (targets fanchart.js.gz fanchart.js.br)
+  (deps (:input fanchart.js))
   (action
-    (run brotli -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target maphilight.js.gz)
+  (alias install)
+  (package geneweb)
+  (targets fanchart.min.js.gz fanchart.min.js.br)
+  (deps (:input fanchart.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets html5sortable.min.js.gz html5sortable.min.js.br)
+  (deps (:input html5sortable.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets jquery.min.js.gz jquery.min.js.br)
+  (deps (:input jquery.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets line.js.gz line.js.br)
+  (deps (:input line.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets maphilight.js.gz maphilight.js.br)
   (deps (:input maphilight.js))
   (action
-    (run gzip -9 -k -f %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
 (rule
-  (target maphilight.js.br)
-  (deps (:input maphilight.js))
+  (alias install)
+  (package geneweb)
+  (targets maphilight.min.js.gz maphilight.min.js.br)
+  (deps (:input maphilight.min.js))
   (action
-    (run brotli -q 11 %{input})))
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets notes_upd_gallery.js.gz notes_upd_gallery.js.br)
+  (deps (:input notes_upd_gallery.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets notes_upd_gallery.min.js.gz notes_upd_gallery.min.js.br)
+  (deps (:input notes_upd_gallery.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets p_mod.js.gz p_mod.js.br)
+  (deps (:input p_mod.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets p_mod.min.js.gz p_mod.min.js.br)
+  (deps (:input p_mod.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets permalink.js.gz permalink.js.br)
+  (deps (:input permalink.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets permalink.min.js.gz permalink.min.js.br)
+  (deps (:input permalink.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets person_picker.js.gz person_picker.js.br)
+  (deps (:input person_picker.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets person_picker.min.js.gz person_picker.min.js.br)
+  (deps (:input person_picker.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets regex.min.js.gz regex.min.js.br)
+  (deps (:input regex.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets relationmatrix.js.gz relationmatrix.js.br)
+  (deps (:input relationmatrix.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets relationmatrix.min.js.gz relationmatrix.min.js.br)
+  (deps (:input relationmatrix.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets rlm_builder.js.gz rlm_builder.js.br)
+  (deps (:input rlm_builder.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets tom-select.complete.min.js.gz tom-select.complete.min.js.br)
+  (deps (:input tom-select.complete.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets updateField.js.gz updateField.js.br)
+  (deps (:input updateField.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))
+
+(rule
+  (alias install)
+  (package geneweb)
+  (targets updateField.min.js.gz updateField.min.js.br)
+  (deps (:input updateField.min.js))
+  (action
+    (concurrent
+      (run gzip -9 -k -f %{input})
+      (run brotli -q 11 %{input}))))

--- a/hd/etc/js/dune.inc
+++ b/hd/etc/js/dune.inc
@@ -1,6 +1,5 @@
 
 (rule
-  (alias install)
   (package geneweb)
   (targets autosize.min.js.gz autosize.min.js.br)
   (deps (:input autosize.min.js))
@@ -10,7 +9,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets bootstrap.bundle.min.js.gz bootstrap.bundle.min.js.br)
   (deps (:input bootstrap.bundle.min.js))
@@ -20,7 +18,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets chart.umd.min.js.gz chart.umd.min.js.br)
   (deps (:input chart.umd.min.js))
@@ -30,7 +27,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets checkdata.js.gz checkdata.js.br)
   (deps (:input checkdata.js))
@@ -40,7 +36,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets checkdata.min.js.gz checkdata.min.js.br)
   (deps (:input checkdata.min.js))
@@ -50,7 +45,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets clearinput.js.gz clearinput.js.br)
   (deps (:input clearinput.js))
@@ -60,7 +54,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets cousins.js.gz cousins.js.br)
   (deps (:input cousins.js))
@@ -70,7 +63,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets cousins.min.js.gz cousins.min.js.br)
   (deps (:input cousins.min.js))
@@ -80,7 +72,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets dagSvg.js.gz dagSvg.js.br)
   (deps (:input dagSvg.js))
@@ -90,7 +81,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets datatables.min.js.gz datatables.min.js.br)
   (deps (:input datatables.min.js))
@@ -100,7 +90,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets fanchart.js.gz fanchart.js.br)
   (deps (:input fanchart.js))
@@ -110,7 +99,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets fanchart.min.js.gz fanchart.min.js.br)
   (deps (:input fanchart.min.js))
@@ -120,7 +108,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets html5sortable.min.js.gz html5sortable.min.js.br)
   (deps (:input html5sortable.min.js))
@@ -130,7 +117,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets jquery.min.js.gz jquery.min.js.br)
   (deps (:input jquery.min.js))
@@ -140,7 +126,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets line.js.gz line.js.br)
   (deps (:input line.js))
@@ -150,7 +135,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets maphilight.js.gz maphilight.js.br)
   (deps (:input maphilight.js))
@@ -160,7 +144,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets maphilight.min.js.gz maphilight.min.js.br)
   (deps (:input maphilight.min.js))
@@ -170,7 +153,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets notes_upd_gallery.js.gz notes_upd_gallery.js.br)
   (deps (:input notes_upd_gallery.js))
@@ -180,7 +162,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets notes_upd_gallery.min.js.gz notes_upd_gallery.min.js.br)
   (deps (:input notes_upd_gallery.min.js))
@@ -190,7 +171,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets p_mod.js.gz p_mod.js.br)
   (deps (:input p_mod.js))
@@ -200,7 +180,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets p_mod.min.js.gz p_mod.min.js.br)
   (deps (:input p_mod.min.js))
@@ -210,7 +189,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets permalink.js.gz permalink.js.br)
   (deps (:input permalink.js))
@@ -220,7 +198,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets permalink.min.js.gz permalink.min.js.br)
   (deps (:input permalink.min.js))
@@ -230,7 +207,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets person_picker.js.gz person_picker.js.br)
   (deps (:input person_picker.js))
@@ -240,7 +216,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets person_picker.min.js.gz person_picker.min.js.br)
   (deps (:input person_picker.min.js))
@@ -250,7 +225,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets regex.min.js.gz regex.min.js.br)
   (deps (:input regex.min.js))
@@ -260,7 +234,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets relationmatrix.js.gz relationmatrix.js.br)
   (deps (:input relationmatrix.js))
@@ -270,7 +243,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets relationmatrix.min.js.gz relationmatrix.min.js.br)
   (deps (:input relationmatrix.min.js))
@@ -280,7 +252,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets rlm_builder.js.gz rlm_builder.js.br)
   (deps (:input rlm_builder.js))
@@ -290,7 +261,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets tom-select.complete.min.js.gz tom-select.complete.min.js.br)
   (deps (:input tom-select.complete.min.js))
@@ -300,7 +270,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets updateField.js.gz updateField.js.br)
   (deps (:input updateField.js))
@@ -310,7 +279,6 @@
       (run brotli -q 11 %{input}))))
 
 (rule
-  (alias install)
   (package geneweb)
   (targets updateField.min.js.gz updateField.min.js.br)
   (deps (:input updateField.min.js))

--- a/rpc/test/dune
+++ b/rpc/test/dune
@@ -12,6 +12,7 @@
   (pps js_of_ocaml-ppx)))
 
 (rule
+ (package geneweb-rpc)
  (target rpc_client.bc.js.gz)
  (deps
   (:input ./rpc_client.bc.js))
@@ -19,6 +20,7 @@
   (run gzip -9 -k -f %{input})))
 
 (rule
+ (package geneweb-rpc)
  (target rpc_client.bc.js.br)
  (deps
   (:input ./rpc_client.bc.js))


### PR DESCRIPTION
The following PR fixes two issues with `dune.inc` files:
- We need to sort the output of `generate_dune_inc` as the iteration order of directories depends on operating system used.
- The `dune build` didn't refresh `dune.inc` if we add or remove files in `css` and `js` directory. 
- I also use `(concurrent ...)` stanza to reduce the size of `dune.inc`.