### PR TITLE
translation: add missing Spanish phrases for v7 UI lexicon entries

### DIFF
--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -2680,7 +2680,7 @@ da: og
 de: und
 en: and
 eo: kaj
-es: y/e 
+es: y
 et: ja
 fi: ja
 fr: et
@@ -3735,6 +3735,7 @@ fr: lien vers le dictionnaire
 co: dizziunariu/dizziunarii
 de: Wörterbuch/Wörterbücher
 en: dictionary/dictionaries
+es: diccionario/diccionarios
 fr: dictionnaire/dictionnaires
 lt: žodynas/žodynai
 oc: diccionari/diccionaris
@@ -13265,6 +13266,7 @@ tr: bilinmeyen atalar
 co: senza data
 de: fehlendes Datum
 en: no date
+es: sin fecha
 fr: sans date
 lt: be datos
 pt: sem data
@@ -15109,7 +15111,7 @@ da: stilling
 de: Beruf/Berufe
 en: occupation/occupations
 eo: okupado
-es: profesión/profesións
+es: profesión/profesiones
 et: amet
 fi: ammatti/ammatti
 fr: profession/professions
@@ -15134,6 +15136,7 @@ tr: meslek/meslekler
 co: di
 de: von
 en: of
+es: de
 fr: de
 pt: de
 sv: av
@@ -15143,6 +15146,7 @@ tr: /
 co: di
 de: von
 en: of
+es: de
 fr: du
 pt: de
 sv: av
@@ -15222,6 +15226,7 @@ fr: d[e |’]%s
 co: uffiziante/uffiziante/uffizianti
 de: Amtsträger/Amtsträgerin/Amtsträger
 en: officer/officer/officers
+es: oficiante/oficiante/oficiantes
 fr: officiant/officiante/officiants
 pt: oficial/oficial/oficiais
 sv: officer/officer/officerer
@@ -18112,12 +18117,14 @@ tr: içinde görüntüle
 co: Selezziunate ogni modulu via un cliccu nant’à u buttone assuciatu (massimu 15).
 de: Wähle die Module durch Klick auf das zugehörige Feld aus (max. 15).
 en: Select each module by clicking on the corresponding button (max 15).
+es: Seleccione cada módulo pulsando en el botón correspondiente (máx. 15).
 fr: Sélectionnez les modules en cliquant sur le bouton correspondant (max 15).
 
     select p_mod
 co: selezziunà i muduli persunalizati
 de: personalisierte Module auswählen
 en: select personalized modules
+es: seleccionar los módulos personalizados
 fr: selectionner les modules personnalisés
 pt: seleccionar os módulos personalizados (por defeito zz)
 sv: välj anpassad modul
@@ -21899,6 +21906,7 @@ tr: tanık/tanık/tanıklar
 co: testimone/testimoni
 de: Zeuge/Zeugen
 en: witness/witnesses
+es: testigo/testigos
 fr: témoin/témoins
 lt: liudytojas/liudytoja/liudytojai/liudytojosės
 pt: testemunha/testemunhas

--- a/hd/lang/lexicon.txt
+++ b/hd/lang/lexicon.txt
@@ -7584,6 +7584,7 @@ tr: terhis
 co: arburiscenza discendente
 de: Ansicht Nachfahren-Baum
 en: descendant tree view
+es: árbol compacto de descendientes
 fr: arborescence descendante
 pt: árvore compacta de descendentes
 sv: trädvy med ättlingar
@@ -7642,6 +7643,7 @@ tr: adına göre liste
 co: arburu di discendenza
 de: Nachkommen-Baum
 en: descendants tree
+es: árbol de descendientes
 fr: arbre de descendance
 pt: árvore de descendentes
 sv: träd av ättlingar
@@ -9614,6 +9616,7 @@ tr: tam ağaç
 co: affissera larghezza sana/affissera nant’à duie culonne
 de: Anzeige volle Breite/Anzeige in zwei Spalten
 en: full width display/columns display
+es: mostrar a ancho completo/mostrar en dos columnas
 fr: affichage pleine largeur/affichage sur deux colonnes
 pt: exibir na largura total/exibir em duas colunas
 sv: full bredd/kolumner
@@ -10428,6 +10431,7 @@ tr: güncelleme geçmişi
 co: accolta
 de: Home
 en: home
+es: inicio
 fr: accueil
 pt: início
 sv: hem
@@ -11166,6 +11170,7 @@ sv: informatör/informatör
 co: cronolugia simplice/cronolugia detagliata
 de: einfache Chronologie/detaillierte Chronologie
 en: simple chronology/detailed chronology
+es: cronología simple/cronología detallada
 fr: chronologie simple/chronologie détaillée
 pt: cronologia simples/cronologia detalhada
 sv: förenklad kronologi/detaljerad kronologi
@@ -13567,6 +13572,7 @@ fr: modifier la taille des images à
 co: modulu/moduli
 de: Modul
 en: module/modules
+es: módulo/módulos
 fr: module/modules
 no: modul/moduler
 pt: módulo/módulos
@@ -16731,6 +16737,7 @@ tr: ilişkileri
 co: arburu di e rilazioni
 de: Baum der Beziehungen
 en: tree of relations
+es: árbol de relaciones
 fr: arbre des relations
 pt: árvore de familiares
 sv: relationsträd
@@ -17155,6 +17162,7 @@ fr: cliquer sur cette en-tête pour supprimer la ou les colonne(s) « %s »
 co: caccià l’ultimu modulu aghjuntu
 de: zuletzt hinzugefügtes Modul entfernen
 en: remove the last added module
+es: quitar el último módulo añadido
 fr: retirer le dernier module ajouté
 pt: remover o último módulo adicionado
 sv: tag bort senast tillagda modul

--- a/hd/lang/version.txt
+++ b/hd/lang/version.txt
@@ -259,6 +259,7 @@ sv: Du kan välja ett annat språk bland de följande:
   <p><strong><font color=red>[
 co: I diritti di i streghi sò attimpati avà per mantenimentu.
 en: Wizard rights are now suspended for maintenance.
+es: Los derechos de los magos están actualmente suspendidos por mantenimiento.
 fr: Les droits des magiciens sont actuellement suspendus pour maintenance.
 oc: Los drreches dels fachilhièrs son suspenduts per ara per mantenença.
 ]</font></strong>


### PR DESCRIPTION
## What problem it solves

Fixes #2905 — eight lexicon entries introduced with the v7 UI have no Spanish (`es`) translation, so `gwd` renders the raw bracketed key when browsing with `lang=es`: the menubar shows `[home]`, person-page modules show `[descendants tree]`, `[module]`, `[full width/columns]`, etc.

## Changes

Adds one `es:` line to each of these entries in `hd/lang/lexicon.txt`, inserted in alphabetical language position:

| key | es |
|---|---|
| `descendant tree view` | árbol compacto de descendientes |
| `descendants tree` | árbol de descendientes |
| `full width/columns` | mostrar a ancho completo/mostrar en dos columnas |
| `home` | inicio |
| `inline chronology` | cronología simple/cronología detallada |
| `module` | módulo/módulos |
| `relations tree` | árbol de relaciones |
| `remove last module` | quitar el último módulo añadido |

Wording and plural/variant structure follow the existing `fr` and `pt` lines of each entry (e.g. `inline chronology` keeps the simple/detailed variant pair). No side effects: pure lexicon data addition, no code changes.

## How to test

Browse any base with `lang=es` and open a person page with the modules menubar: the previously raw `[key]` labels now render in Spanish. Verified against a live GeneWeb 7 deployment (the same keys confirmed missing in current `master`).

Same nature as the recently merged #2865 (German phrases).