### PR TITLE
guard gwc against 4Go limit in base size

### DIFF
--- a/lib/db/iovalue.ml
+++ b/lib/db/iovalue.ml
@@ -57,6 +57,7 @@ let rec input_loop ifuns ic =
     let () = assert (Sys.word_size = 64) in
     Obj.magic (input_binary_int64 ifuns ic)
   else if code = code_BLOCK32 then
+    (* WARNING should be masked to 32 bits or aligned with writer/marshall *)
     let header = ifuns.input_binary_int ic in
     Obj.magic (input_block ifuns ic (header land 0xff) (header lsr 10))
   else if code = code_BLOCK64 then

--- a/lib/db/outbase.ml
+++ b/lib/db/outbase.ml
@@ -438,6 +438,26 @@ let safe_rename src dst =
     Filesystem.copy_file src dst;
     Mutil.rm src
 
+let test_size bname =
+  (* Final size check for large bases (e.g. Roglo). Positions in the base
+     file are unsigned 32-bit integers (see lib/db/position.mli): writing
+     past 4 GiB raises Position.Overflow and no base is created. Warn at
+     90% of that limit. *)
+  let base_file = Filename.concat bname "base" in
+  let sz = (Unix.LargeFile.stat base_file).Unix.LargeFile.st_size in
+  let limit =
+    0x1_0000_0000L
+    (* 2^32 *)
+  in
+  if Int64.compare sz (Int64.div (Int64.mul limit 9L) 10L) > 0 then
+    Printf.eprintf
+      "Warning: %s is %Ld bytes (%.1f%% of the 4 GiB limit of 32-bit positions \
+       in format GnWb0024).\n\
+       A wider position format will be required soon.\n\
+       %!"
+      base_file sz
+      (100. *. Int64.to_float sz /. Int64.to_float limit)
+
 let output base =
   (* create database directory *)
   let bname = base.data.bdir in
@@ -625,4 +645,6 @@ let output base =
   Mutil.rm (Filename.concat bname "nb_persons");
   (* FIXME: should not be present in this part of the code? *)
   Mutil.rm (Filename.concat bname "tstab");
-  Mutil.rm (Filename.concat bname "tstab_visitor")
+  Mutil.rm (Filename.concat bname "tstab_visitor");
+  (* final test against 4Go size limit *)
+  test_size bname

--- a/lib/search/trie.ml
+++ b/lib/search/trie.ml
@@ -117,7 +117,7 @@ module Make (W : Word.S) = struct
     let qm, rm = eucl i (1 lsl 20) in
     let qk, rk = eucl rm (1 lsl 10) in
     if qm > 0 then Fmt.pf ppf "%d Mio" qm
-    else if qk > 0 then Fmt.pf ppf "%d Kio" rk
+    else if qk > 0 then Fmt.pf ppf "%d Kio" qk
     else Fmt.pf ppf "%d o" rk
 
   let pp_statistics ppf t =


### PR DESCRIPTION
A recent experience with Roglo spotted a size limit which, in the case of Roglo, silently created a polluted base.
Analysis of similar problems with GeneWeb v7 led to the conclusion that the only potential problem is related to the size of the base file which currently cannot exceed 4Go.
This PR adds a warning message in gwc that will trigger when 90% of this limit is reached.
Note that if the size limit was reached, gwc would fail with an overflow message, and no base would be created.
The current situation of Roglo is at 51% of the limit