### PR TITLE
Document plugin phase-out and person-page variable shadowing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,9 @@ Avoid bloating catch-all modules. `perso.ml` (~4000 LOC) and
 `templ.ml` is the template engine runtime; changes there affect every
 page.
 
+`plugins/` is legacy and is being phased out. Do not add new plugins,
+and do not propose a plugin as the solution to a feature request.
+
 ## OCaml Conventions
 
 1. Never disable compiler warnings.
@@ -71,6 +74,15 @@ page.
 Templates are `.txt` files in `hd/etc/`. The engine is in
 `lib/templ/` (parser/lexer) and `lib/templ.ml` (runtime). Custom
 template engine.
+
+### Variable Resolution on Person Pages
+
+Variables are resolved through the `eval_*` chain of `perso.ml`
+before reaching the generic one in `templ.ml`. A name defined in
+`perso.ml` therefore shadows the generic one silently, with no
+warning: the variable still returns a value, just not the expected
+one. `%source;` on a person page is the person's genealogical source
+field, not `Version.src`.
 
 ### Syntax
 


### PR DESCRIPTION
Two additions to CLAUDE.md, both behaviour rules rather than
descriptions of the current state.

The plugin entry is there to stop assistants proposing new plugins:
without it, reading `plugins/` suggests a supported extension point.

The shadowing note comes from #2727, where @nick-spies hit it on
`%source;`. It is not specific to that variable: any name defined in
the `perso.ml` dispatch chain masks the generic one, and the failure
is silent.