### PR TITLE
Use the value of `-bd` CLI option in `Gwexport` module

### DIFF
--- a/bin/gwb2ged/gwb2ged.ml
+++ b/bin/gwb2ged/gwb2ged.ml
@@ -22,11 +22,12 @@ let ansel_warning =
   "Warning: ANSEL charset was administratively withdrawn in 2013. UTF-8 is \
    recommended for new GEDCOM files."
 
+let ( // ) = Filename.concat
+
 let () =
   let opts = ref Gwexport.default_opts in
   Arg.parse (speclist opts) anonfun usage;
-  let bases_dir = Dirs.path Secure.default_base_dir in
-  Secure.set_base_dir bases_dir;
+  Secure.set_base_dir !opts.bases_dir;
   if !opts.Gwexport.charset = Gwexport.Ansel then
     Printf.eprintf "%s\n%!" ansel_warning;
   match !bname with
@@ -37,11 +38,11 @@ let () =
       let oc, name, close =
         if !Gwexport.out_file = "" then (stdout, "", fun () -> flush stdout)
         else
-          let path = Gwexport.resolve_out_file () in
+          let path = Gwexport.resolve_out_file !opts in
           let oc = open_out path in
           (oc, path, fun () -> close_out oc)
       in
       opts := { !opts with Gwexport.oc = (name, output_string oc, close) };
-      Driver.with_database (Filename.concat bases_dir bname) @@ fun base ->
+      Driver.with_database (!opts.bases_dir // bname) @@ fun base ->
       let select = Gwexport.select base !opts [] in
       Gwb2gedLib.gwb2ged base !with_indexes !opts select

--- a/bin/gwexport/gwexport.ml
+++ b/bin/gwexport/gwexport.ml
@@ -6,14 +6,10 @@ module Gutil = Geneweb_db.Gutil
 
 type gwexport_charset = Ansel | Ansi | Ascii | Utf8
 
-let bases_dir = ref (Dirs.path Secure.default_base_dir)
 let out_file = ref ""
 
-let resolve_out_file () =
-  if Filename.is_relative !out_file then Filename.concat !bases_dir !out_file
-  else !out_file
-
 type gwexport_opts = {
+  bases_dir : string;
   asc : int option;
   ascdesc : int option;
   censor : int;
@@ -34,8 +30,14 @@ type gwexport_opts = {
   test : bool;
 }
 
+let resolve_out_file opts =
+  if Filename.is_relative !out_file then
+    Filename.concat opts.bases_dir !out_file
+  else !out_file
+
 let default_opts =
   {
+    bases_dir = Dirs.path Secure.default_base_dir;
     asc = None;
     ascdesc = None;
     censor = 0;
@@ -63,7 +65,12 @@ let speclist c =
     ( "-a",
       Arg.Int (fun s -> c := { !c with asc = Some s }),
       "<N> maximum generation of the root's ascendants" );
-    ("-bd", Arg.String (fun s -> bases_dir := s), "<dir> bases directory.");
+    ( "-bd",
+      Arg.String (fun s -> c := { !c with bases_dir = s }),
+      Fmt.str
+        "<DIR> Specify where the bases directory with databases is installed \
+         (default if empty is %S)."
+        (Dirs.name Secure.default_base_dir) );
     ( "-ad",
       Arg.Int (fun s -> c := { !c with ascdesc = Some s }),
       "<N> maximum generation of the root's ascendants descendants \

--- a/bin/gwexport/gwexport.mli
+++ b/bin/gwexport/gwexport.mli
@@ -1,6 +1,7 @@
 type gwexport_charset = Ansel | Ansi | Ascii | Utf8
 
 type gwexport_opts = {
+  bases_dir : string; (* Specify the location of the bases directory. *)
   asc : int option; (* Maximum generation of the root's ascendants *)
   ascdesc : int option;
       (* Maximum generation of the root's ascendants descendants *)
@@ -31,14 +32,11 @@ type gwexport_opts = {
 val default_opts : gwexport_opts
 (** Default set of options *)
 
-val bases_dir : string ref
-(** Bases directory, set by [-bd] (default: [Secure.default_base_dir]). *)
-
 val out_file : string ref
 (** Output file name, set by [-o] ([""] means tool default). *)
 
-val resolve_out_file : unit -> string
-(** [!out_file], prefixed by [!bases_dir] when relative. *)
+val resolve_out_file : gwexport_opts -> string
+(** [!out_file], prefixed by [bases_dir] when relative. *)
 
 val speclist : gwexport_opts ref -> (Arg.key * Arg.spec * Arg.doc) list
 (** Given a set of options, returns default command line arguments for selecting

--- a/bin/gwu/gwu.ml
+++ b/bin/gwu/gwu.ml
@@ -3,116 +3,120 @@ module Driver = Geneweb_db.Driver
 module Dirs = Geneweb_dirs
 
 let isolated = ref false
-
-let speclist opts =
-  ( "-odir",
-    Arg.String (fun s -> GwuLib.out_dir := s),
-    "<dir> create files from original name in directory (else on -o file)" )
-  :: ( "-isolated",
-       Arg.Set isolated,
-       " export isolated persons (work only if export all database)." )
-  :: ( "-old_gw",
-       Arg.Set GwuLib.old_gw,
-       " do not export additional fields (for backward compatibility: < 7.00)"
-     )
-  :: ( "-raw",
-       Arg.Set GwuLib.raw_output,
-       " raw output (without possible utf-8 conversion)" )
-  :: ( "-sep",
-       Arg.String (fun s -> GwuLib.separate_list := s :: !GwuLib.separate_list),
-       " <1st_name.num surname> To use together with the option \"-odir\": \
-        separate this person and all his ancestors and descendants sharing the \
-        same surname. All the concerned families are displayed on standard \
-        output instead of their associated files. This option can be used \
-        several times." )
-  :: ( "-sep_only_file",
-       Arg.String (fun s -> GwuLib.only_file := s),
-       "<file> with option \"-sep\", tells to separate only groups of that \
-        file." )
-  :: ( "-sep_limit",
-       Arg.Int (fun i -> GwuLib.sep_limit := i),
-       "<num> When using the option \"-sep\", groups of families can become \
-        isolated in the files. Gwu reconnects them to the separated families \
-        (i.e. displays them to standard output) if the size of these groups is \
-        less than "
-       ^ string_of_int !GwuLib.sep_limit
-       ^ ". The present option changes this limit." )
-  :: Gwexport.speclist opts
-  |> List.sort (fun (a, _, _) (b, _, _) -> String.compare a b)
-  |> Arg.align
-
 let bname = ref None
 
-let anonfun s =
-  if !bname = None then bname := Some (Filename.basename s)
-  else raise (Arg.Bad "Cannot treat several databases")
-
-let () =
+let parse_cmd () =
+  let speclist opts =
+    ( "-odir",
+      Arg.String (fun s -> GwuLib.out_dir := s),
+      "<dir> create files from original name in directory (else on -o file)" )
+    :: ( "-isolated",
+         Arg.Set isolated,
+         " export isolated persons (work only if export all database)." )
+    :: ( "-old_gw",
+         Arg.Set GwuLib.old_gw,
+         " do not export additional fields (for backward compatibility: < 7.00)"
+       )
+    :: ( "-raw",
+         Arg.Set GwuLib.raw_output,
+         " raw output (without possible utf-8 conversion)" )
+    :: ( "-sep",
+         Arg.String
+           (fun s -> GwuLib.separate_list := s :: !GwuLib.separate_list),
+         " <1st_name.num surname> To use together with the option \"-odir\": \
+          separate this person and all his ancestors and descendants sharing \
+          the same surname. All the concerned families are displayed on \
+          standard output instead of their associated files. This option can \
+          be used several times." )
+    :: ( "-sep_only_file",
+         Arg.String (fun s -> GwuLib.only_file := s),
+         "<file> with option \"-sep\", tells to separate only groups of that \
+          file." )
+    :: ( "-sep_limit",
+         Arg.Int (fun i -> GwuLib.sep_limit := i),
+         "<num> When using the option \"-sep\", groups of families can become \
+          isolated in the files. Gwu reconnects them to the separated families \
+          (i.e. displays them to standard output) if the size of these groups \
+          is less than "
+         ^ string_of_int !GwuLib.sep_limit
+         ^ ". The present option changes this limit." )
+    :: Gwexport.speclist opts
+    |> List.sort (fun (a, _, _) (b, _, _) -> String.compare a b)
+    |> Arg.align
+  in
+  let anonfun s =
+    if !bname = None then bname := Some (Filename.basename s)
+    else raise (Arg.Bad "Cannot treat several databases")
+  in
   let opts = ref Gwexport.default_opts in
   Arg.parse (speclist opts) anonfun Gwexport.errmsg;
-  let bases_dir = Dirs.path Secure.default_base_dir in
-  Secure.set_base_dir bases_dir;
   match !bname with
   | None ->
       Arg.usage (speclist opts) Gwexport.errmsg;
       exit 2
-  | Some bname ->
-      let name =
-        if !Gwexport.out_file = "" then Filename.concat bases_dir (bname ^ ".gw")
-        else Gwexport.resolve_out_file ()
-      in
-      let oc = open_out name in
-      opts :=
-        {
-          !opts with
-          Gwexport.oc = (name, output_string oc, fun () -> close_out oc);
-        };
-      let opts = !opts in
-      Driver.with_database (Filename.concat bases_dir bname) @@ fun base ->
-      let select = Gwexport.select base opts [] in
-      let src_oc_ht = Hashtbl.create 1009 in
-      Driver.load_ascends_array base;
-      Driver.load_strings_array base;
-      if not opts.Gwexport.mem then (
-        Driver.load_couples_array base;
-        Driver.load_unions_array base;
-        Driver.load_descends_array base;
-        ());
-      (if opts.Gwexport.test then
-         let iper_filter, ifam_filter = select in
-         let nb_persons =
-           Geneweb_db.Collection.fold
-             (fun count i ->
-               if iper_filter i then (
-                 Printf.eprintf "P: %s\n"
-                   (Geneweb_db.Gutil.designation base (Driver.poi base i));
-                 count + 1)
-               else count)
-             0 (Driver.ipers base)
-         in
-         let nb_families =
-           Geneweb_db.Collection.fold
-             (fun count i ->
-               if ifam_filter i then (
-                 let father = Driver.get_father (Driver.foi base i) in
-                 let mother = Driver.get_mother (Driver.foi base i) in
-                 Printf.eprintf "F: %s & %s\n"
-                   (Geneweb_db.Gutil.designation base (Driver.poi base father))
-                   (Geneweb_db.Gutil.designation base (Driver.poi base mother));
-                 count + 1)
-               else count)
-             0 (Driver.ifams base)
-         in
-         Printf.eprintf "Exporting %d persons and %d families\n" nb_persons
-           nb_families);
-      let _ofile, oc, close = opts.Gwexport.oc in
-      if not !GwuLib.raw_output then oc "encoding: utf-8\n";
-      if !GwuLib.old_gw then oc "\n" else oc "gwplus\n\n";
-      let in_dir =
-        let full = Filename.concat (Secure.base_dir ()) bname in
-        if Filename.check_suffix full ".gwb" then full else full ^ ".gwb"
-      in
-      GwuLib.prepare_free_occ base;
-      GwuLib.gwu opts !isolated base in_dir !out_dir src_oc_ht select;
-      Hashtbl.iter (fun _ (_, _, close) -> close ()) src_oc_ht;
-      close ()
+  | Some bname -> (opts, bname)
+
+let ( // ) = Filename.concat
+
+let () =
+  let opts, bname = parse_cmd () in
+  Secure.set_base_dir !opts.bases_dir;
+  let name =
+    if !Gwexport.out_file = "" then !opts.bases_dir // (bname ^ ".gw")
+    else Gwexport.resolve_out_file !opts
+  in
+  let oc = open_out name in
+  opts :=
+    {
+      !opts with
+      Gwexport.oc = (name, output_string oc, fun () -> close_out oc);
+    };
+  let opts = !opts in
+  Driver.with_database (opts.bases_dir // bname) @@ fun base ->
+  let select = Gwexport.select base opts [] in
+  let src_oc_ht = Hashtbl.create 1009 in
+  Driver.load_ascends_array base;
+  Driver.load_strings_array base;
+  if not opts.Gwexport.mem then (
+    Driver.load_couples_array base;
+    Driver.load_unions_array base;
+    Driver.load_descends_array base;
+    ());
+  (if opts.Gwexport.test then
+     let iper_filter, ifam_filter = select in
+     let nb_persons =
+       Geneweb_db.Collection.fold
+         (fun count i ->
+           if iper_filter i then (
+             Printf.eprintf "P: %s\n"
+               (Geneweb_db.Gutil.designation base (Driver.poi base i));
+             count + 1)
+           else count)
+         0 (Driver.ipers base)
+     in
+     let nb_families =
+       Geneweb_db.Collection.fold
+         (fun count i ->
+           if ifam_filter i then (
+             let father = Driver.get_father (Driver.foi base i) in
+             let mother = Driver.get_mother (Driver.foi base i) in
+             Printf.eprintf "F: %s & %s\n"
+               (Geneweb_db.Gutil.designation base (Driver.poi base father))
+               (Geneweb_db.Gutil.designation base (Driver.poi base mother));
+             count + 1)
+           else count)
+         0 (Driver.ifams base)
+     in
+     Printf.eprintf "Exporting %d persons and %d families\n" nb_persons
+       nb_families);
+  let _ofile, oc, close = opts.Gwexport.oc in
+  if not !GwuLib.raw_output then oc "encoding: utf-8\n";
+  if !GwuLib.old_gw then oc "\n" else oc "gwplus\n\n";
+  let in_dir =
+    let full = Filename.concat (Secure.base_dir ()) bname in
+    if Filename.check_suffix full ".gwb" then full else full ^ ".gwb"
+  in
+  GwuLib.prepare_free_occ base;
+  GwuLib.gwu opts !isolated base in_dir !out_dir src_oc_ht select;
+  Hashtbl.iter (fun _ (_, _, close) -> close ()) src_oc_ht;
+  close ()


### PR DESCRIPTION
The `Gwexport` module exposes a CLI option for the bases directory but both `gwu` and `gwb2ged` ignore it. This commit fixes this issues and refactor a bit the code.

Should fix #2943 