### PR TITLE
Port witness notes (wnote) from gnt to master

### DIFF
--- a/bin/ged2gwb/ged2gwb.ml
+++ b/bin/ged2gwb/ged2gwb.ml
@@ -1297,6 +1297,11 @@ let find_event_witness gen tag ip r =
     function
       [] -> []
     | r :: asso_l ->
+        let wnote =
+          match find_all_fields "NOTE" r.rsons with
+          | [] -> string_empty
+          | rl -> add_string gen (treat_notes gen rl)
+        in
         if find_field_with_value "TYPE" tag r.rsons then
           let witness = forward_pevent_witn gen ip (strip_spaces r.rval) in
           let witness_kind =
@@ -1304,7 +1309,7 @@ let find_event_witness gen tag ip r =
               Some rr -> witness_kind_of_rval rr.rval
             | _ -> Witness
           in
-          (witness, witness_kind) :: find_witnesses asso_l
+          (witness, witness_kind, wnote) :: find_witnesses asso_l
         else
           let witness = forward_pevent_witn gen ip (strip_spaces r.rval) in
           let witness_kind =
@@ -1312,7 +1317,7 @@ let find_event_witness gen tag ip r =
               Some rr -> witness_kind_of_rval rr.rval
             | _ -> Witness
           in
-          (witness, witness_kind) :: find_witnesses asso_l
+          (witness, witness_kind, wnote) :: find_witnesses asso_l
   in
   let witnesses =
     match find_all_fields "ASSO" r.rsons with
@@ -1326,6 +1331,11 @@ let find_fevent_witness gen tag ifath r =
     function
       [] -> []
     | r :: asso_l ->
+        let wnote =
+          match find_all_fields "NOTE" r.rsons with
+          | [] -> string_empty
+          | rl -> add_string gen (treat_notes gen rl)
+        in
         if find_field_with_value "TYPE" tag r.rsons then
           let witness = forward_fevent_witn gen ifath (strip_spaces r.rval) in
           let witness_kind =
@@ -1333,7 +1343,7 @@ let find_fevent_witness gen tag ifath r =
               Some rr -> witness_kind_of_rval rr.rval
             | _ -> Witness
           in
-          (witness, witness_kind) :: find_witnesses asso_l
+          (witness, witness_kind, wnote) :: find_witnesses asso_l
         else
           let witness = forward_fevent_witn gen ifath (strip_spaces r.rval) in
           let witness_kind =
@@ -1341,7 +1351,7 @@ let find_fevent_witness gen tag ifath r =
               Some rr -> witness_kind_of_rval rr.rval
             | _ -> Witness
           in
-          (witness, witness_kind) :: find_witnesses asso_l
+          (witness, witness_kind, wnote) :: find_witnesses asso_l
   in
   let witnesses =
     match find_all_fields "ASSO" r.rsons with
@@ -2290,14 +2300,14 @@ let reconstitute_from_fevents gen gay fevents marr witn div =
           Efam_Engage ->
             if !found_marriage then loop l marr witn div
             else
-              let witn = Array.map fst evt.efam_witnesses in
+              let witn = Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses in
               let marr =
                 Engaged, evt.efam_date, evt.efam_place, evt.efam_note,
                 evt.efam_src
               in
               let () = found_marriage := true in loop l marr witn div
         | Efam_Marriage ->
-            let witn = Array.map fst evt.efam_witnesses in
+            let witn = Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses in
             let marr =
               Married, evt.efam_date, evt.efam_place, evt.efam_note,
               evt.efam_src
@@ -2306,7 +2316,7 @@ let reconstitute_from_fevents gen gay fevents marr witn div =
         | Efam_MarriageContract ->
             if !found_marriage then loop l marr witn div
             else
-              let witn = Array.map fst evt.efam_witnesses in
+              let witn = Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses in
               (* Pour différencier le fait qu'on recopie le *)
               (* mariage, on met une précision "vers".      *)
               let date =
@@ -2325,7 +2335,7 @@ let reconstitute_from_fevents gen gay fevents marr witn div =
           Efam_Annulation | Efam_PACS ->
             if !found_marriage then loop l marr witn div
             else
-              let witn = Array.map fst evt.efam_witnesses in
+              let witn = Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses in
               let marr =
                 NoMention, evt.efam_date, evt.efam_place, evt.efam_note,
                 evt.efam_src
@@ -2334,7 +2344,7 @@ let reconstitute_from_fevents gen gay fevents marr witn div =
         | Efam_NoMarriage ->
             if !found_marriage then loop l marr witn div
             else
-              let witn = Array.map fst evt.efam_witnesses in
+              let witn = Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses in
               let marr =
                 NotMarried, evt.efam_date, evt.efam_place, evt.efam_note,
                 evt.efam_src

--- a/bin/gwb2ged/gwb2gedLib.ml
+++ b/bin/gwb2ged/gwb2gedLib.ml
@@ -461,11 +461,14 @@ let ged_pevent opts base per_sel evt =
   let src = Driver.sou base evt.epers_src in
   ged_ev_detail opts 2 typ date place note src;
   Array.iter
-    (fun (ip, wk) ->
+    (fun (ip, wk, wnote) ->
       if per_sel ip then (
         Printf.ksprintf (oc opts) "2 ASSO @I%d@\n" (int_of_iper ip + 1);
         Printf.ksprintf (oc opts) "3 TYPE INDI\n";
-        oc_witness_kind opts wk))
+        oc_witness_kind opts wk;
+        let wnote = Driver.sou base wnote in
+        if opts.Gwexport.no_notes <> `nnn && wnote <> "" then
+          display_note opts 3 wnote))
     evt.epers_witnesses
 
 let adop_fam_list = ref []
@@ -642,11 +645,14 @@ let ged_fevent opts base per_sel evt =
   let src = Driver.sou base evt.efam_src in
   ged_ev_detail opts 2 typ date place note src;
   Array.iter
-    (fun (ip, wk) ->
+    (fun (ip, wk, wnote) ->
       if per_sel ip then (
         Printf.ksprintf (oc opts) "2 ASSO @I%d@\n" (int_of_iper ip + 1);
         Printf.ksprintf (oc opts) "3 TYPE INDI\n";
-        oc_witness_kind opts wk))
+        oc_witness_kind opts wk;
+        let wnote = Driver.sou base wnote in
+        if opts.Gwexport.no_notes <> `nnn && wnote <> "" then
+          display_note opts 3 wnote))
     evt.efam_witnesses
 
 let ged_child opts per_sel chil =

--- a/bin/gwc/db1link.ml
+++ b/bin/gwc/db1link.ml
@@ -756,7 +756,9 @@ let update_family_with_fevents _gen fam =
         | Some relation' ->
             if !found_marriage then loop l fam
             else
-              let witnesses = Array.map fst evt.efam_witnesses in
+              let witnesses =
+                Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses
+              in
               let fam =
                 {
                   fam with
@@ -806,7 +808,9 @@ let update_fevents_with_family gen fam =
       | Pacs -> Efam_PACS
       | Residence -> Efam_Residence
     in
-    let witnesses = Array.map (fun ip -> (ip, Witness)) fam.witnesses in
+    let witnesses =
+      Array.map (fun ip -> (ip, Witness, empty_string)) fam.witnesses
+    in
     let evt =
       {
         efam_name = name;
@@ -926,11 +930,11 @@ let insert_family gen co fath_sex moth_sex witl fevtl fo deo =
         (* insert all event witnesses *)
         let witnesses =
           List.map
-            (fun (wit, sex, wk) ->
+            (fun (wit, sex, wk, wnote) ->
               let p, ip = insert_somebody gen wit in
               notice_sex gen p sex;
               p.m_related <- ifath :: p.m_related;
-              (ip, wk))
+              (ip, wk, unique_string gen wnote))
             witl
         in
         {
@@ -1069,13 +1073,13 @@ let insert_pevents fname gen sb pevtl =
         (fun (name, date, place, reason, src, notes, witl) ->
           let witnesses =
             List.map
-              (fun (wit, sex, wk) ->
+              (fun (wit, sex, wk, wnote) ->
                 (* insert witnesses *)
                 let wp, wip = insert_somebody gen wit in
                 notice_sex gen wp sex;
                 (* add concerned person as witness' relation *)
                 wp.m_related <- ip :: wp.m_related;
-                (wip, wk))
+                (wip, wk, unique_string gen wnote))
               witl
           in
           {

--- a/bin/gwc/gwcomp.ml
+++ b/bin/gwc/gwcomp.ml
@@ -36,7 +36,7 @@ type gw_syntax =
         * string
         * string
         * string
-        * (somebody * sex * witness_kind) list)
+        * (somebody * sex * witness_kind * string) list)
         list
       * ( (Driver.iper, Driver.iper, string) gen_person,
           Driver.ifam,
@@ -70,7 +70,7 @@ type gw_syntax =
         * string
         * string
         * string
-        * (somebody * sex * witness_kind) list)
+        * (somebody * sex * witness_kind * string) list)
         list
       (** Block that defines events of a person. Specific to gwplus format.
           Contains:
@@ -1106,6 +1106,27 @@ let loop_note line ic =
   in
   loop_note [] line
 
+(** Read succesive witness note lines (starting with "wnote") and concat them.
+*)
+let loop_witness_note line ic =
+  let rec loop acc str =
+    match fields str with
+    | "wnote" :: tl ->
+        let note =
+          if tl = [] then ""
+          else
+            String.sub str
+              (String.length "wnote" + 1)
+              (String.length str - String.length "wnote" - 1)
+        in
+        loop (note :: acc) (input_a_line ic)
+    | _ ->
+        ( Mutil.strip_all_trailing_spaces
+            (String.concat "\n" (List.rev @@ ("" :: acc))),
+          str )
+  in
+  loop [] line
+
 (** Parse witnesses across the lines and returns list of [(wit,wsex,wk)] where
     wit is a witness definition/reference, [wsex] is a sex of witness and [wk]
     is a kind of witness relationship to the family. *)
@@ -1122,7 +1143,9 @@ let loop_witn ~bname line ic =
         let wkind, l = get_event_witness_kind l in
         let wk, _, l = parse_parent ~bname str l in
         if l <> [] then failwith str;
-        loop_witn ((wk, sex, wkind) :: acc) (input_a_line ic)
+        (* read witness note which starts on the following line(s) *)
+        let wnote, str = loop_witness_note (input_a_line ic) ic in
+        loop_witn ((wk, sex, wkind, wnote) :: acc) str
     | _ -> (List.rev acc, str)
   in
   loop_witn [] line

--- a/bin/gwc/gwcomp.mli
+++ b/bin/gwc/gwcomp.mli
@@ -37,7 +37,7 @@ type gw_syntax =
         * string
         * string
         * string
-        * (somebody * sex * witness_kind) list)
+        * (somebody * sex * witness_kind * string) list)
         list
       * ( (Geneweb_db.Driver.iper, Geneweb_db.Driver.iper, string) gen_person,
           Geneweb_db.Driver.ifam,
@@ -72,7 +72,7 @@ type gw_syntax =
         * string
         * string
         * string
-        * (somebody * sex * witness_kind) list)
+        * (somebody * sex * witness_kind * string) list)
         list
       (** Block that defines events of a person. Specific to gwplus format.
           Contains:

--- a/bin/gwu/gwuLib.ml
+++ b/bin/gwu/gwuLib.ml
@@ -573,6 +573,23 @@ let print_witness opts base gen p =
     | _ -> gen.notes_pl_p <- p :: gen.notes_pl_p);
     if Driver.get_pevents p <> [] then gen.pevents_pl_p <- p :: gen.pevents_pl_p)
 
+let print_witness_note opts base wnote =
+  if opts.no_notes <> `nnn then
+    match Driver.sou base wnote with
+    | "" -> ()
+    | wnote ->
+        if !old_gw then
+          (* Ancien format : pas de mot-clé `wnote` (illisible par un ancien
+             binaire). On reporte la note du témoin en texte libre, dans un
+             paragraphe séparé. *)
+          List.iter
+            (fun line -> Printf.ksprintf (oc opts) "%s\n" line)
+            ("" :: String.split_on_char '\n' wnote)
+        else
+          List.iter
+            (fun line -> Printf.ksprintf (oc opts) "wnote %s\n" line)
+            (String.split_on_char '\n' wnote)
+
 let print_pevent opts base gen e =
   (match e.epers_name with
   | Epers_Birth -> Printf.ksprintf (oc opts) "#birt"
@@ -638,7 +655,7 @@ let print_pevent opts base gen e =
   if opts.source = None then print_if_no_empty opts base "#s" e.epers_src;
   Printf.ksprintf (oc opts) "\n";
   Array.iter
-    (fun (ip, wk) ->
+    (fun (ip, wk, wnote) ->
       if gen.per_sel ip then (
         let p = Driver.poi base ip in
         Printf.ksprintf (oc opts) "wit";
@@ -652,7 +669,8 @@ let print_pevent opts base gen e =
         | Some s -> Printf.ksprintf (oc opts) (s ^^ " ")
         | None -> ());
         print_witness opts base gen p;
-        Printf.ksprintf (oc opts) "\n"))
+        Printf.ksprintf (oc opts) "\n";
+        print_witness_note opts base wnote))
     e.epers_witnesses;
   let note =
     if opts.no_notes <> `nnn then Driver.sou base e.epers_note else ""
@@ -741,7 +759,7 @@ let print_fevent opts base gen in_comment e =
   if opts.source = None then print_if_no_empty opts base "#s" e.efam_src;
   print_sep ();
   Array.iter
-    (fun (ip, wk) ->
+    (fun (ip, wk, wnote) ->
       if gen.per_sel ip then (
         let p = Driver.poi base ip in
         Printf.ksprintf (oc opts) "wit";
@@ -755,7 +773,14 @@ let print_fevent opts base gen in_comment e =
         | Some s -> Printf.ksprintf (oc opts) (s ^^ " ")
         | None -> ());
         print_witness opts base gen p;
-        print_sep ()))
+        print_sep ();
+        if not in_comment then print_witness_note opts base wnote
+        else
+          (* Ancien format, évènement familial sérialisé sur une seule ligne
+             (champ `comm`) : on accole la note du témoin en texte. *)
+          match Driver.sou base wnote with
+          | "" -> ()
+          | wn -> Printf.ksprintf (oc opts) "wit-note: %s " (no_newlines wn)))
     e.efam_witnesses;
   let note =
     if opts.no_notes <> `nnn then Driver.sou base e.efam_note else ""
@@ -994,7 +1019,7 @@ let notes_aliases bdir =
 let print_notes_for_person opts base gen p =
   let print_witness_in_notes witnesses =
     Array.iter
-      (fun (ip, wk) ->
+      (fun (ip, wk, wnote) ->
         let p = Driver.poi base ip in
         Printf.ksprintf (oc opts) "wit";
         (match Driver.get_sex p with
@@ -1007,7 +1032,8 @@ let print_notes_for_person opts base gen p =
         | Some s -> Printf.ksprintf (oc opts) (s ^^ " ")
         | None -> ());
         print_witness opts base gen p;
-        Printf.ksprintf (oc opts) "\n")
+        Printf.ksprintf (oc opts) "\n";
+        print_witness_note opts base wnote)
       witnesses
   in
   let epers_name_to_string evt =

--- a/lib/checkItem.ml
+++ b/lib/checkItem.ml
@@ -525,7 +525,7 @@ let check_witness_pevents base warning origin =
       | None -> ()
       | Some d2 ->
           Array.iter
-            (fun (iw, witness_kind) ->
+            (fun (iw, witness_kind, _wnote) ->
               let p = Driver.poi base iw in
               check_witness_pevents_aux warning origin evt d2
                 (Date.od_of_cdate @@ Driver.get_birth p)
@@ -538,8 +538,10 @@ let check_witness_pevents base warning origin =
     wether it was found associated only with the Mentionned or Other witness
     kind. **)
 let witness_occur :
-    Driver.iper -> (Driver.iper * witness_kind) array -> bool * bool =
-  let f iper (is_witness, only_mentioned_or_other) (i, wk) =
+    Driver.iper ->
+    (Driver.iper * witness_kind * Driver.istr) array ->
+    bool * bool =
+  let f iper (is_witness, only_mentioned_or_other) (i, wk, _wnote) =
     if i = iper then
       ( true,
         only_mentioned_or_other
@@ -747,7 +749,7 @@ let check_witness_fevents base warning fam =
       | None -> ()
       | Some d2 ->
           Array.iter
-            (fun (iw, witness_kind) ->
+            (fun (iw, witness_kind, _wnote) ->
               let p = Driver.poi base iw in
               check_witness_fevents_aux warning fam evt d2
                 (Date.od_of_cdate @@ Driver.get_birth p)

--- a/lib/def/def.ml
+++ b/lib/def/def.ml
@@ -142,7 +142,7 @@ type ('person, 'string) gen_pers_event = {
   epers_reason : 'string;
   epers_note : 'string;
   epers_src : 'string;
-  epers_witnesses : ('person * witness_kind) array;
+  epers_witnesses : ('person * witness_kind * 'string) array;
 }
 [@@deriving show { with_path = false }]
 (** Personal event information *)
@@ -171,7 +171,7 @@ type ('person, 'string) gen_fam_event = {
   efam_reason : 'string;
   efam_note : 'string;
   efam_src : 'string;
-  efam_witnesses : ('person * witness_kind) array;
+  efam_witnesses : ('person * witness_kind * 'string) array;
 }
 [@@deriving show { with_path = false }]
 (** Event information pertaining a family. *)

--- a/lib/event.ml
+++ b/lib/event.ml
@@ -54,7 +54,7 @@ type 'a event_item =
   * Driver.istr
   * Driver.istr
   * Driver.istr
-  * (Driver.iper * witness_kind) array
+  * (Driver.iper * witness_kind * Driver.istr) array
   * Driver.iper option
 
 let events conf base p =

--- a/lib/event.mli
+++ b/lib/event.mli
@@ -10,7 +10,7 @@ type 'a event_item =
   * Geneweb_db.Driver.istr
   * Geneweb_db.Driver.istr
   * Geneweb_db.Driver.istr
-  * (Geneweb_db.Driver.iper * Def.witness_kind) array
+  * (Geneweb_db.Driver.iper * Def.witness_kind * Geneweb_db.Driver.istr) array
   * Geneweb_db.Driver.iper option
 (** a representation of events *)
 

--- a/lib/fixbase.ml
+++ b/lib/fixbase.ml
@@ -270,7 +270,7 @@ let check_pevents_witnesses ?report progress base =
       let ip = Driver.get_iper p in
       List.iter
         (fun evt ->
-          let witn = Array.map fst evt.epers_witnesses in
+          let witn = Array.map (fun (ip, _, _) -> ip) evt.epers_witnesses in
           for j = 0 to Array.length witn - 1 do
             let ip2 = witn.(j) in
             let p2 = Driver.poi base ip2 in
@@ -295,7 +295,7 @@ let check_fevents_witnesses ?report progress base =
       let ifath = Driver.get_father fam in
       List.iter
         (fun evt ->
-          let witn = Array.map fst evt.efam_witnesses in
+          let witn = Array.map (fun (ip, _, _) -> ip) evt.efam_witnesses in
           for j = 0 to Array.length witn - 1 do
             let ip = witn.(j) in
             let p = Driver.poi base ip in

--- a/lib/hasher.ml
+++ b/lib/hasher.ml
@@ -96,6 +96,7 @@ module Make (H : Digestif.S) = struct
   let list f l ctx = List.fold_left (fun ctx a -> f a ctx) ctx l
   let array f l ctx = Array.fold_left (fun ctx a -> f a ctx) ctx l
   let pair f g (x, y) = f x <+> g y
+  let triple f g h (x, y, z) = f x <+> g y <+> h z
 
   let option f x =
     match x with Some u -> string "Some" <+> f u | None -> string "None"
@@ -292,7 +293,7 @@ module Make (H : Digestif.S) = struct
     <+> feed_string epers_note
     <+> feed_string epers_note
     <+> feed_string epers_src
-    <+> (array @@ pair feed_pers witness_kind) epers_witnesses)
+    <+> (array @@ triple feed_pers witness_kind feed_string) epers_witnesses)
     [@ocamlformat "disable"]
 
   let gen_person feed_iper feed_pers feed_string
@@ -412,7 +413,7 @@ module Make (H : Digestif.S) = struct
     <+> feed_string efam_reason
     <+> feed_string efam_note
     <+> feed_string efam_src
-    <+> (array @@ pair feed_pers witness_kind) efam_witnesses)
+    <+> (array @@ triple feed_pers witness_kind feed_string) efam_witnesses)
     [@ocamlformat "disable"]
 
   let relation_kind (k : Def.relation_kind) =

--- a/lib/historyDiffDisplay.ml
+++ b/lib/historyDiffDisplay.ml
@@ -264,7 +264,7 @@ let string_of_divorce conf divorce =
 
 let string_of_event_witness conf base witnesses =
   Array.fold_right
-    (fun (ip, wk) accu ->
+    (fun (ip, wk, _wnote) accu ->
       let witn = person_of_iper conf base ip in
       let kind =
         Util.string_of_witness_kind conf

--- a/lib/mergeIndOk.ml
+++ b/lib/mergeIndOk.ml
@@ -355,14 +355,14 @@ let redirect_relations_of_added_related base p ip2 rel_chil =
               let e, mod_pc, p_related, mod_p =
                 let witnesses, mod_p, p_related =
                   List.fold_right
-                    (fun (ip, k) (witnesses, mod_p, p_related) ->
+                    (fun (ip, k, n) (witnesses, mod_p, p_related) ->
                       if ip = ip2 then
                         let p_related, mod_p =
                           if List.mem ipc p_related then (p_related, mod_p)
                           else (ipc :: p_related, true)
                         in
-                        ((p.key_index, k) :: witnesses, mod_p, p_related)
-                      else ((ip, k) :: witnesses, mod_p, p_related))
+                        ((p.key_index, k, n) :: witnesses, mod_p, p_related)
+                      else ((ip, k, n) :: witnesses, mod_p, p_related))
                     (Array.to_list e.epers_witnesses)
                     ([], mod_pc, p_related)
                 in
@@ -415,9 +415,10 @@ let redirect_relations_of_added_related base p ip2 rel_chil =
                             (p_related, mod_p)
                           else
                             let p_related, mod_p =
-                              if fst e.efam_witnesses.(j) = ip2 then (
-                                let _, wk = e.efam_witnesses.(j) in
-                                e.efam_witnesses.(j) <- (p.key_index, wk);
+                              let wip, _, _ = e.efam_witnesses.(j) in
+                              if wip = ip2 then (
+                                let _, wk, wn = e.efam_witnesses.(j) in
+                                e.efam_witnesses.(j) <- (p.key_index, wk, wn);
                                 if List.mem ipc p_related then (p_related, mod_p)
                                 else (ipc :: p_related, true))
                               else (p_related, mod_p)
@@ -464,7 +465,7 @@ let redirect_added_families base p ip2 p2_family =
         List.iter
           (fun evt ->
             Array.iter
-              (fun (ip, _) ->
+              (fun (ip, _, _) ->
                 let w = Driver.poi base ip in
                 if not (List.mem p.key_index (Driver.get_related w)) then
                   let w = Driver.gen_person_of_person w in

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1453,7 +1453,7 @@ let get_marriage_witnesses fam =
 let get_nb_marriage_witnesses_of_kind fam wk =
   let witnesses = get_marriage_witnesses fam in
   Array.fold_left
-    (fun acc (_, w) -> if wk = w then acc + 1 else acc)
+    (fun acc (_, w, _) -> if wk = w then acc + 1 else acc)
     0 witnesses
 
 let number_of_descendants_aux conf base env all_levels sl eval_int =
@@ -4989,7 +4989,7 @@ let print_foreach conf base print_ast eval_expr =
       (fun (name, _, _, _, _, wl, _) ->
         if name = Event.Pevent epers_event then
           Array.iteri
-            (fun i (ip, _) ->
+            (fun i (ip, _, _) ->
               let p = pget conf base ip in
               let env =
                 Templ.Env.(
@@ -5007,7 +5007,7 @@ let print_foreach conf base print_ast eval_expr =
       match get_env "event" env with
       | Vevent (_, (_, _, _, _, _, witnesses, _)) ->
           Array.iteri
-            (fun i (ip, wk) ->
+            (fun i (ip, wk, _wnote) ->
               let p = pget conf base ip in
               let wk_s =
                 Util.string_of_witness_kind conf (Driver.get_sex p) wk
@@ -5073,7 +5073,7 @@ let print_foreach conf base print_ast eval_expr =
     | Vfam (_, fam, _, true) ->
         let _ =
           Array.fold_left
-            (fun (i, first) (ip, wk) ->
+            (fun (i, first) (ip, wk, _wnote) ->
               let p = pget conf base ip in
               (* TODO if witness_kind = Witness, we might want wk = "" *)
               let wk_s =
@@ -5944,7 +5944,7 @@ let print_isolated conf base =
       List.find_map
         (fun evt ->
           Mutil.array_find_map
-            (fun (wip, wk) -> if wip = iper then Some wk else None)
+            (fun (wip, wk, _) -> if wip = iper then Some wk else None)
             evt.Def.epers_witnesses)
         (Driver.get_pevents rp)
     in
@@ -5956,7 +5956,7 @@ let print_isolated conf base =
             List.find_map
               (fun evt ->
                 Mutil.array_find_map
-                  (fun (wip, wk) -> if wip = iper then Some wk else None)
+                  (fun (wip, wk, _) -> if wip = iper then Some wk else None)
                   evt.Def.efam_witnesses)
               (Driver.get_fevents (Driver.foi base ifam)))
           (Driver.get_family rp)
@@ -6037,7 +6037,7 @@ let print_isolated conf base =
         List.filter_map
           (fun (_, _, _, _, _, wl, _) ->
             Mutil.array_find_map
-              (fun (wip, wk) -> if wip = iper then Some wk else None)
+              (fun (wip, wk, _) -> if wip = iper then Some wk else None)
               wl)
           (Event.sorted_events conf base rp))
       (Driver.get_related (Driver.poi base iper))

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1455,7 +1455,7 @@ let get_marriage_witnesses fam =
 let get_nb_marriage_witnesses_of_kind fam wk =
   let witnesses = get_marriage_witnesses fam in
   Array.fold_left
-    (fun acc (_, w) -> if wk = w then acc + 1 else acc)
+    (fun acc (_, w, _) -> if wk = w then acc + 1 else acc)
     0 witnesses
 
 let number_of_descendants_aux conf base env all_levels sl eval_int =
@@ -5014,7 +5014,7 @@ let print_foreach conf base print_ast eval_expr =
       (fun (name, _, _, _, _, wl, _) ->
         if name = Event.Pevent epers_event then
           Array.iteri
-            (fun i (ip, _) ->
+            (fun i (ip, _, _) ->
               let p = pget conf base ip in
               let env =
                 Templ.Env.(
@@ -5032,7 +5032,7 @@ let print_foreach conf base print_ast eval_expr =
       match get_env "event" env with
       | Vevent (_, (_, _, _, _, _, witnesses, _)) ->
           Array.iteri
-            (fun i (ip, wk) ->
+            (fun i (ip, wk, _wnote) ->
               let p = pget conf base ip in
               let wk_s =
                 Util.string_of_witness_kind conf (Driver.get_sex p) wk
@@ -5098,7 +5098,7 @@ let print_foreach conf base print_ast eval_expr =
     | Vfam (_, fam, _, true) ->
         let _ =
           Array.fold_left
-            (fun (i, first) (ip, wk) ->
+            (fun (i, first) (ip, wk, _wnote) ->
               let p = pget conf base ip in
               (* TODO if witness_kind = Witness, we might want wk = "" *)
               let wk_s =
@@ -5969,7 +5969,7 @@ let print_isolated conf base =
       List.find_map
         (fun evt ->
           Mutil.array_find_map
-            (fun (wip, wk) -> if wip = iper then Some wk else None)
+            (fun (wip, wk, _) -> if wip = iper then Some wk else None)
             evt.Def.epers_witnesses)
         (Driver.get_pevents rp)
     in
@@ -5981,7 +5981,7 @@ let print_isolated conf base =
             List.find_map
               (fun evt ->
                 Mutil.array_find_map
-                  (fun (wip, wk) -> if wip = iper then Some wk else None)
+                  (fun (wip, wk, _) -> if wip = iper then Some wk else None)
                   evt.Def.efam_witnesses)
               (Driver.get_fevents (Driver.foi base ifam)))
           (Driver.get_family rp)
@@ -6062,7 +6062,7 @@ let print_isolated conf base =
         List.filter_map
           (fun (_, _, _, _, _, wl, _) ->
             Mutil.array_find_map
-              (fun (wip, wk) -> if wip = iper then Some wk else None)
+              (fun (wip, wk, _) -> if wip = iper then Some wk else None)
               wl)
           (Event.sorted_events conf base rp))
       (Driver.get_related (Driver.poi base iper))

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -1211,7 +1211,7 @@ let check_missing_witnesses_names conf get list =
     let rec loop i =
       if i = len then None
       else
-        let (fn, sn, _, _, _), _ = Array.get witnesses i in
+        let (fn, sn, _, _, _), _, _ = Array.get witnesses i in
         if fn = "" && sn = "" then loop (i + 1)
         else if fn = "" || fn = "?" then
           Some

--- a/lib/update.ml
+++ b/lib/update.ml
@@ -1216,7 +1216,7 @@ let check_missing_witnesses_names conf get list =
     let rec loop i =
       if i = len then None
       else
-        let (fn, sn, _, _, _), _ = Array.get witnesses i in
+        let (fn, sn, _, _, _), _, _ = Array.get witnesses i in
         if fn = "" && sn = "" then loop (i + 1)
         else if fn = "" || fn = "?" then
           Some

--- a/lib/update.mli
+++ b/lib/update.mli
@@ -154,7 +154,7 @@ val check_greg_day : config -> Adef.dmy -> unit
 
 val check_missing_witnesses_names :
   config ->
-  ('a -> ((string * string * 'b * 'c * 'd) * 'e) array) ->
+  ('a -> ((string * string * 'b * 'c * 'd) * 'e * 'f) array) ->
   'a list ->
   update_error option
 

--- a/lib/updateFam.ml
+++ b/lib/updateFam.ml
@@ -80,7 +80,9 @@ let family_events_opt env fam =
 let witness_person_of_event_opt env e =
   match get_env "wcnt" env with
   | Vint i when i - 1 >= 0 && i - 1 < Array.length e.efam_witnesses ->
-      Some (fst e.efam_witnesses.(i - 1))
+      Some
+        (let p, _, _ = e.efam_witnesses.(i - 1) in
+         p)
   | Vint i when i - 1 >= 0 && i - 1 < 2 && Array.length e.efam_witnesses < 2 ->
       Some ("", "", 0, Update.Create (Neuter, None), "")
   | _ -> None
@@ -218,7 +220,7 @@ and eval_event_str conf base env fam =
         let src = Util.safe_html (Driver.sou base e.efam_src) in
         let wit =
           Array.fold_right
-            (fun (w, _) accu ->
+            (fun (w, _, _) accu ->
               (transl_nth conf "witness/witnesses" 0
               ^<^ transl conf ":"
               ^<^ Util.gen_person_text conf base (Driver.poi base w))
@@ -256,7 +258,9 @@ and eval_fwitness_kind env fam =
           | Vint i ->
               let i = i - 1 in
               if i >= 0 && i < Array.length e.efam_witnesses then
-                eval_witness_kind (snd e.efam_witnesses.(i))
+                eval_witness_kind
+                  (let _, wk, _ = e.efam_witnesses.(i) in
+                   wk)
               else if i >= 0 && i < 2 && Array.length e.efam_witnesses < 2 then
                 str_val ""
               else raise Not_found

--- a/lib/updateFamOk.ml
+++ b/lib/updateFamOk.ml
@@ -181,16 +181,21 @@ let rec reconstitute_events conf ext cnt =
               let witnesses, ext = loop (i + 1) ext in
               let create = update_ci conf create key in
               let c = (fn, sn, occ, create, var) in
+              let witness_note =
+                match p_getenv conf.env (key ^ "_note") with
+                | Some n -> n
+                | None -> ""
+              in
               let c =
                 match p_getenv conf.env (key ^ "_kind") with
-                | Some "godp" -> (c, Witness_GodParent)
-                | Some "offi" -> (c, Witness_CivilOfficer)
-                | Some "reli" -> (c, Witness_ReligiousOfficer)
-                | Some "info" -> (c, Witness_Informant)
-                | Some "atte" -> (c, Witness_Attending)
-                | Some "ment" -> (c, Witness_Mentioned)
-                | Some "othe" -> (c, Witness_Other)
-                | Some _ | None -> (c, Witness)
+                | Some "godp" -> (c, Witness_GodParent, witness_note)
+                | Some "offi" -> (c, Witness_CivilOfficer, witness_note)
+                | Some "reli" -> (c, Witness_ReligiousOfficer, witness_note)
+                | Some "info" -> (c, Witness_Informant, witness_note)
+                | Some "atte" -> (c, Witness_Attending, witness_note)
+                | Some "ment" -> (c, Witness_Mentioned, witness_note)
+                | Some "othe" -> (c, Witness_Other, witness_note)
+                | Some _ | None -> (c, Witness, witness_note)
               in
               match
                 p_getenv conf.env
@@ -208,7 +213,8 @@ let rec reconstitute_events conf ext cnt =
                         else
                           let new_witn =
                             ( ("", "", 0, Update.Create (Neuter, None), ""),
-                              Witness )
+                              Witness,
+                              "" )
                           in
                           let witnesses = new_witn :: witnesses in
                           loop_witn (n - 1) witnesses
@@ -216,7 +222,9 @@ let rec reconstitute_events conf ext cnt =
                       loop_witn n witnesses
                   | Some _ | None ->
                       let new_witn =
-                        (("", "", 0, Update.Create (Neuter, None), ""), Witness)
+                        ( ("", "", 0, Update.Create (Neuter, None), ""),
+                          Witness,
+                          "" )
                       in
                       (c :: new_witn :: witnesses, true))
               | Some _ | None -> (c :: witnesses, ext))
@@ -234,7 +242,9 @@ let rec reconstitute_events conf ext cnt =
                   if n = 0 then (witnesses, true)
                   else
                     let new_witn =
-                      (("", "", 0, Update.Create (Neuter, None), ""), Witness)
+                      ( ("", "", 0, Update.Create (Neuter, None), ""),
+                        Witness,
+                        "" )
                     in
                     let witnesses = new_witn :: witnesses in
                     loop_witn (n - 1) witnesses
@@ -242,7 +252,7 @@ let rec reconstitute_events conf ext cnt =
                 loop_witn n witnesses
             | Some _ | None ->
                 let new_witn =
-                  (("", "", 0, Update.Create (Neuter, None), ""), Witness)
+                  (("", "", 0, Update.Create (Neuter, None), ""), Witness, "")
                 in
                 (new_witn :: witnesses, true))
         | Some _ | None -> (witnesses, ext)
@@ -280,7 +290,7 @@ let reconstitute_from_fevents (nsck : bool) (empty_string : 'string)
       * 'string
       * 'string
       * 'string
-      * ('person * Def.witness_kind) array)
+      * ('person * Def.witness_kind * 'string) array)
       option
       ref =
     ref None
@@ -507,7 +517,8 @@ let strip_events fevents =
   let strip_array_witness pl =
     Array.of_list
     @@ Array.fold_right
-         (fun (((f, _, _, _, _), _) as p) pl -> if f = "" then pl else p :: pl)
+         (fun (((f, _, _, _, _), _, _) as p) pl ->
+           if f = "" then pl else p :: pl)
          pl []
   in
   List.fold_right
@@ -680,7 +691,7 @@ let infer_origin_file conf base ifam ncpl ndes =
 let fwitnesses_of fevents =
   List.fold_left
     (fun ipl e ->
-      Array.fold_left (fun ipl (ip, _) -> ip :: ipl) ipl e.efam_witnesses)
+      Array.fold_left (fun ipl (ip, _, _) -> ip :: ipl) ipl e.efam_witnesses)
     [] fevents
 
 (* Lorsqu'on ajout naissance décès par exemple en créant une personne. *)
@@ -790,7 +801,7 @@ let update_family_with_fevents conf base fam =
   in
   let relation, marriage, marriage_place, marriage_note, marriage_src = marr in
   let divorce = div in
-  let witnesses = Array.map fst witnesses in
+  let witnesses = Array.map (fun (ip, _, _) -> ip) witnesses in
   {
     fam with
     marriage;

--- a/lib/updateFamOk.mli
+++ b/lib/updateFamOk.mli
@@ -4,7 +4,7 @@ val reconstitute_from_fevents :
   ('person, 'string) Def.gen_fam_event list ->
   (Def.relation_kind * Adef.cdate * 'string * 'string * 'string)
   * Def.divorce
-  * ('person * Def.witness_kind) array
+  * ('person * Def.witness_kind * 'string) array
 (** [reconstitute_from_fevents nsck empty_string family_events] Iterate over
     family's events and returns a tuple with:
 

--- a/lib/updateInd.ml
+++ b/lib/updateInd.ml
@@ -313,7 +313,8 @@ and eval_simple_var conf base env p = function
                   let i = i - 1 in
                   let k =
                     if i >= 0 && i < Array.length e.epers_witnesses then
-                      fst e.epers_witnesses.(i)
+                      let p, _, _ = e.epers_witnesses.(i) in
+                      p
                     else if
                       i >= 0 && i < 2 && Array.length e.epers_witnesses < 2
                     then ("", "", 0, Update.Create (Neuter, None), "")
@@ -335,7 +336,10 @@ and eval_simple_var conf base env p = function
               | Vint i ->
                   let i = i - 1 in
                   if i >= 0 && i < Array.length e.epers_witnesses then
-                    match snd e.epers_witnesses.(i) with
+                    match
+                      let _, wk, _ = e.epers_witnesses.(i) in
+                      wk
+                    with
                     | Witness_GodParent -> str_val "godp"
                     | Witness_CivilOfficer -> str_val "offi"
                     | Witness_ReligiousOfficer -> str_val "reli"

--- a/lib/updateIndOk.ml
+++ b/lib/updateIndOk.ml
@@ -222,16 +222,21 @@ let rec reconstitute_pevents conf ext cnt =
               let create = update_ci conf create key in
               let c = (fn, sn, occ, create, var) in
               let key_c = key ^ "_kind" in
+              let witness_note =
+                match p_getenv conf.env (key ^ "_note") with
+                | Some n -> n
+                | None -> ""
+              in
               let c =
                 match p_getenv conf.env key_c with
-                | Some "godp" -> (c, Witness_GodParent)
-                | Some "offi" -> (c, Witness_CivilOfficer)
-                | Some "reli" -> (c, Witness_ReligiousOfficer)
-                | Some "info" -> (c, Witness_Informant)
-                | Some "atte" -> (c, Witness_Attending)
-                | Some "ment" -> (c, Witness_Mentioned)
-                | Some "othe" -> (c, Witness_Other)
-                | _ -> (c, Witness)
+                | Some "godp" -> (c, Witness_GodParent, witness_note)
+                | Some "offi" -> (c, Witness_CivilOfficer, witness_note)
+                | Some "reli" -> (c, Witness_ReligiousOfficer, witness_note)
+                | Some "info" -> (c, Witness_Informant, witness_note)
+                | Some "atte" -> (c, Witness_Attending, witness_note)
+                | Some "ment" -> (c, Witness_Mentioned, witness_note)
+                | Some "othe" -> (c, Witness_Other, witness_note)
+                | _ -> (c, Witness, witness_note)
               in
               let var_w =
                 "e" ^ string_of_int cnt ^ "_ins_witn" ^ string_of_int i
@@ -248,7 +253,9 @@ let rec reconstitute_pevents conf ext cnt =
                         if n = 0 then (c :: witnesses, true)
                         else
                           let new_witn =
-                            (("", "", 0, Update.Create (Neuter, None), ""), wk)
+                            ( ("", "", 0, Update.Create (Neuter, None), ""),
+                              wk,
+                              "" )
                           in
                           let witnesses = new_witn :: witnesses in
                           loop_witn (n - 1) witnesses
@@ -256,7 +263,7 @@ let rec reconstitute_pevents conf ext cnt =
                       loop_witn n witnesses
                   | _ ->
                       let new_witn =
-                        (("", "", 0, Update.Create (Neuter, None), ""), wk)
+                        (("", "", 0, Update.Create (Neuter, None), ""), wk, "")
                       in
                       (c :: new_witn :: witnesses, true))
               | _ -> (c :: witnesses, ext))
@@ -275,7 +282,7 @@ let rec reconstitute_pevents conf ext cnt =
                   if n = 0 then (witnesses, true)
                   else
                     let new_witn =
-                      (("", "", 0, Update.Create (Neuter, None), ""), wk)
+                      (("", "", 0, Update.Create (Neuter, None), ""), wk, "")
                     in
                     let witnesses = new_witn :: witnesses in
                     loop_witn (n - 1) witnesses
@@ -283,7 +290,7 @@ let rec reconstitute_pevents conf ext cnt =
                 loop_witn n witnesses
             | Some _ | None ->
                 let new_witn =
-                  (("", "", 0, Update.Create (Neuter, None), ""), wk)
+                  (("", "", 0, Update.Create (Neuter, None), ""), wk, "")
                 in
                 (new_witn :: witnesses, true))
         | Some _ | None -> (witnesses, ext)
@@ -764,7 +771,8 @@ let strip_pevents p =
   let strip_array_witness pl =
     let pl =
       Array.fold_right
-        (fun (((f, _, _, _, _), _) as p) pl -> if f = "" then pl else p :: pl)
+        (fun (((f, _, _, _, _), _, _) as p) pl ->
+          if f = "" then pl else p :: pl)
         pl []
     in
     Array.of_list pl
@@ -837,7 +845,7 @@ let rparents_of rparents =
 let pwitnesses_of pevents =
   List.fold_left
     (fun ipl e ->
-      Array.fold_left (fun ipl (ip, _) -> ip :: ipl) ipl e.epers_witnesses)
+      Array.fold_left (fun ipl (ip, _, _) -> ip :: ipl) ipl e.epers_witnesses)
     [] pevents
 
 (* sp.death *)
@@ -907,8 +915,8 @@ let update_relations_of_related base ip old_related =
           (fun e (list, rad) ->
             let witnesses, rad =
               Array.fold_right
-                (fun (ip2, k) (accu, rad) ->
-                  if ip2 = ip then (accu, true) else ((ip2, k) :: accu, rad))
+                (fun (ip2, k, n) (accu, rad) ->
+                  if ip2 = ip then (accu, true) else ((ip2, k, n) :: accu, rad))
                 e.epers_witnesses ([], rad)
             in
             let e = { e with epers_witnesses = Array.of_list witnesses } in
@@ -933,8 +941,8 @@ let update_relations_of_related base ip old_related =
             (fun e (list, rad) ->
               let witnesses, rad =
                 Array.fold_right
-                  (fun (ip2, k) (accu, rad) ->
-                    if ip2 = ip then (accu, true) else ((ip2, k) :: accu, rad))
+                  (fun (ip2, k, n) (accu, rad) ->
+                    if ip2 = ip then (accu, true) else ((ip2, k, n) :: accu, rad))
                   e.efam_witnesses ([], rad)
               in
               let e = { e with efam_witnesses = Array.of_list witnesses } in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -3154,12 +3154,12 @@ let record_visited conf ip =
 let array_mem_witn conf base x a =
   let rec loop i =
     if i = Array.length a then None
-    else if x = fst a.(i) then
-      Some
-        (string_of_witness_kind conf
-           (Driver.get_sex @@ Driver.poi base x)
-           (snd a.(i)))
-    else loop (i + 1)
+    else
+      let wip, wk, _ = a.(i) in
+      if x = wip then
+        Some
+          (string_of_witness_kind conf (Driver.get_sex @@ Driver.poi base x) wk)
+      else loop (i + 1)
   in
   loop 0
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -3248,12 +3248,12 @@ let record_visited conf ip =
 let array_mem_witn conf base x a =
   let rec loop i =
     if i = Array.length a then None
-    else if x = fst a.(i) then
-      Some
-        (string_of_witness_kind conf
-           (Driver.get_sex @@ Driver.poi base x)
-           (snd a.(i)))
-    else loop (i + 1)
+    else
+      let wip, wk, _ = a.(i) in
+      if x = wip then
+        Some
+          (string_of_witness_kind conf (Driver.get_sex @@ Driver.poi base x) wk)
+      else loop (i + 1)
   in
   loop 0
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -700,7 +700,7 @@ val array_mem_witn :
   Config.config ->
   Geneweb_db.Driver.base ->
   Geneweb_db.Driver.iper ->
-  (Geneweb_db.Driver.iper * Def.witness_kind) array ->
+  (Geneweb_db.Driver.iper * Def.witness_kind * Geneweb_db.Driver.istr) array ->
   Adef.safe_string option
 (** [array_mem_witn conf base ip array] checks if [ip] is in [array] and returns
     corresponding [string_of_witness_kind] if so. *)

--- a/lib/util/futil.ml
+++ b/lib/util/futil.ml
@@ -57,7 +57,9 @@ let map_pers_event ?(fd = identity) fp fs e =
   let epers_reason = fs e.epers_reason in
   let epers_note = fs e.epers_note in
   let epers_src = fs e.epers_src in
-  let epers_witnesses = Array.map (fun (p, w) -> (fp p, w)) e.epers_witnesses in
+  let epers_witnesses =
+    Array.map (fun (p, w, n) -> (fp p, w, fs n)) e.epers_witnesses
+  in
   {
     epers_name;
     epers_date;
@@ -83,7 +85,9 @@ let map_fam_event ?(fd = identity) fp fs e =
   let efam_reason = fs e.efam_reason in
   let efam_note = fs e.efam_note in
   let efam_src = fs e.efam_src in
-  let efam_witnesses = Array.map (fun (p, w) -> (fp p, w)) e.efam_witnesses in
+  let efam_witnesses =
+    Array.map (fun (p, w, n) -> (fp p, w, fs n)) e.efam_witnesses
+  in
   {
     efam_name;
     efam_date;

--- a/plugins/gwxjg/gwxjg_data.ml
+++ b/plugins/gwxjg/gwxjg_data.ml
@@ -447,18 +447,20 @@ and mk_event conf base d =
     | [||] -> Tarray [||]
     | w ->
         let lw =
-          lazy (Array.map (fun (i, _) -> get_n_mk_person conf base i) w)
+          lazy (Array.map (fun (i, _, _) -> get_n_mk_person conf base i) w)
         in
         (* We may want to filter on [ip] or [k] before really accessing the person entity *)
         Tarray
           (Array.mapi
-             (fun i (ip, k) ->
+             (fun i (ip, k, wnote) ->
                let kind = mk_witness_kind k in
                let iper = Tstr (Driver.Iper.to_string ip) in
+               let wnote = Tsafe (Driver.sou base wnote) in
                Tpat
                  (function
                  | "kind" -> kind
                  | "iper" -> iper
+                 | "wnote" -> wnote
                  | s -> unbox_pat (Lazy.force lw).(i) @@ s))
              w)
   in


### PR DESCRIPTION
Add a per-witness free-text note to personal and family events.

- def: epers/efam_witnesses become (person * witness_kind * 'string) array
- .gw format: new 'wnote' lines after 'wit:' (gwcomp parser, gwuLib export)
- GEDCOM: 3 NOTE under 2 ASSO (gwb2gedLib export, ged2gwb import)
- storage: carried automatically via dbdisk marshaling + Futil string map
- ripple: checkItem, hasher, event, futil, update*/merge*, perso, gwxjg, .mli

NOTE: web edit-form template field for the note still to be wired (hd/etc).