### PR TITLE
Forbid daemon mode on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 
 *.bat text eol=crlf
 *.iss text eol=crlf
+test/gwd/windows.t eol=crlf
 
 *.config text eol=lf
 *.cgi text eol=lf

--- a/bin/gwd/cmd.ml
+++ b/bin/gwd/cmd.ml
@@ -450,7 +450,10 @@ let cgi =
 
 let daemon =
   let doc = "Run the process in the background (UNIX only)." in
-  C.Arg.(value & flag & info [ "daemon" ] ~docs:http_section ~doc)
+  let error = "--daemon is available only on UNIX." in
+  C.Arg.(
+    unix_only_flag ~error & value & flag
+    & info [ "daemon" ] ~docs:http_section ~doc)
 
 (* Web interface commands *)
 

--- a/test/gwd/dune
+++ b/test/gwd/dune
@@ -8,8 +8,14 @@
 
 (cram
  (package geneweb)
- (applies_to help log ancient)
+ (applies_to help log ancient windows)
  (deps %{bin:gwd}))
+
+(cram
+ (package geneweb)
+ (applies_to windows)
+ (enabled_if
+  (= %{os_type} Win32)))
 
 (cram
  (package geneweb)

--- a/test/gwd/windows.t
+++ b/test/gwd/windows.t
@@ -1,0 +1,21 @@
+  $ gwd --connection-timeout 10
+  gwd: --connection-timeout is available only on UNIX.
+  [124]
+
+  $ gwd --max-pending-requests 100
+  gwd: --max-pending-requests is available only on UNIX.
+  [124]
+
+  $ gwd --max-clients 100
+  gwd: deprecated option --max-clients: No effect. Use `--n-workers` and
+                  `--max-pending-requests` instead.
+  gwd: --max-clients is available only on UNIX.
+  [124]
+
+  $ gwd --n-workers 5
+  gwd: --n-workers is available only on UNIX.
+  [124]
+
+  $ gwd --daemon
+  gwd: --daemon is available only on UNIX.
+  [124]


### PR DESCRIPTION
This bug was probably introduced during the modernization of the CLI of gwd. The commit introduces cram tests on Windows too.