### PR TITLE
notes/wiki: Render edited section and fix last-section navigation

### DIFF
--- a/lib/notesDisplay.ml
+++ b/lib/notesDisplay.ml
@@ -171,12 +171,9 @@ let print_notes_part conf base fnotes (title : Adef.safe_string) s cnt0 =
       if (title :> string) = "" then
         Output.print_string conf (Util.escape_html fnotes)
       else Output.print_string conf title);
-  if cnt0 = 0 && (title :> string) <> "" then (
-    Output.print_sstring conf "<br><br><h1>";
-    Output.print_string conf title;
-    Output.print_sstring conf "</h1>");
   let s = string_with_macros conf [] s in
   let lines = Wiki.extract_sub_part s cnt0 in
+  let has_next = Wiki.extract_sub_part s (cnt0 + 1) <> [] in
   let mode = "NOTES" in
   let wi =
     {
@@ -187,7 +184,7 @@ let print_notes_part conf base fnotes (title : Adef.safe_string) s cnt0 =
       Wiki.wi_always_show_link = conf.wizard || conf.friend;
     }
   in
-  Wiki.print_sub_part conf wi conf.wizard mode fnotes cnt0 lines;
+  Wiki.print_sub_part conf wi ~has_next conf.wizard mode fnotes cnt0 lines;
   Hutil.trailer conf
 
 let fmt_fnote_title conf base fnotes =

--- a/lib/wiki.ml
+++ b/lib/wiki.ml
@@ -796,7 +796,7 @@ let rev_extract_sub_part (s : string) (v : int) : string list =
 
 let extract_sub_part s v = List.rev (rev_extract_sub_part s v)
 
-let print_sub_part_links conf edit_mode sfn cnt0 is_empty =
+let print_sub_part_links conf edit_mode sfn cnt0 has_next =
   Output.print_sstring conf "<div class=\"btn-group mb-3\">";
   if cnt0 >= first_cnt then (
     Output.print_sstring conf {|<a href="|};
@@ -834,7 +834,7 @@ let print_sub_part_links conf edit_mode sfn cnt0 is_empty =
     (transl_nth conf "visualize/show/hide/summary" 1 |> Utf8.capitalize_fst);
   Output.print_sstring conf "</a>";
 
-  if not is_empty then (
+  if has_next then (
     Output.print_sstring conf {|<a href="|};
     Output.print_string conf (commd conf);
     Output.print_sstring conf "m=";
@@ -867,12 +867,12 @@ let print_sub_part_text conf wi edit_opt cnt0 lines =
   in
   Output.print_string conf (Util.safe_html s)
 
-let print_sub_part conf wi can_edit edit_mode sub_fname cnt0 lines =
+let print_sub_part conf wi ~has_next can_edit edit_mode sub_fname cnt0 lines =
   let edit_opt = Some (can_edit, edit_mode, sub_fname) in
   let sfn =
     if sub_fname = "" then Adef.encoded "" else "&f=" ^<^ Mutil.encode sub_fname
   in
-  print_sub_part_links conf (Mutil.encode edit_mode) sfn cnt0 (lines = []);
+  print_sub_part_links conf (Mutil.encode edit_mode) sfn cnt0 has_next;
   print_sub_part_text conf wi edit_opt cnt0 lines
 
 let print_mod_view_header conf can_edit (mode : Adef.encoded_string)
@@ -969,7 +969,7 @@ let print_mod_view_page conf can_edit mode fname title env s =
   let sub_part =
     if not has_v then s else String.concat "\n" (extract_sub_part s v)
   in
-  let is_empty = sub_part = "" in
+  let has_next = has_v && extract_sub_part s (v + 1) <> [] in
   let is_new_note = Util.p_getenv conf.env "new" <> None in
   let sfn =
     if fname = "" then Adef.encoded "" else "&f=" ^<^ Mutil.encode fname
@@ -980,7 +980,7 @@ let print_mod_view_page conf can_edit mode fname title env s =
     (can_edit && not is_new_note)
     mode sfn has_v v title;
   if can_edit && has_v then
-    print_sub_part_links conf (mode_pref ^^^ mode) sfn v is_empty;
+    print_sub_part_links conf (mode_pref ^^^ mode) sfn v has_next;
   print_mod_view_form_start conf can_edit mode fname has_v v s is_new_note;
   if is_new_note then print_new_note_input conf;
   print_mod_view_editor conf can_edit sub_part is_new_note;
@@ -1079,19 +1079,23 @@ let print_ok conf wi edit_mode fname title_is_1st s =
           (Utf8.capitalize_fst (Util.transl conf "note modified"))
   in
   Hutil.header conf title;
-  let get_v = Util.p_getint conf.env "v" in
-  let v = match get_v with Some v -> v | None -> 0 in
-  let title, s =
-    if v = 0 && title_is_1st then
-      let env, s = split_title_and_text s in
-      ((try List.assoc "TITLE" env with Not_found -> ""), s)
-    else ("", s)
+  let v, lines, has_next =
+    match Util.p_getint conf.env "v" with
+    | Some v -> (v, extract_sub_part s v, extract_sub_part s (v + 1) <> [])
+    | None ->
+        let title, s =
+          if title_is_1st then
+            let env, s = split_title_and_text s in
+            ((try List.assoc "TITLE" env with Not_found -> ""), s)
+          else ("", s)
+        in
+        let lines, _ = lines_list_of_string s in
+        let lines =
+          if title <> "" then ("<h1>" ^ title ^ "</h1>") :: lines else lines
+        in
+        (0, lines, false)
   in
-  let lines, _ = lines_list_of_string s in
-  let lines =
-    if v = 0 && title <> "" then ("<h1>" ^ title ^ "</h1>") :: lines else lines
-  in
-  print_sub_part conf wi conf.wizard edit_mode fname v lines;
+  print_sub_part conf wi ~has_next conf.wizard edit_mode fname v lines;
   Hutil.trailer conf
 
 let do_mod_ok conf edit_mode fname read_string commit =

--- a/lib/wiki.mli
+++ b/lib/wiki.mli
@@ -72,8 +72,18 @@ val split_title_and_text : string -> (string * string) list * string
     Otherwise, the title is the empty string. *)
 
 val print_sub_part :
-  config -> wiki_info -> bool -> string -> string -> int -> string list -> unit
-(** Prints an exctracted sub part *)
+  config ->
+  wiki_info ->
+  has_next:bool ->
+  bool ->
+  string ->
+  string ->
+  int ->
+  string list ->
+  unit
+(** [print_sub_part conf wi ~has_next can_edit edit_mode sub_fname cnt0 lines]
+    prints the extracted section [cnt0]. [has_next] enables the next-section
+    navigation button. *)
 
 val print_mod_view_page :
   config (* conf *) ->

--- a/lib/wiznotesDisplay.ml
+++ b/lib/wiznotesDisplay.ml
@@ -421,6 +421,9 @@ let print_part_wiznote conf base wz s cnt0 =
   in
   let file_path = Notes.file_path conf base in
   let can_edit = (conf.wizard && conf.user = wz) || conf.manitou in
+  let has_next =
+    Wiki.extract_sub_part (s : Adef.safe_string :> string) (cnt0 + 1) <> []
+  in
   let wi =
     {
       Wiki.wi_mode = "NOTES";
@@ -430,7 +433,7 @@ let print_part_wiznote conf base wz s cnt0 =
       Wiki.wi_always_show_link = conf.wizard || conf.friend;
     }
   in
-  Wiki.print_sub_part conf wi can_edit "WIZNOTES" wz cnt0 lines;
+  Wiki.print_sub_part conf wi ~has_next can_edit "WIZNOTES" wz cnt0 lines;
   Hutil.trailer conf
 
 let wizard_auth_file_name conf =


### PR DESCRIPTION
Several coupled fixes kept in one commit because print_ok and the MOD_NOTES edit form now rely on the new print_sub_part `~has_next` flag.

After MOD_NOTES_OK, render only the edited section. Distinguish an absent v (whole-note edit, rendered in full) from v=0 (intro section, rendered alone via `extract_sub_part`) instead of collapsing both to the whole note. Restores the per-section feedback after saving.

print_sub_part takes a required `~has_next` flag, computed by every caller (notes/wiznotes section views, MOD_NOTES edit form, post-save view) from the existence of section v+1; the “next section” button is shown only when a next section exists, no longer leading to an empty page at the last section. The previous test keyed on the current section being empty, which never matched the last section.

Also drop the duplicate title in section view (v=0): `print_notes_part` emitted the note title both through `header_with_title` and an explicit `<h1>` block for cnt0=0, showing it twice on m=NOTES&f=...&v=0.

Closes #2858