### PR TITLE
Do not display a wrong url while starting gwd

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -2041,10 +2041,7 @@ let slashify = String.map (fun c -> match c with '\\' -> '/' | _ -> c)
 let pp_item pp ppf (name, v) =
   Fmt.pf ppf "%a: %a@\n" Fmt.(styled (`Fg `Blue) string) name pp v
 
-let display_infos ?interface ~port () =
-  let hostname =
-    match interface with None -> Unix.gethostname () | Some a -> a
-  in
+let display_infos () =
   let git_info =
     [
       ("source", Version.src);
@@ -2070,10 +2067,7 @@ let display_infos ?interface ~port () =
     Fmt.Dump.string ppf s
   in
   Log.app (fun k ->
-      let s =
-        Fmt.str "Geneweb %s\nListen to http://%s:%d/base" Version.ver hostname
-          port
-      in
+      let s = Fmt.str "Geneweb %s" Version.ver in
       k "%a" Fmt.(styled (`Fg `Green) string) s);
   Log.app (fun k -> k "Type CTRL+C to stop the service");
   Log.app (fun k ->
@@ -2094,7 +2088,7 @@ let geneweb_server ~predictable_mode ~loaded_plugins ?interface ~port ~daemon ()
     | _ -> retrieve_secret_salt ()
     | exception Not_found ->
         daemonize ~daemon @@ fun () ->
-        display_infos ?interface ~port ();
+        display_infos ();
         create_cnt_dir ();
         (* A secret salt is added to the environment to ensure that workers
            use the same salt for digests on both Unix and Windows platforms. *)
@@ -2108,7 +2102,7 @@ let geneweb_server ~predictable_mode ~loaded_plugins ?interface ~port ~daemon ()
      `geneweb` and `geneweb-http`. We must remove it after refactoring
      the encoded string subsystem. *)
   let connection x y z = connection x y (Adef.encoded z) in
-  Server.start ?addr:!selected_addr ~port:!selected_port ~timeout:!conn_timeout
+  Server.start ?addr:interface ~port ~timeout:!conn_timeout
     ~max_pending_requests:!max_pending_requests ~n_workers:!n_workers
     (connection ~predictable_mode ~loaded_plugins ~secret_salt)
 

--- a/http/server.ml
+++ b/http/server.ml
@@ -367,7 +367,7 @@ let start ?addr ~port ?(timeout = 0) ~max_pending_requests ~n_workers callback =
           | Some (addr, socket) ->
               Unix.listen socket max_pending_requests;
               Log.info (fun k ->
-                  k ~tags:timestamp "Ready on %a." pp_sockaddr addr);
+                  k ~tags:timestamp "Ready on http://%a." pp_sockaddr addr);
               if n_workers = 0 then
                 ignore @@ Sys.signal Sys.sigpipe Sys.Signal_ignore;
               accept_connections ~timeout ~n_workers callback socket))


### PR DESCRIPTION
The gwd binary cannot infer the right url before starting the HTTP server itself. In particular, if the user didn't specify an interface, the previous code returned the value of `Unix.gethostname`.

The `Unix.gethostname` function returns the hostname of the computer and we cannot access locally the server from its hostname.

To test this PR, run `dune exec gwd -- --debug`.