### PR TITLE
Fix custom event field and deletion on person/family forms

### DIFF
--- a/hd/etc/menubar.txt
+++ b/hd/etc/menubar.txt
@@ -495,10 +495,7 @@
       </div>
     </div>
   </nav>
-  %( exclusion because AD/MO|D_|PAR/FAM have a menubar if e.ip!="" but the new ADDFAM don’t! %)
-  %if;(not (e.ip!="" and "D_FAM" in e.m or "D_PAR" in e.m))
-    %include;home
-  %end;
+  %include;home
   %if;(evar.m="C" and (e.v1!="" or e.v2!="") and not cancel_links)
     %include;buttons_cousins
   %end;

--- a/hd/etc/upd_js.txt
+++ b/hd/etc/upd_js.txt
@@ -80,17 +80,18 @@ function sortSelectOptions() {
 /** Gère l'affichage du champ d'événement personnalisé */
 function showEventLabel(type, defaultName, cnt) {
   const selector = document.getElementById(type + '_select' + cnt);
-  const label = document.getElementById(type + '_label_selector' + cnt);
+  const wrapper = document.getElementById(type + '_label_selector' + cnt);
   const input = document.getElementById('e_name' + cnt);
+  if (!selector || !wrapper || !input) return;
   const selectedOption = selector.options[selector.selectedIndex];
   
   input.value = (selector.value === '') 
     ? (defaultName && defaultName.charAt(0) !== '#' ? defaultName : '')
     : selector.value;
   
-  const isCustom = selectedOption.id === 'custom' + cnt;
-  label.style.display = isCustom ? 'inline' : 'none';
-  input.style.display = isCustom ? 'inline' : 'none';
+  const isCustom = !!selectedOption && selectedOption.id === 'custom' + cnt;
+  wrapper.classList.toggle('d-none', !isCustom);
+  if (isCustom && document.activeElement === selector) input.focus();
 }
 
 function show_pevent_label(xxname, xcnt) {
@@ -105,9 +106,7 @@ function show_fevent_label(xxname, xcnt) {
 function initCustomEvents() {
   document.querySelectorAll('.other_evts').forEach(evt => {
     const input = evt.querySelector('input');
-    if (input?.value && input.value.charAt(0) !== '#') {
-      evt.style.display = '';
-    }
+    evt.classList.toggle('d-none', !(input?.value && input.value.charAt(0) !== '#'));
   });
 }
 

--- a/hd/etc/upd_js.txt
+++ b/hd/etc/upd_js.txt
@@ -84,12 +84,17 @@ function showEventLabel(type, defaultName, cnt) {
   const input = document.getElementById('e_name' + cnt);
   if (!selector || !wrapper || !input) return;
   const selectedOption = selector.options[selector.selectedIndex];
-  
-  input.value = (selector.value === '') 
-    ? (defaultName && defaultName.charAt(0) !== '#' ? defaultName : '')
-    : selector.value;
-  
   const isCustom = !!selectedOption && selectedOption.id === 'custom' + cnt;
+  const isDelete = !!selectedOption && selectedOption.id === 'delete' + cnt;
+  
+  if (isDelete) {
+    input.value = '';
+  } else if (isCustom) {
+    input.value = (defaultName && defaultName.charAt(0) !== '#') ? defaultName : '';
+  } else {
+    input.value = selector.value;
+  }
+
   wrapper.classList.toggle('d-none', !isCustom);
   if (isCustom && document.activeElement === selector) input.focus();
 }

--- a/hd/etc/upd_js.txt
+++ b/hd/etc/upd_js.txt
@@ -153,12 +153,12 @@ function initSelectToggle() {
 }
 
 /** Gestion du scroll pour le banner */
-document.addEventListener('scroll', () => {
+function updateBannerState() {
   const banner = document.getElementById('banner');
-  if (banner) {
-    banner.classList.toggle('scrolled', window.scrollY > 35);
-  }
-});
+  if (banner) banner.classList.toggle('scrolled', window.scrollY > 35);
+}
+document.addEventListener('scroll', updateBannerState, { passive: true });
+document.addEventListener('DOMContentLoaded', updateBannerState);
 
 /** Configuration des mois par type de calendrier */
 const CALENDAR_MONTHS = {

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -476,7 +476,7 @@
       %apply;selector_fevent(xcnt)
     </div>
     <div class="col-sm-7">
-      <label id="fevent_label_selectorxcnt" style="display:none" class="other_evts w-100">
+      <label id="fevent_label_selectorxcnt" class="other_evts w-100 d-none">
         <input type="text" class="form-control fw-bold" name="e_namexcnt" value="%if;(event.e_name="")#marr%else;%event.e_name;%end;" id="e_namexcnt" placeholder="[*event/events]0">
       </label>
     </div>

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -471,14 +471,14 @@
 
 %define;one_fevent(xcnt, has_fevents)
   <div class="row">
-    <h5 class="col-form-label col-sm-2 mb-1 text-uppercase"><label for="e_namexcnt" class="mb-0">[*event/events]0 xcnt</label></h5>
+    <h5 class="col-form-label col-sm-2 mb-1 text-uppercase"><label for="fevent_selectxcnt" class="mb-0">[*event/events]0 xcnt</label></h5>
     <div class="col-sm-3">
       %apply;selector_fevent(xcnt)
     </div>
     <div class="col-sm-7">
-      <label id="fevent_label_selectorxcnt" class="other_evts w-100 d-none">
-        <input type="text" class="form-control fw-bold" name="e_namexcnt" value="%if;(event.e_name="")#marr%else;%event.e_name;%end;" id="e_namexcnt" placeholder="[*event/events]0">
-      </label>
+      <div id="fevent_label_selectorxcnt" class="other_evts w-100 d-none">
+        <input type="text" class="form-control fw-bold" name="e_namexcnt" value="%if;(event.e_name="")#marr%else;%event.e_name;%end;" id="e_namexcnt" placeholder="[*event/events]0" aria-label="[*custom event]">
+      </div>
     </div>
   </div>
   <div class="row mb-2">

--- a/hd/etc/updfam.txt
+++ b/hd/etc/updfam.txt
@@ -26,7 +26,7 @@
 %message_to_wizard;
 <div class="container">
 %( do not use %include;menubar %)
-%include_menubar
+%include_menubar;
 %let;datalist_fnames; list="datalist_fnames" data-book="fn"%in;
 %let;datalist_snames; list="datalist_snames" data-book="sn"%in;
 %let;datalist_places; list="datalist_places" data-book="place"%in;

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -471,7 +471,7 @@
         %apply;selector_pevent(xcnt)
       </div>
       <div class="col">
-        <label id="pevent_label_selectorxcnt" style="display:none" class="other_evts w-100">
+        <label id="pevent_label_selectorxcnt" class="other_evts w-100 d-none">
           <input type="text" class="form-control fw-bold" name="e_namexcnt" value="%event.e_name;" id="e_namexcnt" placeholder="[*event/events]0">
         </label>
       </div>

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -268,7 +268,7 @@
   <select class="form-select fw-bold sortable-select" id="pevent_selectxcnt" onchange="show_pevent_label(document.getElementById('e_namexcnt')?.defaultValue || '', 'xcnt')">
     <option value="" id="deletexcnt">[*select/delete an event]1</option>
     <option disabled>──────────────────</option>
-    <option value="">[*custom event]</option>
+    <option value=""%if;(not ("#" in event.e_name) and event.e_name!="") selected%end; id="customxcnt">[*custom event]</option>
     <option disabled>──────────────────</option>
     <option data-insert="1" value=""%if;(event.e_name="") selected%end; disabled> [*select/delete an event]0 </option>
     <option value="#acco" data-sort="1"%if;(event.e_name="#acco") selected%end;>[*accomplishment]</option>

--- a/hd/etc/updind.txt
+++ b/hd/etc/updind.txt
@@ -471,9 +471,9 @@
         %apply;selector_pevent(xcnt)
       </div>
       <div class="col">
-        <label id="pevent_label_selectorxcnt" class="other_evts w-100 d-none">
-          <input type="text" class="form-control fw-bold" name="e_namexcnt" value="%event.e_name;" id="e_namexcnt" placeholder="[*event/events]0">
-        </label>
+        <div id="pevent_label_selectorxcnt" class="other_evts w-100 d-none">
+          <input type="text" class="form-control fw-bold" name="e_namexcnt" value="%event.e_name;" id="e_namexcnt" placeholder="[*event/events]0" aria-label="[*custom event]">
+        </div>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Fixes #2904, plus a second defect in the same area: deleting a custom event
was impossible on both forms.

The event type `<select>` has no `name` attribute and is never submitted. The
only field reaching the server is `e_name<cnt>`, driven entirely by
`showEventLabel()` in `upd_js.txt`. Both bugs live there and in the
consistency of the option ids between the two templates: three options share
`value=""` (delete / custom / separator), so they can only be told apart by
their id.