### PR TITLE
Remove setup.gwf file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,6 @@ endif
 	mkdir $(DISTRIB_DIR)/gw/setup
 	cp bin/setup/intro.txt $(DISTRIB_DIR)/gw/setup/
 	mkdir $(DISTRIB_DIR)/gw/setup/lang
-	cp bin/setup/setup.gwf $(DISTRIB_DIR)/gw/setup/
 	cp bin/setup/setup.css $(DISTRIB_DIR)/gw/setup/
 	cp bin/setup/lang/*.htm $(DISTRIB_DIR)/gw/setup/lang/
 	cp bin/setup/lang/lexicon.txt $(DISTRIB_DIR)/gw/setup/lang/

--- a/bin/setup/setup.gwf
+++ b/bin/setup/setup.gwf
@@ -1,3 +1,0 @@
-# variable cannot contain double-quotes (")
-#body_prop=style='font-family:-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;'
-# other bvars available to gwsetup

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -604,7 +604,7 @@ let rec copy_from_stream conf print strm =
                   print_specific_file conf print outfile strm
               | 'I' ->
                   (* %Ivar;value;{var = value part|false part} *)
-                  (* var is a evar from url or a bvar from basename.gwf or setup.gwf *)
+                  (* var is a evar from url or a bvar from basename.gwf *)
                   let k1 = get_variable strm in
                   let k2 = get_variable strm in
                   print_if_else conf print (s_getenv conf.env k1 = k2) strm


### PR DESCRIPTION
This file was introduced to permit customization of gwsetup interface. The feature is not fully implemented. Removing this file simplifies gwsetup installation.

@hgouraud I didn't find specific code to handle this file in the git history? Could you review this PR to ensure that 
I removed everything please?