### PR TITLE
Remove Geneweb_templ cache

### DIFF
--- a/lib/templ.ml
+++ b/lib/templ.ml
@@ -50,9 +50,7 @@ let resolve_include conf _loc fl =
 
 let parse conf fl =
   let fl = Util.etc_file_name conf fl in
-  let cached = not conf.predictable_mode in
-  Parser.parse ~cached ~on_exn ~resolve_include:(resolve_include conf)
-    (`File fl)
+  Parser.parse ~on_exn ~resolve_include:(resolve_include conf) (`File fl)
 
 let sort_apply_parameters loc f_expr xl vl =
   let named_vl, unnamed_vl =
@@ -1352,9 +1350,8 @@ and print_var print_ast_list conf ifun env ep loc sl =
           try
             let fl = Util.etc_file_name conf templ in
             let astl =
-              let cached = not conf.predictable_mode in
-              Parser.parse ~cached ~on_exn
-                ~resolve_include:(resolve_include conf) (`File fl)
+              Parser.parse ~on_exn ~resolve_include:(resolve_include conf)
+                (`File fl)
             in
             print_ast_list env ep astl
           with _ ->

--- a/lib/templ/parser.ml
+++ b/lib/templ/parser.ml
@@ -1,13 +1,3 @@
-let with_cache (type a b) (f : a -> b) : a -> b =
-  let cache : (a, b) Hashtbl.t = Hashtbl.create 17 in
-  fun x ->
-    match Hashtbl.find cache x with
-    | exception Not_found ->
-        let r = f x in
-        Hashtbl.add cache x r;
-        r
-    | r -> r
-
 let parse_ast ~src lexbuf =
   let st = Lexer.State.create ~src lexbuf in
   Lexer.parse_ast (Buffer.create 1024) [] st lexbuf |> fst
@@ -21,10 +11,9 @@ let parse_file ~src fl =
   let lexbuf = Lexing.from_channel ~with_positions:false ic in
   parse_ast ~src lexbuf
 
-let parse_source ~cached src =
+let parse_source src =
   match src with
-  | `File fl ->
-      if cached then with_cache (parse_file ~src) fl else parse_file ~src fl
+  | `File fl -> parse_file ~src fl
   | `Raw s -> parse_ast ~src (Lexing.from_string ~with_positions:false s)
 
 let comment fl =
@@ -35,9 +24,9 @@ let comment fl =
   in
   Ast.mk_text s
 
-let parse ?(cached = true) ~on_exn ~resolve_include src =
+let parse ~on_exn ~resolve_include src =
   let parse_include ~loc src =
-    try Ast.mk_pack ~loc @@ parse_source ~cached src
+    try Ast.mk_pack ~loc @@ parse_source src
     with e ->
       let bt = Printexc.get_raw_backtrace () in
       on_exn e bt;
@@ -61,4 +50,4 @@ let parse ?(cached = true) ~on_exn ~resolve_include src =
             Ast.mk_pack @@ [ comment fl; expand t; comment fl ]
         | `Raw s -> expand @@ parse_include ~loc (`Raw s))
   and expand_list l = List.map expand l in
-  expand_list @@ parse_source ~cached src
+  expand_list @@ parse_source src

--- a/lib/templ/parser.mli
+++ b/lib/templ/parser.mli
@@ -1,13 +1,10 @@
 val parse :
-  ?cached:bool ->
   on_exn:(exn -> Printexc.raw_backtrace -> unit) ->
   resolve_include:(Loc.t -> string -> string) ->
   Loc.source ->
   Ast.t list
 (** [parse ?cached ~on_exn ~find src] parses [src] and expands included
     templates.
-    - [cached] option enables caching of the parsing process. The default is
-      [true].
     - [resolve_include] function resolves paths for included files.
     - [on_exn] callback handles exceptions raised during included template
       parsing, providing both the exception and its backtrace. *)

--- a/test/templ/templ_test.ml
+++ b/test/templ/templ_test.ml
@@ -4,8 +4,7 @@ module Compat = Geneweb_compat
 
 let parse_file fl =
   let resolve_include _loc s = s in
-  Parser.parse ~cached:false ~on_exn:Printexc.raise_with_backtrace
-    ~resolve_include (`File fl)
+  Parser.parse ~on_exn:Printexc.raise_with_backtrace ~resolve_include (`File fl)
 
 (* HOTFIX: dune 3.24 changed the way it handles path. The latest versions
    introduces systematically a leading dot and the previous version trim it.


### PR DESCRIPTION
This PR removes the local cache in Geneweb_templ library. As we noticed recently, invalidating this cache requires carefulness and its impact on the current performance is negligeable on most of the pages. A better cache will be introduce after the release.

The main motivation of this cache is to ensure that new templates are immediately read on the disk after the next request.