### PR TITLE
Terminate workers if the master terminates

### DIFF
--- a/http/dune
+++ b/http/dune
@@ -1,4 +1,4 @@
 (library
  (package geneweb-http)
  (name geneweb_http)
- (libraries camlp-streams logs unix fmt))
+ (libraries camlp-streams logs threads unix fmt))

--- a/http/my_unix.ml
+++ b/http/my_unix.ml
@@ -5,3 +5,7 @@ let rec waitpid_noeintr flags pid =
 let rec accept_noeintr ?cloexec fd =
   try Unix.accept ?cloexec fd
   with Unix.Unix_error (Unix.EINTR, _, _) -> accept_noeintr ?cloexec fd
+
+let rec select_noeintr l1 l2 l3 t =
+  try Unix.select l1 l2 l3 t
+  with Unix.Unix_error (Unix.EINTR, _, _) -> select_noeintr l1 l2 l3 t

--- a/http/my_unix.mli
+++ b/http/my_unix.mli
@@ -17,5 +17,5 @@ val select_noeintr :
   Unix.file_descr list ->
   float ->
   Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
-(** Equivalent to [Unix.select_noeintr], but this variant restart upon
-    interruption by signals. *)
+(** Equivalent to [Unix.select], but this variant restart upon interruption by
+    signals. *)

--- a/http/my_unix.mli
+++ b/http/my_unix.mli
@@ -10,3 +10,12 @@ val accept_noeintr :
   ?cloexec:bool -> Unix.file_descr -> Unix.file_descr * Unix.sockaddr
 (** Equivalent to [Unix.accept], but this variant restart upon interruption by
     signals. *)
+
+val select_noeintr :
+  Unix.file_descr list ->
+  Unix.file_descr list ->
+  Unix.file_descr list ->
+  float ->
+  Unix.file_descr list * Unix.file_descr list * Unix.file_descr list
+(** Equivalent to [Unix.select_noeintr], but this variant restart upon
+    interruption by signals. *)

--- a/http/pool.ml
+++ b/http/pool.ml
@@ -2,64 +2,91 @@ let src = Logs.Src.create ~doc:"Pool" "POOL"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-type worker = int
-type t = { workers : (worker, unit) Hashtbl.t } [@@unboxed]
-
-(* Fork the current process using a dead man approach to detect
-   parent termination.
+(* Implement a deadman strategy to detect parent termination.
 
    A pipe is established between the parent and the child process. The child
-   monitors the read-end of the pipe. If the parent process dies, the operating
-   system closes the write-end, unblocking the [Unix.select] call. *)
-let fork child parent =
-  let fd_in, fd_out = Unix.pipe ~cloexec:true () in
-  let check_dead_man () =
-    let fds, _, _ = My_unix.select_noeintr [ fd_in ] [] [] (-1.) in
-    assert (fds == [ fd_in ]);
+   monitors the read-end of the pipe with [watcher]. The parent leaks the
+   file descriptors. If the parent dies, the operating system closes the
+   writ-end, unblocking the watcher. *)
+module Deadman : sig
+  type t
+
+  val create : unit -> t
+
+  val watch : t -> unit
+  (** [watch d] watches the deadman [d]. If the parent is dead, the child is
+      immediately exited. *)
+end = struct
+  type t = { pid : int; fd_in : Unix.file_descr; fd_out : Unix.file_descr }
+
+  let create () =
+    let pid = Unix.getpid () in
+    let fd_in, fd_out = Unix.pipe ~cloexec:true () in
+    { pid; fd_in; fd_out }
+
+  let watcher fd =
+    let l, _, _ = My_unix.select_noeintr [ fd ] [] [] (-1.) in
+    assert (l = [ fd ]);
     Unix._exit 1
-  in
-  match Unix.fork () with
-  | 0 ->
+
+  let watch { pid; fd_in; fd_out } =
+    if pid = Unix.getpid () then
+      failwith "watch: cannot watch yourself Narcisse!"
+    else (
       Unix.close fd_out;
-      (* One doesn't need to join this watchdog thread at the end of the child
-         process, as the process will exit in [child]. *)
-      let (_ : Thread.t) = Thread.create check_dead_man () in
-      child ()
-  | pid ->
-      (* Intentionally keep [fd_out] open. It must remain inaccessible to
-         the rest of the parent and will be closed automatically by the
-         operating system if the parent dies. *)
-      Unix.close fd_in;
-      parent pid
+      (* Some signals are used by the OCaml runtime and one shouldn't block
+         them. Currently, GeneWeb uses two process-wide signals:
+         - [Sys.sigalrm] is used for timeout per request.
+         - [Sys.sighup] is used to reload log files. *)
+      let signals = [ Sys.sigalrm; Sys.sighup ] in
+      let old_mask = Unix.sigprocmask SIG_BLOCK signals in
+      let finally () =
+        ignore (Unix.sigprocmask SIG_SETMASK old_mask : int list)
+      in
+      Fun.protect ~finally @@ fun () ->
+      ignore (Thread.create watcher fd_in : Thread.t))
+end
+
+type worker = int
+type t = { workers : (worker, unit) Hashtbl.t; deadman : Deadman.t }
 
 let add_worker t k =
-  let child () =
-    while true do
-      k @@ Unix.getpid ()
-    done
-  in
-  let parent pid =
-    Log.debug (fun k -> k "Creating worker %d" pid);
-    Hashtbl.replace t.workers pid ()
-  in
-  fork child parent
+  match Unix.fork () with
+  | 0 ->
+      Deadman.watch t.deadman;
+      while true do
+        k @@ Unix.getpid ()
+      done;
+      assert false
+  | pid ->
+      (* Intentionally leaking the deadman descriptors in the parent process.
+         - [fd_out] is kept open as its closure is used as a signal for the
+           child of the parent termination.
+         - [fd_in] is kept open to be able to create new worker with the
+           same deadman. *)
+      Hashtbl.add t.workers pid ();
+      Log.debug (fun k -> k "Creating worker %d" pid)
 
 let wait_any_child () = My_unix.waitpid_noeintr [] (-1) |> fst
 
 let start n k =
   if (not Sys.unix) || n < 1 then invalid_arg "start";
-  let t = { workers = Hashtbl.create n } in
+  let deadman = Deadman.create () in
+  let t = { workers = Hashtbl.create n; deadman } in
   for _ = 0 to n - 1 do
     add_worker t k
   done;
   while true do
-    let pid = wait_any_child () in
-    (* We never run out of children because each time a worker terminates,
-       it is immediately replaced with a new one. *)
-    assert (pid > 0);
-    match Hashtbl.find t.workers pid with
-    | () ->
-        Log.debug (fun k -> k "Worker %d is dead, replace it" pid);
-        add_worker t k
-    | exception Not_found -> assert false
+    match wait_any_child () with
+    | exception Unix.Unix_error (ECHILD, _, _) ->
+        (* We never run out of children because each time a worker terminates,
+           it is immediately replaced with a new one. *)
+        assert false
+    | pid -> (
+        match Hashtbl.find t.workers pid with
+        | () ->
+            Log.debug (fun k -> k "Worker %d is dead, replace it" pid);
+            Hashtbl.remove t.workers pid;
+            add_worker t k
+        | exception Not_found -> assert false)
   done

--- a/http/pool.ml
+++ b/http/pool.ml
@@ -2,35 +2,53 @@ let src = Logs.Src.create ~doc:"Pool" "POOL"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-type worker = { pid : int } [@@unboxed]
+type worker = int
 type t = { workers : (worker, unit) Hashtbl.t } [@@unboxed]
 
-let add_worker t k =
+(* Fork the current process using a dead man approach to detect
+   parent termination.
+
+   A pipe is established between the parent and the child process. The child
+   monitors the read-end of the pipe. If the parent process dies, the operating
+   system closes the write-end, unblocking the [Unix.select] call. *)
+let fork child parent =
+  let fd_in, fd_out = Unix.pipe ~cloexec:true () in
+  let check_dead_man () =
+    let fds, _, _ = My_unix.select_noeintr [ fd_in ] [] [] (-1.) in
+    assert (fds == [ fd_in ]);
+    Unix._exit 1
+  in
   match Unix.fork () with
   | 0 ->
-      while true do
-        k @@ Unix.getpid ()
-      done
+      Unix.close fd_out;
+      (* One doesn't need to join this watchdog thread at the end of the child
+         process, as the process will exit in [child]. *)
+      let (_ : Thread.t) = Thread.create check_dead_man () in
+      child ()
   | pid ->
-      Log.debug (fun k -> k "Creating worker %d" pid);
-      Hashtbl.replace t.workers { pid } ()
+      (* Intentionally keep [fd_out] open. It must remain inaccessible to
+         the rest of the parent and will be closed automatically by the
+         operating system if the parent dies. *)
+      Unix.close fd_in;
+      parent pid
 
-let cleanup { workers } =
-  Log.debug (fun k -> k "Cleanup workers...");
-  Hashtbl.iter
-    (fun { pid } () ->
-      Log.debug (fun k -> k "Kill worker %d" pid);
-      try Unix.kill pid Sys.sigterm with _ -> ())
-    workers
+let add_worker t k =
+  let child () =
+    while true do
+      k @@ Unix.getpid ()
+    done
+  in
+  let parent pid =
+    Log.debug (fun k -> k "Creating worker %d" pid);
+    Hashtbl.replace t.workers pid ()
+  in
+  fork child parent
 
 let wait_any_child () = My_unix.waitpid_noeintr [] (-1) |> fst
 
 let start n k =
   if (not Sys.unix) || n < 1 then invalid_arg "start";
   let t = { workers = Hashtbl.create n } in
-  let parent_pid = Unix.getpid () in
-  let finally () = if Unix.getpid () = parent_pid then cleanup t in
-  Fun.protect ~finally @@ fun () ->
   for _ = 0 to n - 1 do
     add_worker t k
   done;
@@ -39,7 +57,7 @@ let start n k =
     (* We never run out of children because each time a worker terminates,
        it is immediately replaced with a new one. *)
     assert (pid > 0);
-    match Hashtbl.find t.workers { pid } with
+    match Hashtbl.find t.workers pid with
     | () ->
         Log.debug (fun k -> k "Worker %d is dead, replace it" pid);
         add_worker t k

--- a/http/pool.ml
+++ b/http/pool.ml
@@ -31,7 +31,7 @@ end = struct
 
   let watch { pid; fd_in; fd_out } =
     if pid = Unix.getpid () then
-      failwith "watch: cannot watch yourself Narcisse!"
+      failwith "watch: cannot watch yourself Narcissus!"
     else (
       Unix.close fd_out;
       (* Some signals are used by the OCaml runtime and one shouldn't block


### PR DESCRIPTION
The workers could outlive the parent on Unix. For instance, run
```console
dune exec gwd -- --debug
kill -TERM `pid`
```
where `pid` is the PID of the master process.

On UNIX, the termination of the parent process doesn't produce a signal to its children. A simple and portable way to ensure termination of the children is to open pipe between the parent and the child. The pipe is closed if the parent dies and you can detect this event in the child.

Notice that no cleanup operations is executed during the termination of the child.