### PR TITLE
fix dropped templ param in normalize_person_pool_url

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -3414,7 +3414,7 @@ let normalize_person_pool_url conf base target_module assoc_txt_opt =
       loop (i + 1))
   in
   loop 1;
-  (prefix_base_password conf :> string)
+  (commd conf :> string)
   ^ "m=" ^ target_module ^ "&"
   ^ String.concat "&" (List.rev !converted_params)
 


### PR DESCRIPTION
normalize_person_pool_url transforms pi=xxx&ni=yyy into i=index.
in the process, it was dropping all the other url parameters (senv, henv)