### PR TITLE
Remove ppx_import from opam files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,6 @@
     ounit
     ppx_blob
     ppx_deriving
-    ppx_import
     stdlib-shims
     (unidecode (>= "0.5.0"))
     uri

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -30,7 +30,6 @@ depends: [
   "ounit"
   "ppx_blob"
   "ppx_deriving"
-  "ppx_import"
   "stdlib-shims"
   "unidecode" {>= "0.5.0"}
   "uri"


### PR DESCRIPTION
This ppx_import is not used and cannot be installed with OCaml 5.5.