### PR TITLE
fix(perso): honour v= as the upper generation bound in build_list_eclair

### DIFF
--- a/hd/etc/anclist.txt
+++ b/hd/etc/anclist.txt
@@ -112,7 +112,7 @@
 %define;definecujus(pp,nn)
   %if;(nn=0)[*define Cujus:::pp]0%elseif;(nn=1)[*define Cujus:::pp]1%end;
 %end;
-%if;(e.v="" and e.v=0)
+%if;(e.v="" or e.v=0)
   [*specify::generation/generations]0.
 %else;
   %if;(e.t="L")
@@ -153,7 +153,7 @@
   %elseif;(e.t="E")
     %( list eclair by alphabetic/place/date/ind/event order %)
         %empty_sorted_list;
-    %foreach;ancestor_surname(e.v)
+    %foreach;ancestor_surname(lvl)
       %apply;add_in_sorted_list%with;
         %if;(e.sort="ind")
           -%ancestor.nb_ind;
@@ -182,22 +182,22 @@
           [*sort by/date begin/alphabetic order/nb individuals/nb events]0
           <a role="button" href="%url_set.sort;"
             class="ms-1 btn btn-link%if;(e.sort="") disabled" aria-disabled="true%end;">
-            <i class="fa-solid fa-arrow-down-a-z me-1"></i>
+            <i class="fa-solid fa-arrow-down-a-z me-1"></i>%nn;
             [sort by/date begin/alphabetic order/nb individuals/nb events]2</a>
           <a role="button" href="%url_set.sort.plc;"
             class="btn btn-link%if;(e.sort="plc") disabled" aria-disabled="true%end;">
             <i class="fa-solid fa-arrow-down-a-z me-1"></i>[place/places]1</a>
           <a role="button" href="%url_set.sort.date;"
             class="btn btn-link%if;(e.sort="date") disabled" aria-disabled="true%end;">
-            <i class="fa-regular fa-calendar-days me-1"></i>
+            <i class="fa-regular fa-calendar-days me-1"></i>%nn;
             [sort by/date begin/alphabetic order/nb individuals/nb events]1</a>
           <a role="button" href="%url_set.sort.ind;"
             class="btn btn-link%if;(e.sort="ind") disabled" aria-disabled="true%end;">
-            <i class="fa-solid fa-arrow-down-wide-short me-1"></i>
+            <i class="fa-solid fa-arrow-down-wide-short me-1"></i>%nn;
             [sort by/date begin/alphabetic order/nb individuals/nb events]3</a>
           <a role="button" href="%url_set.sort.evt;"
             class="btn btn-link%if;(e.sort="evt") disabled" aria-disabled="true%end;">
-            <i class="fa-solid fa-arrow-down-wide-short me-1"></i>
+            <i class="fa-solid fa-arrow-down-wide-short me-1"></i>%nn;
             [sort by/date begin/alphabetic order/nb individuals/nb events]4</a>
         </div>
       %end;
@@ -250,7 +250,7 @@
     %( surnames branch sorted by number of branches %)
     %empty_sorted_list;
     %reset_count;
-    %foreach;ancestor_surname(e.v)
+    %foreach;ancestor_surname(lvl)
       %incr_count;
       %let;neg_ancestor_nb_times;%expr(0-ancestor.nb_times)%in;
       %apply;add_in_sorted_list(
@@ -265,7 +265,6 @@
         ancestor.date_end.prec,
         ancestor.date_end.year)
     %end;
-    %let;nb_gen;%apply;min(e.v, max_anc_level)%in;
     %if;(count > 100)
       <span class="ms-3">[*number of branches][:]</span>
       %foreach;sorted_list_item;
@@ -355,7 +354,6 @@
 
   %elseif;(e.t="F")
     %( surnames branch %)
-    %let;nb_gen;%apply;min(e.v, max_anc_level)%in;
     %if;(not cancel_links)
       <div class="ms-3 mb-3">
         [*help surname branch].<br>
@@ -376,7 +374,7 @@
       </tr>
       </thead>
       <tbody>
-      %foreach;ancestor_surname(e.v)
+      %foreach;ancestor_surname(lvl)
         <tr>
           <td>
             %ancestor.surname_end;%ancestor.surname_begin;

--- a/hd/etc/buttons.txt
+++ b/hd/etc/buttons.txt
@@ -191,7 +191,8 @@
           %end;
         %end;
         <span class="col-auto px-0 me-2">[*generation/generations]0</span>
-        %if;not ((e.m="D" and (e.t="D" or e.t="L" or e.t="A")) or (e.m="A" and (e.t="H" or e.t="G")))
+        %if;not ((e.m="D" and (e.t="D" or e.t="L" or e.t="A"))
+              or (e.m="A" and (e.t="E" or e.t="F" or e.t="H" or e.t="G")))
           <div class="input-group flex-nowrap me-2">
             <label for="input_v0" class="input-group-text" title="v0= (min<=max)">min</label>
             <input type="number" id="input_v0" name="v0" class="form-control"

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1086,19 +1086,21 @@ let build_list_eclair conf base v p =
   (* Parcours les ascendants de p et les ajoute dans la Hashtbl. *)
   let rec loop lev p =
     let surn = Driver.get_surname p in
-    if lev > v then
+    if lev >= v then
       (* TODO verify equation and see if hide_person should be used *)
       if is_hide_names conf p && not (authorized_age conf base p) then ()
       else add_person p surn
-    else add_person p surn;
-    match Driver.get_parents p with
-    | None -> ()
-    | Some ifam ->
-        let cpl = Driver.foi base ifam in
-        let fath = pget conf base (Driver.get_father cpl) in
-        let moth = pget conf base (Driver.get_mother cpl) in
-        if not (is_hidden fath) then loop (lev + 1) fath;
-        if not (is_hidden moth) then loop (lev + 1) moth
+    else begin
+      add_person p surn;
+      match Driver.get_parents p with
+      | None -> ()
+      | Some ifam ->
+          let cpl = Driver.foi base ifam in
+          let fath = pget conf base (Driver.get_father cpl) in
+          let moth = pget conf base (Driver.get_mother cpl) in
+          if not (is_hidden fath) then loop (lev + 1) fath;
+          if not (is_hidden moth) then loop (lev + 1) moth
+    end
   in
   (* Construction de la Hashtbl. *)
   loop 1 p;


### PR DESCRIPTION
The recursive walk had lost its terminal case: the `match get_parents p` block sat outside the `if lev > v` conditional, so every branch was followed down to its root whatever the generation limit passed through `v=`. The quick list (m=A&t=E) consequently reported all ancestral generations, and paid the full traversal, hashtable and sort cost on large ascendancies, no matter how small a `v` the user asked for.

The condition was inverted on top of that: past the bound the person was still added, behind a name-visibility check, instead of ending the walk. `v` had been reduced to selecting who goes through the privacy filter.

Restore the shape of build_surnames_list, the sibling builder behind the same `ancestor_surname` iterator, which still behaves correctly: collect generations 1..v, keep the is_hide_names / authorized_age guard on the terminal generation, stop recursing there. t=E and t=F now cover the same set of ancestors for a given v, which had not been true for a while.

Use `>=` rather than `=` for the terminal test: print_foreach_anc_surn falls back to max_level = 0 when the iterator is called with no argument and max_anc_level is absent from the template environment; an equality test would never fire and would restore the unbounded walk.

This closes #2950.

In addition, in “anclist” template:
Pass `lvl` instead of the raw `e.v` to the three ancestor_surname iterators, so the collected generations match what the page header already announces through `togena(lvl)`. On bases with no max_anc_level in their .gwf this applies the historical 7-generation cap, which t=F was silently escaping for v>7 — the header claimed 7, the table listed more.

Widen the early guard from `e.v="" and e.v=0` to `or`. An explicit v=0 now falls into the "specify a generation" message instead of reaching the iterators, where max_level=0 would yield an empty list with no explanation.

Drop two dead `%let;nb_gen;` bindings in the t=F branches: leftovers from a version that computed the generation bound template-side and passed it to the engine. Nothing has read them since.

Also remove superfluous spaces in buttons after icons.

In “buttons” template: Drop the “min” input for m=A&t=E and m=A&t=F too.