### PR TITLE
Fix OCaml 5.5 CI: bypass not-ocamlfind in the ged2gwb preprocess rule

### DIFF
--- a/bin/ged2gwb/dune
+++ b/bin/ged2gwb/dune
@@ -5,11 +5,10 @@
  (preprocess
   (action
    (run
-    not-ocamlfind
-    preprocess
-    -package
-    camlp5.extend,camlp5.quotations,camlp5.pr_o
-    -syntax
     camlp5o
+    %{lib:camlp5:pa_extend.cmo}
+    %{lib:camlp5:q_MLast.cmo}
+    %{lib:camlp5:o_keywords.cmo}
+    %{lib:camlp5:pr_o.cmo}
     %{input-file})))
  (libraries camlp5 unix str geneweb_db geneweb))


### PR DESCRIPTION
**Symptom.** Since OCaml 5.5.0 (2026-06-19), the `5` compiler of the CI matrix resolves to 5.5.0 (setup-ocaml's alias tracks the latest 5.x) and the job fails on all three OSes at ged2gwb's preprocessing step:

```
ocamlfind: Package `camlp5.extend' not found
```

**Diagnosis.** camlp5 is not the culprit: 8.05.02 supports 5.5, the very same version builds green on the 4.14 jobs, `camlp5.extend` is present in the installed META, and the installed ocamlfind resolves the full transitive closure under the syntax predicates (`ocamlfind query -r -predicates byte,syntax,preprocessor,camlp5o camlp5.extend camlp5.quotations camlp5.pr_o` succeeds, compiler-libs.common included).

The variable on the 5.5 lane is findlib: `ocamlfind.1.9.8` is capped at `< "5.5.0~"`, so 5.5 forces `ocamlfind.1.9.9~preview`, which generates a *relocatable* `findlib.conf` (`destdir="."`, `path="./ocaml:."`) where 1.9.8 wrote absolute paths. `not-ocamlfind`, which our dune rule invoked, is statically linked against its own vendored copy of findlib (`INC= -I local-packages/ocamlfind/src/findlib findlib.cma` in its Makefile). It works from any directory under `opam exec`, but fails specifically when dune runs it inside a `(preprocess (action ...))` sandbox on such a switch. Reported upstream: chetmurthy/not-ocamlfind#4.

**Fix.** Drop the findlib command-line machinery from the build path: invoke `camlp5o` directly, with dune locating the `.cmo` files itself via `%{lib:camlp5:...}` (dune parses META files natively). `o_keywords.cmo` must precede `pr_o.cmo` since camlp5 8.03. Same pipeline (pa_extend, q_MLast, pr_o), same generated source. Validated: the 5.5/Ubuntu job is green in ~6 min.

**Alternative considered.** A single workflow line also unblocks the CI by feeding the vendored findlib an absolute search path:

```yaml
      - run: echo "OCAMLPATH=$(opam var lib):$(opam var lib)/ocaml" >> "$GITHUB_ENV"
```

Trade-offs: it fixes CI only — a contributor building on a local 5.5 switch (or in a notebook, or a distro packager) still hits the failure unless they export it themselves; it acts at a distance from the dune rule; and it is untested here, while the stanza is validated. Preference goes to the stanza; the env line is documented for anyone hitting the same not-ocamlfind/findlib-preview class of problem in another project.

**Lifetime.** Both variants are scaffolding: #2927 (complete camlp5 removal) deletes this preprocessing rule altogether. This PR only exists to unblock the ~10 pending PRs waiting on green 5.5 CI.
