### PR TITLE
Harden Base64.decode against malformed input

### DIFF
--- a/bin/gwd/base64.ml
+++ b/bin/gwd/base64.ml
@@ -1,42 +1,33 @@
-(* $Id: base64.ml,v 5.2 2007-01-19 01:53:16 ddr Exp $ *)
+(* $Id: base64.ml v7.1 23/06/2026 04:02:33 ddr Exp *)
 (* Copyright (c) 1998-2007 INRIA *)
 
-(* For basic credentials only *)
-(* Encoding is [A-Z][a-z][0-9]+/= *)
-(* 3 chars = 24 bits = 4 * 6-bit groups -> 4 chars *)
-
-(* Init the index *)
 let index64 =
-  let index64 = Array.make 128 0 in
-  for i = 0 to 25 do
-    index64.(i + Char.code 'A') <- i
-  done;
-  for i = 0 to 25 do
-    index64.(i + Char.code 'a') <- i + 26
-  done;
-  for i = 0 to 9 do
-    index64.(i + Char.code '0') <- i + 52
-  done;
-  index64.(Char.code '+') <- 62;
-  index64.(Char.code '/') <- 63;
-  index64
+  let t = Array.make 256 0 in
+  String.iteri
+    (fun i c -> t.(Char.code c) <- i)
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  t
 
 let decode s =
-  let rpos = ref 0 and wpos = ref 0 and len = String.length s in
-  let res = Bytes.create (len / 4 * 3) in
-  while !rpos < len do
-    let v1 = index64.(Char.code s.[!rpos]) in
-    let v2 = index64.(Char.code s.[!rpos + 1]) in
-    let v3 = index64.(Char.code s.[!rpos + 2]) in
-    let v4 = index64.(Char.code s.[!rpos + 3]) in
-    let i = (v1 lsl 18) lor (v2 lsl 12) lor (v3 lsl 6) lor v4 in
-    Bytes.set res !wpos (Char.chr (i lsr 16));
-    Bytes.set res (!wpos + 1) (Char.chr ((i lsr 8) land 0xFF));
-    Bytes.set res (!wpos + 2) (Char.chr (i land 0xFF));
-    rpos := !rpos + 4;
-    wpos := !wpos + 3
-  done;
-  let cut =
-    if s.[len - 1] = '=' then if s.[len - 2] = '=' then 2 else 1 else 0
-  in
-  Bytes.sub_string res 0 (Bytes.length res - cut)
+  let len = String.length s in
+  if len = 0 || len mod 4 <> 0 then ""
+  else begin
+    let res = Bytes.create (len / 4 * 3) in
+    for k = 0 to (len / 4) - 1 do
+      let p = k * 4 in
+      let i =
+        (index64.(Char.code s.[p]) lsl 18)
+        lor (index64.(Char.code s.[p + 1]) lsl 12)
+        lor (index64.(Char.code s.[p + 2]) lsl 6)
+        lor index64.(Char.code s.[p + 3])
+      in
+      let q = k * 3 in
+      Bytes.set res q (Char.chr (i lsr 16));
+      Bytes.set res (q + 1) (Char.chr ((i lsr 8) land 0xFF));
+      Bytes.set res (q + 2) (Char.chr (i land 0xFF))
+    done;
+    let cut =
+      if s.[len - 1] = '=' then if s.[len - 2] = '=' then 2 else 1 else 0
+    in
+    Bytes.sub_string res 0 (Bytes.length res - cut)
+  end

--- a/bin/gwd/base64.mli
+++ b/bin/gwd/base64.mli
@@ -1,3 +1,4 @@
 val decode : string -> string
-(** Decode {i Base64} binary-to-text encoding used at the moment of basic
-    autorization *)
+(** Decode a {i Base64} string as used in HTTP basic authorization. Input is
+    expected padded (length multiple of 4); returns the empty string on empty or
+    malformed-length input. *)

--- a/bin/gwd/dune
+++ b/bin/gwd/dune
@@ -20,7 +20,7 @@
   dune-site
   dune-site.plugins
   cmdliner)
- (modules request sites cmd cmd_legacy robot))
+ (modules base64 request sites cmd cmd_legacy robot))
 
 (executable
  (package geneweb)
@@ -40,4 +40,4 @@
   str
   unix
   uri)
- (modules base64 gwd))
+ (modules gwd))

--- a/test/base64_test.ml
+++ b/test/base64_test.ml
@@ -1,0 +1,65 @@
+module A = Alcotest
+module Q = QCheck
+
+let dec = Gwd_lib.Base64.decode
+
+let alphabet =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+let encode s =
+  let len = String.length s in
+  let buf = Buffer.create ((len + 2) / 3 * 4) in
+  let byte i = if i < len then Char.code s.[i] else 0 in
+  let rec loop i =
+    if i < len then begin
+      let n = (byte i lsl 16) lor (byte (i + 1) lsl 8) lor byte (i + 2) in
+      let rem = len - i in
+      Buffer.add_char buf alphabet.[(n lsr 18) land 0x3F];
+      Buffer.add_char buf alphabet.[(n lsr 12) land 0x3F];
+      Buffer.add_char buf
+        (if rem >= 2 then alphabet.[(n lsr 6) land 0x3F] else '=');
+      Buffer.add_char buf (if rem >= 3 then alphabet.[n land 0x3F] else '=');
+      loop (i + 3)
+    end
+  in
+  loop 0;
+  Buffer.contents buf
+
+let test_vectors () =
+  let check expected input = A.(check string) input expected (dec input) in
+  check "" "";
+  check "f" "Zg==";
+  check "fo" "Zm8=";
+  check "foo" "Zm9v";
+  check "foob" "Zm9vYg==";
+  check "fooba" "Zm9vYmE=";
+  check "foobar" "Zm9vYmFy";
+  check "Aladdin:open sesame" "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+
+let test_malformed () =
+  let empty input = A.(check string) input "" (dec input) in
+  empty "Z";
+  empty "Zg";
+  empty "Zm9"
+
+let byte = Q.Gen.(map Char.chr (int_bound 255))
+
+let roundtrip =
+  let gen = Q.Gen.string_size ~gen:byte (Q.Gen.int_bound 64) in
+  let t =
+    Q.Test.make ~count:1000 ~name:"decode (encode s) = s"
+      (Q.make ~print:String.escaped gen)
+    @@ fun s -> String.equal (dec (encode s)) s
+  in
+  QCheck_alcotest.to_alcotest t
+
+let () =
+  A.run __FILE__
+    [
+      ( "Base64.decode",
+        [
+          A.test_case "RFC 4648 vectors" `Quick test_vectors;
+          A.test_case "malformed length" `Quick test_malformed;
+          roundtrip;
+        ] );
+    ]

--- a/test/dune
+++ b/test/dune
@@ -25,3 +25,9 @@
  (package geneweb)
  (name heap_test)
  (libraries qcheck qcheck-alcotest geneweb_search))
+
+(test
+ (package geneweb)
+ (name base64_test)
+ (modules base64_test)
+ (libraries alcotest qcheck qcheck-alcotest gwd_lib))


### PR DESCRIPTION
Return empty string on empty or non-multiple-of-4 input instead of raising Invalid_argument, and size the lookup table to 256 entries to avoid out-of-bounds on bytes >= 128. Input comes from the client-controlled Authorization header and was not wrapped in an exception handler at either call site in gwd.ml.

Replace local refs with an indexed loop and build the index table in a single pass.