### PR TITLE
several fixes in setup.ml (\\, log files location)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,20 @@ gwd: ## Build ondy gwd/gwc executables
 	dune build @bin/gwd/all @bin/gwc/all
 	@printf "Done."
 
+install: ## Install geneweb into the current opam switch (needed for gwtolatex, which depends on the pinned geneweb library)
+	@printf "\n\033[1;1mInstalling geneweb into opam switch\033[0m\n"
+	dune build @install
+	dune install
+	@printf "Done.\n"
+
+uninstall: ## Remove geneweb from the current opam switch
+	@printf "\n\033[1;1mUninstalling geneweb from opam switch\033[0m\n"
+	dune uninstall
+	@printf "Done.\n"
+
 distrib: ## Build the project and copy what is necessary for distribution
+	@printf "\n\033[1;1mCleaning previous build artifacts\033[0m\n"
+	@rm -rf _build
 	dune build --release @bin/all @lib/all
 	@printf "Done.\n"
 	@rm -rf $(DISTRIB_DIR)

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -113,8 +113,8 @@ let compile_gw_files ~bname bar inputs =
       (fname, separate, bnotes, shift, was_gw))
     inputs
 
-let base_dir = ref None
-let set_base_dir s = base_dir := Some s
+let bases_dir = ref None
+let set_base_dir s = bases_dir := Some s
 let just_comp = ref false
 let kill_gwo = ref false
 let no_warn = ref false
@@ -244,7 +244,7 @@ let anonfun fname =
   in
   (* If -bd was not provided, derive it from the directory of the first
      input file given with an absolute path. *)
-  if !base_dir = None then set_base_dir (Filename.dirname fname);
+  if !bases_dir = None then set_base_dir (Filename.dirname fname);
   separate := default_separate;
   bnotes := default_bnotes;
   add_input { fname; kind; separate = sep; bnotes = bn; shift = !shift }
@@ -268,8 +268,8 @@ let parse_cmd () =
   Arg.parse speclist anonfun errmsg;
   let inputs = List.rev !rev_inputs in
   let bname = parse_output inputs !output in
-  let base_dir = Option.value ~default:Filename.current_dir_name !base_dir in
-  (inputs, bname, base_dir)
+  let bases_dir = Option.value ~default:Filename.current_dir_name !bases_dir in
+  (inputs, bname, bases_dir)
 
 let with_timer f =
   let start = Unix.gettimeofday () in
@@ -282,8 +282,8 @@ let pp_duration ppf d =
 
 let ( // ) = Filename.concat
 
-let check_database_exists base_dir bname =
-  let path = base_dir // Fmt.str "%s.gwb" bname in
+let check_database_exists bases_dir bname =
+  let path = bases_dir // Fmt.str "%s.gwb" bname in
   Sys.file_exists path
 
 let cleanup gwo_files =
@@ -292,8 +292,10 @@ let cleanup gwo_files =
     gwo_files
 
 let () =
-  let inputs, bname, base_dir = parse_cmd () in
-  Secure.set_base_dir base_dir;
+  let inputs, bname, bases_dir = parse_cmd () in
+  Secure.set_base_dir bases_dir;
+  if not (Sys.file_exists (Filename.concat bases_dir "tmp")) then
+    Unix.mkdir (Filename.concat bases_dir "tmp") 0o755;
   GWPARAM.init ();
   let dist_etc_d = Filename.concat (Filename.dirname Sys.argv.(0)) "etc" in
   if !Db1link.particules_file = "" then
@@ -309,7 +311,7 @@ let () =
   in
   Format.eprintf "Compilation: %a@." pp_duration duration;
   if not !just_comp then (
-    if (not !GWPARAM.force) && check_database_exists base_dir bname then (
+    if (not !GWPARAM.force) && check_database_exists bases_dir bname then (
       if !kill_gwo then cleanup gwo_files;
       Fmt.epr "Database %S already exists. Use -f to overwrite.@." bname;
       exit 2);

--- a/bin/gwc/gwc.ml
+++ b/bin/gwc/gwc.ml
@@ -297,6 +297,8 @@ let cleanup gwo_files =
 let () =
   let inputs, bname, bases_dir = parse_cmd () in
   Secure.set_base_dir bases_dir;
+  if not (Sys.file_exists (Filename.concat bases_dir "tmp")) then
+    Unix.mkdir (Filename.concat bases_dir "tmp") 0o755;
   GWPARAM.init ();
   let dist_etc_d = Filename.concat (Filename.dirname Sys.argv.(0)) "etc" in
   if !Db1link.particules_file = "" then

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -50,11 +50,6 @@ let parse_cmd () =
   in
   let opts = ref Gwexport.default_opts in
   Arg.parse (speclist opts) anonfun Gwexport.errmsg;
-<<<<<<< HEAD
-=======
-  let bases_dir = !Gwexport.bases_dir in
-  Secure.set_base_dir bases_dir;
->>>>>>> 810e9e252 (several fixes in gwu and setup)
   match !bname with
   | None ->
       Arg.usage (speclist opts) Gwexport.errmsg;

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -50,6 +50,11 @@ let parse_cmd () =
   in
   let opts = ref Gwexport.default_opts in
   Arg.parse (speclist opts) anonfun Gwexport.errmsg;
+<<<<<<< HEAD
+=======
+  let bases_dir = !Gwexport.bases_dir in
+  Secure.set_base_dir bases_dir;
+>>>>>>> 810e9e252 (several fixes in gwu and setup)
   match !bname with
   | None ->
       Arg.usage (speclist opts) Gwexport.errmsg;

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -270,7 +270,9 @@ let parse_upto lim =
     | Some '\\' -> (
         Stream.junk strm__;
         (match Stream.peek strm__ with
-        | Some c -> Printf.eprintf "backslash followed by %C\n%!" c
+        | Some c ->
+            Printf.eprintf "backslash followed by %C | lim=%C | so far=%S\n%!" c
+              lim (Buff.get len)
         | None -> Printf.eprintf "backslash at eof\n%!");
         match Stream.peek strm__ with
         | Some '\r' ->
@@ -578,6 +580,7 @@ let rec copy_from_stream conf print strm =
               (* depending on when %f is called, conf may be sketchy *)
               (* conf will know bvars from basename.gwf and evars from url *)
               copy_from_stream conf print (Stream.of_string s)
+          | 'c' -> print (comm_log ^ "\n")
           | 'g' -> print_specific_file conf print comm_log strm
           | 'h' ->
               print "<input type=hidden name=lang value=";
@@ -629,8 +632,13 @@ let rec copy_from_stream conf print strm =
               (* | 'F' see 'V' *)
               (* the current directory may have changes with -bd *)
               | 'G' ->
+                  print
+                    (String.concat Filename.dir_sep
+                       [ !bases_dir; "tmp"; "gwsetup.log" ]
+                    ^ "\n");
                   print_specific_file_tail conf print
-                    (Filename.concat !launch_dir "gwsetup.log")
+                    (String.concat Filename.dir_sep
+                       [ !bases_dir; "tmp"; "gwsetup.log" ])
                     strm
               | 'H' ->
                   (* print the content of -o filename, prepend bname *)
@@ -1754,6 +1762,8 @@ let intro () =
   in
   Arg.parse speclist anonfun usage;
   if !bin_dir = "" then bin_dir := !setup_dir;
+  if not (Sys.file_exists (Filename.concat !bases_dir "tmp")) then
+    Unix.mkdir (Filename.concat !bases_dir "tmp") 0o755;
   launch_dir := Sys.getcwd ();
   (* All tool invocations inject -bd via exec_f so they find bases in
      bases_dir regardless of cwd. *)

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -813,16 +813,19 @@ and wrap_print width print =
     String.iter
       (fun c ->
         match c with
-        | '\n' | '\r' -> print "\n"; col := 0
+        | '\n' | '\r' ->
+            print "\n";
+            col := 0
         | c ->
-            if !col >= width then (print "\n"; col := 0);
+            if !col >= width then (
+              print "\n";
+              col := 0);
             print (String.make 1 c);
             incr col)
       s
+
 and print_specific_file ?wrap conf print fname strm =
-  let print =
-    match wrap with Some w -> wrap_print w print | None -> print
-  in
+  let print = match wrap with Some w -> wrap_print w print | None -> print in
   match Stream.next strm with
   | '{' -> (
       let s = parse_upto '}' strm in

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -139,16 +139,12 @@ let header_no_page_title conn conf title =
   Output.print_sstring printer_conf "</title></head><body>"
 
 let abs_setup_dir () =
-  if Filename.is_relative !setup_dir then
-    Filename.concat (Sys.getcwd ()) !setup_dir
+  if Filename.is_relative !setup_dir then Sys.getcwd () // !setup_dir
   else !setup_dir
 
 (** Resolve a base name against [!bases_dir]. Absolute paths pass through. *)
 let base_path name =
-  if Filename.is_relative name then
-    let bases_dir = get_bases_dir () in
-    bases_dir // name
-  else name
+  if Filename.is_relative name then !bases_dir // name else name
 
 let trailer conn _conf =
   let printer_conf = printer_conf conn in
@@ -669,10 +665,7 @@ let rec copy_from_stream conf print strm =
                    conf.env)
                 strm
           | 'l' -> print conf.lang
-          | 'r' ->
-              print_specific_file conf print
-                (Filename.concat !setup_dir "gwd.arg")
-                strm
+          | 'r' -> print_specific_file conf print (!setup_dir // "gwd.arg") strm
           | 's' -> for_all conf print (selected conf.env) strm
           | 't' -> print_if conf print (not Sys.unix) strm
           | 'v' ->
@@ -681,7 +674,7 @@ let rec copy_from_stream conf print strm =
                 let s = strip_spaces (s_getenv conf.env "bd") in
                 if s = "" then get_bases_dir () else s
               in
-              let base = Filename.concat bd out in
+              let base = bd // out in
               print_if conf print (Sys.file_exists (base ^ ".gwb")) strm
           | 'z' -> print (string_of_int !port)
           | ('A' .. 'Z' | '0' .. '9') as c -> (
@@ -699,12 +692,9 @@ let rec copy_from_stream conf print strm =
               (* the current directory may have changes with -bd *)
               | 'G' ->
                   print
-                    (String.concat Filename.dir_sep
-                       [ !bases_dir; "tmp"; "gwsetup.log" ]
-                    ^ "\n");
+                    ("File: " ^ (!bases_dir // "tmp" // "gwsetup.log") ^ "\n");
                   print_specific_file_tail conf print
-                    (String.concat Filename.dir_sep
-                       [ !bases_dir; "tmp"; "gwsetup.log" ])
+                    (!bases_dir // "tmp" // "gwsetup.log")
                     strm
               | 'H' ->
                   (* print the content of -o filename, prepend bname *)
@@ -759,8 +749,7 @@ let rec copy_from_stream conf print strm =
                   let outfile2 = strip_spaces (s_getenv conf.env "o1") in
                   let outfile =
                     if outfile2 <> "" then outfile2
-                    else if bname <> "" then
-                      Filename.concat (bname ^ ".gwb") outfile1
+                    else if bname <> "" then (bname ^ ".gwb") // outfile1
                     else outfile1
                   in
                   print outfile
@@ -894,9 +883,9 @@ and print_selector conf print =
             else if sel.[String.length sel - 1] <> '\\' then
               Filename.dirname sel ^ "\\"
             else Filename.dirname sel
-          else Filename.concat sel x
+          else sel // x
         in
-        let x = if is_directory d then Filename.concat x "" else x in
+        let x = if is_directory d then x // "" else x in
         (d, x))
       list
   in
@@ -1258,12 +1247,11 @@ let cleanup_1 conn conf =
     Printf.eprintf "$ del %s\\%s\\*.*\n" old_dir in_base_dir;
     Printf.eprintf "$ rmdir %s\\%s\n" old_dir in_base_dir);
   flush stderr;
-  (try Mutil.rm_rf (Filename.concat old_dir in_base_dir)
-   with Sys_error _ -> ());
+  (try Mutil.rm_rf (old_dir // in_base_dir) with Sys_error _ -> ());
   if Sys.unix then Printf.eprintf "$ mv %s %s/.\n" in_base_dir_path old_dir
   else Printf.eprintf "$ move %s %s\\.\n" in_base_dir_path old_dir;
   flush stderr;
-  Sys.rename in_base_dir_path (Filename.concat old_dir in_base_dir);
+  Sys.rename in_base_dir_path (old_dir // in_base_dir);
   let rc1 =
     exec_f conf ~path:(!bin_dir // "gwc") [ tmp_gw; "-nofail"; "-o"; in_base ]
   in
@@ -1336,13 +1324,13 @@ let rename conn conf =
             String.sub filename (String.length k1)
               (String.length filename - String.length k1)
           in
-          let old_path = Filename.concat dir filename in
-          let new_path = Filename.concat dir (v1 ^ suffix) in
+          let old_path = dir // filename in
+          let new_path = dir // (v1 ^ suffix) in
           Unix.rename old_path new_path;
           if Filename.remove_extension filename = k then
             let ext = Filename.extension filename in
-            let old_path = Filename.concat dir filename in
-            let new_path = Filename.concat dir (v ^ ext) in
+            let old_path = dir // filename in
+            let new_path = dir // (v ^ ext) in
             Unix.rename old_path new_path))
       files
   in
@@ -1459,8 +1447,7 @@ let gwf conn conf =
   else
     let benv = loc_read_base_env in_base in
     let trailer =
-      if !GWPARAM.reorg then
-        Filename.concat (!GWPARAM.lang_d in_base "") (in_base ^ ".trl")
+      if !GWPARAM.reorg then !GWPARAM.lang_d in_base "" // (in_base ^ ".trl")
       else
         get_bases_dir () // "lang" // (in_base ^ ".trl")
         |> file_contents |> Util.escape_html
@@ -1480,8 +1467,7 @@ let gwf_1 conn conf =
   let vars, _ = variables "gwf_1.htm" in
   let oc =
     open_out
-      (if !GWPARAM.reorg then
-         Filename.concat (!GWPARAM.bpath in_base) in_base ^ ".gwf"
+      (if !GWPARAM.reorg then !GWPARAM.bpath in_base // (in_base ^ ".gwf")
        else in_base ^ ".gwf")
   in
   let body_prop =
@@ -1506,7 +1492,7 @@ let gwf_1 conn conf =
   let trl = strip_spaces (strip_control_m (s_getenv conf.env "trailer")) in
 
   let trl_dir = !GWPARAM.etc_d in_base in
-  let trl_file = Filename.concat trl_dir "trl.txt" in
+  let trl_file = trl_dir // "trl.txt" in
   if trl_dir = "" then failwith "trl_dir est vide (etc_d absent ?)";
   (try Unix.mkdir trl_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   (try
@@ -1839,8 +1825,6 @@ let intro () =
   parse_cmd ();
   setup_log ~debug:!debug;
   if !bin_dir = "" then bin_dir := !setup_dir;
-  if not (Sys.file_exists (Filename.concat !bases_dir "tmp")) then
-    Unix.mkdir (Filename.concat !bases_dir "tmp") 0o755;
   launch_dir := Sys.getcwd ();
   (* All tool invocations inject -bd via exec_f so they find bases in
      bases_dir regardless of cwd. *)

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -144,7 +144,7 @@ let abs_setup_dir () =
 
 (** Resolve a base name against [!bases_dir]. Absolute paths pass through. *)
 let base_path name =
-  if Filename.is_relative name then !bases_dir // name else name
+  if Filename.is_relative name then (get_bases_dir ()) // name else name
 
 let trailer conn _conf =
   let printer_conf = printer_conf conn in
@@ -691,7 +691,7 @@ let rec copy_from_stream conf print strm =
               (* | 'F' see 'V' *)
               (* the current directory may have changes with -bd *)
               | 'G' ->
-                  let fname = !bases_dir // "tmp" // "gwsetup.log" in
+                  let fname = (get_bases_dir ()) // "tmp" // "gwsetup.log" in
                   print ("File: " ^ fname ^ "\n");
                   print_specific_file_tail conf print fname strm
               | 'H' ->

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -691,11 +691,9 @@ let rec copy_from_stream conf print strm =
               (* | 'F' see 'V' *)
               (* the current directory may have changes with -bd *)
               | 'G' ->
-                  print
-                    ("File: " ^ (!bases_dir // "tmp" // "gwsetup.log") ^ "\n");
-                  print_specific_file_tail conf print
-                    (!bases_dir // "tmp" // "gwsetup.log")
-                    strm
+                  let fname = !bases_dir // "tmp" // "gwsetup.log" in
+                  print ("File: " ^ fname ^ "\n");
+                  print_specific_file_tail conf print fname strm
               | 'H' ->
                   (* print the content of -o filename, prepend bname *)
                   let outfile = strip_spaces (s_getenv conf.env "o") in
@@ -722,6 +720,14 @@ let rec copy_from_stream conf print strm =
                     | None -> conf.env
                   in
                   print_if_else conf print (s_getenv env k1 = k2) strm
+              | 'R' -> (
+                  (* %R{reorg part|not reorg part} *)
+                  match p_getenv conf.env "anon" with
+                  | Some in_base ->
+                      print_if_else conf print
+                        (GWPARAM.is_reorg_base in_base)
+                        strm
+                  | None -> print_if_else conf print false strm)
               | 'J' ->
                   (* %Jvar;value;{var = value part|false part} *)
                   (* var and value may contain %m macros *)
@@ -771,6 +777,11 @@ let rec copy_from_stream conf print strm =
                   | Some v -> print v
                   | None -> ())
               | 'W' -> print (gwsetup_config ())
+              | 'Z' -> (
+                  let c = Stream.next strm in
+                  match c with
+                  | 't' -> print "Za test macro"
+                  | _ -> print (Printf.sprintf "BAD Zx macro (%%Z%c)" c))
               | _ -> (
                   match p_getenv conf.env (String.make 1 c) with
                   | Some v -> (
@@ -790,7 +801,7 @@ let rec copy_from_stream conf print strm =
                           print "\"";
                           if v = s then print " checked"
                       | _ -> print (strip_spaces v))
-                  | None -> print ("BAD MACRO 2" ^ String.make 1 c)))
+                  | None -> print (Printf.sprintf "BAD MACRO 2 (%c)" c)))
           | c -> print (macro conf c))
       | c -> print (String.make 1 c)
     done
@@ -1447,11 +1458,8 @@ let gwf conn conf =
   else
     let benv = loc_read_base_env in_base in
     let trailer =
-      if !GWPARAM.reorg then !GWPARAM.lang_d in_base "" // (in_base ^ ".trl")
-      else
-        get_bases_dir () // "lang" // (in_base ^ ".trl")
-        |> file_contents |> Util.escape_html
-        |> fun s -> (s :> string)
+      !GWPARAM.etc_d in_base // "trl.txt" |> file_contents |> Util.escape_html
+      |> fun s -> (s :> string)
     in
     let conf = { conf with env = benv @ (("trailer", trailer) :: conf.env) } in
     print_file "gwf_1.htm" conn conf
@@ -1467,8 +1475,8 @@ let gwf_1 conn conf =
   let vars, _ = variables "gwf_1.htm" in
   let oc =
     open_out
-      (if !GWPARAM.reorg then !GWPARAM.bpath in_base // (in_base ^ ".gwf")
-       else in_base ^ ".gwf")
+      (if !GWPARAM.reorg then GWPARAM.config_reorg in_base
+       else GWPARAM.config_legacy in_base)
   in
   let body_prop =
     match p_getenv conf.env "proposed_body_prop" with
@@ -1491,10 +1499,8 @@ let gwf_1 conn conf =
   close_out oc;
   let trl = strip_spaces (strip_control_m (s_getenv conf.env "trailer")) in
 
-  let trl_dir = !GWPARAM.etc_d in_base in
-  let trl_file = trl_dir // "trl.txt" in
-  if trl_dir = "" then failwith "trl_dir est vide (etc_d absent ?)";
-  (try Unix.mkdir trl_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let trl_file = !GWPARAM.etc_d in_base // "trl.txt" in
+  if !GWPARAM.etc_d in_base = "" then failwith "etc_d absent ?";
   (try
      if trl = "" then Sys.remove trl_file
      else

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -332,7 +332,9 @@ let parse_upto lim =
     | Some '\\' -> (
         Stream.junk strm__;
         (match Stream.peek strm__ with
-        | Some c -> Printf.eprintf "backslash followed by %C\n%!" c
+        | Some c ->
+            Printf.eprintf "backslash followed by %C | lim=%C | so far=%S\n%!" c
+              lim (Buff.get len)
         | None -> Printf.eprintf "backslash at eof\n%!");
         match Stream.peek strm__ with
         | Some '\r' ->
@@ -644,7 +646,8 @@ let rec copy_from_stream conf print strm =
               (* depending on when %f is called, conf may be sketchy *)
               (* conf will know bvars from basename.gwf and evars from url *)
               copy_from_stream conf print (Stream.of_string s)
-          | 'g' -> print_specific_file conf print comm_log strm
+          | 'c' -> print (comm_log ^ "\n")
+          | 'g' -> print_specific_file ~wrap:128 conf print comm_log strm
           | 'h' ->
               print "<input type=hidden name=lang value=";
               print conf.lang;
@@ -695,8 +698,13 @@ let rec copy_from_stream conf print strm =
               (* | 'F' see 'V' *)
               (* the current directory may have changes with -bd *)
               | 'G' ->
+                  print
+                    (String.concat Filename.dir_sep
+                       [ !bases_dir; "tmp"; "gwsetup.log" ]
+                    ^ "\n");
                   print_specific_file_tail conf print
-                    (Filename.concat !launch_dir "gwsetup.log")
+                    (String.concat Filename.dir_sep
+                       [ !bases_dir; "tmp"; "gwsetup.log" ])
                     strm
               | 'H' ->
                   (* print the content of -o filename, prepend bname *)
@@ -799,7 +807,22 @@ let rec copy_from_stream conf print strm =
     done
   with Stream.Failure -> ()
 
-and print_specific_file conf print fname strm =
+and wrap_print width print =
+  let col = ref 0 in
+  fun s ->
+    String.iter
+      (fun c ->
+        match c with
+        | '\n' | '\r' -> print "\n"; col := 0
+        | c ->
+            if !col >= width then (print "\n"; col := 0);
+            print (String.make 1 c);
+            incr col)
+      s
+and print_specific_file ?wrap conf print fname strm =
+  let print =
+    match wrap with Some w -> wrap_print w print | None -> print
+  in
   match Stream.next strm with
   | '{' -> (
       let s = parse_upto '}' strm in
@@ -1813,6 +1836,8 @@ let intro () =
   parse_cmd ();
   setup_log ~debug:!debug;
   if !bin_dir = "" then bin_dir := !setup_dir;
+  if not (Sys.file_exists (Filename.concat !bases_dir "tmp")) then
+    Unix.mkdir (Filename.concat !bases_dir "tmp") 0o755;
   launch_dir := Sys.getcwd ();
   (* All tool invocations inject -bd via exec_f so they find bases in
      bases_dir regardless of cwd. *)

--- a/bin/setup/statics/lang/comm.htm
+++ b/bin/setup/statics/lang/comm.htm
@@ -24,6 +24,8 @@
 
 <dl><dt><dd>
 <pre>
+File: %c
+
 %g{- [empty file]
 -}
 </pre>

--- a/bin/setup/statics/lang/ged2gwb.htm
+++ b/bin/setup/statics/lang/ged2gwb.htm
@@ -127,12 +127,12 @@ fault.
 <p>
 <table class="setup">
 <tr align=left><td>    </td>
-<td>["first names enclosed": the -fne option must be followed by a two characters string "be". When creating a person, if the GEDCOM first name part holds a part between 'b' (any character) and 'e' (any character), it is considered to be the usual first name: e.g. -fne "\\" or -fne "()".]
+<td>["first names enclosed": the -fne option must be followed by a two characters string "be". When creating a person, if the GEDCOM first name part holds a part between 'b' (any character) and 'e' (any character), it is considered to be the usual first name: e.g. -fne "&#92;&#92;" or -fne "()".]
 %(
 "first names enclosed": the -fne option must be followed by a two characters str
 ing "be". When creating a person, if the GEDCOM first name part holds a part bet
 ween 'b' (any character) and 'e' (any character), it is considered to be the usu
-al first name: e.g. -fne "\\" or -fne "()".
+al first name: e.g. -fne "&#92;&#92;" or -fne "()".
 %)
 </td></tr>
 

--- a/bin/setup/statics/lang/gwf_1.htm
+++ b/bin/setup/statics/lang/gwf_1.htm
@@ -584,7 +584,7 @@ an use HTML tags.
 </tr>
 <tr align=left>
 <td>
-<input type="checkbox" name="reorg" id="reorg">[Reorg mode]
+<input type="checkbox" name="reorg" id="reorg" %R{checked|}>[Reorg mode]
 </td>
 </tr>
 </table>

--- a/bin/setup/statics/lang/gwf_ok.htm
+++ b/bin/setup/statics/lang/gwf_ok.htm
@@ -28,12 +28,12 @@
 <p>
 [For information][:]
 <ul>
-<li>[The parameters are recorded in the text file "%a.gwf" in the directory "%w".]
-<li>[If you gave a text to put in the bottom of the pages, this text is recorded in the file named "%a.trl" in the subdirectory "lang" of the directory "%w".]
-%(
-If you gave a text to put in the bottom of the pages, this text is recorded in
-the file named "%a.trl" in the subdirectory "lang" of the directory "%w".
-%)
+<li>
+[The parameters are recorded in the text file]
+%R{"%w%/%a.gwb%/config%/%a.gwf"|"%w%/%a.gwf"}.
+
+<li>[If you gave a text to put in the bottom of the pages, this text is recorded
+in the file] "%w%/lang%/%a%/trl.txt".
 </ul>
 <p>
 [Return to the main menu.] (<a href="gwsetup?lang=%l;v=welcome.htm">welcome</a>)

--- a/bin/setup/statics/lang/gwu_ok.htm
+++ b/bin/setup/statics/lang/gwu_ok.htm
@@ -22,7 +22,7 @@
 
 <p>
 %Iodir;;{
-[This has built the file] "%w%/%Io;;{%a.gw|%o}".
+[This has built the file] "%w%/%a.gw".
 |
 [Files were reconstructed in the designated directory.]
 <br>

--- a/bin/setup/statics/lang/lexicon.txt
+++ b/bin/setup/statics/lang/lexicon.txt
@@ -117,6 +117,14 @@ fr: Entrez le nom du dossier contenant les bases.
 en: If you write nothing, it will be taken as "."
 fr: Si vous ne mettez rien, la valeur par défaut sera "."
 
+    gwsetup configuration
+en: Environnment
+fr: Environnement
+
+    The parameters are recorded in the text file
+en: The parameters are recorded in the text file
+fr: Les paramètres sont enregistrés dans le fichier texte
+
     public names
 en: Public names
 fr: Noms publics
@@ -2542,32 +2550,24 @@ sv: Om du ändrar namnet på din databas, men databasen har funnits ett bra \
   då att se en sida som hänvisar dem till den nya databasen.
 
     If you gave a text to put in the bottom of the pages, this text is \
-  recorded in the file named "%a.trl" in the subdirectory "lang" of the \
-  directory "%w".
+  recorded in the file
 aa: gwf_ok.htm
 co: S’è vò avete datu un testu à piazzà à u bassu di e pagine, stu \
-  testu serà arregistratu in u schedariu di nome « %a.trl » in u \
-  sottucartulare « lang » di u cartulare « %w ».
+  testu serà arregistratu in u schedariu
 de: Falls du einen Text angegeben hast, der am Fuß der Seiten angezeigt \
-  werden soll, wurde er in der Datei "%a.trl" im Unterverzeichnis "lang" des \
-  Verzeichnisses "%w" gespeichert.
+  werden soll, wurde er in
 en: If you gave a text to put in the bottom of the pages, this text is \
-  recorded in the file named "%a.trl" in the subdirectory "lang" of the \
-  directory "%w".
+  recorded in the file
 es: Si Ud. ha escogido la opción de agregar un texto en la parte inferior de \
-  las páginas, este texto es registrado en el fichero denominado "%a.trl" en \
-  la sub-carpeta "lang" de la carpeta "%w".
+  las páginas, este texto es registrado en el fichero
 fr: Si vous avez donné un texte à mettre au bas des pages, ce texte est \
-  enregistré dans le fichier de nom "%a.trl" dans le sous-répertoire "lang" \
-  du répertoire "%w".
+  enregistré dans le fichier
 it: Se avete scelto l'opzione di aggiungere un testo in piede di pagina, \
-  questo testo è registrato nel file chiamato "%a.trl" nella sub-directory \
-  "lang" della directory "%w".
+  questo testo è registrato nel file
 lv: Ja Jûs norâdîjât arî katras lappuses noslçguma tekstu, tad ðis \
-  teksts ir ierakstîts datnç "%a.trl" kataloga "%w" apakðkatalogâ "lang".
+  teksts ir ierakstîts
 sv: Om du angav en text som ska stå längst ner på sidan, har denna text \
-  sparats i filen benämnd "%a.trl" i underkatalogen "lang" för katalogen \
-  "%w".
+  sparats i filen
 
     If you just made this, it is probably its result, and therefore it is not \
   important. Else, return to the previous page and choose another name for \
@@ -4534,22 +4534,16 @@ sv: Operationen "%d" kommer att appliceras på din databas "%a". Varning: det \
   kan ta några sekunder eller några minuter, beroende på fallet. Ha \
   tålamod.
 
-    The parameters are recorded in the text file "%a.gwf" in the directory \
-  "%w".
+    The parameters are recorded in the text file
 aa: gwf_ok.htm
-co: I parametri sò arregistrati in u schedariu di testu « %a.gwf » in u \
-  cartulare « %w ».
-de: Die Parameter sind in der Textdatei "%a.gwf" im Verzeichnis "%w".
-en: The parameters are recorded in the text file "%a.gwf" in the directory \
-  "%w".
-es: Los parámetros son registrados en el fichero texto "%a.gwf" en la \
-  carpeta "%w".
-fr: Les paramètres sont enregistrés dans le fichier texte "%a.gwf" dans le \
-  répertoire "%w".
-it: I parametri sono stati registrati nel file testo "%a.gwf" nella directory \
-  "%w".
-lv: Ðie parametri ir ierakstîti teksta datnç "%a.gwf" katalogâ "%w".
-sv: Parametrarna har sparats i textfilen "%a.gwf" i katalogen "%w".
+co: I parametri sò arregistrati in u schedariu di testu
+de: Die Parameter sind in der Textdatei
+en: The parameters are recorded in the text file
+es: Los parámetros son registrados en el fichero texto
+fr: Les paramètres sont enregistrés dans le fichier texte
+it: I parametri sono stati registrati nel file testo
+lv: Ðie parametri ir ierakstîti teksta datnç
+sv: Parametrarna har sparats i textfilen
 
     parameters of a database
 aa: welcome.htm

--- a/bin/setup/statics/lang/welcome.htm
+++ b/bin/setup/statics/lang/welcome.htm
@@ -67,7 +67,7 @@
       <li>[parameters of a database] (<a href="gwsetup?lang=%l;v=gwf.htm">.gwf</a>)
       <li>[build cache files] (<a href="gwsetup?lang=%l;v=cache_files.htm">cache_files</a>)
     </ul>
-    <span><b>[gwsetup configuration]</b></span>
+    <span><b>[Environnment]</b></span>
     <p style="margin-left: 2em;">
     %W
     </p>

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -365,7 +365,7 @@ fr: Les <strong>droits des magiciens</strong> sont actuellement <strong>suspendu
 en: Around the tree
 fr: Autour de l'arbre
 ]
-    %else;[*tools]%end;
+    %else;[*tools]%end; <small>(mode %if;reorg;reorg%else;legacy%end;)</small>
   </div>
   <div class="d-flex flex-wrap justify-content-md-center">
     %if;(wizard and not base.has_notes)

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -139,11 +139,6 @@ module Legacy = struct
     Filename.concat (base_dir ()) (bname ^ ".gwb")
 end
 
-(* Check if a base is in reorg format *)
-let is_reorg_base bname =
-  let bname = Filename.remove_extension bname in
-  Sys.file_exists (config_reorg bname)
-
 (* Initialize path functions based on mode *)
 let init () =
   Secure.add_assets Filename.current_dir_name;
@@ -172,9 +167,18 @@ let init () =
     images_d := Legacy.images_d;
     albums_d := Legacy.albums_d)
 
+<<<<<<< HEAD
 let set_reorg bname force =
   let res = match force with Some b -> b | None -> is_reorg_base bname in
   reorg := res;
+=======
+let is_reorg_base bname =
+  let bname = Filename.remove_extension bname in
+  Sys.file_exists (config_reorg bname)
+
+let test_reorg bname =
+  reorg := is_reorg_base bname;
+>>>>>>> d47fd89a8 (fix .gwf file handling in gwsetup)
   init ()
 
 let get_timestamp () =

--- a/lib/GWPARAM.ml
+++ b/lib/GWPARAM.ml
@@ -167,18 +167,13 @@ let init () =
     images_d := Legacy.images_d;
     albums_d := Legacy.albums_d)
 
-<<<<<<< HEAD
-let set_reorg bname force =
-  let res = match force with Some b -> b | None -> is_reorg_base bname in
-  reorg := res;
-=======
 let is_reorg_base bname =
   let bname = Filename.remove_extension bname in
   Sys.file_exists (config_reorg bname)
 
-let test_reorg bname =
-  reorg := is_reorg_base bname;
->>>>>>> d47fd89a8 (fix .gwf file handling in gwsetup)
+let set_reorg bname force =
+  let res = match force with Some b -> b | None -> is_reorg_base bname in
+  reorg := res;
   init ()
 
 let get_timestamp () =

--- a/lib/srcfileDisplay.ml
+++ b/lib/srcfileDisplay.ml
@@ -506,6 +506,7 @@ let eval_var conf base env () _loc = function
       VVstring s
   | [ "permalink" ] ->
       VVstring (Permalink.script conf (Permalink.query conf base) :> string)
+  | [ "reorg" ] -> VVbool !GWPARAM.reorg
   | [ "sosa_ref" ] -> (
       match get_env "sosa_ref" env with
       | Vsosa_ref v -> (

--- a/lib/util/progrBar.ml
+++ b/lib/util/progrBar.ml
@@ -20,8 +20,8 @@ let default_full = '#'
    The two APIs target different channels: [with_bar]/[progress] print to a
    formatter (in practice [Format.std_formatter], i.e. stdout), while the
    deprecated [start]/[run]/[finish] print to stderr. Hence the two checks. *)
-let stdout_is_tty = lazy (Unix.isatty Unix.stdout)
-let stderr_is_tty = lazy (Unix.isatty Unix.stderr)
+let stdout_is_tty = Unix.isatty Unix.stdout
+let stderr_is_tty = Unix.isatty Unix.stderr
 
 type t = {
   ppf : Format.formatter;
@@ -49,15 +49,12 @@ let progress t current total =
       Format.pp_print_flush t.ppf ())
 
 let finish_bar t =
-  (* On a tty, overwrite the in-place bar with the completed one; otherwise
-     print a single clean completion line with no leading carriage return. *)
   if t.tty then
     Format.fprintf t.ppf "\r[%s] 100%%@." (String.make t.width t.full)
   else Format.fprintf t.ppf "[%s] 100%%@." (String.make t.width t.full)
 
 let with_bar ?(width = default_width) ?(empty = default_empty)
-    ?(full = default_full) ?(disabled = false) ?(tty = Lazy.force stdout_is_tty)
-    ppf f =
+    ?(full = default_full) ?(disabled = false) ?(tty = stdout_is_tty) ppf f =
   let t = { ppf; width; empty; full; disabled; tty; last_output = 0. } in
   if not disabled then (
     Format.pp_print_flush t.ppf ();
@@ -65,14 +62,14 @@ let with_bar ?(width = default_width) ?(empty = default_empty)
   else f t
 
 let start () =
-  if Lazy.force stderr_is_tty then (
+  if stderr_is_tty then (
     for _i = 1 to size do
       Printf.eprintf "%c" !empty
     done;
     Printf.eprintf "\013")
 
 let run cnt max_cnt =
-  if Lazy.force stderr_is_tty then (
+  if stderr_is_tty then (
     let pb_cnt = if max_cnt < pb_cnt then size * draw_len else pb_cnt in
     let already_disp = cnt * size / max_cnt in
     let to_disp = (cnt + 1) * size / max_cnt in
@@ -89,7 +86,7 @@ let run cnt max_cnt =
     flush stderr)
 
 let suspend () =
-  if Lazy.force stderr_is_tty then (
+  if stderr_is_tty then (
     Printf.eprintf "%c\n" !full;
     flush stderr)
 
@@ -100,6 +97,6 @@ let restart cnt max_cnt =
   done
 
 let finish () =
-  if Lazy.force stderr_is_tty then (
+  if stderr_is_tty then (
     Printf.eprintf "\n";
     flush stderr)

--- a/lib/util/progrBar.ml
+++ b/lib/util/progrBar.ml
@@ -12,17 +12,29 @@ let default_width = 60
 let default_empty = '.'
 let default_full = '#'
 
+(* Progress bars redraw in place using carriage returns. That only makes sense
+   on a terminal: when output is redirected to a file (e.g. comm.log) the
+   redraws are never overwritten and pile up into one huge line. So the bar is
+   gated on whether the relevant channel is a tty.
+
+   The two APIs target different channels: [with_bar]/[progress] print to a
+   formatter (in practice [Format.std_formatter], i.e. stdout), while the
+   deprecated [start]/[run]/[finish] print to stderr. Hence the two checks. *)
+let stdout_is_tty = lazy (Unix.isatty Unix.stdout)
+let stderr_is_tty = lazy (Unix.isatty Unix.stderr)
+
 type t = {
   ppf : Format.formatter;
   width : int;
   empty : char;
   full : char;
   disabled : bool;
+  tty : bool;
   mutable last_output : float;
 }
 
 let progress t current total =
-  if not @@ t.disabled then
+  if (not t.disabled) && t.tty then
     let now = Unix.gettimeofday () in
     if now -. t.last_output < 0.2 then ()
     else (
@@ -36,42 +48,50 @@ let progress t current total =
       Format.fprintf t.ppf "\r[%s] %d%%" bar (current * 100 / total);
       Format.pp_print_flush t.ppf ())
 
-let finish t =
-  Format.fprintf t.ppf "\r[%s] 100%%@." (String.make t.width t.full)
+let finish_bar t =
+  (* On a tty, overwrite the in-place bar with the completed one; otherwise
+     print a single clean completion line with no leading carriage return. *)
+  if t.tty then
+    Format.fprintf t.ppf "\r[%s] 100%%@." (String.make t.width t.full)
+  else Format.fprintf t.ppf "[%s] 100%%@." (String.make t.width t.full)
 
 let with_bar ?(width = default_width) ?(empty = default_empty)
-    ?(full = default_full) ?(disabled = false) ppf f =
-  let t = { ppf; width; empty; full; disabled; last_output = 0. } in
+    ?(full = default_full) ?(disabled = false) ?(tty = Lazy.force stdout_is_tty)
+    ppf f =
+  let t = { ppf; width; empty; full; disabled; tty; last_output = 0. } in
   if not disabled then (
     Format.pp_print_flush t.ppf ();
-    Fun.protect ~finally:(fun () -> finish t) @@ fun () -> f t)
+    Fun.protect ~finally:(fun () -> finish_bar t) @@ fun () -> f t)
   else f t
 
 let start () =
-  for _i = 1 to size do
-    Printf.eprintf "%c" !empty
-  done;
-  Printf.eprintf "\013"
+  if Lazy.force stderr_is_tty then (
+    for _i = 1 to size do
+      Printf.eprintf "%c" !empty
+    done;
+    Printf.eprintf "\013")
 
 let run cnt max_cnt =
-  let pb_cnt = if max_cnt < pb_cnt then size * draw_len else pb_cnt in
-  let already_disp = cnt * size / max_cnt in
-  let to_disp = (cnt + 1) * size / max_cnt in
-  for _i = already_disp + 1 to to_disp do
-    Printf.eprintf "%c" !full
-  done;
-  let already_disp = cnt * pb_cnt / max_cnt in
-  let to_disp = (cnt + 1) * pb_cnt / max_cnt in
-  (if cnt = max_cnt - 1 then Printf.eprintf " \008"
-   else if to_disp > already_disp then
-     let k = to_disp mod draw_len in
-     let k = if k < 0 then draw_len + k else k in
-     Printf.eprintf "%c\008" draw.[k]);
-  flush stderr
+  if Lazy.force stderr_is_tty then (
+    let pb_cnt = if max_cnt < pb_cnt then size * draw_len else pb_cnt in
+    let already_disp = cnt * size / max_cnt in
+    let to_disp = (cnt + 1) * size / max_cnt in
+    for _i = already_disp + 1 to to_disp do
+      Printf.eprintf "%c" !full
+    done;
+    let already_disp = cnt * pb_cnt / max_cnt in
+    let to_disp = (cnt + 1) * pb_cnt / max_cnt in
+    (if cnt = max_cnt - 1 then Printf.eprintf " \008"
+     else if to_disp > already_disp then
+       let k = to_disp mod draw_len in
+       let k = if k < 0 then draw_len + k else k in
+       Printf.eprintf "%c\008" draw.[k]);
+    flush stderr)
 
 let suspend () =
-  Printf.eprintf "%c\n" !full;
-  flush stderr
+  if Lazy.force stderr_is_tty then (
+    Printf.eprintf "%c\n" !full;
+    flush stderr)
 
 let restart cnt max_cnt =
   start ();
@@ -80,5 +100,6 @@ let restart cnt max_cnt =
   done
 
 let finish () =
-  Printf.eprintf "\n";
-  flush stderr
+  if Lazy.force stderr_is_tty then (
+    Printf.eprintf "\n";
+    flush stderr)

--- a/lib/util/progrBar.mli
+++ b/lib/util/progrBar.mli
@@ -14,6 +14,7 @@ val with_bar :
   ?empty:char ->
   ?full:char ->
   ?disabled:bool ->
+  ?tty:bool ->
   Format.formatter ->
   (t -> 'a) ->
   'a
@@ -24,7 +25,15 @@ val with_bar :
     To work properly, one should not print anything on [ppf] in [f].
 
     If [ppf] is the standard output or the error output, one should not print
-    anything of both of them. *)
+    anything of both of them.
+
+    [tty] controls the in-place redraws that use carriage returns. It defaults
+    to [Unix.isatty Unix.stdout], matching the usual [Format.std_formatter]
+    destination of the bar; pass it explicitly if [ppf] targets another channel.
+    When [false] (typically because output is redirected to a file such as
+    comm.log), the intermediate redraws are suppressed and only a single
+    completion line is printed, avoiding the huge one-line output that
+    accumulated carriage returns would otherwise produce. *)
 
 (* XXX: The below bar is deprecated and should not be used in new code. *)
 
@@ -35,20 +44,22 @@ val full : char ref
 (** Character that represents passed part of progression bar *)
 
 val start : unit -> unit
-(** Prints empty bar with carriage return. *)
+(** Prints empty bar with carriage return. No-op when stderr is not a tty. *)
 
 val run : int -> int -> unit
 (** [run i len] modifies progression bar that is now filled proportionally to
-    [i] by comparison with [len]. *)
+    [i] by comparison with [len]. No-op when stderr is not a tty. *)
 
 (* XXX: This function cannot be used in hot loops without impacting
         performance. *)
 
 val finish : unit -> unit
-(** Stop printing progression bar and prints a new line. *)
+(** Stop printing progression bar and prints a new line. No-op when stderr is
+    not a tty. *)
 
 val suspend : unit -> unit
-(** Stop printing progression bar and prints a new line. *)
+(** Stop printing progression bar and prints a new line. No-op when stderr is
+    not a tty. *)
 
 val restart : int -> int -> unit
 (** [restart i len] restart progression bar. It's equivalent to call

--- a/lib/util/progrBar.mli
+++ b/lib/util/progrBar.mli
@@ -25,15 +25,7 @@ val with_bar :
     To work properly, one should not print anything on [ppf] in [f].
 
     If [ppf] is the standard output or the error output, one should not print
-    anything of both of them.
-
-    [tty] controls the in-place redraws that use carriage returns. It defaults
-    to [Unix.isatty Unix.stdout], matching the usual [Format.std_formatter]
-    destination of the bar; pass it explicitly if [ppf] targets another channel.
-    When [false] (typically because output is redirected to a file such as
-    comm.log), the intermediate redraws are suppressed and only a single
-    completion line is printed, avoiding the huge one-line output that
-    accumulated carriage returns would otherwise produce. *)
+    anything of both of them. *)
 
 (* XXX: The below bar is deprecated and should not be used in new code. *)
 


### PR DESCRIPTION
- replace base_dir by bases_dir hwere appropriate
- suppress the backlash after '\' message
- put gwd.log and gwsetup.log in bases_dir/tmp/