### PR TITLE
fix cnt_dir race on worker's first request (wizard token lookup)

### DIFF
--- a/bin/gwd/gwd.ml
+++ b/bin/gwd/gwd.ml
@@ -1297,6 +1297,7 @@ let make_conf ~predictable_mode ~cgi ~loaded_plugins ~secret_salt conn from_addr
   in
   (* read base environment from the right location *)
   GWPARAM.set_reorg base_file None;
+  GWPARAM.cnt_dir := !GWPARAM.cnt_d base_file;
   let base_env =
     if base_file = "" then []
     else Util.read_base_env base_file (Option.get !gw_prefix) !debug
@@ -1482,7 +1483,6 @@ let make_conf ~predictable_mode ~cgi ~loaded_plugins ~secret_salt conn from_addr
       predictable_mode;
     }
   in
-  GWPARAM.cnt_dir := !GWPARAM.cnt_d conf.bname;
   (conf, ar)
 
 (* Filter to avoid logging requests that don't provide useful information *)

--- a/bin/setup/setup.ml
+++ b/bin/setup/setup.ml
@@ -1326,6 +1326,7 @@ let rename conn conf =
     List.iter
       (fun (k, v) ->
         if k <> v then begin
+          GWPARAM.set_reorg k None;
           Printf.eprintf "Start renaming (%s -> %s)\n" k v;
           flush stderr;
           try


### PR DESCRIPTION
GWPARAM.cnt_dir is a global mutable ref, populated by calling !GWPARAM.cnt_d <bname>. At gwd startup, this is called once with an empty bname (gwd.ml:2273), before the worker pool is forked, so every worker inherits the generic base_dir()/cnt path. The only place that corrected it to the real per-base path (base_dir()/<base>.gwb/config/cnt in reorg mode) was the last line of make_conf — which runs *after* authorization(), and therefore after get_token/set_token have already resolved gwd.lck and actlog via the stale cnt_dir.

Effect: a worker's very first request in its lifetime performed its wizard-token read/write against the wrong actlog file. Since workers are separate forked processes and each only "self-corrects" after handling one request, this reliably broke wizard auth (silently, as ATnormal) on first use per worker — most visible right after a fresh restart or under a burst of concurrent requests, when many still-fresh workers each hit their own first request in parallel.

Fix: call GWPARAM.cnt_dir := !GWPARAM.cnt_d base_file right after set_reorg in make_conf, so cnt_dir is correct before authorization runs.