### PR TITLE
Fix relationship target search in relmenu

### DIFF
--- a/bin/gwd/request.ml
+++ b/bin/gwd/request.ml
@@ -44,13 +44,10 @@ let person_selected conf base p =
 
 let person_selected_with_redirect conf base p =
   match p_getenv conf.senv "em" with
-  | Some "R" ->
-      let p1 = find_person_in_env_pref conf base "e" in
-      RelationDisplay.print conf base p p1
-  | Some _ -> request_issue conf base ~key:"incorrect em value"
-  | None ->
+  | Some "R" | None ->
       Server.http_redirect_temporarily
         (commd conf ^^^ Util.acces conf base p :> string)
+  | Some _ -> request_issue conf base ~key:"incorrect em value"
 
 (* Print “Not found” page *)
 let unknown conf n =
@@ -633,9 +630,10 @@ let treat_request =
                              request_issue conf base
                                ~key:"missing fn and sn for search"))
                  | Some i ->
-                     RelationDisplay.print conf base
-                       (pget conf base (Driver.Iper.of_string i))
-                       (find_person_in_env_pref conf base "e"))
+                     let p = pget conf base (Driver.Iper.of_string i) in
+                     Server.http_redirect_temporarily
+                       (Adef.(Util.commd conf ^^^ Util.acces conf base p)
+                         :> string))
              | "NOTES" ->
                  w_base (fun conf base ->
                      match p_getenv conf.env "ref" with

--- a/hd/etc/advanced.txt
+++ b/hd/etc/advanced.txt
@@ -118,7 +118,7 @@
 %end;
 
 <form class="mx-2 mt-3" method="POST" action="%action;">
-  %hidden;
+  %hidden_no_senv;
   <input type="hidden" name="m" value="AS_OK">
   <div class="row">
     <div class="col-6">

--- a/hd/etc/home.txt
+++ b/hd/etc/home.txt
@@ -61,7 +61,7 @@
       <div class="modal-content">
         <div class="modal-body" id="ModalSearch">
           <form id="collapse_search" method="get" action="%prefix;">
-            %hidden;
+            %hidden_no_senv;
             <input type="hidden" name="m" value="S">
             <div class="d-flex flex-column flex-md-row justify-content-center gap-2">
               <h3 class="rounded modal-title my-2 ms-3 ms-md-0 text-md-center w-md-50 align-self-md-center" id="searchpopup">[*search/case sensitive]0 [person/persons]0</h3>

--- a/hd/etc/relmenu.txt
+++ b/hd/etc/relmenu.txt
@@ -41,7 +41,7 @@
     %end;
   %end;
   %if;cgi;<input type="hidden" name="b" value="%base.name;">%end;
-  <input type="hidden" name="m" value="R">
+  <input type="hidden" name="m" value="NG">
   <div class="row">
     <div id="rel_form_shortcut" class="col-4">
       <input type="hidden" name="em" value="R">
@@ -125,12 +125,12 @@
           <label class="form-check-label" for="radio_R">[*search/case sensitive]0 [any individual in the base][:]</label>
         </div>
         <div>
-          <label class="visually-hidden" for="pn">[*public name], [alias]%if;browsing_with_sosa_ref;, [n° Sosa relative to]%end;…</label>
-          <input type="search" id="pn" class="form-control mt-2" name="pn" placeholder="[*public name], [alias]%if;browsing_with_sosa_ref;, [n° Sosa relative to]%end;…" autofocus>
+          <label class="visually-hidden" for="fullname">[*public name], [alias]%if;browsing_with_sosa_ref;, [n° Sosa relative to]%end;…</label>
+          <input type="search" id="fullname" class="form-control mt-2" name="n" placeholder="[*public name], [alias]%if;browsing_with_sosa_ref;, [n° Sosa relative to]%end;…" autofocus>
           <label class="visually-hidden" for="firstname">[*first name/first names]0</label>
-          <input type="search" id="firstname" class="form-control mt-2" name="p" placeholder="[*first name/first names]0">
+          <input type="search" id="firstname" class="form-control mt-2" name="fn" placeholder="[*first name/first names]0">
           <label class="visually-hidden" for="surname">[*surname/surnames]0</label>
-          <input type="search" id="surname" class="form-control mt-2" name="n" placeholder="[*surname/surnames]0">
+          <input type="search" id="surname" class="form-control mt-2" name="sn" placeholder="[*surname/surnames]0">
         </div>
       </div>
       <div class="text-center my-4">

--- a/hd/etc/relmenu.txt
+++ b/hd/etc/relmenu.txt
@@ -28,19 +28,7 @@
   %sp;[and]0…%nn;
 </h1>
 <form name="relationship" method="get" action="%action;">
-  %( Propagate henv only, NOT senv — senv contains stale em/ei/et
-     from a previous relationship computation that would conflict
-     with the explicit form inputs below. %)
-  %foreach;env_binding;
-    %if;(env.key="pz" or env.key="nz" or env.key="ocz" or env.key="iz"
-      or env.key="escache" or env.key="alwsurn" or env.key="pure_xhtml"
-      or env.key="size" or env.key="p_mod" or env.key="wide"
-      or env.key="manitou" or env.key="fmode" or env.key="templ"
-      or env.key="dsrc" or env.key="lang")
-      <input type="hidden" name="%env.key;" value="%env.val;">
-    %end;
-  %end;
-  %if;cgi;<input type="hidden" name="b" value="%base.name;">%end;
+  %hidden_no_senv;
   <input type="hidden" name="m" value="NG">
   <div class="row">
     <div id="rel_form_shortcut" class="col-4">

--- a/hd/etc/welcome.txt
+++ b/hd/etc/welcome.txt
@@ -194,7 +194,7 @@ fr: Les <strong>droits des magiciens</strong> sont actuellement <strong>suspendu
   <div id="welcome-search" class="d-flex flex-wrap justify-content-center mt-3 mt-lg-1">
     <div class="col col-md-10 col-xl-9">
       <form id="main-search" class="mt-2 mt-xl-4" method="get" action="%prefix;">
-        %hidden;
+        %hidden_no_senv;
         <input type="hidden" name="m" value="S" class="has_validation">
         <div class="d-flex justify-content-center">
           <div class="d-flex flex-column justify-content-center w-100">
@@ -305,7 +305,7 @@ fr: Les <strong>droits des magiciens</strong> sont actuellement <strong>suspendu
       <div class="d-flex flex-wrap flex-md-nowrap justify-content-center align-items-md-center mt-1 mt-md-3">
         %if;(b.propose_titles!="no")
           <form id="title-search" class="d-flex flex-column flex-md-row align-items-start align-items-md-center col-12 col-md-9 ms-md-4" method="get" action="%action;">
-            %hidden;
+            %hidden_no_senv;
             <input type="hidden" name="m" value="TT">
             <div class="d-flex align-items-center w-100 mb-2 mb-md-0">
               <a class="me-2" role="button" data-bs-toggle="tooltip" data-bs-placement="bottom"

--- a/lib/relationDisplay.ml
+++ b/lib/relationDisplay.ml
@@ -327,11 +327,11 @@ let print_shortest_path conf base p1 p2 =
             Templ.output_simple conf Templ.Env.empty "buttons_rel");
         if excl_faml = [] then
           Output.printf conf
-            {|%s.<br><p><span><a href="%s&m=R&%s">%s</a> %s</span></p>|}
+            {|%s.<br><p><span><a href="%sm=R&%s">%s</a> %s.</span></p>|}
             (([ s1; s2 ] : Adef.safe_string list :> string list)
             |> Util.cftransl conf "no known relationship link between %s and %s"
             |> Utf8.capitalize_fst)
-            (Util.commd ~excl:[ "m" ] conf :> string)
+            (Util.commd ~excl:[ "m"; "em"; "ei"; "et" ] conf :> string)
             (Util.acces conf base p1 :> string)
             (Util.transl_nth conf "try another/relationship computing" 0
             |> Utf8.capitalize_fst)
@@ -946,7 +946,7 @@ let print_main_relationship conf base long p1 p2 rel =
         Output.print_sstring conf " ")
       else
         Output.printf conf
-          {|%s.<br><p><span><a href="%s&m=R&%s">%s</a> %s.</span></p>|}
+          {|%s.<br><p><span><a href="%sm=R&%s">%s</a> %s.</span></p>|}
           (([
               Util.gen_person_title_text Util.reference conf base p1;
               Util.gen_person_title_text Util.reference conf base p2;
@@ -955,7 +955,7 @@ let print_main_relationship conf base long p1 p2 rel =
              :> string list)
           |> Util.cftransl conf "no known relationship link between %s and %s"
           |> Utf8.capitalize_fst)
-          (Util.commd ~excl:[ "m" ] conf :> string)
+          (Util.commd ~excl:[ "m"; "em"; "ei"; "et" ] conf :> string)
           (Util.acces conf base p1 :> string)
           (Util.transl_nth conf "try another/relationship computing" 0
           |> Utf8.capitalize_fst)

--- a/lib/relationDisplay.ml
+++ b/lib/relationDisplay.ml
@@ -274,6 +274,23 @@ let next_relation_link_txt conf ip1 ip2 excl_faml : Adef.escaped_string =
   ^<^ (if sps then "" else "&sp=0")
   ^<^ Adef.escaped ("&et=S" ^ sl)
 
+let print_no_relationship_link conf base p1 p2 =
+  Output.printf conf
+    {|%s.<br><p><span><a href="%sm=R&%s">%s</a> %s.</span></p>|}
+    (([
+        Util.gen_person_title_text Util.reference conf base p1;
+        Util.gen_person_title_text Util.reference conf base p2;
+      ]
+       : Adef.safe_string list
+       :> string list)
+    |> Util.cftransl conf "no known relationship link between %s and %s"
+    |> Utf8.capitalize_fst)
+    (Util.commd ~excl:[ "m"; "em"; "ei"; "et" ] conf :> string)
+    (Util.acces conf base p1 :> string)
+    (Util.transl_nth conf "try another/relationship computing" 0
+    |> Utf8.capitalize_fst)
+    (Util.transl_nth conf "try another/relationship computing" 1)
+
 let print_relation_path conf base ip1 ip2 path ifam excl_faml =
   if path = [] then (
     let title _ =
@@ -325,17 +342,7 @@ let print_shortest_path conf base p1 p2 =
         | _ ->
             let conf = { conf with is_printed_by_template = false } in
             Templ.output_simple conf Templ.Env.empty "buttons_rel");
-        if excl_faml = [] then
-          Output.printf conf
-            {|%s.<br><p><span><a href="%sm=R&%s">%s</a> %s.</span></p>|}
-            (([ s1; s2 ] : Adef.safe_string list :> string list)
-            |> Util.cftransl conf "no known relationship link between %s and %s"
-            |> Utf8.capitalize_fst)
-            (Util.commd ~excl:[ "m"; "em"; "ei"; "et" ] conf :> string)
-            (Util.acces conf base p1 :> string)
-            (Util.transl_nth conf "try another/relationship computing" 0
-            |> Utf8.capitalize_fst)
-            (Util.transl_nth conf "try another/relationship computing" 1)
+        if excl_faml = [] then print_no_relationship_link conf base p1 p2
         else
           Output.printf conf "<ul><li>%s</li><li>%s</li></ul>"
             (s1 : Adef.safe_string :> string)
@@ -944,22 +951,7 @@ let print_main_relationship conf base long p1 p2 rel =
         Util.transl conf "it is the same person!"
         |> Utf8.capitalize_fst |> Output.print_sstring conf;
         Output.print_sstring conf " ")
-      else
-        Output.printf conf
-          {|%s.<br><p><span><a href="%sm=R&%s">%s</a> %s.</span></p>|}
-          (([
-              Util.gen_person_title_text Util.reference conf base p1;
-              Util.gen_person_title_text Util.reference conf base p2;
-            ]
-             : Adef.safe_string list
-             :> string list)
-          |> Util.cftransl conf "no known relationship link between %s and %s"
-          |> Utf8.capitalize_fst)
-          (Util.commd ~excl:[ "m"; "em"; "ei"; "et" ] conf :> string)
-          (Util.acces conf base p1 :> string)
-          (Util.transl_nth conf "try another/relationship computing" 0
-          |> Utf8.capitalize_fst)
-          (Util.transl_nth conf "try another/relationship computing" 1)
+      else print_no_relationship_link conf base p1 p2
   | Some (rl, _, relationship) ->
       let a1 = p1 in
       let a2 = p2 in

--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -1385,6 +1385,7 @@ and print_simple_variable conf = function
       Output.print_sstring conf
         (String.concat ", " (Util.get_bases_list ~format_fun:format_link ()))
   | "hidden" -> Util.hidden_env conf
+  | "hidden_no_senv" -> Util.hidden_env ~senv:false conf
   | "message_to_wizard" -> Util.message_to_wizard conf
   | "query_time" ->
       (* FIXME: This variable have been introduced in order to display the

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -791,9 +791,9 @@ let hidden_input_s conf k v = aux_input_s conf (Adef.encoded "hidden") k v
 let hidden_input conf k v = hidden_input_s conf k (Mutil.decode v)
 let hidden_env_aux conf = List.iter (fun (k, v) -> hidden_input conf k v)
 
-let hidden_env conf =
+let hidden_env ?(senv = true) conf =
   hidden_env_aux conf conf.henv;
-  hidden_env_aux conf conf.senv
+  if senv then hidden_env_aux conf conf.senv
 
 let submit_input conf k v =
   aux_input_s conf (Adef.encoded "submit") k (Mutil.decode v)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1104,9 +1104,13 @@ let reference_flags with_id conf base p (s : Adef.safe_string) =
   (* let is_hidden = is_empty_string (get_surname p) !! *)
   if (not (GWPARAM.p_auth conf base p)) || cgl then s
   else
+    let excl =
+      match p_getenv conf.env "m" with
+      | None | Some ("" | "R" | "RL" | "RLM") -> [ "em"; "ei"; "et" ]
+      | _ -> []
+    in
     "<a href=\""
-    ^<^ (commd ~excl:[ "em"; "ei"; "et" ] conf ^^^ acces conf base p
-          :> Adef.safe_string)
+    ^<^ (commd ~excl conf ^^^ acces conf base p :> Adef.safe_string)
     ^^^ (if with_id then "\" id=\"i" else "")
     ^<^ (if with_id then Driver.Iper.to_string iper else "")
     ^<^ "\">" ^<^ s ^>^ "</a>"

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -333,7 +333,13 @@ val reference :
   Adef.safe_string
 (** [reference conf base p desc] returns HTML link to the person where [desc] is
     content of the link (generaly his first name and surname description). If
-    person is hidden returns [desc] (do not create link). *)
+    person is hidden returns [desc] (do not create link).
+
+    Relationship-selection parameters ([em], [ei], [et]) are propagated so that
+    listing pages can be used to pick a target, and stripped where the
+    relationship is being displayed and person links must lead to the person
+    page: the [R], [RL] and [RLM] routes, and requests with no [m] at all, which
+    is how [person_selected] reaches the relationship display from [senv]. *)
 
 val reference_noid :
   config ->
@@ -341,7 +347,8 @@ val reference_noid :
   Geneweb_db.Driver.person ->
   Adef.safe_string ->
   Adef.safe_string
-(** Same as [reference] but link doesn't has "id" field *)
+(** Same as {!reference} without the [id] attribute; the same [em], [ei], [et]
+    rule applies. *)
 
 val no_reference :
   config ->

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -88,10 +88,13 @@ val hidden_env_aux : config -> (string * Adef.encoded_string) list -> unit
 (** [hidden_env_aux env] Creates a hidden HTML input for every key and value in
     [env]. *)
 
-val hidden_env : config -> unit
-(** Creates a hidden HTML input for every key and value in [conf.henv] and
-    [conf.senv]. Used to include immutable environement bindings in the HTML
-    form. *)
+val hidden_env : ?senv:bool -> config -> unit
+(** [hidden_env conf] emits [conf.henv] then [conf.senv] as hidden form inputs.
+    With [~senv:false], only [conf.henv] is emitted: use it on forms that start
+    a new navigation rather than continue the current one. [conf.senv] carries
+    the state of the computation in progress ([em], [ei], [et], [long],
+    [spouse]); a search form that reconducts it resolves its result as a
+    relationship target instead of displaying the person. *)
 
 val hidden_textarea : config -> string -> Adef.encoded_string -> unit
 


### PR DESCRIPTION
Fix relationship target selection

Two distinct defects made the relmenu search unusable as a target picker.

The default relmenu form submitted m=R with the main-search parameter
names (pn, p, n). m=R resolves a single person from a complete key, so a
query on a first name or a surname alone reached the route with p or n
empty and was rejected with "Missing p= and n= for m=R" (#2951); a query
on the public-name field only worked by accident, since pn was ignored
and the two remaining fields happened to form a key. Restore m=NG and its
parameter names (n, fn, sn), as still used by the templm template, so the
three fields go through the search engine and the result feeds em=R.

Util.reference and Util.reference_noid then stripped em, ei and et from
every person link they produced. Any page rendered through them lost the
origin of the pending relationship computation: the surname-by-branch
view offered plain person links where the first-name list and the
alphabetic view, which build their anchors with commd directly, kept the
context. Strip those parameters only on the R, RL and RLM routes, where a
person link must lead to the person page rather than restart a computation.